### PR TITLE
Standardize bundle directory to .gitspace/ only

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ fi
 
 Bundles can be loaded from:
 
-1. **In-repo** (automatic): `.gitspace/`, `.gitspace-config/`, `.spaces-config/`, or `.spaces/` in the cloned repository
+1. **In-repo** (automatic): `.gitspace/` directory in the cloned repository
 2. **Local path**: `gssh add project --bundle-path /path/to/bundle/`
 3. **Remote URL**: `gssh add project --bundle-url https://example.com/bundle.zip`
 

--- a/docs/SITE_DOCS_FIGMA_MAKE.md
+++ b/docs/SITE_DOCS_FIGMA_MAKE.md
@@ -311,18 +311,18 @@ git status
 
 ### Repo Config Bundles
 
-Bundles allow repository owners to share onboarding configurations. Place in `.gitspace-config/` in your repo:
+Bundles allow repository owners to share onboarding configurations. Place in `.gitspace/` in your repo:
 
 ```
-.gitspace-config/
-├── gitspace-bundle.json    # Bundle manifest with onboarding steps
+.gitspace/
+├── bundle.json           # Bundle manifest with onboarding steps
 ├── pre/                  # Scripts to run before setup
 ├── setup/                # Scripts to run on first workspace creation
 ├── select/               # Scripts to run every time workspace is opened
 └── remove/               # Scripts to run before workspace deletion
 ```
 
-Bundle manifest example (`gitspace-bundle.json`):
+Bundle manifest example (`bundle.json`):
 ```json
 {
   "version": "1.0",
@@ -388,7 +388,7 @@ fi
 ```
 
 Bundle sources:
-- **In-repo** (automatic): `.gitspace-config/`, `gitspace-config/`, or `.gitspace/` in the cloned repository
+- **In-repo** (automatic): `.gitspace/` directory in the cloned repository
 - **Local path**: `gssh add project --bundle-path /path/to/bundle/`
 - **Remote URL**: `gssh add project --bundle-url https://example.com/bundle.zip`
 
@@ -920,11 +920,11 @@ git status
 
 SECTION: Local Workflow - Repo Config Bundles
 
-Bundles allow teams to share onboarding configurations. Place in `.gitspace-config/`:
+Bundles allow teams to share onboarding configurations. Place in `.gitspace/`:
 
 ```
-.gitspace-config/
-├── gitspace-bundle.json    # Manifest
+.gitspace/
+├── bundle.json           # Manifest
 ├── pre/                  # Pre-setup scripts
 ├── setup/                # Setup scripts
 └── select/               # Select scripts

--- a/src/core/bundle.ts
+++ b/src/core/bundle.ts
@@ -23,7 +23,7 @@ import type { SpacesBundle, LoadedBundle } from '../types/bundle.js';
 import { getScriptsPhaseDir } from './config.js';
 
 const BUNDLE_FILENAME = 'bundle.json';
-const BUNDLE_SUBDIRS = ['.gitspace', '.gitspace-config', 'gitspace-config', '.spaces-config', 'spaces-config', '.spaces'];
+const BUNDLE_SUBDIRS = ['.gitspace'];
 const SCRIPT_PHASES = ['pre', 'setup', 'select', 'remove'] as const;
 
 function assertSafeExtractedPaths(rootDir: string): void {


### PR DESCRIPTION
Drop support for legacy bundle directory names (.gitspace-config, gitspace-config, .spaces-config, spaces-config, .spaces) and standardize on .gitspace/ as the single supported location.