### PR TITLE
branch names now allow slashes, but get sanitized

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -128,7 +128,13 @@ addCommand
 	.action(async (workspaceName, options) => {
 		await checkFirstTimeSetup()
 		try {
-			await addWorkspace(workspaceName, options)
+			// Map commander option names to CreateWorkspaceOptions property names
+			await addWorkspace(workspaceName, {
+				branchName: options.branch,
+				fromBranch: options.from,
+				noShell: options.shell === false,
+				noSetup: options.setup === false,
+			})
 		} catch (error) {
 			handleError(error)
 		}

--- a/src/tui/app.tsx
+++ b/src/tui/app.tsx
@@ -98,7 +98,8 @@ type WorkspaceFlowState =
   | { type: 'loading'; title: string; message: string }
   | { type: 'branch-select'; branches: string[]; selectedIndex: number }
   | { type: 'linear-select'; issues: LinearIssue[]; selectedIndex: number }
-  | { type: 'manual-input'; inputValue: string; error: string | null }
+  | { type: 'manual-name-input'; inputValue: string; error: string | null }
+  | { type: 'manual-branch-input'; workspaceName: string; inputValue: string }
   | { type: 'creating'; workspaceName: string };
 
 /** Project flow states - explicit state machine for project creation */
@@ -691,7 +692,7 @@ function App({ relayConfig, onQuit }: AppProps) {
         setWorkspaceFlow({ type: 'closed' });
       }
     } else if (source === 'manual') {
-      setWorkspaceFlow({ type: 'manual-input', inputValue: '', error: null });
+      setWorkspaceFlow({ type: 'manual-name-input', inputValue: '', error: null });
     }
   }, [state.currentProject, flow]);
 
@@ -707,17 +708,24 @@ function App({ relayConfig, onQuit }: AppProps) {
     await createWorkspaceAndOpenSession(workspaceName, workspaceName, false, issue);
   }, [createWorkspaceAndOpenSession]);
 
-  // Handle manual name submission
-  const handleManualSubmit = useCallback(async (name: string) => {
+  // Handle manual workspace name submission (advances to branch input)
+  const handleManualNameSubmit = useCallback((name: string) => {
     if (!name || name.trim().length === 0) {
-      setWorkspaceFlow(prev => prev.type === 'manual-input' ? { ...prev, error: 'Workspace name is required' } : prev);
+      setWorkspaceFlow(prev => prev.type === 'manual-name-input' ? { ...prev, error: 'Workspace name is required' } : prev);
       return;
     }
     if (!isValidWorkspaceName(name)) {
-      setWorkspaceFlow(prev => prev.type === 'manual-input' ? { ...prev, error: 'Use only letters, numbers, hyphens, underscores' } : prev);
+      setWorkspaceFlow(prev => prev.type === 'manual-name-input' ? { ...prev, error: 'Use only letters, numbers, hyphens, underscores' } : prev);
       return;
     }
-    await createWorkspaceAndOpenSession(name, name, false);
+    // Advance to branch input step, pre-fill with workspace name
+    setWorkspaceFlow({ type: 'manual-branch-input', workspaceName: name, inputValue: name });
+  }, []);
+
+  // Handle manual branch name submission (creates the workspace)
+  const handleManualBranchSubmit = useCallback(async (workspaceName: string, branchName: string) => {
+    const finalBranch = branchName.trim() || workspaceName;
+    await createWorkspaceAndOpenSession(workspaceName, finalBranch, false);
   }, [createWorkspaceAndOpenSession]);
 
   // Main handler to start new workspace flow
@@ -1207,9 +1215,9 @@ function App({ relayConfig, onQuit }: AppProps) {
         return;
       }
 
-      if (workspaceFlow.type === 'manual-input') {
+      if (workspaceFlow.type === 'manual-name-input') {
         if (key.name === 'return') {
-          await handleManualSubmit(workspaceFlow.inputValue);
+          handleManualNameSubmit(workspaceFlow.inputValue);
         } else if (key.name === 'backspace') {
           setWorkspaceFlow({
             ...workspaceFlow,
@@ -1221,6 +1229,23 @@ function App({ relayConfig, onQuit }: AppProps) {
             ...workspaceFlow,
             inputValue: workspaceFlow.inputValue + key.raw,
             error: null,
+          });
+        }
+        return;
+      }
+
+      if (workspaceFlow.type === 'manual-branch-input') {
+        if (key.name === 'return') {
+          await handleManualBranchSubmit(workspaceFlow.workspaceName, workspaceFlow.inputValue);
+        } else if (key.name === 'backspace') {
+          setWorkspaceFlow({
+            ...workspaceFlow,
+            inputValue: workspaceFlow.inputValue.slice(0, -1),
+          });
+        } else if (key.raw && key.raw.length === 1 && !key.ctrl && !key.meta) {
+          setWorkspaceFlow({
+            ...workspaceFlow,
+            inputValue: workspaceFlow.inputValue + key.raw,
           });
         }
         return;
@@ -1536,8 +1561,10 @@ function WorkspaceFlowModal({ flow }: { flow: WorkspaceFlowState }) {
   // Calculate modal height based on content:
   // - source-select: title + spacer + (options * 2 lines each) + (spacers between) + spacer + hint + border/padding
   // - branch/linear-select: title + items (scrollable) + hint + border/padding
-  // - manual-input: title + label + input box + error? + hint + border/padding
-  const modalHeight = flow.type === 'manual-input' ? 10 :
+  // - manual-name-input: title + label + input box + error? + hint + border/padding
+  // - manual-branch-input: title + label + input box + workspace display + hint + border/padding
+  const modalHeight = flow.type === 'manual-name-input' ? 10 :
+                      flow.type === 'manual-branch-input' ? 12 :
                       flow.type === 'loading' || flow.type === 'creating' ? 6 :
                       flow.type === 'source-select' ? 6 + flow.options.length * 3 :
                       flow.type === 'branch-select' ? Math.min(16, 6 + flow.branches.length) :
@@ -1636,10 +1663,10 @@ function WorkspaceFlowModal({ flow }: { flow: WorkspaceFlowState }) {
           </>
         )}
 
-        {/* Manual input */}
-        {flow.type === 'manual-input' && (
+        {/* Manual workspace name input */}
+        {flow.type === 'manual-name-input' && (
           <>
-            <text fg={COLORS.title} height={1}>New Workspace</text>
+            <text fg={COLORS.title} height={1}>New Workspace (1/2)</text>
             <text fg={COLORS.text} height={1} marginTop={1}>Enter workspace name:</text>
             <box
               marginTop={1}
@@ -1651,6 +1678,25 @@ function WorkspaceFlowModal({ flow }: { flow: WorkspaceFlowState }) {
               <text fg={COLORS.text} height={1}>{flow.inputValue || ' '}_</text>
             </box>
             {flow.error && <text fg={COLORS.error} height={1} marginTop={1}>{flow.error}</text>}
+            <text fg={COLORS.textDim} height={1} marginTop={1}>[Enter] Next  [Esc] Cancel</text>
+          </>
+        )}
+
+        {/* Manual branch name input */}
+        {flow.type === 'manual-branch-input' && (
+          <>
+            <text fg={COLORS.title} height={1}>New Workspace (2/2)</text>
+            <text fg={COLORS.text} height={1} marginTop={1}>Enter branch name (slashes allowed):</text>
+            <box
+              marginTop={1}
+              borderStyle="rounded"
+              borderColor={COLORS.border}
+              padding={0}
+              width="100%"
+            >
+              <text fg={COLORS.text} height={1}>{flow.inputValue || ' '}_</text>
+            </box>
+            <text fg={COLORS.textDim} height={1} marginTop={1}>Workspace: {flow.workspaceName}</text>
             <text fg={COLORS.textDim} height={1} marginTop={1}>[Enter] Create  [Esc] Cancel</text>
           </>
         )}

--- a/src/tui/app.tsx
+++ b/src/tui/app.tsx
@@ -63,7 +63,7 @@ import { listRemoteBranches, createWorktree, getDefaultBranch } from '../core/gi
 import { deleteWorkspaceCore, deleteProjectCore } from '../core/workspace.js';
 import { fetchUnstartedIssues } from '../core/linear.js';
 import { generateMarkdown } from '../utils/markdown.js';
-import { sanitizeForFileSystem, generateWorkspaceName, isValidWorkspaceName, extractRepoName } from '../utils/sanitize.js';
+import { sanitizeForFileSystem, generateWorkspaceName, isValidWorkspaceName, isValidBranchName, extractRepoName } from '../utils/sanitize.js';
 import { existsSync, mkdirSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import type { LinearIssue } from '../types/workspace.js';
@@ -710,21 +710,26 @@ function App({ relayConfig, onQuit }: AppProps) {
 
   // Handle manual workspace name submission (advances to branch input)
   const handleManualNameSubmit = useCallback((name: string) => {
-    if (!name || name.trim().length === 0) {
+    const trimmedName = name.trim();
+    if (!trimmedName) {
       setWorkspaceFlow(prev => prev.type === 'manual-name-input' ? { ...prev, error: 'Workspace name is required' } : prev);
       return;
     }
-    if (!isValidWorkspaceName(name)) {
+    if (!isValidWorkspaceName(trimmedName)) {
       setWorkspaceFlow(prev => prev.type === 'manual-name-input' ? { ...prev, error: 'Use only letters, numbers, hyphens, underscores' } : prev);
       return;
     }
     // Advance to branch input step, pre-fill with workspace name
-    setWorkspaceFlow({ type: 'manual-branch-input', workspaceName: name, inputValue: name });
+    setWorkspaceFlow({ type: 'manual-branch-input', workspaceName: trimmedName, inputValue: trimmedName });
   }, []);
 
   // Handle manual branch name submission (creates the workspace)
   const handleManualBranchSubmit = useCallback(async (workspaceName: string, branchName: string) => {
     const finalBranch = branchName.trim() || workspaceName;
+    if (!isValidBranchName(finalBranch)) {
+      setWorkspaceFlow(prev => prev.type === 'manual-branch-input' ? { ...prev, error: 'Invalid branch name (no spaces, .., or special chars like : ? * [ \\ ~)' } : prev);
+      return;
+    }
     await createWorkspaceAndOpenSession(workspaceName, finalBranch, false);
   }, [createWorkspaceAndOpenSession]);
 

--- a/src/utils/sanitize.ts
+++ b/src/utils/sanitize.ts
@@ -84,6 +84,70 @@ export function isValidWorkspaceName(name: string): boolean {
 }
 
 /**
+ * Validate a git branch name according to git-check-ref-format rules
+ * See: https://git-scm.com/docs/git-check-ref-format
+ *
+ * @param name Branch name to validate
+ * @returns true if valid, false otherwise
+ */
+export function isValidBranchName(name: string): boolean {
+  if (!name || name.length === 0) {
+    return false;
+  }
+
+  // Cannot have two consecutive dots
+  if (name.includes('..')) {
+    return false;
+  }
+
+  // Cannot have ASCII control characters, space, tilde, caret, colon,
+  // question mark, asterisk, open bracket, or backslash
+  if (/[\x00-\x1f\x7f ~^:?*\[\\]/.test(name)) {
+    return false;
+  }
+
+  // Cannot start or end with a slash, or have consecutive slashes
+  if (name.startsWith('/') || name.endsWith('/') || name.includes('//')) {
+    return false;
+  }
+
+  // Cannot end with a dot
+  if (name.endsWith('.')) {
+    return false;
+  }
+
+  // Cannot contain @{
+  if (name.includes('@{')) {
+    return false;
+  }
+
+  // Cannot be exactly @
+  if (name === '@') {
+    return false;
+  }
+
+  // Cannot end with .lock
+  if (name.endsWith('.lock')) {
+    return false;
+  }
+
+  // Cannot start with a dash
+  if (name.startsWith('-')) {
+    return false;
+  }
+
+  // Each component cannot start with a dot
+  const components = name.split('/');
+  for (const component of components) {
+    if (component.startsWith('.') || component.length === 0) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+/**
  * Extract repository name from owner/repo format
  *
  * @param repository Repository in "owner/repo" format


### PR DESCRIPTION
This pull request refactors the manual workspace creation flow in the TUI (`src/tui/app.tsx`) to separate the workspace name and branch name input steps, improving clarity and user experience. It also updates the command-line interface (`src/index.ts`) to map options more explicitly. The most important changes are grouped below.

**Manual Workspace Creation Flow Improvements:**

* Split manual workspace creation into two explicit steps: first input for workspace name (`manual-name-input`), then input for branch name (`manual-branch-input`). This provides clearer prompts and error handling for each step. [[1]](diffhunk://#diff-6c55ec19eeee8aecc725e998ace4f857c9035d9fc49bb2864319c13ac5914d62L101-R102) [[2]](diffhunk://#diff-6c55ec19eeee8aecc725e998ace4f857c9035d9fc49bb2864319c13ac5914d62L694-R695) [[3]](diffhunk://#diff-6c55ec19eeee8aecc725e998ace4f857c9035d9fc49bb2864319c13ac5914d62L710-R728)
* Updated key handling logic to support the new two-step flow, including advancing between steps and handling input for both workspace name and branch name. [[1]](diffhunk://#diff-6c55ec19eeee8aecc725e998ace4f857c9035d9fc49bb2864319c13ac5914d62L1210-R1220) [[2]](diffhunk://#diff-6c55ec19eeee8aecc725e998ace4f857c9035d9fc49bb2864319c13ac5914d62R1237-R1253)
* Improved modal UI to reflect the two-step process, with distinct titles, input boxes, and contextual hints for each step. [[1]](diffhunk://#diff-6c55ec19eeee8aecc725e998ace4f857c9035d9fc49bb2864319c13ac5914d62L1539-R1567) [[2]](diffhunk://#diff-6c55ec19eeee8aecc725e998ace4f857c9035d9fc49bb2864319c13ac5914d62L1639-R1669) [[3]](diffhunk://#diff-6c55ec19eeee8aecc725e998ace4f857c9035d9fc49bb2864319c13ac5914d62R1681-R1699)

**Command-line Interface Consistency:**

* Updated the `addCommand` action in `src/index.ts` to explicitly map CLI options to the correct properties for workspace creation, ensuring consistency between CLI and TUI flows.