### PR TITLE
Accept branch-like names in workspace input and sanitize them

### DIFF
--- a/src/commands/add.ts
+++ b/src/commands/add.ts
@@ -33,6 +33,7 @@ import {
   sanitizeForFileSystem,
   generateWorkspaceName,
   extractRepoName,
+  isValidBranchName,
 } from '../utils/sanitize.js';
 import {
   SpacesError,
@@ -269,6 +270,15 @@ export async function addWorkspace(
     workspaceName = sanitizedName;
     // Use original input as branch name if no explicit branch specified (preserves slashes)
     branchName = options.branchName || workspaceNameArg;
+
+    // Validate the branch name is a valid git ref
+    if (!isValidBranchName(branchName)) {
+      throw new SpacesError(
+        `Invalid branch name: ${branchName}\nBranch names cannot contain spaces, .., or special characters like : ? * [ \\ ~`,
+        'USER_ERROR',
+        1
+      );
+    }
   } else {
     // No workspace name provided, prompt for source
     const sourceOptions = ['Create from GitHub branch', 'Create with manual name'];
@@ -366,6 +376,10 @@ export async function addWorkspace(
           const sanitized = sanitizeForFileSystem(input);
           if (!sanitized) {
             return 'Name must contain at least one letter or number';
+          }
+          // Validate it can be used as a branch name
+          if (!isValidBranchName(input)) {
+            return 'Invalid branch name (no spaces, .., or special chars like : ? * [ \\ ~)';
           }
           return true;
         },

--- a/src/commands/add.ts
+++ b/src/commands/add.ts
@@ -32,7 +32,6 @@ import { fetchUnstartedIssues } from '../core/linear.js';
 import {
   sanitizeForFileSystem,
   generateWorkspaceName,
-  isValidWorkspaceName,
   extractRepoName,
 } from '../utils/sanitize.js';
 import {
@@ -257,17 +256,19 @@ export async function addWorkspace(
   let selectedLinearIssue: Awaited<ReturnType<typeof fetchUnstartedIssues>>[0] | undefined;
 
   if (workspaceNameArg) {
-    // Workspace name provided as argument
-    if (!isValidWorkspaceName(workspaceNameArg)) {
+    // Workspace name provided as argument - sanitize it (allows branch-like names like fix/bla-bla-blah)
+    const sanitizedName = sanitizeForFileSystem(workspaceNameArg);
+    if (!sanitizedName) {
       throw new SpacesError(
-        `Invalid workspace name: ${workspaceNameArg}\nWorkspace names must contain only alphanumeric characters, hyphens, and underscores (no spaces).`,
+        `Invalid workspace name: ${workspaceNameArg}\nName must contain at least one letter or number.`,
         'USER_ERROR',
         1
       );
     }
 
-    workspaceName = workspaceNameArg;
-    branchName = options.branchName || workspaceName;
+    workspaceName = sanitizedName;
+    // Use original input as branch name if no explicit branch specified (preserves slashes)
+    branchName = options.branchName || workspaceNameArg;
   } else {
     // No workspace name provided, prompt for source
     const sourceOptions = ['Create from GitHub branch', 'Create with manual name'];
@@ -356,14 +357,15 @@ export async function addWorkspace(
       workspaceName = generateWorkspaceName(selectedLinearIssue.identifier, selectedLinearIssue.title);
       branchName = options.branchName || workspaceName;
     } else {
-      // Manual entry
-      const name = await promptInput('Enter workspace name:', {
+      // Manual entry - accepts branch-like names (e.g., fix/bla-bla-blah) and sanitizes them
+      const name = await promptInput('Enter workspace name (branch-like names will be sanitized):', {
         validate: (input) => {
           if (!input || input.trim().length === 0) {
             return 'Workspace name is required';
           }
-          if (!isValidWorkspaceName(input)) {
-            return 'Workspace name must contain only alphanumeric characters, hyphens, and underscores (no spaces)';
+          const sanitized = sanitizeForFileSystem(input);
+          if (!sanitized) {
+            return 'Name must contain at least one letter or number';
           }
           return true;
         },
@@ -374,8 +376,10 @@ export async function addWorkspace(
         return;
       }
 
-      workspaceName = name;
-      branchName = options.branchName || workspaceName;
+      const sanitizedName = sanitizeForFileSystem(name);
+      workspaceName = sanitizedName;
+      // Use original input as branch name (preserves slashes)
+      branchName = options.branchName || name;
     }
   }
 

--- a/src/tui/app.tsx
+++ b/src/tui/app.tsx
@@ -63,7 +63,7 @@ import { listRemoteBranches, createWorktree, getDefaultBranch } from '../core/gi
 import { deleteWorkspaceCore, deleteProjectCore } from '../core/workspace.js';
 import { fetchUnstartedIssues } from '../core/linear.js';
 import { generateMarkdown } from '../utils/markdown.js';
-import { sanitizeForFileSystem, generateWorkspaceName, isValidWorkspaceName, isValidBranchName, extractRepoName } from '../utils/sanitize.js';
+import { sanitizeForFileSystem, generateWorkspaceName, isValidBranchName, extractRepoName } from '../utils/sanitize.js';
 import { existsSync, mkdirSync, writeFileSync } from 'fs';
 import { join } from 'path';
 
@@ -759,18 +759,21 @@ function App({ relayConfig, onQuit }: AppProps) {
   }, [createWorkspaceAndOpenSession]);
 
   // Handle manual workspace name submission (advances to branch input)
+  // Accepts branch-like names (e.g., fix/bla-bla-blah) and sanitizes them for workspace name
   const handleManualNameSubmit = useCallback((name: string) => {
     const trimmedName = name.trim();
     if (!trimmedName) {
       setWorkspaceFlow(prev => prev.type === 'manual-name-input' ? { ...prev, error: 'Workspace name is required' } : prev);
       return;
     }
-    if (!isValidWorkspaceName(trimmedName)) {
-      setWorkspaceFlow(prev => prev.type === 'manual-name-input' ? { ...prev, error: 'Use only letters, numbers, hyphens, underscores' } : prev);
+    // Sanitize the input to create a valid workspace name (converts slashes to hyphens, etc.)
+    const sanitizedName = sanitizeForFileSystem(trimmedName);
+    if (!sanitizedName) {
+      setWorkspaceFlow(prev => prev.type === 'manual-name-input' ? { ...prev, error: 'Name must contain at least one letter or number' } : prev);
       return;
     }
-    // Advance to branch input step, pre-fill with workspace name
-    setWorkspaceFlow({ type: 'manual-branch-input', workspaceName: trimmedName, inputValue: trimmedName });
+    // Advance to branch input step, pre-fill with original input (allows branch names with slashes)
+    setWorkspaceFlow({ type: 'manual-branch-input', workspaceName: sanitizedName, inputValue: trimmedName });
   }, []);
 
   // Handle manual branch name submission (creates the workspace)

--- a/src/tui/app.tsx
+++ b/src/tui/app.tsx
@@ -772,6 +772,11 @@ function App({ relayConfig, onQuit }: AppProps) {
       setWorkspaceFlow(prev => prev.type === 'manual-name-input' ? { ...prev, error: 'Name must contain at least one letter or number' } : prev);
       return;
     }
+    // Validate it can be used as a branch name (no spaces, special chars, etc.)
+    if (!isValidBranchName(trimmedName)) {
+      setWorkspaceFlow(prev => prev.type === 'manual-name-input' ? { ...prev, error: 'Invalid branch name (no spaces, .., or special chars like : ? * [ \\ ~)' } : prev);
+      return;
+    }
     // Advance to branch input step, pre-fill with original input (allows branch names with slashes)
     setWorkspaceFlow({ type: 'manual-branch-input', workspaceName: sanitizedName, inputValue: trimmedName });
   }, []);

--- a/src/utils/sanitize.test.ts
+++ b/src/utils/sanitize.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from 'bun:test';
+import {
+  sanitizeForFileSystem,
+  generateWorkspaceName,
+  isValidWorkspaceName,
+  isValidBranchName,
+  extractRepoName,
+} from './sanitize';
+
+describe('sanitizeForFileSystem', () => {
+  it('should convert slashes to hyphens', () => {
+    expect(sanitizeForFileSystem('fix/bla-bla-blah')).toBe('fix-bla-bla-blah');
+  });
+
+  it('should handle feature branch patterns', () => {
+    expect(sanitizeForFileSystem('feature/user-auth')).toBe('feature-user-auth');
+  });
+
+  it('should handle multiple slashes', () => {
+    expect(sanitizeForFileSystem('feature/auth/oauth')).toBe('feature-auth-oauth');
+  });
+
+  it('should convert to lowercase', () => {
+    expect(sanitizeForFileSystem('Fix/BLA-Blah')).toBe('fix-bla-blah');
+  });
+
+  it('should collapse multiple hyphens', () => {
+    expect(sanitizeForFileSystem('fix//double-slash')).toBe('fix-double-slash');
+  });
+
+  it('should remove leading and trailing hyphens', () => {
+    expect(sanitizeForFileSystem('/leading-slash')).toBe('leading-slash');
+    expect(sanitizeForFileSystem('trailing-slash/')).toBe('trailing-slash');
+  });
+
+  it('should handle spaces', () => {
+    expect(sanitizeForFileSystem('fix login bug')).toBe('fix-login-bug');
+  });
+
+  it('should handle special characters', () => {
+    expect(sanitizeForFileSystem('fix!@#$%bug')).toBe('fix-bug');
+  });
+
+  it('should preserve underscores', () => {
+    expect(sanitizeForFileSystem('fix_login_bug')).toBe('fix_login_bug');
+  });
+
+  it('should return empty string for input with no valid characters', () => {
+    expect(sanitizeForFileSystem('!@#$%')).toBe('');
+  });
+
+  it('should limit length to 100 characters', () => {
+    const longName = 'a'.repeat(150);
+    expect(sanitizeForFileSystem(longName).length).toBe(100);
+  });
+});
+
+describe('isValidWorkspaceName', () => {
+  it('should accept valid names', () => {
+    expect(isValidWorkspaceName('my-workspace')).toBe(true);
+    expect(isValidWorkspaceName('workspace123')).toBe(true);
+    expect(isValidWorkspaceName('my_workspace')).toBe(true);
+  });
+
+  it('should reject names with spaces', () => {
+    expect(isValidWorkspaceName('my workspace')).toBe(false);
+  });
+
+  it('should reject names with slashes', () => {
+    expect(isValidWorkspaceName('fix/bug')).toBe(false);
+  });
+
+  it('should reject empty names', () => {
+    expect(isValidWorkspaceName('')).toBe(false);
+  });
+
+  it('should reject names starting or ending with hyphens', () => {
+    expect(isValidWorkspaceName('-workspace')).toBe(false);
+    expect(isValidWorkspaceName('workspace-')).toBe(false);
+  });
+});
+
+describe('isValidBranchName', () => {
+  it('should accept valid branch names with slashes', () => {
+    expect(isValidBranchName('fix/bla-bla-blah')).toBe(true);
+    expect(isValidBranchName('feature/user-auth')).toBe(true);
+  });
+
+  it('should accept simple branch names', () => {
+    expect(isValidBranchName('main')).toBe(true);
+    expect(isValidBranchName('develop')).toBe(true);
+  });
+
+  it('should reject names with consecutive dots', () => {
+    expect(isValidBranchName('branch..name')).toBe(false);
+  });
+
+  it('should reject names starting or ending with slash', () => {
+    expect(isValidBranchName('/branch')).toBe(false);
+    expect(isValidBranchName('branch/')).toBe(false);
+  });
+
+  it('should reject names with consecutive slashes', () => {
+    expect(isValidBranchName('branch//name')).toBe(false);
+  });
+
+  it('should reject names ending with .lock', () => {
+    expect(isValidBranchName('branch.lock')).toBe(false);
+  });
+
+  it('should reject names with special characters', () => {
+    expect(isValidBranchName('branch~name')).toBe(false);
+    expect(isValidBranchName('branch^name')).toBe(false);
+    expect(isValidBranchName('branch:name')).toBe(false);
+    expect(isValidBranchName('branch?name')).toBe(false);
+    expect(isValidBranchName('branch*name')).toBe(false);
+    expect(isValidBranchName('branch[name')).toBe(false);
+    expect(isValidBranchName('branch\\name')).toBe(false);
+  });
+
+  it('should reject components starting with dot', () => {
+    expect(isValidBranchName('.hidden')).toBe(false);
+    expect(isValidBranchName('feature/.hidden')).toBe(false);
+  });
+
+  it('should reject names starting with dash', () => {
+    expect(isValidBranchName('-branch')).toBe(false);
+  });
+});
+
+describe('generateWorkspaceName', () => {
+  it('should combine identifier and sanitized title', () => {
+    expect(generateWorkspaceName('ENG-123', 'Fix Login Bug!')).toBe('eng-123-fix-login-bug');
+  });
+
+  it('should handle spaces in title', () => {
+    expect(generateWorkspaceName('FEAT-456', 'Add Dark Mode')).toBe('feat-456-add-dark-mode');
+  });
+});
+
+describe('extractRepoName', () => {
+  it('should extract repo name from owner/repo format', () => {
+    expect(extractRepoName('myorg/my-app')).toBe('my-app');
+  });
+
+  it('should handle simple repo name', () => {
+    expect(extractRepoName('my-app')).toBe('my-app');
+  });
+});


### PR DESCRIPTION
## Summary
- Users can now paste branch names like `fix/bla-bla-blah` when creating workspaces
- Input is sanitized for the workspace directory (slashes → hyphens) while preserving the original as the branch name
- Added 29 unit tests for sanitize utilities

## Test plan
- [x] Run `bun test src/utils/sanitize.test.ts` - all 29 tests pass
- [x] In TUI, create workspace with name `fix/test-feature` - should create `fix-test-feature` workspace with `fix/test-feature` branch
- [x] In CLI, run `gssh add fix/test-feature` - same behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)