### PR TITLE
Fix j/k keys not working in text input modals

### DIFF
--- a/src/tui/app.tsx
+++ b/src/tui/app.tsx
@@ -1332,7 +1332,24 @@ function App({ relayConfig, onQuit }: AppProps) {
         return;
       }
 
-      // Handle other modals
+      // Handle text input modals FIRST (before j/k navigation)
+      // This ensures typing 'j' or 'k' adds the character instead of navigating
+      if (isFlowInput(flow.flow) || isFlowConfirmTyped(flow.flow)) {
+        if (key.name === 'escape') {
+          flow.handleCancel();
+        } else if (key.name === 'return') {
+          await flow.handleConfirm();
+        } else if (key.name === 'backspace') {
+          const current = flow.flow.inputValue || '';
+          flow.handleInput(current.slice(0, -1));
+        } else if (key.raw && key.raw.length === 1 && !key.ctrl && !key.meta) {
+          const current = flow.flow.inputValue || '';
+          flow.handleInput(current + key.raw);
+        }
+        return;
+      }
+
+      // Handle other modals (select, message, etc.) - j/k navigation works here
       if (key.name === 'escape') {
         flow.handleCancel();
       } else if (key.name === 'return') {
@@ -1341,24 +1358,6 @@ function App({ relayConfig, onQuit }: AppProps) {
         flow.moveUp();
       } else if (key.name === 'down' || key.raw === 'j') {
         flow.moveDown();
-      } else if (key.raw && isFlowInput(flow.flow)) {
-        // Handle text input (now properly typed)
-        if (key.name === 'backspace') {
-          const current = flow.flow.inputValue || '';
-          flow.handleInput(current.slice(0, -1));
-        } else if (key.raw.length === 1 && !key.ctrl && !key.meta) {
-          const current = flow.flow.inputValue || '';
-          flow.handleInput(current + key.raw);
-        }
-      } else if (key.raw && isFlowConfirmTyped(flow.flow)) {
-        // Handle typed confirmation input (now properly typed)
-        if (key.name === 'backspace') {
-          const current = flow.flow.inputValue || '';
-          flow.handleInput(current.slice(0, -1));
-        } else if (key.raw.length === 1 && !key.ctrl && !key.meta) {
-          const current = flow.flow.inputValue || '';
-          flow.handleInput(current + key.raw);
-        }
       }
       return;
     }


### PR DESCRIPTION
The j/k navigation shortcuts were being checked before text input handling in FlowInput and FlowConfirmTyped modals. This caused typing 'j' or 'k' in modals like the delete workspace confirmation to trigger navigation instead of adding the character to the input field.

Reorder the keyboard handling so text input modals process all characters first, while other modals (select, message) retain j/k navigation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed text input handling in modals to prevent navigation shortcuts from interfering with typing, ensuring keyboard input is captured correctly when entering text in input fields.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->