### PR TITLE
Fix TUI terminal scroll and performance issues

### DIFF
--- a/src/tui/components/Terminal.tsx
+++ b/src/tui/components/Terminal.tsx
@@ -7,7 +7,7 @@
 
 import { useState, useEffect, useRef, useCallback, useMemo } from 'react';
 import { extend, useKeyboard, useRenderer } from '@opentui/react';
-import type { PasteEvent } from '@opentui/core';
+import type { PasteEvent, ScrollBoxRenderable } from '@opentui/core';
 import { GhosttyTerminalRenderable } from 'ghostty-opentui/terminal-buffer';
 import { appendFileSync } from 'fs';
 import type { Session, SessionEvent } from '../../lib/tmux-lite/protocol.js';
@@ -104,6 +104,7 @@ export function Terminal({ session, onDetach, onExit, onKicked, onError }: Termi
 
   // Refs
   const terminalRef = useRef<GhosttyTerminalRenderable | null>(null);
+  const scrollBoxRef = useRef<ScrollBoxRenderable | null>(null);
   const socketRef = useRef<Awaited<ReturnType<typeof Bun.connect>> | null>(null);
   const socketWriterRef = useRef<ReturnType<typeof createBufferedSocketWriter> | null>(null);
   const bufferRef = useRef<Buffer>(Buffer.alloc(0));
@@ -133,6 +134,17 @@ export function Terminal({ session, onDetach, onExit, onKicked, onError }: Termi
   useEffect(() => {
     statusRef.current = status;
   }, [status]);
+
+  // Reset refs when session changes to prevent stale state
+  useEffect(() => {
+    bufferRef.current = Buffer.alloc(0);
+    ptyUtf8BufferRef.current = Buffer.alloc(0);
+    pendingPtyDataRef.current = [];
+    initialDataReceivedRef.current = false;
+    bracketedPasteRef.current = new BracketedPasteModeTracker();
+    setInitialData(null);
+    setTerminalMounted(false);
+  }, [session.socketPath]);
 
   const updateBracketedPasteMode = useCallback((chunk: Buffer) => {
     bracketedPasteRef.current.update(chunk);
@@ -485,21 +497,44 @@ export function Terminal({ session, onDetach, onExit, onKicked, onError }: Termi
 
       {/* Only render terminal once we have initial data */}
       {initialData !== null && (
-        <ghostty-terminal
-          ref={(el: GhosttyTerminalRenderable | null) => {
-            terminalRef.current = el;
-            if (el) {
-              debugLog('Terminal mounted with initial data');
-              setTerminalMounted(true);
-            }
+        <scrollbox
+          ref={(el: ScrollBoxRenderable | null) => {
+            scrollBoxRef.current = el;
           }}
-          persistent={true}
-          showCursor={true}
-          cursorStyle="block"
-          cols={termSize.cols}
-          rows={termSize.rows}
-          ansi={initialData}
-        />
+          flexGrow={1}
+          viewportCulling={true}
+          stickyScroll={true}
+          stickyStart="bottom"
+        >
+          <ghostty-terminal
+            ref={(el: GhosttyTerminalRenderable | null) => {
+              terminalRef.current = el;
+              if (el) {
+                debugLog('Terminal mounted with initial data');
+                setTerminalMounted(true);
+                // Scroll to cursor position after mount
+                requestAnimationFrame(() => {
+                  if (el && scrollBoxRef.current) {
+                    try {
+                      const [, cursorY] = el.getCursor();
+                      const scrollPos = el.getScrollPositionForLine(cursorY);
+                      scrollBoxRef.current.scrollTo(scrollPos);
+                      debugLog(`Scrolled to cursor position: line ${cursorY}, scrollPos ${scrollPos}`);
+                    } catch (err) {
+                      debugLog(`Failed to scroll to cursor: ${err}`);
+                    }
+                  }
+                });
+              }
+            }}
+            persistent={true}
+            showCursor={true}
+            cursorStyle="block"
+            cols={termSize.cols}
+            rows={termSize.rows}
+            ansi={initialData}
+          />
+        </scrollbox>
       )}
     </box>
   );

--- a/src/tui/components/Terminal.tsx
+++ b/src/tui/components/Terminal.tsx
@@ -508,23 +508,12 @@ export function Terminal({ session, onDetach, onExit, onKicked, onError }: Termi
         >
           <ghostty-terminal
             ref={(el: GhosttyTerminalRenderable | null) => {
+              const wasNull = terminalRef.current === null;
               terminalRef.current = el;
-              if (el) {
+              if (el && wasNull) {
                 debugLog('Terminal mounted with initial data');
-                setTerminalMounted(true);
-                // Scroll to cursor position after mount
-                requestAnimationFrame(() => {
-                  if (el && scrollBoxRef.current) {
-                    try {
-                      const [, cursorY] = el.getCursor();
-                      const scrollPos = el.getScrollPositionForLine(cursorY);
-                      scrollBoxRef.current.scrollTo(scrollPos);
-                      debugLog(`Scrolled to cursor position: line ${cursorY}, scrollPos ${scrollPos}`);
-                    } catch (err) {
-                      debugLog(`Failed to scroll to cursor: ${err}`);
-                    }
-                  }
-                });
+                // Defer state update to avoid setState during render
+                queueMicrotask(() => setTerminalMounted(true));
               }
             }}
             persistent={true}


### PR DESCRIPTION
- Wrap ghostty-terminal in scrollbox with viewportCulling for O(viewport) rendering instead of O(total lines) - fixes session slowdown over time
- Add stickyScroll and stickyStart="bottom" for proper auto-scroll behavior
- Scroll to cursor position on attach instead of top of scrollback
- Reset client refs on session change to prevent stale state

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Terminal rendering now uses an integrated scroll container to provide smoother, stable scrolling and correct cursor visibility on init.

* **Bug Fixes**
  * Reset terminal buffers and related state when switching sessions to prevent stale data.
  * Improved mount sequencing to avoid render-timing issues and ensure consistent initialization.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->