### PR TITLE
Fix TUI onboarding checkCommand hanging

### DIFF
--- a/src/tui/app.tsx
+++ b/src/tui/app.tsx
@@ -76,11 +76,8 @@ import type { LinearIssue } from '../types/workspace.js';
 import { listAllRepos, cloneRepository } from '../core/github.js';
 import { detectBundleInRepo, loadBundleFromPath, copyBundleScripts } from '../core/bundle.js';
 import { setProjectSecret } from '../utils/secrets.js';
+import { checkCommandExists } from '../utils/deps.js';
 import type { OnboardingStep } from '../types/bundle.js';
-import { exec } from 'child_process';
-import { promisify } from 'util';
-
-const execAsync = promisify(exec);
 
 // TUI hooks
 import { useRemoteMachines, type RelayConfig } from './hooks/useRemoteMachines.js';
@@ -833,14 +830,10 @@ function App({ relayConfig, onQuit }: AppProps) {
   }, [refreshProjects, flow]);
 
   // Check if a command exists (for onboarding confirm steps)
-  const checkCommand = useCallback(async (command: string): Promise<boolean> => {
-    try {
-      await execAsync(command);
-      return true;
-    } catch {
-      return false;
-    }
-  }, []);
+  const checkCommand = useCallback(
+    (command: string) => checkCommandExists(command),
+    []
+  );
 
   // Advance to the next onboarding step
   const advanceOnboardingStep = useCallback(async () => {

--- a/src/utils/deps.test.ts
+++ b/src/utils/deps.test.ts
@@ -1,0 +1,31 @@
+import { describe, test, expect } from 'bun:test';
+import { checkCommandExists } from './deps.js';
+
+describe('checkCommandExists', () => {
+  test('returns true for commands that exist', async () => {
+    // These should exist on any system running this test
+    expect(await checkCommandExists('ls')).toBe(true);
+    expect(await checkCommandExists('which')).toBe(true);
+  });
+
+  test('returns false for commands that do not exist', async () => {
+    expect(await checkCommandExists('nonexistent-command-xyz-123')).toBe(false);
+  });
+
+  test('returns false for invalid command names (injection prevention)', async () => {
+    expect(await checkCommandExists('ls; echo hacked')).toBe(false);
+    expect(await checkCommandExists('ls && rm -rf /')).toBe(false);
+    expect(await checkCommandExists('$(whoami)')).toBe(false);
+    expect(await checkCommandExists('ls | cat')).toBe(false);
+    expect(await checkCommandExists('')).toBe(false);
+    expect(await checkCommandExists('cmd with spaces')).toBe(false);
+  });
+
+  test('allows valid command name characters', async () => {
+    // These are valid command name formats (alphanumeric, dash, underscore)
+    // They may not exist, but should pass validation
+    expect(await checkCommandExists('my-command')).toBe(false); // valid format, doesn't exist
+    expect(await checkCommandExists('my_command')).toBe(false); // valid format, doesn't exist
+    expect(await checkCommandExists('command123')).toBe(false); // valid format, doesn't exist
+  });
+});

--- a/src/utils/deps.ts
+++ b/src/utils/deps.ts
@@ -2,13 +2,14 @@
  * Dependency checking utilities
  */
 
-import { exec } from 'child_process';
+import { exec, execFile } from 'child_process';
 import { promisify } from 'util';
 import type { Dependency } from '../types/workspace.js';
 import { DependencyError, GitHubAuthError } from '../types/errors.js';
 import { logger } from './logger.js';
 
 const execAsync = promisify(exec);
+const execFileAsync = promisify(execFile);
 
 /**
  * Required system dependencies
@@ -64,7 +65,7 @@ export async function checkCommandExists(command: string): Promise<boolean> {
   }
 
   try {
-    await execAsync(`which ${command}`);
+    await execFileAsync('which', [command]);
     return true;
   } catch {
     return false;

--- a/src/utils/deps.ts
+++ b/src/utils/deps.ts
@@ -43,11 +43,28 @@ export const REQUIRED_DEPS: Dependency[] = [
 ];
 
 /**
- * Check if a command exists
+ * Check if a command exists by running it with args
  */
 async function commandExists(command: string, checkArgs: string[]): Promise<boolean> {
   try {
     await execAsync(`${command} ${checkArgs.join(' ')}`);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Check if a command exists in PATH using `which`
+ * Validates command name to prevent injection
+ */
+export async function checkCommandExists(command: string): Promise<boolean> {
+  if (!/^[a-zA-Z0-9_-]+$/.test(command)) {
+    return false;
+  }
+
+  try {
+    await execAsync(`which ${command}`);
     return true;
   } catch {
     return false;

--- a/src/utils/onboarding.ts
+++ b/src/utils/onboarding.ts
@@ -3,10 +3,9 @@
  * Runs interactive onboarding steps from bundle manifests
  */
 
-import { execFile } from 'child_process';
-import { promisify } from 'util';
 import { logger } from './logger.js';
 import { promptInput, promptConfirm, promptPassword } from './prompts.js';
+import { checkCommandExists } from './deps.js';
 import type {
   OnboardingStep,
   OnboardingResult,
@@ -15,8 +14,6 @@ import type {
   SecretStep,
   InputStep,
 } from '../types/bundle.js';
-
-const execFileAsync = promisify(execFile);
 
 /**
  * Execute all onboarding steps
@@ -194,22 +191,6 @@ async function executeInputStep(step: InputStep): Promise<string | null> {
   });
 
   return value;
-}
-
-/**
- * Check if a command exists in PATH
- */
-async function checkCommandExists(command: string): Promise<boolean> {
-  if (!/^[a-zA-Z0-9_-]+$/.test(command)) {
-    return false;
-  }
-
-  try {
-    await execFileAsync('which', [command]);
-    return true;
-  } catch {
-    return false;
-  }
 }
 
 /**


### PR DESCRIPTION
## Summary

- Fix bug where TUI onboarding `checkCommand` would hang forever by running the command directly (e.g., `bun` opens a REPL)
- Add shared `checkCommandExists()` utility to `src/utils/deps.ts` that uses `which` to check PATH
- Consolidate duplicate implementations from `onboarding.ts` and `app.tsx`
- Add unit tests with injection prevention coverage

## Test plan

- [x] Run `bun test src/utils/deps.test.ts` - all tests pass
- [x] Test TUI onboarding with a bundle.json that has `checkCommand` fields
- [x] Verify commands like `bun`, `gh` are detected correctly without hanging

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized command-existence checks into a shared utility and updated onboarding to use it, simplifying flow while preserving user behavior.

* **Tests**
  * Added comprehensive tests for command validation, covering existing/non-existent commands, invalid inputs, and injection edge cases.

* **Chores**
  * Removed duplicate local command-check implementations and related cleanup.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->