### PR TITLE
Notifications: toast inbox + shell hooks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ npm/
 *.tsbuildinfo
 src/relay/embedded-assets.generated.js
 src/version.generated.ts
+src/version.generated.js
 
 # Environment
 .env

--- a/bun.lock
+++ b/bun.lock
@@ -28,11 +28,13 @@
         "ws": "^8.18.3",
       },
       "devDependencies": {
+        "@testing-library/react": "^16.3.1",
         "@types/bun": "^1.3.4",
         "@types/node": "^20.11.20",
         "@types/react": "^19.2.7",
         "@types/react-dom": "^19.2.3",
         "eslint": "^8.57.0",
+        "happy-dom": "^20.3.0",
         "typescript": "^5.3.3",
       },
       "optionalDependencies": {
@@ -44,6 +46,12 @@
     },
   },
   "packages": {
+    "@babel/code-frame": ["@babel/code-frame@7.28.6", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-JYgintcMjRiCvS8mMECzaEn+m3PfoQiyqukOMCCVQtoJGYJw8j/8LBJEiqkHLkfwCcs74E3pbAUFNg7d9VNJ+Q=="],
+
+    "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
+
+    "@babel/runtime": ["@babel/runtime@7.28.6", "", {}, "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA=="],
+
     "@dimforge/rapier2d-simd-compat": ["@dimforge/rapier2d-simd-compat@0.17.3", "", {}, "sha512-bijvwWz6NHsNj5e5i1vtd3dU2pDhthSaTUZSh14DUGGKJfw8eMnlWZsxwHBxB/a3AXVNDjL9abuHw1k9FGR+jg=="],
 
     "@eslint-community/eslint-utils": ["@eslint-community/eslint-utils@4.9.0", "", { "dependencies": { "eslint-visitor-keys": "^3.4.3" }, "peerDependencies": { "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0" } }, "sha512-ayVFHdtZ+hsq1t2Dy24wCmGXGe4q9Gu3smhLYALJrr473ZH27MsnSL+LKUlimp4BWJqMDMLmPpx/Q9R3OAlL4g=="],
@@ -190,7 +198,13 @@
 
     "@sindresorhus/merge-streams": ["@sindresorhus/merge-streams@4.0.0", "", {}, "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ=="],
 
+    "@testing-library/dom": ["@testing-library/dom@10.4.1", "", { "dependencies": { "@babel/code-frame": "^7.10.4", "@babel/runtime": "^7.12.5", "@types/aria-query": "^5.0.1", "aria-query": "5.3.0", "dom-accessibility-api": "^0.5.9", "lz-string": "^1.5.0", "picocolors": "1.1.1", "pretty-format": "^27.0.2" } }, "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg=="],
+
+    "@testing-library/react": ["@testing-library/react@16.3.1", "", { "dependencies": { "@babel/runtime": "^7.12.5" }, "peerDependencies": { "@testing-library/dom": "^10.0.0", "@types/react": "^18.0.0 || ^19.0.0", "@types/react-dom": "^18.0.0 || ^19.0.0", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-gr4KtAWqIOQoucWYD/f6ki+j5chXfcPc74Col/6poTyqTmn7zRmodWahWRCp8tYd+GMqBonw6hstNzqjbs6gjw=="],
+
     "@tokenizer/token": ["@tokenizer/token@0.3.0", "", {}, "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="],
+
+    "@types/aria-query": ["@types/aria-query@5.0.4", "", {}, "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw=="],
 
     "@types/bun": ["@types/bun@1.3.4", "", { "dependencies": { "bun-types": "1.3.4" } }, "sha512-EEPTKXHP+zKGPkhRLv+HI0UEX8/o+65hqARxLy8Ov5rIxMBPNTjeZww00CIihrIQGEQBYg+0roO5qOnS/7boGA=="],
 
@@ -199,6 +213,8 @@
     "@types/react": ["@types/react@19.2.7", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg=="],
 
     "@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
+
+    "@types/whatwg-mimetype": ["@types/whatwg-mimetype@3.0.2", "", {}, "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA=="],
 
     "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
 
@@ -231,6 +247,8 @@
     "any-base": ["any-base@1.1.0", "", {}, "sha512-uMgjozySS8adZZYePpaWs8cxB9/kdzmpX6SgJZ+wbz1K5eYk5QMYDVJaZKhxyIHUdnnJkfR7SVgStgH7LkGUyg=="],
 
     "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
+
+    "aria-query": ["aria-query@5.3.0", "", { "dependencies": { "dequal": "^2.0.3" } }, "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A=="],
 
     "atomically": ["atomically@2.0.3", "", { "dependencies": { "stubborn-fs": "^1.2.5", "when-exit": "^2.1.1" } }, "sha512-kU6FmrwZ3Lx7/7y3hPS5QnbJfaohcIul5fGqf7ok+4KklIEk9tJ0C2IQPdacSbVUWv6zVHXEBWoWd6NrVMT7Cw=="],
 
@@ -302,9 +320,13 @@
 
     "define-lazy-prop": ["define-lazy-prop@3.0.0", "", {}, "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg=="],
 
+    "dequal": ["dequal@2.0.3", "", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
+
     "diff": ["diff@8.0.2", "", {}, "sha512-sSuxWU5j5SR9QQji/o2qMvqRNYRDOcBTgsJ/DeCf4iSN4gW+gNMXM7wFIP+fdXZxoNiAnHUTGjCr+TSWXdRDKg=="],
 
     "doctrine": ["doctrine@3.0.0", "", { "dependencies": { "esutils": "^2.0.2" } }, "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w=="],
+
+    "dom-accessibility-api": ["dom-accessibility-api@0.5.16", "", {}, "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg=="],
 
     "dot-prop": ["dot-prop@8.0.2", "", { "dependencies": { "type-fest": "^3.8.0" } }, "sha512-xaBe6ZT4DHPkg0k4Ytbvn5xoxgpG0jOS1dYxSOwAHPuNLjP3/OzN0gH55SrLqpx8cBfSaVt91lXYkApjb+nYdQ=="],
 
@@ -382,6 +404,8 @@
 
     "graphql": ["graphql@15.10.1", "", {}, "sha512-BL/Xd/T9baO6NFzoMpiMD7YUZ62R6viR5tp/MULVEnbYJXZA//kRNW7J0j1w/wXArgL0sCxhDfK5dczSKn3+cg=="],
 
+    "happy-dom": ["happy-dom@20.3.0", "", { "dependencies": { "@types/node": "^20.0.0", "@types/whatwg-mimetype": "^3.0.2", "@types/ws": "^8.18.1", "whatwg-mimetype": "^3.0.0", "ws": "^8.18.3" } }, "sha512-5qJbkqcvR8j/a4av5IWqqIWmEGf9dt6OhGMS6qxCgjSOBGzGa5XLoqg40OyD8XNzQ+g1g2zsXi10kjfpzYH55Q=="],
+
     "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
 
     "human-signals": ["human-signals@8.0.1", "", {}, "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ=="],
@@ -438,6 +462,8 @@
 
     "jpeg-js": ["jpeg-js@0.4.4", "", {}, "sha512-WZzeDOEtTOBK4Mdsar0IqEU5sMr3vSV2RqkAIzUEV2BHnUfKGyswWFPFwK5EeDo93K3FohSHbLAjj0s1Wzd+dg=="],
 
+    "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
+
     "js-yaml": ["js-yaml@4.1.0", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA=="],
 
     "json-buffer": ["json-buffer@3.0.1", "", {}, "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="],
@@ -457,6 +483,8 @@
     "lodash.merge": ["lodash.merge@4.6.2", "", {}, "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="],
 
     "log-symbols": ["log-symbols@6.0.0", "", { "dependencies": { "chalk": "^5.3.0", "is-unicode-supported": "^1.3.0" } }, "sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw=="],
+
+    "lz-string": ["lz-string@1.5.0", "", { "bin": { "lz-string": "bin/bin.js" } }, "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ=="],
 
     "mime": ["mime@3.0.0", "", { "bin": { "mime": "cli.js" } }, "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A=="],
 
@@ -512,6 +540,8 @@
 
     "peek-readable": ["peek-readable@4.1.0", "", {}, "sha512-ZI3LnwUv5nOGbQzD9c2iDG6toheuXSZP5esSHBjopsXH4dg19soufvpUGA3uohi5anFtGb2lhAVdHzH6R/Evvg=="],
 
+    "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
+
     "pixelmatch": ["pixelmatch@5.3.0", "", { "dependencies": { "pngjs": "^6.0.0" }, "bin": { "pixelmatch": "bin/pixelmatch" } }, "sha512-o8mkY4E/+LNUf6LzX96ht6k6CEDi65k9G2rjMtBe9Oo+VPKSvl+0GKHuH/AlG+GA5LPG/i5hrekkxUc3s2HU+Q=="],
 
     "planck": ["planck@1.4.2", "", { "peerDependencies": { "stage-js": "^1.0.0-alpha.12" } }, "sha512-mNbhnV3g8X2rwGxzcesjmN8BDA6qfXgQxXVMkWau9MCRlQY0RLNEkyHlVp6yFy/X6qrzAXyNONCnZ1cGDLrNew=="],
@@ -521,6 +551,8 @@
     "powershell-utils": ["powershell-utils@0.1.0", "", {}, "sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A=="],
 
     "prelude-ls": ["prelude-ls@1.2.1", "", {}, "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="],
+
+    "pretty-format": ["pretty-format@27.5.1", "", { "dependencies": { "ansi-regex": "^5.0.1", "ansi-styles": "^5.0.0", "react-is": "^17.0.1" } }, "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ=="],
 
     "pretty-ms": ["pretty-ms@9.3.0", "", { "dependencies": { "parse-ms": "^4.0.0" } }, "sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ=="],
 
@@ -533,6 +565,10 @@
     "react": ["react@19.2.3", "", {}, "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA=="],
 
     "react-devtools-core": ["react-devtools-core@7.0.1", "", { "dependencies": { "shell-quote": "^1.6.1", "ws": "^7" } }, "sha512-C3yNvRHaizlpiASzy7b9vbnBGLrhvdhl1CbdU6EnZgxPNbai60szdLtl+VL76UNOt5bOoVTOz5rNWZxgGt+Gsw=="],
+
+    "react-dom": ["react-dom@19.2.3", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.3" } }, "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg=="],
+
+    "react-is": ["react-is@17.0.2", "", {}, "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="],
 
     "react-reconciler": ["react-reconciler@0.32.0", "", { "dependencies": { "scheduler": "^0.26.0" }, "peerDependencies": { "react": "^19.1.0" } }, "sha512-2NPMOzgTlG0ZWdIf3qG+dcbLSoAc/uLfOwckc3ofy5sSK0pLJqnQLpUFxvGcN2rlXSjnVtGeeFLNimCQEj5gOQ=="],
 
@@ -560,7 +596,7 @@
 
     "sax": ["sax@1.4.3", "", {}, "sha512-yqYn1JhPczigF94DMS+shiDMjDowYO6y9+wB/4WgO0Y19jWYk0lQ4tuG5KI7kj4FTp1wxPj5IFfcrz/s1c3jjQ=="],
 
-    "scheduler": ["scheduler@0.26.0", "", {}, "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA=="],
+    "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
 
     "semver": ["semver@7.7.3", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q=="],
 
@@ -630,6 +666,8 @@
 
     "webidl-conversions": ["webidl-conversions@3.0.1", "", {}, "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="],
 
+    "whatwg-mimetype": ["whatwg-mimetype@3.0.0", "", {}, "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q=="],
+
     "whatwg-url": ["whatwg-url@5.0.0", "", { "dependencies": { "tr46": "~0.0.3", "webidl-conversions": "^3.0.0" } }, "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw=="],
 
     "when-exit": ["when-exit@2.1.4", "", {}, "sha512-4rnvd3A1t16PWzrBUcSDZqcAmsUIy4minDXT/CZ8F2mVDgd65i4Aalimgz1aQkRGU0iH5eT5+6Rx2TK8o443Pg=="],
@@ -682,7 +720,11 @@
 
     "pixelmatch/pngjs": ["pngjs@6.0.0", "", {}, "sha512-TRzzuFRRmEoSW/p1KVAmiOgPco2Irlah+bGFCeNfJXxxYGwSw7YwAOAcd7X28K/m5bjBWKsC29KyoMfHbypayg=="],
 
+    "pretty-format/ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
+
     "react-devtools-core/ws": ["ws@7.5.10", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": "^5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ=="],
+
+    "react-reconciler/scheduler": ["scheduler@0.26.0", "", {}, "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA=="],
 
     "string-width/strip-ansi": ["strip-ansi@7.1.2", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA=="],
 

--- a/package.json
+++ b/package.json
@@ -63,11 +63,13 @@
     "ws": "^8.18.3"
   },
   "devDependencies": {
+    "@testing-library/react": "^16.3.1",
     "@types/bun": "^1.3.4",
     "@types/node": "^20.11.20",
     "@types/react": "^19.2.7",
     "@types/react-dom": "^19.2.3",
     "eslint": "^8.57.0",
+    "happy-dom": "^20.3.0",
     "typescript": "^5.3.3"
   },
   "engines": {

--- a/src/commands/__tests__/notifications.test.ts
+++ b/src/commands/__tests__/notifications.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, beforeEach, afterEach } from 'bun:test';
-import { mkdtempSync, rmSync, writeFileSync, readFileSync, existsSync, mkdirSync } from 'fs';
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, existsSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import {

--- a/src/commands/__tests__/notifications.test.ts
+++ b/src/commands/__tests__/notifications.test.ts
@@ -1,0 +1,345 @@
+import { describe, expect, it, beforeEach, afterEach } from 'bun:test';
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, existsSync, mkdirSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import {
+  isHookInstalled,
+  installHook,
+  uninstallHook,
+  MARKER_START_EXPORT as MARKER_START,
+  MARKER_END_EXPORT as MARKER_END,
+  BASH_ZSH_HOOK_EXPORT as BASH_ZSH_HOOK,
+  FISH_HOOK_EXPORT as FISH_HOOK,
+} from '../notifications';
+
+// ============================================================================
+// Test Setup
+// ============================================================================
+
+let tempDir: string;
+
+beforeEach(() => {
+  tempDir = mkdtempSync(join(tmpdir(), 'gssh-notifications-test-'));
+});
+
+afterEach(() => {
+  rmSync(tempDir, { recursive: true, force: true });
+});
+
+// ============================================================================
+// isHookInstalled
+// ============================================================================
+
+describe('isHookInstalled', () => {
+  it('should return false for non-existent file', () => {
+    const filePath = join(tempDir, 'nonexistent');
+    expect(isHookInstalled(filePath)).toBe(false);
+  });
+
+  it('should return false for file without hook', () => {
+    const filePath = join(tempDir, '.zshrc');
+    writeFileSync(filePath, '# My zsh config\nexport PATH="/usr/local/bin:$PATH"\n');
+
+    expect(isHookInstalled(filePath)).toBe(false);
+  });
+
+  it('should return true for file with hook marker', () => {
+    const filePath = join(tempDir, '.zshrc');
+    writeFileSync(filePath, `# My config\n${MARKER_START}\n# hook content\n${MARKER_END}\n`);
+
+    expect(isHookInstalled(filePath)).toBe(true);
+  });
+
+  it('should detect hook anywhere in file', () => {
+    const filePath = join(tempDir, '.bashrc');
+    const content = `
+# Existing config
+export FOO=bar
+
+${MARKER_START}
+# hook content here
+${MARKER_END}
+
+# More config after
+alias ll='ls -la'
+`;
+    writeFileSync(filePath, content);
+
+    expect(isHookInstalled(filePath)).toBe(true);
+  });
+});
+
+// ============================================================================
+// installHook
+// ============================================================================
+
+describe('installHook', () => {
+  it('should create file and install hook if file does not exist', () => {
+    const filePath = join(tempDir, '.zshrc');
+
+    const result = installHook(filePath, BASH_ZSH_HOOK);
+
+    expect(result.installed).toBe(true);
+    expect(result.created).toBe(true);
+    expect(existsSync(filePath)).toBe(true);
+
+    const content = readFileSync(filePath, 'utf-8');
+    expect(content).toContain(MARKER_START);
+    expect(content).toContain(MARKER_END);
+    expect(content).toContain('__gitspace_preexec');
+  });
+
+  it('should append hook to existing file', () => {
+    const filePath = join(tempDir, '.zshrc');
+    const existingContent = '# My existing config\nexport PATH="/usr/local/bin:$PATH"\n';
+    writeFileSync(filePath, existingContent);
+
+    const result = installHook(filePath, BASH_ZSH_HOOK);
+
+    expect(result.installed).toBe(true);
+    expect(result.created).toBe(false);
+
+    const content = readFileSync(filePath, 'utf-8');
+    expect(content).toContain('My existing config');
+    expect(content).toContain(MARKER_START);
+  });
+
+  it('should be idempotent - not install twice', () => {
+    const filePath = join(tempDir, '.zshrc');
+    writeFileSync(filePath, '');
+
+    // First install
+    const result1 = installHook(filePath, BASH_ZSH_HOOK);
+    expect(result1.installed).toBe(true);
+
+    const contentAfterFirst = readFileSync(filePath, 'utf-8');
+    const markerCount1 = (contentAfterFirst.match(new RegExp(MARKER_START, 'g')) || []).length;
+    expect(markerCount1).toBe(1);
+
+    // Second install - should not add duplicate
+    const result2 = installHook(filePath, BASH_ZSH_HOOK);
+    expect(result2.installed).toBe(false);
+    expect(result2.created).toBe(false);
+
+    const contentAfterSecond = readFileSync(filePath, 'utf-8');
+    const markerCount2 = (contentAfterSecond.match(new RegExp(MARKER_START, 'g')) || []).length;
+    expect(markerCount2).toBe(1);
+  });
+
+  it('should create parent directories if needed', () => {
+    const nestedPath = join(tempDir, '.config', 'fish', 'config.fish');
+
+    const result = installHook(nestedPath, FISH_HOOK);
+
+    expect(result.installed).toBe(true);
+    expect(result.created).toBe(true);
+    expect(existsSync(nestedPath)).toBe(true);
+
+    const content = readFileSync(nestedPath, 'utf-8');
+    expect(content).toContain('__gitspace_preexec');
+    expect(content).toContain('fish_preexec');
+  });
+
+  it('should install fish hook with correct syntax', () => {
+    const filePath = join(tempDir, 'config.fish');
+
+    installHook(filePath, FISH_HOOK);
+
+    const content = readFileSync(filePath, 'utf-8');
+    expect(content).toContain('set -q TMUX_LITE');
+    expect(content).toContain('function __gitspace_preexec --on-event fish_preexec');
+    expect(content).toContain('function __gitspace_postexec --on-event fish_postexec');
+  });
+});
+
+// ============================================================================
+// uninstallHook
+// ============================================================================
+
+describe('uninstallHook', () => {
+  it('should return false for non-existent file', () => {
+    const filePath = join(tempDir, 'nonexistent');
+    expect(uninstallHook(filePath)).toBe(false);
+  });
+
+  it('should return false for file without hook', () => {
+    const filePath = join(tempDir, '.zshrc');
+    writeFileSync(filePath, '# My config\nexport FOO=bar\n');
+
+    expect(uninstallHook(filePath)).toBe(false);
+
+    // Content should be unchanged
+    const content = readFileSync(filePath, 'utf-8');
+    expect(content).toBe('# My config\nexport FOO=bar\n');
+  });
+
+  it('should remove hook block from file', () => {
+    const filePath = join(tempDir, '.zshrc');
+    const contentWithHook = `# Before hook
+export FOO=bar
+
+${BASH_ZSH_HOOK}
+
+# After hook
+export BAZ=qux
+`;
+    writeFileSync(filePath, contentWithHook);
+
+    const result = uninstallHook(filePath);
+
+    expect(result).toBe(true);
+
+    const content = readFileSync(filePath, 'utf-8');
+    expect(content).not.toContain(MARKER_START);
+    expect(content).not.toContain(MARKER_END);
+    expect(content).not.toContain('__gitspace_preexec');
+    expect(content).toContain('FOO=bar');
+    expect(content).toContain('BAZ=qux');
+  });
+
+  it('should be idempotent - only remove once', () => {
+    const filePath = join(tempDir, '.zshrc');
+    writeFileSync(filePath, `# Config\n${BASH_ZSH_HOOK}\n# End\n`);
+
+    // First uninstall
+    expect(uninstallHook(filePath)).toBe(true);
+
+    // Second uninstall - nothing to remove
+    expect(uninstallHook(filePath)).toBe(false);
+  });
+
+  it('should handle hook at start of file', () => {
+    const filePath = join(tempDir, '.bashrc');
+    writeFileSync(filePath, `${BASH_ZSH_HOOK}\n# Rest of config\n`);
+
+    const result = uninstallHook(filePath);
+
+    expect(result).toBe(true);
+    const content = readFileSync(filePath, 'utf-8');
+    expect(content).not.toContain(MARKER_START);
+    expect(content).toContain('Rest of config');
+  });
+
+  it('should handle hook at end of file', () => {
+    const filePath = join(tempDir, '.bashrc');
+    writeFileSync(filePath, `# Start of config\nexport PATH="/bin"\n${BASH_ZSH_HOOK}`);
+
+    const result = uninstallHook(filePath);
+
+    expect(result).toBe(true);
+    const content = readFileSync(filePath, 'utf-8');
+    expect(content).not.toContain(MARKER_START);
+    expect(content).toContain('Start of config');
+  });
+
+  it('should preserve file content outside hook block', () => {
+    const filePath = join(tempDir, '.zshrc');
+    const beforeHook = `# ZSH Configuration
+export EDITOR=vim
+export PATH="/usr/local/bin:$PATH"
+
+# Aliases
+alias gs='git status'
+alias gd='git diff'
+`;
+    const afterHook = `
+# More config
+alias ll='ls -la'
+export NODE_ENV=development
+`;
+    writeFileSync(filePath, `${beforeHook}${BASH_ZSH_HOOK}${afterHook}`);
+
+    uninstallHook(filePath);
+
+    const content = readFileSync(filePath, 'utf-8');
+    expect(content).toContain('export EDITOR=vim');
+    expect(content).toContain("alias gs='git status'");
+    expect(content).toContain("alias ll='ls -la'");
+    expect(content).toContain('export NODE_ENV=development');
+  });
+});
+
+// ============================================================================
+// Round-trip tests (install then uninstall)
+// ============================================================================
+
+describe('install/uninstall round-trip', () => {
+  it('should restore file to near-original state after round-trip', () => {
+    const filePath = join(tempDir, '.zshrc');
+    const originalContent = `# My ZSH config
+export PATH="/usr/local/bin:$PATH"
+alias ll='ls -la'
+`;
+    writeFileSync(filePath, originalContent);
+
+    // Install
+    installHook(filePath, BASH_ZSH_HOOK);
+    const afterInstall = readFileSync(filePath, 'utf-8');
+    expect(afterInstall).toContain(MARKER_START);
+
+    // Uninstall
+    uninstallHook(filePath);
+    const afterUninstall = readFileSync(filePath, 'utf-8');
+
+    // Should contain original content
+    expect(afterUninstall).toContain('My ZSH config');
+    expect(afterUninstall).toContain('PATH="/usr/local/bin');
+    expect(afterUninstall).toContain("alias ll='ls -la'");
+    expect(afterUninstall).not.toContain(MARKER_START);
+  });
+
+  it('should work with fish shell config', () => {
+    const filePath = join(tempDir, 'config.fish');
+    const originalContent = `# Fish config
+set -x PATH /usr/local/bin $PATH
+`;
+    writeFileSync(filePath, originalContent);
+
+    installHook(filePath, FISH_HOOK);
+    expect(isHookInstalled(filePath)).toBe(true);
+
+    uninstallHook(filePath);
+    expect(isHookInstalled(filePath)).toBe(false);
+
+    const content = readFileSync(filePath, 'utf-8');
+    expect(content).toContain('Fish config');
+  });
+});
+
+// ============================================================================
+// Hook content validation
+// ============================================================================
+
+describe('hook content validation', () => {
+  it('BASH_ZSH_HOOK should contain required markers', () => {
+    expect(BASH_ZSH_HOOK).toContain(MARKER_START);
+    expect(BASH_ZSH_HOOK).toContain(MARKER_END);
+  });
+
+  it('BASH_ZSH_HOOK should check for TMUX_LITE env var', () => {
+    expect(BASH_ZSH_HOOK).toContain('TMUX_LITE');
+  });
+
+  it('BASH_ZSH_HOOK should emit OSC 133 sequences', () => {
+    expect(BASH_ZSH_HOOK).toContain('133;C');
+    expect(BASH_ZSH_HOOK).toContain('133;D');
+  });
+
+  it('BASH_ZSH_HOOK should emit OSC 777 for exit notifications', () => {
+    expect(BASH_ZSH_HOOK).toContain('777;exit');
+  });
+
+  it('FISH_HOOK should contain required markers', () => {
+    expect(FISH_HOOK).toContain(MARKER_START);
+    expect(FISH_HOOK).toContain(MARKER_END);
+  });
+
+  it('FISH_HOOK should check for TMUX_LITE env var', () => {
+    expect(FISH_HOOK).toContain('set -q TMUX_LITE');
+  });
+
+  it('FISH_HOOK should use fish event handlers', () => {
+    expect(FISH_HOOK).toContain('--on-event fish_preexec');
+    expect(FISH_HOOK).toContain('--on-event fish_postexec');
+  });
+});

--- a/src/commands/notifications.ts
+++ b/src/commands/notifications.ts
@@ -1,0 +1,331 @@
+/**
+ * Notifications command - manage shell integration hooks
+ *
+ * Commands:
+ *   gssh notifications install   - Install shell hooks for notification integration
+ *   gssh notifications uninstall - Remove shell hooks
+ *   gssh notifications hook      - Print shell hook snippet
+ *   gssh notifications status    - Show current notification config
+ */
+
+import { existsSync, readFileSync, writeFileSync, appendFileSync, mkdirSync } from 'fs';
+import { join } from 'path';
+import { homedir } from 'os';
+import { logger } from '../utils/logger.js';
+import { getNotificationConfig, updateNotificationConfig } from '../core/config.js';
+
+// ============================================================================
+// Shell Hook Snippets
+// ============================================================================
+
+const MARKER_START = '# >>> gitspace notifications >>>';
+const MARKER_END = '# <<< gitspace notifications <<<';
+
+/**
+ * Bash/Zsh hook snippet
+ * Uses PROMPT_COMMAND for bash, precmd for zsh
+ * Emits OSC 133 C/D for command start/done and OSC 777 for exit codes
+ */
+const BASH_ZSH_HOOK = `${MARKER_START}
+# GitSpace notification hooks - do not edit this block manually
+# Emits OSC 133 (semantic shell integration) and OSC 777 (exit notifications)
+
+# Only run inside tmux-lite sessions
+if [[ -n "\${TMUX_LITE:-}" ]]; then
+  # OSC 133 command start
+  __gitspace_preexec() {
+    printf '\\033]133;C\\007'
+  }
+
+  # OSC 133 command done + OSC 777 exit notification
+  __gitspace_precmd() {
+    local exit_code=$?
+    printf '\\033]133;D;%d\\007' "$exit_code"
+    if [[ $exit_code -ne 0 ]]; then
+      printf '\\033]777;exit:%d\\007' "$exit_code"
+    fi
+  }
+
+  # Install hooks based on shell
+  if [[ -n "\${ZSH_VERSION:-}" ]]; then
+    # Zsh: use preexec and precmd hooks
+    autoload -Uz add-zsh-hook 2>/dev/null || true
+    if type add-zsh-hook &>/dev/null; then
+      add-zsh-hook preexec __gitspace_preexec
+      add-zsh-hook precmd __gitspace_precmd
+    fi
+  elif [[ -n "\${BASH_VERSION:-}" ]]; then
+    # Bash: use DEBUG trap and PROMPT_COMMAND
+    __gitspace_debug_trap() {
+      if [[ "\${BASH_COMMAND:-}" != "\${PROMPT_COMMAND:-}" ]] && [[ -z "\${__gitspace_in_prompt:-}" ]]; then
+        __gitspace_preexec
+      fi
+    }
+    trap '__gitspace_debug_trap' DEBUG
+
+    __gitspace_prompt_cmd() {
+      __gitspace_in_prompt=1
+      __gitspace_precmd
+      unset __gitspace_in_prompt
+    }
+    PROMPT_COMMAND="__gitspace_prompt_cmd\${PROMPT_COMMAND:+;}\${PROMPT_COMMAND:-}"
+  fi
+fi
+${MARKER_END}`;
+
+/**
+ * Fish hook snippet
+ * Uses fish_preexec and fish_postexec
+ */
+const FISH_HOOK = `${MARKER_START}
+# GitSpace notification hooks - do not edit this block manually
+# Emits OSC 133 (semantic shell integration) and OSC 777 (exit notifications)
+
+# Only run inside tmux-lite sessions
+if set -q TMUX_LITE
+  function __gitspace_preexec --on-event fish_preexec
+    printf '\\033]133;C\\007'
+  end
+
+  function __gitspace_postexec --on-event fish_postexec
+    set -l exit_code $status
+    printf '\\033]133;D;%d\\007' $exit_code
+    if test $exit_code -ne 0
+      printf '\\033]777;exit:%d\\007' $exit_code
+    end
+  end
+end
+${MARKER_END}`;
+
+// ============================================================================
+// Shell Config Paths
+// ============================================================================
+
+interface ShellConfig {
+  name: string;
+  paths: string[];
+  hook: string;
+}
+
+function getShellConfigs(): ShellConfig[] {
+  const home = homedir();
+  return [
+    {
+      name: 'bash',
+      paths: [
+        join(home, '.bashrc'),
+        join(home, '.bash_profile'),
+      ],
+      hook: BASH_ZSH_HOOK,
+    },
+    {
+      name: 'zsh',
+      paths: [
+        join(home, '.zshrc'),
+      ],
+      hook: BASH_ZSH_HOOK,
+    },
+    {
+      name: 'fish',
+      paths: [
+        join(home, '.config', 'fish', 'config.fish'),
+      ],
+      hook: FISH_HOOK,
+    },
+  ];
+}
+
+// ============================================================================
+// Install/Uninstall Functions (exported for testing)
+// ============================================================================
+
+/** Exported for testing */
+export const MARKER_START_EXPORT = MARKER_START;
+export const MARKER_END_EXPORT = MARKER_END;
+export const BASH_ZSH_HOOK_EXPORT = BASH_ZSH_HOOK;
+export const FISH_HOOK_EXPORT = FISH_HOOK;
+
+/**
+ * Check if hook is already installed in a file
+ */
+export function isHookInstalled(filePath: string): boolean {
+  if (!existsSync(filePath)) return false;
+  const content = readFileSync(filePath, 'utf-8');
+  return content.includes(MARKER_START);
+}
+
+/**
+ * Install hook in a file (idempotent)
+ */
+export function installHook(filePath: string, hook: string): { installed: boolean; created: boolean } {
+  // Check if already installed
+  if (isHookInstalled(filePath)) {
+    return { installed: false, created: false };
+  }
+
+  // Create parent directories if needed
+  const dir = join(filePath, '..');
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true });
+  }
+
+  // Create file if it doesn't exist
+  const created = !existsSync(filePath);
+  if (created) {
+    writeFileSync(filePath, '', 'utf-8');
+  }
+
+  // Append hook
+  appendFileSync(filePath, '\n' + hook + '\n', 'utf-8');
+  return { installed: true, created };
+}
+
+/**
+ * Remove hook from a file
+ */
+export function uninstallHook(filePath: string): boolean {
+  if (!existsSync(filePath)) return false;
+
+  const content = readFileSync(filePath, 'utf-8');
+  if (!content.includes(MARKER_START)) {
+    return false;
+  }
+
+  // Remove the hook block (including surrounding newlines)
+  const pattern = new RegExp(
+    `\\n?${escapeRegExp(MARKER_START)}[\\s\\S]*?${escapeRegExp(MARKER_END)}\\n?`,
+    'g'
+  );
+  const newContent = content.replace(pattern, '\n');
+  writeFileSync(filePath, newContent, 'utf-8');
+  return true;
+}
+
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+// ============================================================================
+// Command Handlers
+// ============================================================================
+
+/**
+ * Install shell hooks for all detected shells
+ */
+export async function notificationsInstall(): Promise<void> {
+  const configs = getShellConfigs();
+  let anyInstalled = false;
+
+  logger.log('Installing GitSpace notification hooks...\n');
+
+  for (const config of configs) {
+    for (const path of config.paths) {
+      // Only install to the first existing file for each shell, or create the primary one
+      const isPrimary = path === config.paths[0];
+
+      if (existsSync(path) || isPrimary) {
+        const result = installHook(path, config.hook);
+        if (result.installed) {
+          if (result.created) {
+            logger.success(`Created and installed hook in: ${path}`);
+          } else {
+            logger.success(`Installed hook in: ${path}`);
+          }
+          anyInstalled = true;
+        } else {
+          logger.dim(`Already installed in: ${path}`);
+        }
+        break; // Only install once per shell
+      }
+    }
+  }
+
+  if (anyInstalled) {
+    logger.log('\nRestart your shell or run "source ~/.bashrc" (or equivalent) to activate.');
+    logger.log('Hooks only activate inside tmux-lite sessions (gssh workspaces).');
+  } else {
+    logger.log('\nAll hooks were already installed.');
+  }
+}
+
+/**
+ * Remove shell hooks from all shell configs
+ */
+export async function notificationsUninstall(): Promise<void> {
+  const configs = getShellConfigs();
+  let anyRemoved = false;
+
+  logger.log('Removing GitSpace notification hooks...\n');
+
+  for (const config of configs) {
+    for (const path of config.paths) {
+      if (uninstallHook(path)) {
+        logger.success(`Removed hook from: ${path}`);
+        anyRemoved = true;
+      }
+    }
+  }
+
+  if (anyRemoved) {
+    logger.log('\nHooks removed. Restart your shell to complete.');
+  } else {
+    logger.log('\nNo hooks were installed.');
+  }
+}
+
+/**
+ * Print shell hook snippet for manual installation
+ */
+export async function notificationsHook(shell?: string): Promise<void> {
+  const configs = getShellConfigs();
+
+  if (!shell) {
+    logger.log('Available shells: bash, zsh, fish');
+    logger.log('Usage: gssh notifications hook --shell <shell>\n');
+    return;
+  }
+
+  const config = configs.find(c => c.name === shell.toLowerCase());
+  if (!config) {
+    logger.error(`Unknown shell: ${shell}`);
+    logger.log('Available shells: bash, zsh, fish');
+    return;
+  }
+
+  logger.log(`# Add this to your ${config.paths[0]}:\n`);
+  console.log(config.hook);
+}
+
+/**
+ * Show current notification settings
+ */
+export async function notificationsStatus(): Promise<void> {
+  const config = getNotificationConfig();
+
+  logger.bold('Notification Settings\n');
+
+  logger.log(`Enabled: ${config.enabled ? 'yes' : 'no'}`);
+  logger.log(`Min command duration: ${config.minCommandDurationMs}ms`);
+  logger.log(`Toast notifications: ${config.toast.enabled ? 'enabled' : 'disabled'}`);
+
+  logger.log('\nNotification types:');
+  logger.log(`  Exit notifications: ${config.types.exit ? 'on' : 'off'}`);
+  logger.log(`  Idle notifications: ${config.types.idle ? 'on' : 'off'}`);
+  logger.log(`  Bell notifications: ${config.types.bell ? 'on' : 'off'}`);
+  logger.log(`  Title change notifications: ${config.types.title ? 'on' : 'off'}`);
+  logger.log(`  OSC notifications: ${config.types.osc ? 'on' : 'off'}`);
+
+  // Check shell hook installation status
+  logger.log('\nShell hooks:');
+  const configs = getShellConfigs();
+  for (const shellConfig of configs) {
+    for (const path of shellConfig.paths) {
+      if (existsSync(path)) {
+        const installed = isHookInstalled(path);
+        const status = installed ? 'installed' : 'not installed';
+        logger.log(`  ${shellConfig.name} (${path}): ${status}`);
+        break;
+      }
+    }
+  }
+}

--- a/src/commands/notifications.ts
+++ b/src/commands/notifications.ts
@@ -12,7 +12,7 @@ import { existsSync, readFileSync, writeFileSync, appendFileSync, mkdirSync } fr
 import { join } from 'path';
 import { homedir } from 'os';
 import { logger } from '../utils/logger.js';
-import { getNotificationConfig, updateNotificationConfig } from '../core/config.js';
+import { getNotificationConfig } from '../core/config.js';
 
 // ============================================================================
 // Shell Hook Snippets

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -13,9 +13,10 @@ import {
 } from 'fs'
 import { join, dirname } from 'path'
 import { homedir } from 'os'
-import type { GlobalConfig, ProjectConfig } from '../types/config.js'
+import type { GlobalConfig, ProjectConfig, NotificationConfig } from '../types/config.js'
 import {
 	DEFAULT_GLOBAL_CONFIG,
+	DEFAULT_NOTIFICATION_CONFIG,
 	createDefaultProjectConfig,
 } from '../types/config.js'
 import { SpacesError } from '../types/errors.js'
@@ -503,4 +504,59 @@ echo "Running Spaces cleanup on: $WORKSPACE_NAME from $REPOSITORY"
 	writeProjectConfig(projectName, config)
 
 	return config
+}
+
+// ============================================================================
+// Notification Config Helpers
+// ============================================================================
+
+/**
+ * Get notification configuration (with defaults for missing fields)
+ */
+export function getNotificationConfig(): NotificationConfig {
+	const globalConfig = readGlobalConfig()
+	const userConfig = globalConfig.notifications
+
+	if (!userConfig) {
+		return { ...DEFAULT_NOTIFICATION_CONFIG }
+	}
+
+	// Merge with defaults to ensure all fields exist
+	return {
+		enabled: userConfig.enabled ?? DEFAULT_NOTIFICATION_CONFIG.enabled,
+		minCommandDurationMs:
+			userConfig.minCommandDurationMs ??
+			DEFAULT_NOTIFICATION_CONFIG.minCommandDurationMs,
+		types: {
+			...DEFAULT_NOTIFICATION_CONFIG.types,
+			...userConfig.types,
+		},
+		toast: {
+			...DEFAULT_NOTIFICATION_CONFIG.toast,
+			...userConfig.toast,
+		},
+	}
+}
+
+/**
+ * Update notification configuration
+ */
+export function updateNotificationConfig(
+	updates: Partial<NotificationConfig>
+): NotificationConfig {
+	const current = getNotificationConfig()
+	const updated: NotificationConfig = {
+		...current,
+		...updates,
+		types: {
+			...current.types,
+			...(updates.types || {}),
+		},
+		toast: {
+			...current.toast,
+			...(updates.toast || {}),
+		},
+	}
+	updateGlobalConfig({ notifications: updated })
+	return updated
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -56,6 +56,7 @@ import { hostReserve, hostRelease, hostList, hostSetPrimary, hostStatus } from '
 import { startTmux, stopTmux, statusTmux, listTmux, newTmux, attachTmux, killTmux } from './commands/tmux.js'
 import { showStatus } from './commands/status.js'
 import { linearSetup, linearShow, linearClear } from './commands/linear.js'
+import { notificationsInstall, notificationsUninstall, notificationsHook, notificationsStatus } from './commands/notifications.js'
 
 const program = new Command()
 
@@ -694,6 +695,60 @@ linearCommand
 		await checkFirstTimeSetup()
 		try {
 			await linearClear(options)
+		} catch (error) {
+			handleError(error)
+		}
+	})
+
+// ============================================================================
+// Notifications Commands
+// ============================================================================
+
+const notificationsCommand = program
+	.command('notifications')
+	.alias('notify')
+	.description('Manage notification settings and shell hooks')
+
+notificationsCommand
+	.command('install')
+	.description('Install shell hooks for notification integration')
+	.action(async () => {
+		try {
+			await notificationsInstall()
+		} catch (error) {
+			handleError(error)
+		}
+	})
+
+notificationsCommand
+	.command('uninstall')
+	.description('Remove shell hooks from shell config files')
+	.action(async () => {
+		try {
+			await notificationsUninstall()
+		} catch (error) {
+			handleError(error)
+		}
+	})
+
+notificationsCommand
+	.command('hook')
+	.description('Print shell hook snippet for manual installation')
+	.option('--shell <shell>', 'Shell type (bash, zsh, fish)')
+	.action(async (options) => {
+		try {
+			await notificationsHook(options.shell)
+		} catch (error) {
+			handleError(error)
+		}
+	})
+
+notificationsCommand
+	.command('status')
+	.description('Show notification settings and hook installation status')
+	.action(async () => {
+		try {
+			await notificationsStatus()
 		} catch (error) {
 			handleError(error)
 		}

--- a/src/lib/remote-session/session-handler.ts
+++ b/src/lib/remote-session/session-handler.ts
@@ -492,18 +492,33 @@ export class RemoteSessionHandler {
 
   /**
    * Handle get_inbox request
+   * Returns unread count bounded by active sessions (one per session max).
    */
   private async handleGetInbox(
     session: RemoteClientSession,
     sendResponse: (data: Uint8Array) => void
   ): Promise<void> {
     try {
-      const items = await getInbox();
-      const unreadCount = items.filter(i => !i.read).length;
+      const [items, activeSessions] = await Promise.all([
+        getInbox(),
+        listSessions(),
+      ]);
+      
+      // Build a set of active session IDs
+      const activeSessionIds = new Set(activeSessions.map(s => s.id));
+      
+      // Count unique sessions that have unread items AND are still active
+      const activeSessionsWithUnread = new Set<string>();
+      for (const item of items) {
+        if (!item.read && activeSessionIds.has(item.sessionId)) {
+          activeSessionsWithUnread.add(item.sessionId);
+        }
+      }
+      
       await this.sendMessage(session, sendResponse, {
         type: "inbox_list",
         items,
-        unreadCount,
+        unreadCount: activeSessionsWithUnread.size,
       });
     } catch (e) {
       console.error("[remote-session] Failed to get inbox:", e);

--- a/src/lib/tmux-lite/cli.ts
+++ b/src/lib/tmux-lite/cli.ts
@@ -306,9 +306,30 @@ export async function getInbox(): Promise<InboxItem[]> {
   throw new Error("Unexpected response");
 }
 
+/**
+ * Get count of unread inbox items, bounded by active sessions.
+ * Returns the number of unique active sessions that have unread notifications,
+ * not the total number of unread items. This prevents the count from growing
+ * unboundedly and caps it at one per active session.
+ */
 export async function getUnreadCount(): Promise<number> {
-  const items = await getInbox();
-  return items.filter(i => !i.read).length;
+  const [items, activeSessions] = await Promise.all([
+    getInbox(),
+    listSessions(),
+  ]);
+  
+  // Build a set of active session IDs
+  const activeSessionIds = new Set(activeSessions.map(s => s.id));
+  
+  // Count unique sessions that have unread items AND are still active
+  const activeSessionsWithUnread = new Set<string>();
+  for (const item of items) {
+    if (!item.read && activeSessionIds.has(item.sessionId)) {
+      activeSessionsWithUnread.add(item.sessionId);
+    }
+  }
+  
+  return activeSessionsWithUnread.size;
 }
 
 export async function clearInbox(id?: string): Promise<void> {

--- a/src/lib/tmux-lite/server.ts
+++ b/src/lib/tmux-lite/server.ts
@@ -11,6 +11,8 @@ import { Terminal as XTerminal } from "@xterm/headless";
 import { SerializeAddon } from "@xterm/addon-serialize";
 import { createBufferedSocketWriter } from "../../utils/bun-socket-writer";
 import { installDsrCprResponder } from "./terminal-queries";
+import { getNotificationConfig, type NotificationConfig } from "../../core/config.js";
+import { DEFAULT_NOTIFICATION_CONFIG } from "../../types/config.js";
 import {
   getRouterSocket,
   getSessionSocketPath,
@@ -50,6 +52,35 @@ if (rawArgs.includes("--test")) {
 const ROUTER_SOCKET = getRouterSocket();
 const PID_FILE = getPidFile();
 const SERVER_START_TIME = Date.now();
+
+// Load notification config (with fallback to defaults)
+let notificationConfig: NotificationConfig;
+try {
+  notificationConfig = getNotificationConfig();
+} catch {
+  // If config can't be loaded (e.g., gitspace not initialized), use defaults
+  notificationConfig = { ...DEFAULT_NOTIFICATION_CONFIG };
+}
+
+/**
+ * Check if a notification type is enabled
+ */
+function isNotificationTypeEnabled(type: InboxItem['type']): boolean {
+  if (!notificationConfig.enabled) return false;
+
+  switch (type) {
+    case 'exit':
+      return notificationConfig.types.exit;
+    case 'idle':
+      return notificationConfig.types.idle;
+    case 'bell':
+      return notificationConfig.types.bell;
+    case 'title':
+      return notificationConfig.types.title;
+    default:
+      return notificationConfig.types.osc;
+  }
+}
 
 // Clean up old socket
 try { unlinkSync(ROUTER_SOCKET); } catch {}
@@ -288,6 +319,11 @@ function genInboxId(): string {
 }
 
 function addInboxItem(item: Omit<InboxItem, 'id' | 'read'>): void {
+  // Check if this notification type is enabled in config
+  if (!isNotificationTypeEnabled(item.type)) {
+    return;
+  }
+
   inbox.push({
     ...item,
     id: genInboxId(),
@@ -477,6 +513,7 @@ function setupXtermEventHandlers(
  */
 interface Osc133State {
   commandRunning: boolean;
+  commandStartTime: number;  // Timestamp when command started (for duration filter)
 }
 
 /**
@@ -536,6 +573,7 @@ function createPtyDataHandler(
     // Command start
     if (OSC_133_CMD_START.test(str)) {
       osc133State.commandRunning = true;
+      osc133State.commandStartTime = now;
       OSC_133_CMD_START.lastIndex = 0; // Reset regex state
     }
 
@@ -544,8 +582,19 @@ function createPtyDataHandler(
     const osc133DoneMatches = [...str.matchAll(OSC_133_DONE_PATTERN)];
     for (const match of osc133DoneMatches) {
       const exitCode = match[1] ? parseInt(match[1], 10) : 0;
-      // Only notify for background sessions with non-zero exit or if command was tracked
-      if (!activelyUsing && (exitCode !== 0 || osc133State.commandRunning)) {
+      const commandDuration = osc133State.commandStartTime > 0
+        ? now - osc133State.commandStartTime
+        : 0;
+
+      // Only notify for background sessions if:
+      // - Non-zero exit (always notify on errors)
+      // - OR command duration >= minCommandDurationMs
+      const shouldNotify = !activelyUsing && (
+        exitCode !== 0 ||
+        (osc133State.commandRunning && commandDuration >= notificationConfig.minCommandDurationMs)
+      );
+
+      if (shouldNotify) {
         const context = getLastLines(xterm, 2) || `Command finished (exit ${exitCode})`;
         addInboxItem(createInboxNotification(
           id,
@@ -555,9 +604,10 @@ function createPtyDataHandler(
           currentProcessTitle,
           exitCode !== 0 ? exitCode : undefined
         ));
-        console.log(`[${sessionName}] OSC 133 command done: exit ${exitCode}`);
+        console.log(`[${sessionName}] OSC 133 command done: exit ${exitCode}, duration ${commandDuration}ms`);
       }
       osc133State.commandRunning = false;
+      osc133State.commandStartTime = 0;
     }
 
     // Pass original data through unchanged to preserve all escape sequences
@@ -984,6 +1034,7 @@ function createSession(name: string | undefined, cwd: string): Session {
   // Initialize OSC 133 state for shell integration
   const osc133State: Osc133State = {
     commandRunning: false,
+    commandStartTime: 0,
   };
 
   // Create the idle checker function

--- a/src/lib/tmux-lite/server.ts
+++ b/src/lib/tmux-lite/server.ts
@@ -335,6 +335,22 @@ function addInboxItem(item: Omit<InboxItem, 'id' | 'read'>): void {
   broadcastTitleUpdate();
 }
 
+/**
+ * Prune inbox items for a destroyed session.
+ * This removes all notifications associated with a session when it exits,
+ * keeping the inbox clean and ensuring the count only reflects active sessions.
+ */
+function pruneInboxForSession(sessionId: string): void {
+  // Find and remove all inbox items for this session
+  let i = inbox.length;
+  while (i--) {
+    if (inbox[i].sessionId === sessionId) {
+      inbox.splice(i, 1);
+    }
+  }
+  console.log(`[inbox] Pruned notifications for session ${sessionId}`);
+}
+
 function getLastLines(xterm: XTerminal, count: number): string {
   const buffer = xterm.buffer.active;
   const lines: string[] = [];
@@ -353,8 +369,23 @@ function getCurrentLine(xterm: XTerminal): string {
   return buffer.getLine(buffer.cursorY)?.translateToString(true)?.trim() || '';
 }
 
+/**
+ * Get count of unread inbox items, bounded by active sessions.
+ * Returns the number of unique active sessions that have unread notifications,
+ * not the total number of unread items. This prevents the count from growing
+ * unboundedly (e.g., to 3000) and instead caps it at one per active session.
+ */
 function getUnreadInboxCount(): number {
-  return inbox.filter(i => !i.read).length;
+  // Get unique session IDs that have unread items AND are still active
+  const activeSessionsWithUnread = new Set<string>();
+  
+  for (const item of inbox) {
+    if (!item.read && sessions.has(item.sessionId)) {
+      activeSessionsWithUnread.add(item.sessionId);
+    }
+  }
+  
+  return activeSessionsWithUnread.size;
 }
 
 function buildTitle(sessionName: string, processTitle?: string): string {
@@ -646,6 +677,10 @@ function handleProcessExit(
 
     // Clean up parser hooks
     try { disposeDsr(); } catch {}
+
+    // Prune old inbox items for this session so inbox stays bounded to active sessions.
+    // Do this before adding the final exit notification so the user still sees the exit event.
+    pruneInboxForSession(id);
 
     // Capture last lines for inbox before disposing xterm
     const context = getLastLines(xterm, 3);

--- a/src/shared/notifications/__tests__/useNotifications.test.ts
+++ b/src/shared/notifications/__tests__/useNotifications.test.ts
@@ -1,0 +1,739 @@
+import { describe, expect, it, beforeEach, afterEach, mock, jest, beforeAll, afterAll } from 'bun:test';
+import { renderHook, act } from '@testing-library/react';
+import { Window } from 'happy-dom';
+import { useNotifications } from '../useNotifications';
+import type { NotificationConfig, ToastNotification } from '../types';
+import type { InboxItem } from '../../types';
+
+// Setup happy-dom for React Testing Library
+const window = new Window();
+const originalWindow = globalThis.window;
+const originalDocument = globalThis.document;
+
+// @ts-expect-error - assigning Window to globalThis
+globalThis.window = window;
+// @ts-expect-error - assigning Document to globalThis
+globalThis.document = window.document;
+
+// ============================================================================
+// Test Fixtures
+// ============================================================================
+
+let idCounter = 0;
+
+function createInboxItem(overrides: Partial<InboxItem> = {}): InboxItem {
+  idCounter++;
+  return {
+    id: `test-id-${idCounter}`,
+    sessionId: 'session-1',
+    sessionName: 'my-project:my-workspace:default',
+    type: 'exit',
+    timestamp: Date.now(),
+    read: false,
+    context: 'Command completed',
+    processTitle: 'npm test',
+    exitCode: 0,
+    ...overrides,
+  };
+}
+
+function createConfig(overrides: Partial<NotificationConfig> = {}): NotificationConfig {
+  return {
+    enabled: true,
+    minCommandDurationMs: 10000,
+    types: {
+      exit: true,
+      idle: true,
+      bell: true,
+      title: true,
+      osc: true,
+    },
+    toast: {
+      enabled: true,
+      holdWhenIdleMs: 15000,
+    },
+    ...overrides,
+  };
+}
+
+// ============================================================================
+// Setup / Teardown
+// ============================================================================
+
+describe('useNotifications', () => {
+  beforeEach(() => {
+    idCounter = 0;
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  // ==========================================================================
+  // Toast showing when user is active
+  // ==========================================================================
+
+  describe('toast showing when user is active', () => {
+    it('should show toast immediately when user is active', () => {
+      const onShowToast = mock<(toast: ToastNotification) => void>(() => {});
+      const config = createConfig();
+      const item = createInboxItem();
+
+      const { rerender } = renderHook(
+        ({ items }) => useNotifications({
+          items,
+          config,
+          onShowToast,
+          isUserActive: true,
+        }),
+        { initialProps: { items: [] as InboxItem[] } }
+      );
+
+      // Add a new item
+      rerender({ items: [item] });
+
+      expect(onShowToast).toHaveBeenCalledTimes(1);
+      expect(onShowToast.mock.calls[0][0]).toMatchObject({
+        id: item.id,
+        sessionId: item.sessionId,
+      });
+    });
+
+    it('should increment toastCount when toast is shown', () => {
+      const onShowToast = mock<(toast: ToastNotification) => void>(() => {});
+      const config = createConfig();
+      const item1 = createInboxItem();
+      const item2 = createInboxItem({ sessionId: 'session-2' });
+
+      const { result, rerender } = renderHook(
+        ({ items }) => useNotifications({
+          items,
+          config,
+          onShowToast,
+          isUserActive: true,
+        }),
+        { initialProps: { items: [] as InboxItem[] } }
+      );
+
+      expect(result.current.toastCount).toBe(0);
+
+      rerender({ items: [item1] });
+      expect(result.current.toastCount).toBe(1);
+
+      rerender({ items: [item1, item2] });
+      expect(result.current.toastCount).toBe(2);
+    });
+
+    it('should set activeToast when toast is shown', () => {
+      const onShowToast = mock<(toast: ToastNotification) => void>(() => {});
+      const config = createConfig();
+      const item = createInboxItem();
+
+      const { result, rerender } = renderHook(
+        ({ items }) => useNotifications({
+          items,
+          config,
+          onShowToast,
+          isUserActive: true,
+        }),
+        { initialProps: { items: [] as InboxItem[] } }
+      );
+
+      expect(result.current.activeToast).toBeNull();
+
+      rerender({ items: [item] });
+      expect(result.current.activeToast).not.toBeNull();
+      expect(result.current.activeToast?.id).toBe(item.id);
+    });
+  });
+
+  // ==========================================================================
+  // Toast holding when user is inactive
+  // ==========================================================================
+
+  describe('toast holding when user is inactive', () => {
+    it('should hold toast when user is inactive and holdWhenIdleMs > 0', () => {
+      const onShowToast = mock<(toast: ToastNotification) => void>(() => {});
+      const config = createConfig({ toast: { enabled: true, holdWhenIdleMs: 15000 } });
+      const item = createInboxItem();
+
+      const { result, rerender } = renderHook(
+        ({ items, isUserActive }) => useNotifications({
+          items,
+          config,
+          onShowToast,
+          isUserActive,
+        }),
+        { initialProps: { items: [] as InboxItem[], isUserActive: false } }
+      );
+
+      // Add a new item while user is inactive
+      rerender({ items: [item], isUserActive: false });
+
+      // Should NOT show toast
+      expect(onShowToast).not.toHaveBeenCalled();
+      // Should hold the toast
+      expect(result.current.heldCount).toBe(1);
+    });
+
+    it('should show toast immediately when holdWhenIdleMs is 0', () => {
+      const onShowToast = mock<(toast: ToastNotification) => void>(() => {});
+      const config = createConfig({ toast: { enabled: true, holdWhenIdleMs: 0 } });
+      const item = createInboxItem();
+
+      const { rerender } = renderHook(
+        ({ items, isUserActive }) => useNotifications({
+          items,
+          config,
+          onShowToast,
+          isUserActive,
+        }),
+        { initialProps: { items: [] as InboxItem[], isUserActive: false } }
+      );
+
+      rerender({ items: [item], isUserActive: false });
+
+      // Should show toast even though user is inactive (holdWhenIdleMs = 0)
+      expect(onShowToast).toHaveBeenCalledTimes(1);
+    });
+
+    it('should keep only latest toast per session when holding', () => {
+      const onShowToast = mock<(toast: ToastNotification) => void>(() => {});
+      const config = createConfig({ toast: { enabled: true, holdWhenIdleMs: 15000 } });
+      const item1 = createInboxItem({ sessionId: 'session-1' });
+      const item2 = createInboxItem({ sessionId: 'session-1', timestamp: Date.now() + 1000 });
+
+      const { result, rerender } = renderHook(
+        ({ items, isUserActive }) => useNotifications({
+          items,
+          config,
+          onShowToast,
+          isUserActive,
+        }),
+        { initialProps: { items: [] as InboxItem[], isUserActive: false } }
+      );
+
+      rerender({ items: [item1], isUserActive: false });
+      expect(result.current.heldCount).toBe(1);
+
+      rerender({ items: [item1, item2], isUserActive: false });
+      // Still 1 because it's the same session (latest replaces previous)
+      expect(result.current.heldCount).toBe(1);
+    });
+  });
+
+  // ==========================================================================
+  // Flush held toasts when user becomes active
+  // ==========================================================================
+
+  describe('flush held toasts when user becomes active', () => {
+    it('should flush held toasts when user becomes active', () => {
+      const onShowToast = mock<(toast: ToastNotification) => void>(() => {});
+      const config = createConfig({ toast: { enabled: true, holdWhenIdleMs: 15000 } });
+      const item = createInboxItem();
+
+      const { result, rerender } = renderHook(
+        ({ items, isUserActive }) => useNotifications({
+          items,
+          config,
+          onShowToast,
+          isUserActive,
+        }),
+        { initialProps: { items: [] as InboxItem[], isUserActive: false } }
+      );
+
+      // Add item while inactive
+      rerender({ items: [item], isUserActive: false });
+      expect(onShowToast).not.toHaveBeenCalled();
+      expect(result.current.heldCount).toBe(1);
+
+      // User becomes active
+      rerender({ items: [item], isUserActive: true });
+      expect(onShowToast).toHaveBeenCalledTimes(1);
+      expect(result.current.heldCount).toBe(0);
+    });
+
+    it('should flush multiple held toasts in chronological order', () => {
+      const shownToasts: ToastNotification[] = [];
+      const onShowToast = mock<(toast: ToastNotification) => void>((toast) => {
+        shownToasts.push(toast);
+      });
+      const config = createConfig({ toast: { enabled: true, holdWhenIdleMs: 15000 } });
+
+      const baseTime = Date.now();
+      const item1 = createInboxItem({ sessionId: 'session-1', timestamp: baseTime + 2000 });
+      const item2 = createInboxItem({ sessionId: 'session-2', timestamp: baseTime + 1000 });
+
+      const { rerender } = renderHook(
+        ({ items, isUserActive }) => useNotifications({
+          items,
+          config,
+          onShowToast,
+          isUserActive,
+        }),
+        { initialProps: { items: [] as InboxItem[], isUserActive: false } }
+      );
+
+      // Add items while inactive
+      rerender({ items: [item1], isUserActive: false });
+      rerender({ items: [item1, item2], isUserActive: false });
+
+      // User becomes active
+      rerender({ items: [item1, item2], isUserActive: true });
+
+      // Should show both, item2 first (earlier timestamp)
+      expect(shownToasts.length).toBe(2);
+      expect(shownToasts[0].sessionId).toBe('session-2');
+      expect(shownToasts[1].sessionId).toBe('session-1');
+    });
+  });
+
+  // ==========================================================================
+  // Auto-dismiss for current session
+  // ==========================================================================
+
+  describe('auto-dismiss for current session', () => {
+    it('should auto-dismiss notifications for current session when user is active', async () => {
+      const onShowToast = mock<(toast: ToastNotification) => void>(() => {});
+      const onMarkRead = mock<(itemId: string) => Promise<void>>(() => Promise.resolve());
+      const config = createConfig();
+      const item = createInboxItem({ sessionId: 'current-session' });
+
+      const { rerender } = renderHook(
+        ({ items }) => useNotifications({
+          items,
+          config,
+          onShowToast,
+          onMarkRead,
+          isUserActive: true,
+          currentSessionId: 'current-session',
+        }),
+        { initialProps: { items: [] as InboxItem[] } }
+      );
+
+      rerender({ items: [item] });
+
+      // Should NOT show toast (user is watching this session)
+      expect(onShowToast).not.toHaveBeenCalled();
+      // Should auto-dismiss (mark as read)
+      expect(onMarkRead).toHaveBeenCalledWith(item.id);
+    });
+
+    it('should hold notification for current session when user is inactive', () => {
+      const onShowToast = mock<(toast: ToastNotification) => void>(() => {});
+      const onMarkRead = mock<(itemId: string) => Promise<void>>(() => Promise.resolve());
+      const config = createConfig({ toast: { enabled: true, holdWhenIdleMs: 15000 } });
+      const item = createInboxItem({ sessionId: 'current-session' });
+
+      const { result, rerender } = renderHook(
+        ({ items, isUserActive }) => useNotifications({
+          items,
+          config,
+          onShowToast,
+          onMarkRead,
+          isUserActive,
+          currentSessionId: 'current-session',
+        }),
+        { initialProps: { items: [] as InboxItem[], isUserActive: false } }
+      );
+
+      rerender({ items: [item], isUserActive: false });
+
+      // Should hold, not show or dismiss
+      expect(onShowToast).not.toHaveBeenCalled();
+      expect(onMarkRead).not.toHaveBeenCalled();
+      expect(result.current.heldCount).toBe(1);
+    });
+
+    it('should auto-dismiss held toast for current session when user becomes active', () => {
+      const onShowToast = mock<(toast: ToastNotification) => void>(() => {});
+      const onMarkRead = mock<(itemId: string) => Promise<void>>(() => Promise.resolve());
+      const config = createConfig({ toast: { enabled: true, holdWhenIdleMs: 15000 } });
+      const item = createInboxItem({ sessionId: 'current-session' });
+
+      const { result, rerender } = renderHook(
+        ({ items, isUserActive }) => useNotifications({
+          items,
+          config,
+          onShowToast,
+          onMarkRead,
+          isUserActive,
+          currentSessionId: 'current-session',
+        }),
+        { initialProps: { items: [] as InboxItem[], isUserActive: false } }
+      );
+
+      // Add item while inactive
+      rerender({ items: [item], isUserActive: false });
+      expect(result.current.heldCount).toBe(1);
+
+      // User becomes active
+      rerender({ items: [item], isUserActive: true });
+
+      // Should NOT show (it's for current session)
+      expect(onShowToast).not.toHaveBeenCalled();
+      // Should auto-dismiss
+      expect(onMarkRead).toHaveBeenCalledWith(item.id);
+      expect(result.current.heldCount).toBe(0);
+    });
+  });
+
+  // ==========================================================================
+  // Held toast cleanup on session detach
+  // ==========================================================================
+
+  describe('held toast cleanup on session detach', () => {
+    it('should auto-dismiss held toasts for detached session', () => {
+      const onShowToast = mock<(toast: ToastNotification) => void>(() => {});
+      const onMarkRead = mock<(itemId: string) => Promise<void>>(() => Promise.resolve());
+      const config = createConfig({ toast: { enabled: true, holdWhenIdleMs: 15000 } });
+      const item = createInboxItem({ sessionId: 'session-1' });
+
+      const { result, rerender } = renderHook(
+        ({ items, isUserActive, currentSessionId }: { items: InboxItem[]; isUserActive: boolean; currentSessionId: string | undefined }) => useNotifications({
+          items,
+          config,
+          onShowToast,
+          onMarkRead,
+          isUserActive,
+          currentSessionId,
+        }),
+        { initialProps: { items: [] as InboxItem[], isUserActive: false, currentSessionId: 'session-1' as string | undefined } }
+      );
+
+      // Add item while inactive and attached to session-1
+      rerender({ items: [item], isUserActive: false, currentSessionId: 'session-1' });
+      expect(result.current.heldCount).toBe(1);
+
+      // Detach from session-1 (switch to different session or undefined)
+      rerender({ items: [item], isUserActive: false, currentSessionId: undefined });
+
+      // Should auto-dismiss the held toast for detached session
+      expect(onMarkRead).toHaveBeenCalledWith(item.id);
+      expect(result.current.heldCount).toBe(0);
+    });
+
+    it('should keep held toasts for other sessions on detach', () => {
+      const onShowToast = mock<(toast: ToastNotification) => void>(() => {});
+      const onMarkRead = mock<(itemId: string) => Promise<void>>(() => Promise.resolve());
+      const config = createConfig({ toast: { enabled: true, holdWhenIdleMs: 15000 } });
+      const item1 = createInboxItem({ sessionId: 'session-1' });
+      const item2 = createInboxItem({ sessionId: 'session-2' });
+
+      const { result, rerender } = renderHook(
+        ({ items, isUserActive, currentSessionId }: { items: InboxItem[]; isUserActive: boolean; currentSessionId: string | undefined }) => useNotifications({
+          items,
+          config,
+          onShowToast,
+          onMarkRead,
+          isUserActive,
+          currentSessionId,
+        }),
+        { initialProps: { items: [] as InboxItem[], isUserActive: false, currentSessionId: 'session-1' as string | undefined } }
+      );
+
+      // Add items while inactive
+      rerender({ items: [item1], isUserActive: false, currentSessionId: 'session-1' });
+      rerender({ items: [item1, item2], isUserActive: false, currentSessionId: 'session-1' });
+      expect(result.current.heldCount).toBe(2);
+
+      // Detach from session-1
+      rerender({ items: [item1, item2], isUserActive: false, currentSessionId: undefined });
+
+      // Should only dismiss session-1's toast
+      expect(onMarkRead).toHaveBeenCalledTimes(1);
+      expect(onMarkRead).toHaveBeenCalledWith(item1.id);
+      expect(result.current.heldCount).toBe(1);
+    });
+  });
+
+  // ==========================================================================
+  // Timer cleanup on unmount
+  // ==========================================================================
+
+  describe('timer cleanup on unmount', () => {
+    it('should clear active toast after timeout', () => {
+      const onShowToast = mock<(toast: ToastNotification) => void>(() => {});
+      const config = createConfig();
+      const item = createInboxItem();
+
+      const { result, rerender } = renderHook(
+        ({ items }) => useNotifications({
+          items,
+          config,
+          onShowToast,
+          isUserActive: true,
+        }),
+        { initialProps: { items: [] as InboxItem[] } }
+      );
+
+      rerender({ items: [item] });
+      expect(result.current.activeToast).not.toBeNull();
+
+      // Advance time by 10 seconds (TOAST_ACTIVE_DURATION_MS)
+      act(() => {
+        jest.advanceTimersByTime(10000);
+      });
+
+      expect(result.current.activeToast).toBeNull();
+    });
+
+    it('should clear timeout on unmount', () => {
+      const onShowToast = mock<(toast: ToastNotification) => void>(() => {});
+      const config = createConfig();
+      const item = createInboxItem();
+
+      const { rerender, unmount } = renderHook(
+        ({ items }) => useNotifications({
+          items,
+          config,
+          onShowToast,
+          isUserActive: true,
+        }),
+        { initialProps: { items: [] as InboxItem[] } }
+      );
+
+      rerender({ items: [item] });
+
+      // Unmount before timeout fires
+      unmount();
+
+      // This should not throw - timeout should be cleared
+      act(() => {
+        jest.advanceTimersByTime(10000);
+      });
+    });
+  });
+
+  // ==========================================================================
+  // Polling behavior
+  // ==========================================================================
+
+  describe('polling behavior', () => {
+    it('should call onRefreshInbox at specified interval', () => {
+      const onRefreshInbox = mock<() => Promise<void>>(() => Promise.resolve());
+      const config = createConfig();
+
+      renderHook(() => useNotifications({
+        items: [],
+        config,
+        pollIntervalMs: 5000,
+        onRefreshInbox,
+        isUserActive: true,
+      }));
+
+      expect(onRefreshInbox).not.toHaveBeenCalled();
+
+      act(() => {
+        jest.advanceTimersByTime(5000);
+      });
+      expect(onRefreshInbox).toHaveBeenCalledTimes(1);
+
+      act(() => {
+        jest.advanceTimersByTime(5000);
+      });
+      expect(onRefreshInbox).toHaveBeenCalledTimes(2);
+    });
+
+    it('should not poll when pollIntervalMs is 0', () => {
+      const onRefreshInbox = mock<() => Promise<void>>(() => Promise.resolve());
+      const config = createConfig();
+
+      renderHook(() => useNotifications({
+        items: [],
+        config,
+        pollIntervalMs: 0,
+        onRefreshInbox,
+        isUserActive: true,
+      }));
+
+      act(() => {
+        jest.advanceTimersByTime(10000);
+      });
+
+      expect(onRefreshInbox).not.toHaveBeenCalled();
+    });
+
+    it('should clear polling interval on unmount', () => {
+      const onRefreshInbox = mock<() => Promise<void>>(() => Promise.resolve());
+      const config = createConfig();
+
+      const { unmount } = renderHook(() => useNotifications({
+        items: [],
+        config,
+        pollIntervalMs: 5000,
+        onRefreshInbox,
+        isUserActive: true,
+      }));
+
+      unmount();
+
+      act(() => {
+        jest.advanceTimersByTime(10000);
+      });
+
+      // Should not have been called after unmount
+      expect(onRefreshInbox).not.toHaveBeenCalled();
+    });
+  });
+
+  // ==========================================================================
+  // clearActiveToast and attachToActiveToast
+  // ==========================================================================
+
+  describe('clearActiveToast', () => {
+    it('should clear active toast and cancel timeout', () => {
+      const onShowToast = mock<(toast: ToastNotification) => void>(() => {});
+      const config = createConfig();
+      const item = createInboxItem();
+
+      const { result, rerender } = renderHook(
+        ({ items }) => useNotifications({
+          items,
+          config,
+          onShowToast,
+          isUserActive: true,
+        }),
+        { initialProps: { items: [] as InboxItem[] } }
+      );
+
+      rerender({ items: [item] });
+      expect(result.current.activeToast).not.toBeNull();
+
+      act(() => {
+        result.current.clearActiveToast();
+      });
+
+      expect(result.current.activeToast).toBeNull();
+    });
+  });
+
+  describe('attachToActiveToast', () => {
+    it('should call onAttachSession with session ID and clear toast', () => {
+      const onShowToast = mock<(toast: ToastNotification) => void>(() => {});
+      const onAttachSession = mock<(sessionId: string) => void>(() => {});
+      const config = createConfig();
+      const item = createInboxItem({ sessionId: 'session-to-attach' });
+
+      const { result, rerender } = renderHook(
+        ({ items }) => useNotifications({
+          items,
+          config,
+          onShowToast,
+          onAttachSession,
+          isUserActive: true,
+        }),
+        { initialProps: { items: [] as InboxItem[] } }
+      );
+
+      rerender({ items: [item] });
+      expect(result.current.activeToast).not.toBeNull();
+
+      act(() => {
+        result.current.attachToActiveToast();
+      });
+
+      expect(onAttachSession).toHaveBeenCalledWith('session-to-attach');
+      expect(result.current.activeToast).toBeNull();
+    });
+
+    it('should do nothing if no active toast', () => {
+      const onAttachSession = mock<(sessionId: string) => void>(() => {});
+      const config = createConfig();
+
+      const { result } = renderHook(() => useNotifications({
+        items: [],
+        config,
+        onAttachSession,
+        isUserActive: true,
+      }));
+
+      act(() => {
+        result.current.attachToActiveToast();
+      });
+
+      expect(onAttachSession).not.toHaveBeenCalled();
+    });
+  });
+
+  // ==========================================================================
+  // mostRecentUnread
+  // ==========================================================================
+
+  describe('mostRecentUnread', () => {
+    it('should return most recent unread item', () => {
+      const config = createConfig();
+      const item1 = createInboxItem({ timestamp: 1000, read: false });
+      const item2 = createInboxItem({ timestamp: 2000, read: false });
+      const item3 = createInboxItem({ timestamp: 3000, read: true });
+
+      const { result } = renderHook(() => useNotifications({
+        items: [item1, item2, item3],
+        config,
+        isUserActive: true,
+      }));
+
+      expect(result.current.mostRecentUnread?.id).toBe(item2.id);
+    });
+
+    it('should return null if no unread items', () => {
+      const config = createConfig();
+      const item = createInboxItem({ read: true });
+
+      const { result } = renderHook(() => useNotifications({
+        items: [item],
+        config,
+        isUserActive: true,
+      }));
+
+      expect(result.current.mostRecentUnread).toBeNull();
+    });
+  });
+
+  // ==========================================================================
+  // Config disabled states
+  // ==========================================================================
+
+  describe('config disabled states', () => {
+    it('should not show toasts when notifications disabled', () => {
+      const onShowToast = mock<(toast: ToastNotification) => void>(() => {});
+      const config = createConfig({ enabled: false });
+      const item = createInboxItem();
+
+      const { rerender } = renderHook(
+        ({ items }) => useNotifications({
+          items,
+          config,
+          onShowToast,
+          isUserActive: true,
+        }),
+        { initialProps: { items: [] as InboxItem[] } }
+      );
+
+      rerender({ items: [item] });
+
+      expect(onShowToast).not.toHaveBeenCalled();
+    });
+
+    it('should not show toasts when toast.enabled is false', () => {
+      const onShowToast = mock<(toast: ToastNotification) => void>(() => {});
+      const config = createConfig({ toast: { enabled: false, holdWhenIdleMs: 15000 } });
+      const item = createInboxItem();
+
+      const { rerender } = renderHook(
+        ({ items }) => useNotifications({
+          items,
+          config,
+          onShowToast,
+          isUserActive: true,
+        }),
+        { initialProps: { items: [] as InboxItem[] } }
+      );
+
+      rerender({ items: [item] });
+
+      expect(onShowToast).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/shared/notifications/index.ts
+++ b/src/shared/notifications/index.ts
@@ -1,0 +1,32 @@
+/**
+ * Shared notifications module
+ *
+ * Provides types, policy logic, and hooks for notification handling
+ * across TUI and Web platforms.
+ */
+
+// Types
+export type {
+  NotificationConfig,
+  ToastNotification,
+  InboxDiff,
+} from './types.js';
+export { DEFAULT_NOTIFICATION_CONFIG } from './types.js';
+
+// Policy functions
+export {
+  isNotificationTypeEnabled,
+  filterByConfig,
+  diffInbox,
+  itemToToast,
+  getToastableItems,
+  getMostRecentUnread,
+  getSessionLabel,
+} from './policy.js';
+
+// Hook
+export type {
+  UseNotificationsOptions,
+  UseNotificationsReturn,
+} from './useNotifications.js';
+export { useNotifications } from './useNotifications.js';

--- a/src/shared/notifications/policy.test.ts
+++ b/src/shared/notifications/policy.test.ts
@@ -1,0 +1,408 @@
+import { describe, expect, it } from 'bun:test';
+import {
+  isNotificationTypeEnabled,
+  filterByConfig,
+  diffInbox,
+  itemToToast,
+  getToastableItems,
+  getMostRecentUnread,
+  getSessionLabel,
+} from './policy';
+import type { NotificationConfig } from './types';
+import type { InboxItem } from '../types';
+
+// ============================================================================
+// Test Fixtures
+// ============================================================================
+
+function createInboxItem(overrides: Partial<InboxItem> = {}): InboxItem {
+  return {
+    id: 'test-id-1',
+    sessionId: 'session-1',
+    sessionName: 'my-project:my-workspace:default',
+    type: 'exit',
+    timestamp: Date.now(),
+    read: false,
+    context: 'Command completed',
+    processTitle: 'npm test',
+    exitCode: 0,
+    ...overrides,
+  };
+}
+
+function createConfig(overrides: Partial<NotificationConfig> = {}): NotificationConfig {
+  return {
+    enabled: true,
+    minCommandDurationMs: 10000,
+    types: {
+      exit: true,
+      idle: true,
+      bell: true,
+      title: true,
+      osc: true,
+    },
+    toast: {
+      enabled: true,
+    },
+    ...overrides,
+  };
+}
+
+// ============================================================================
+// isNotificationTypeEnabled
+// ============================================================================
+
+describe('isNotificationTypeEnabled', () => {
+  it('should return false when notifications are disabled globally', () => {
+    const config = createConfig({ enabled: false });
+    expect(isNotificationTypeEnabled('exit', config)).toBe(false);
+    expect(isNotificationTypeEnabled('bell', config)).toBe(false);
+  });
+
+  it('should return true for enabled notification types', () => {
+    const config = createConfig();
+    expect(isNotificationTypeEnabled('exit', config)).toBe(true);
+    expect(isNotificationTypeEnabled('idle', config)).toBe(true);
+    expect(isNotificationTypeEnabled('bell', config)).toBe(true);
+    expect(isNotificationTypeEnabled('title', config)).toBe(true);
+  });
+
+  it('should return false for disabled notification types', () => {
+    const config = createConfig({
+      types: { exit: false, idle: false, bell: true, title: true, osc: true },
+    });
+    expect(isNotificationTypeEnabled('exit', config)).toBe(false);
+    expect(isNotificationTypeEnabled('idle', config)).toBe(false);
+    expect(isNotificationTypeEnabled('bell', config)).toBe(true);
+  });
+
+  it('should handle unknown types by checking osc setting', () => {
+    const configOscOn = createConfig({ types: { exit: true, idle: true, bell: true, title: true, osc: true } });
+    const configOscOff = createConfig({ types: { exit: true, idle: true, bell: true, title: true, osc: false } });
+
+    // Unknown types fall through to osc check
+    expect(isNotificationTypeEnabled('unknown' as any, configOscOn)).toBe(true);
+    expect(isNotificationTypeEnabled('unknown' as any, configOscOff)).toBe(false);
+  });
+});
+
+// ============================================================================
+// filterByConfig
+// ============================================================================
+
+describe('filterByConfig', () => {
+  it('should return empty array when notifications disabled', () => {
+    const items = [createInboxItem({ type: 'exit' }), createInboxItem({ type: 'bell' })];
+    const config = createConfig({ enabled: false });
+
+    expect(filterByConfig(items, config)).toEqual([]);
+  });
+
+  it('should filter out disabled notification types', () => {
+    const exitItem = createInboxItem({ id: '1', type: 'exit' });
+    const bellItem = createInboxItem({ id: '2', type: 'bell' });
+    const idleItem = createInboxItem({ id: '3', type: 'idle' });
+
+    const items = [exitItem, bellItem, idleItem];
+    const config = createConfig({
+      types: { exit: true, idle: false, bell: true, title: true, osc: true },
+    });
+
+    const result = filterByConfig(items, config);
+    expect(result).toHaveLength(2);
+    expect(result.map((i) => i.id)).toEqual(['1', '2']);
+  });
+
+  it('should return all items when all types enabled', () => {
+    const items = [
+      createInboxItem({ id: '1', type: 'exit' }),
+      createInboxItem({ id: '2', type: 'bell' }),
+      createInboxItem({ id: '3', type: 'idle' }),
+      createInboxItem({ id: '4', type: 'title' }),
+    ];
+    const config = createConfig();
+
+    expect(filterByConfig(items, config)).toHaveLength(4);
+  });
+
+  it('should use default config when not provided', () => {
+    const items = [createInboxItem({ type: 'exit' })];
+    // Default config has all types enabled
+    expect(filterByConfig(items)).toHaveLength(1);
+  });
+});
+
+// ============================================================================
+// diffInbox
+// ============================================================================
+
+describe('diffInbox', () => {
+  it('should detect newly added items', () => {
+    const previous: InboxItem[] = [];
+    const current = [createInboxItem({ id: 'new-1' }), createInboxItem({ id: 'new-2' })];
+
+    const diff = diffInbox(previous, current);
+
+    expect(diff.added).toHaveLength(2);
+    expect(diff.added.map((i) => i.id)).toEqual(['new-1', 'new-2']);
+    expect(diff.removed).toHaveLength(0);
+    expect(diff.read).toHaveLength(0);
+  });
+
+  it('should detect removed items', () => {
+    const previous = [createInboxItem({ id: 'old-1' }), createInboxItem({ id: 'old-2' })];
+    const current = [createInboxItem({ id: 'old-1' })];
+
+    const diff = diffInbox(previous, current);
+
+    expect(diff.added).toHaveLength(0);
+    expect(diff.removed).toHaveLength(1);
+    expect(diff.removed[0].id).toBe('old-2');
+  });
+
+  it('should detect items marked as read', () => {
+    const previous = [
+      createInboxItem({ id: 'item-1', read: false }),
+      createInboxItem({ id: 'item-2', read: false }),
+    ];
+    const current = [
+      createInboxItem({ id: 'item-1', read: true }),
+      createInboxItem({ id: 'item-2', read: false }),
+    ];
+
+    const diff = diffInbox(previous, current);
+
+    expect(diff.added).toHaveLength(0);
+    expect(diff.removed).toHaveLength(0);
+    expect(diff.read).toHaveLength(1);
+    expect(diff.read[0].id).toBe('item-1');
+  });
+
+  it('should handle mixed changes', () => {
+    const previous = [
+      createInboxItem({ id: 'kept', read: false }),
+      createInboxItem({ id: 'removed', read: false }),
+      createInboxItem({ id: 'marked-read', read: false }),
+    ];
+    const current = [
+      createInboxItem({ id: 'kept', read: false }),
+      createInboxItem({ id: 'marked-read', read: true }),
+      createInboxItem({ id: 'added', read: false }),
+    ];
+
+    const diff = diffInbox(previous, current);
+
+    expect(diff.added).toHaveLength(1);
+    expect(diff.added[0].id).toBe('added');
+    expect(diff.removed).toHaveLength(1);
+    expect(diff.removed[0].id).toBe('removed');
+    expect(diff.read).toHaveLength(1);
+    expect(diff.read[0].id).toBe('marked-read');
+  });
+
+  it('should not include previously read items in read list', () => {
+    const previous = [createInboxItem({ id: 'already-read', read: true })];
+    const current = [createInboxItem({ id: 'already-read', read: true })];
+
+    const diff = diffInbox(previous, current);
+    expect(diff.read).toHaveLength(0);
+  });
+});
+
+// ============================================================================
+// itemToToast
+// ============================================================================
+
+describe('itemToToast', () => {
+  it('should convert exit item with zero exit code', () => {
+    const item = createInboxItem({
+      id: 'exit-0',
+      type: 'exit',
+      exitCode: 0,
+      processTitle: 'npm test',
+      context: 'Tests passed\nAll 42 tests passed',
+    });
+
+    const toast = itemToToast(item);
+
+    expect(toast.id).toBe('exit-0');
+    expect(toast.sessionId).toBe('session-1');
+    expect(toast.sessionName).toBe('my-project:my-workspace:default');
+    expect(toast.icon).toBe('✅');
+    expect(toast.title).toBe('Completed: npm test');
+    expect(toast.preview).toBe('Tests passed');
+    expect(toast.item).toBe(item);
+  });
+
+  it('should convert exit item with non-zero exit code', () => {
+    const item = createInboxItem({
+      type: 'exit',
+      exitCode: 1,
+      processTitle: 'npm build',
+      context: 'Build failed',
+    });
+
+    const toast = itemToToast(item);
+
+    expect(toast.icon).toBe('❌');
+    expect(toast.title).toBe('Exit code 1: npm build');
+  });
+
+  it('should convert bell item', () => {
+    const item = createInboxItem({
+      type: 'bell',
+      processTitle: undefined,
+      context: 'Alert notification',
+    });
+
+    const toast = itemToToast(item);
+
+    expect(toast.icon).toBe('🔔');
+    expect(toast.title).toBe('Bell');
+  });
+
+  it('should convert idle item', () => {
+    const item = createInboxItem({
+      type: 'idle',
+      processTitle: 'vim',
+      context: 'No activity for 5 minutes',
+    });
+
+    const toast = itemToToast(item);
+
+    expect(toast.icon).toBe('⏸️');
+    expect(toast.title).toBe('Activity Complete: vim');
+  });
+
+  it('should convert title item', () => {
+    const item = createInboxItem({
+      type: 'title',
+      processTitle: 'bash',
+      context: 'Title changed to: ~/projects',
+    });
+
+    const toast = itemToToast(item);
+
+    expect(toast.icon).toBe('📝');
+    expect(toast.title).toBe('Title Change: bash');
+  });
+
+  it('should truncate long preview text', () => {
+    const longContext = 'A'.repeat(100) + '\nSecond line';
+    const item = createInboxItem({ context: longContext });
+
+    const toast = itemToToast(item);
+
+    expect(toast.preview.length).toBeLessThanOrEqual(60);
+  });
+});
+
+// ============================================================================
+// getToastableItems
+// ============================================================================
+
+describe('getToastableItems', () => {
+  it('should return empty array when notifications disabled', () => {
+    const items = [createInboxItem()];
+    const config = createConfig({ enabled: false });
+
+    expect(getToastableItems(items, config)).toEqual([]);
+  });
+
+  it('should return empty array when toasts disabled', () => {
+    const items = [createInboxItem()];
+    const config = createConfig({ toast: { enabled: false } });
+
+    expect(getToastableItems(items, config)).toEqual([]);
+  });
+
+  it('should filter and convert items to toasts', () => {
+    const items = [
+      createInboxItem({ id: '1', type: 'exit' }),
+      createInboxItem({ id: '2', type: 'bell' }),
+    ];
+    const config = createConfig({
+      types: { exit: true, idle: true, bell: false, title: true, osc: true },
+    });
+
+    const toasts = getToastableItems(items, config);
+
+    expect(toasts).toHaveLength(1);
+    expect(toasts[0].id).toBe('1');
+  });
+
+  it('should use default config when not provided', () => {
+    const items = [createInboxItem({ id: '1' })];
+
+    const toasts = getToastableItems(items);
+
+    expect(toasts).toHaveLength(1);
+  });
+});
+
+// ============================================================================
+// getMostRecentUnread
+// ============================================================================
+
+describe('getMostRecentUnread', () => {
+  it('should return null for empty array', () => {
+    expect(getMostRecentUnread([])).toBeNull();
+  });
+
+  it('should return null when all items are read', () => {
+    const items = [
+      createInboxItem({ id: '1', read: true }),
+      createInboxItem({ id: '2', read: true }),
+    ];
+
+    expect(getMostRecentUnread(items)).toBeNull();
+  });
+
+  it('should return the most recent unread item', () => {
+    const now = Date.now();
+    const items = [
+      createInboxItem({ id: 'old', read: false, timestamp: now - 2000 }),
+      createInboxItem({ id: 'newest', read: false, timestamp: now }),
+      createInboxItem({ id: 'middle', read: false, timestamp: now - 1000 }),
+    ];
+
+    const result = getMostRecentUnread(items);
+
+    expect(result).not.toBeNull();
+    expect(result!.id).toBe('newest');
+  });
+
+  it('should skip read items even if more recent', () => {
+    const now = Date.now();
+    const items = [
+      createInboxItem({ id: 'read-newest', read: true, timestamp: now }),
+      createInboxItem({ id: 'unread-older', read: false, timestamp: now - 1000 }),
+    ];
+
+    const result = getMostRecentUnread(items);
+
+    expect(result).not.toBeNull();
+    expect(result!.id).toBe('unread-older');
+  });
+});
+
+// ============================================================================
+// getSessionLabel
+// ============================================================================
+
+describe('getSessionLabel', () => {
+  it('should format session name into label', () => {
+    expect(getSessionLabel('my-project:my-workspace:default')).toBe(
+      'my-project / my-workspace / default'
+    );
+  });
+
+  it('should handle missing parts', () => {
+    expect(getSessionLabel('project')).toBe('project / unknown / unknown');
+    expect(getSessionLabel('project:workspace')).toBe('project / workspace / unknown');
+  });
+
+  it('should handle empty string', () => {
+    expect(getSessionLabel('')).toBe('unknown / unknown / unknown');
+  });
+});

--- a/src/shared/notifications/policy.test.ts
+++ b/src/shared/notifications/policy.test.ts
@@ -43,6 +43,7 @@ function createConfig(overrides: Partial<NotificationConfig> = {}): Notification
     },
     toast: {
       enabled: true,
+      holdWhenIdleMs: 15000,
     },
     ...overrides,
   };
@@ -311,7 +312,7 @@ describe('getToastableItems', () => {
 
   it('should return empty array when toasts disabled', () => {
     const items = [createInboxItem()];
-    const config = createConfig({ toast: { enabled: false } });
+    const config = createConfig({ toast: { enabled: false, holdWhenIdleMs: 15000 } });
 
     expect(getToastableItems(items, config)).toEqual([]);
   });

--- a/src/shared/notifications/policy.ts
+++ b/src/shared/notifications/policy.ts
@@ -1,0 +1,136 @@
+/**
+ * Notification Policy
+ *
+ * Shared logic for filtering notifications based on user config.
+ * Used by both TUI and Web to determine which notifications to show.
+ */
+
+import type { InboxItem } from '../types.js';
+import type { NotificationConfig, ToastNotification, InboxDiff } from './types.js';
+import { DEFAULT_NOTIFICATION_CONFIG } from './types.js';
+import {
+  parseSessionName,
+  getInboxIcon,
+  getInboxTypeLabel,
+} from '../components/Inbox.js';
+
+/**
+ * Check if a notification type is enabled in config
+ */
+export function isNotificationTypeEnabled(
+  type: InboxItem['type'],
+  config: NotificationConfig
+): boolean {
+  if (!config.enabled) return false;
+
+  switch (type) {
+    case 'exit':
+      return config.types.exit;
+    case 'idle':
+      return config.types.idle;
+    case 'bell':
+      return config.types.bell;
+    case 'title':
+      return config.types.title;
+    default:
+      // OSC notifications come through as 'bell' type with context
+      return config.types.osc;
+  }
+}
+
+/**
+ * Filter inbox items based on notification config
+ */
+export function filterByConfig(
+  items: InboxItem[],
+  config: NotificationConfig = DEFAULT_NOTIFICATION_CONFIG
+): InboxItem[] {
+  if (!config.enabled) return [];
+
+  return items.filter((item) => isNotificationTypeEnabled(item.type, config));
+}
+
+/**
+ * Compare two inbox states and return the diff
+ */
+export function diffInbox(
+  previous: InboxItem[],
+  current: InboxItem[]
+): InboxDiff {
+  const prevIds = new Set(previous.map((i) => i.id));
+  const currIds = new Set(current.map((i) => i.id));
+  const prevReadIds = new Set(previous.filter((i) => i.read).map((i) => i.id));
+
+  const added = current.filter((i) => !prevIds.has(i.id));
+  const removed = previous.filter((i) => !currIds.has(i.id));
+  const read = current.filter(
+    (i) => i.read && prevIds.has(i.id) && !prevReadIds.has(i.id)
+  );
+
+  return { added, removed, read };
+}
+
+/**
+ * Convert an inbox item to a toast notification
+ */
+export function itemToToast(item: InboxItem): ToastNotification {
+  const icon = getInboxIcon(item);
+  const typeLabel = getInboxTypeLabel(item);
+
+  // Build a concise title
+  let title = typeLabel;
+  if (item.processTitle) {
+    title = `${typeLabel}: ${item.processTitle}`;
+  }
+
+  // Preview is the first line of context, truncated
+  const preview = item.context.split('\n')[0]?.substring(0, 60) || '';
+
+  return {
+    id: item.id,
+    sessionId: item.sessionId,
+    sessionName: item.sessionName,
+    icon,
+    title,
+    preview,
+    timestamp: item.timestamp,
+    item,
+  };
+}
+
+/**
+ * Get toast-eligible notifications from new inbox items
+ *
+ * Filters by config and returns ToastNotification objects
+ * for items that should trigger a toast.
+ */
+export function getToastableItems(
+  newItems: InboxItem[],
+  config: NotificationConfig = DEFAULT_NOTIFICATION_CONFIG
+): ToastNotification[] {
+  if (!config.enabled || !config.toast.enabled) {
+    return [];
+  }
+
+  return filterByConfig(newItems, config).map(itemToToast);
+}
+
+/**
+ * Get the most recent unread item (for quick-jump)
+ */
+export function getMostRecentUnread(items: InboxItem[]): InboxItem | null {
+  const unread = items.filter((i) => !i.read);
+  if (unread.length === 0) return null;
+
+  // Sort by timestamp descending
+  unread.sort((a, b) => b.timestamp - a.timestamp);
+  return unread[0];
+}
+
+/**
+ * Session label for display (project / workspace / session)
+ */
+export function getSessionLabel(sessionName: string): string {
+  const parts = parseSessionName(sessionName);
+  return `${parts.project} / ${parts.workspace} / ${parts.session}`;
+}

--- a/src/shared/notifications/types.ts
+++ b/src/shared/notifications/types.ts
@@ -1,0 +1,79 @@
+/**
+ * Shared notification types
+ *
+ * Types used across TUI, Web, and tmux-lite for notification handling.
+ */
+
+import type { InboxItem } from '../types.js';
+
+/**
+ * Notification config as used by the shared notification system.
+ * This matches the structure from types/config.ts but is redeclared
+ * for environments (like web) that can't import node-only config modules.
+ */
+export interface NotificationConfig {
+  enabled: boolean;
+  minCommandDurationMs: number;
+  types: {
+    exit: boolean;
+    idle: boolean;
+    bell: boolean;
+    title: boolean;
+    osc: boolean;
+  };
+  toast: {
+    enabled: boolean;
+  };
+}
+
+/**
+ * Default notification config (matches types/config.ts)
+ */
+export const DEFAULT_NOTIFICATION_CONFIG: NotificationConfig = {
+  enabled: true,
+  minCommandDurationMs: 10000,
+  types: {
+    exit: true,
+    idle: true,
+    bell: true,
+    title: true,
+    osc: true,
+  },
+  toast: {
+    enabled: true,
+  },
+};
+
+/**
+ * Toast notification data
+ */
+export interface ToastNotification {
+  /** Unique ID for deduplication */
+  id: string;
+  /** Session ID to attach to */
+  sessionId: string;
+  /** Session display name */
+  sessionName: string;
+  /** Notification type icon */
+  icon: string;
+  /** Title for the toast */
+  title: string;
+  /** Preview/context text */
+  preview: string;
+  /** Timestamp */
+  timestamp: number;
+  /** Original inbox item */
+  item: InboxItem;
+}
+
+/**
+ * Result from comparing inbox states
+ */
+export interface InboxDiff {
+  /** Newly added items since last check */
+  added: InboxItem[];
+  /** Items that were removed */
+  removed: InboxItem[];
+  /** Items that were marked as read */
+  read: InboxItem[];
+}

--- a/src/shared/notifications/types.ts
+++ b/src/shared/notifications/types.ts
@@ -23,6 +23,8 @@ export interface NotificationConfig {
   };
   toast: {
     enabled: boolean;
+    /** Hold toasts when user is idle for this duration (ms). 0 = disabled. (default: 15000) */
+    holdWhenIdleMs: number;
   };
 }
 
@@ -41,6 +43,7 @@ export const DEFAULT_NOTIFICATION_CONFIG: NotificationConfig = {
   },
   toast: {
     enabled: true,
+    holdWhenIdleMs: 15000,
   },
 };
 

--- a/src/shared/notifications/useNotifications.ts
+++ b/src/shared/notifications/useNotifications.ts
@@ -1,0 +1,179 @@
+/**
+ * useNotifications Hook
+ *
+ * Shared hook for managing notification toasts and quick-attach.
+ * Works with both TUI and Web by accepting platform-specific callbacks.
+ */
+
+import { useState, useCallback, useRef, useEffect } from 'react';
+import type { InboxItem } from '../types.js';
+import type { NotificationConfig, ToastNotification } from './types.js';
+import { DEFAULT_NOTIFICATION_CONFIG } from './types.js';
+import { diffInbox, getToastableItems, getMostRecentUnread } from './policy.js';
+
+/**
+ * Options for useNotifications hook
+ */
+export interface UseNotificationsOptions {
+  /** Current inbox items */
+  items: InboxItem[];
+  /** Notification config */
+  config?: NotificationConfig;
+  /** Callback when a toast should be shown */
+  onShowToast?: (notification: ToastNotification) => void;
+  /** Callback to attach to a session */
+  onAttachSession?: (sessionId: string) => void;
+  /** Polling interval in ms (0 to disable) */
+  pollIntervalMs?: number;
+  /** Callback to refresh inbox */
+  onRefreshInbox?: () => Promise<void>;
+}
+
+/**
+ * Return type for useNotifications hook
+ */
+export interface UseNotificationsReturn {
+  /** Currently visible toast (for hotkey handling) */
+  activeToast: ToastNotification | null;
+  /** Clear the active toast */
+  clearActiveToast: () => void;
+  /** Attach to the active toast's session (for hotkey) */
+  attachToActiveToast: () => void;
+  /** Get most recent unread item */
+  mostRecentUnread: InboxItem | null;
+  /** Number of toasts shown since mount */
+  toastCount: number;
+}
+
+/**
+ * Hook for managing notification toasts
+ *
+ * Tracks inbox changes and triggers toast callbacks for new items.
+ * Maintains an "active toast" reference for quick-attach via hotkey.
+ *
+ * @example
+ * ```tsx
+ * const notifications = useNotifications({
+ *   items: inbox,
+ *   config: notificationConfig,
+ *   onShowToast: (toast) => {
+ *     // Show platform-specific toast
+ *     sonner.info(toast.title, { description: toast.preview });
+ *   },
+ *   onAttachSession: (sessionId) => {
+ *     terminal.attachSession({ sessionId });
+ *   },
+ * });
+ *
+ * // Handle Shift+Tab to attach to active toast
+ * if (event.shiftKey && event.key === 'Tab' && notifications.activeToast) {
+ *   notifications.attachToActiveToast();
+ * }
+ * ```
+ */
+export function useNotifications(
+  options: UseNotificationsOptions
+): UseNotificationsReturn {
+  const {
+    items,
+    config = DEFAULT_NOTIFICATION_CONFIG,
+    onShowToast,
+    onAttachSession,
+    pollIntervalMs = 0,
+    onRefreshInbox,
+  } = options;
+
+  // Track previous inbox items for diffing
+  const prevItemsRef = useRef<InboxItem[]>([]);
+
+  // Active toast (most recent, for hotkey attach)
+  const [activeToast, setActiveToast] = useState<ToastNotification | null>(null);
+
+  // Toast count for debugging/stats
+  const [toastCount, setToastCount] = useState(0);
+
+  // Timer ref for clearing active toast
+  const clearTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Clear active toast after a delay (e.g., 10 seconds)
+  const TOAST_ACTIVE_DURATION_MS = 10000;
+
+  const clearActiveToast = useCallback(() => {
+    if (clearTimerRef.current) {
+      clearTimeout(clearTimerRef.current);
+      clearTimerRef.current = null;
+    }
+    setActiveToast(null);
+  }, []);
+
+  const attachToActiveToast = useCallback(() => {
+    if (activeToast && onAttachSession) {
+      onAttachSession(activeToast.sessionId);
+      clearActiveToast();
+    }
+  }, [activeToast, onAttachSession, clearActiveToast]);
+
+  // Detect new items and trigger toasts
+  useEffect(() => {
+    if (!config.enabled || !config.toast.enabled) {
+      prevItemsRef.current = items;
+      return;
+    }
+
+    const diff = diffInbox(prevItemsRef.current, items);
+    prevItemsRef.current = items;
+
+    if (diff.added.length === 0) return;
+
+    const toastable = getToastableItems(diff.added, config);
+    if (toastable.length === 0) return;
+
+    // Show toasts for new items
+    for (const toast of toastable) {
+      onShowToast?.(toast);
+      setToastCount((c) => c + 1);
+    }
+
+    // Set the most recent as active toast
+    const mostRecent = toastable[toastable.length - 1];
+    setActiveToast(mostRecent);
+
+    // Clear active toast after timeout
+    if (clearTimerRef.current) {
+      clearTimeout(clearTimerRef.current);
+    }
+    clearTimerRef.current = setTimeout(() => {
+      setActiveToast(null);
+    }, TOAST_ACTIVE_DURATION_MS);
+  }, [items, config, onShowToast]);
+
+  // Polling for inbox refresh
+  useEffect(() => {
+    if (pollIntervalMs <= 0 || !onRefreshInbox) return;
+
+    const interval = setInterval(() => {
+      onRefreshInbox();
+    }, pollIntervalMs);
+
+    return () => clearInterval(interval);
+  }, [pollIntervalMs, onRefreshInbox]);
+
+  // Cleanup timer on unmount
+  useEffect(() => {
+    return () => {
+      if (clearTimerRef.current) {
+        clearTimeout(clearTimerRef.current);
+      }
+    };
+  }, []);
+
+  const mostRecentUnread = getMostRecentUnread(items);
+
+  return {
+    activeToast,
+    clearActiveToast,
+    attachToActiveToast,
+    mostRecentUnread,
+    toastCount,
+  };
+}

--- a/src/shared/notifications/useNotifications.ts
+++ b/src/shared/notifications/useNotifications.ts
@@ -3,6 +3,13 @@
  *
  * Shared hook for managing notification toasts and quick-attach.
  * Works with both TUI and Web by accepting platform-specific callbacks.
+ *
+ * Features:
+ * - Show toasts for new inbox items
+ * - Hold toasts when user is inactive (latest per session)
+ * - Auto-dismiss notifications for the current active session
+ * - Flush held toasts when user becomes active
+ * - Auto-dismiss held toasts on session detach
  */
 
 import { useState, useCallback, useRef, useEffect } from 'react';
@@ -23,10 +30,16 @@ export interface UseNotificationsOptions {
   onShowToast?: (notification: ToastNotification) => void;
   /** Callback to attach to a session */
   onAttachSession?: (sessionId: string) => void;
+  /** Callback to mark an inbox item as read (for auto-dismiss) */
+  onMarkRead?: (itemId: string) => Promise<void>;
   /** Polling interval in ms (0 to disable) */
   pollIntervalMs?: number;
   /** Callback to refresh inbox */
   onRefreshInbox?: () => Promise<void>;
+  /** Whether user is currently active (for holding toasts). Default: true */
+  isUserActive?: boolean;
+  /** Session ID user is currently attached to (skip/auto-dismiss toasts for this session) */
+  currentSessionId?: string;
 }
 
 /**
@@ -43,6 +56,8 @@ export interface UseNotificationsReturn {
   mostRecentUnread: InboxItem | null;
   /** Number of toasts shown since mount */
   toastCount: number;
+  /** Number of toasts currently held (waiting for activity) */
+  heldCount: number;
 }
 
 /**
@@ -57,18 +72,17 @@ export interface UseNotificationsReturn {
  *   items: inbox,
  *   config: notificationConfig,
  *   onShowToast: (toast) => {
- *     // Show platform-specific toast
  *     sonner.info(toast.title, { description: toast.preview });
  *   },
  *   onAttachSession: (sessionId) => {
  *     terminal.attachSession({ sessionId });
  *   },
+ *   onMarkRead: async (itemId) => {
+ *     await markInboxRead(itemId);
+ *   },
+ *   isUserActive,
+ *   currentSessionId: attachedSession?.id,
  * });
- *
- * // Handle Shift+Tab to attach to active toast
- * if (event.shiftKey && event.key === 'Tab' && notifications.activeToast) {
- *   notifications.attachToActiveToast();
- * }
  * ```
  */
 export function useNotifications(
@@ -79,18 +93,31 @@ export function useNotifications(
     config = DEFAULT_NOTIFICATION_CONFIG,
     onShowToast,
     onAttachSession,
+    onMarkRead,
     pollIntervalMs = 0,
     onRefreshInbox,
+    isUserActive = true,
+    currentSessionId,
   } = options;
 
   // Track previous inbox items for diffing
   const prevItemsRef = useRef<InboxItem[]>([]);
+
+  // Track previous session ID to detect detach
+  const prevSessionIdRef = useRef<string | undefined>(undefined);
+
+  // Track previous isUserActive to detect activity resumption
+  const prevIsUserActiveRef = useRef<boolean>(true);
 
   // Active toast (most recent, for hotkey attach)
   const [activeToast, setActiveToast] = useState<ToastNotification | null>(null);
 
   // Toast count for debugging/stats
   const [toastCount, setToastCount] = useState(0);
+
+  // Held toasts (sessionId -> latest toast) - waiting for user to become active
+  const heldToastsRef = useRef<Map<string, ToastNotification>>(new Map());
+  const [heldCount, setHeldCount] = useState(0);
 
   // Timer ref for clearing active toast
   const clearTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -113,7 +140,82 @@ export function useNotifications(
     }
   }, [activeToast, onAttachSession, clearActiveToast]);
 
-  // Detect new items and trigger toasts
+  // Helper to show a toast and update state
+  const showToast = useCallback((toast: ToastNotification) => {
+    onShowToast?.(toast);
+    setToastCount((c) => c + 1);
+    setActiveToast(toast);
+
+    // Clear active toast after timeout
+    if (clearTimerRef.current) {
+      clearTimeout(clearTimerRef.current);
+    }
+    clearTimerRef.current = setTimeout(() => {
+      setActiveToast(null);
+    }, TOAST_ACTIVE_DURATION_MS);
+  }, [onShowToast]);
+
+  // Helper to auto-dismiss a notification
+  const autoDismiss = useCallback(async (itemId: string) => {
+    if (onMarkRead) {
+      try {
+        await onMarkRead(itemId);
+      } catch {
+        // Ignore errors - notification is best-effort
+      }
+    }
+  }, [onMarkRead]);
+
+  // Detect session detach and auto-dismiss held toasts for that session
+  useEffect(() => {
+    const prevSessionId = prevSessionIdRef.current;
+    prevSessionIdRef.current = currentSessionId;
+
+    // If we just detached from a session (had a session, now don't or different)
+    if (prevSessionId && prevSessionId !== currentSessionId) {
+      // Auto-dismiss any held toasts for the detached session
+      const heldForSession = heldToastsRef.current.get(prevSessionId);
+      if (heldForSession) {
+        autoDismiss(heldForSession.id);
+        heldToastsRef.current.delete(prevSessionId);
+        setHeldCount(heldToastsRef.current.size);
+      }
+    }
+  }, [currentSessionId, autoDismiss]);
+
+  // Detect activity resumption and flush held toasts
+  useEffect(() => {
+    const wasActive = prevIsUserActiveRef.current;
+    prevIsUserActiveRef.current = isUserActive;
+
+    // If user just became active (was inactive, now active)
+    if (!wasActive && isUserActive && heldToastsRef.current.size > 0) {
+      // Get held toasts, excluding current session
+      const toastsToShow = Array.from(heldToastsRef.current.entries())
+        .filter(([sessionId]) => sessionId !== currentSessionId)
+        .map(([, toast]) => toast)
+        .sort((a, b) => a.timestamp - b.timestamp);
+
+      // Auto-dismiss held toasts for current session (if any)
+      if (currentSessionId) {
+        const currentSessionToast = heldToastsRef.current.get(currentSessionId);
+        if (currentSessionToast) {
+          autoDismiss(currentSessionToast.id);
+        }
+      }
+
+      // Clear held toasts
+      heldToastsRef.current.clear();
+      setHeldCount(0);
+
+      // Show the flushed toasts
+      for (const toast of toastsToShow) {
+        showToast(toast);
+      }
+    }
+  }, [isUserActive, currentSessionId, showToast, autoDismiss]);
+
+  // Detect new items and handle them based on activity state
   useEffect(() => {
     if (!config.enabled || !config.toast.enabled) {
       prevItemsRef.current = items;
@@ -128,24 +230,34 @@ export function useNotifications(
     const toastable = getToastableItems(diff.added, config);
     if (toastable.length === 0) return;
 
-    // Show toasts for new items
+    const holdWhenIdleMs = config.toast.holdWhenIdleMs || 0;
+    const shouldHold = holdWhenIdleMs > 0 && !isUserActive;
+
     for (const toast of toastable) {
-      onShowToast?.(toast);
-      setToastCount((c) => c + 1);
-    }
+      // Case 1: Notification is for the session user is actively watching
+      if (currentSessionId && toast.sessionId === currentSessionId) {
+        if (isUserActive) {
+          // User is actively watching this session - auto-dismiss
+          autoDismiss(toast.id);
+        } else {
+          // User is attached but inactive - hold it
+          heldToastsRef.current.set(toast.sessionId, toast);
+          setHeldCount(heldToastsRef.current.size);
+        }
+        continue;
+      }
 
-    // Set the most recent as active toast
-    const mostRecent = toastable[toastable.length - 1];
-    setActiveToast(mostRecent);
-
-    // Clear active toast after timeout
-    if (clearTimerRef.current) {
-      clearTimeout(clearTimerRef.current);
+      // Case 2: Notification is for a different session
+      if (shouldHold) {
+        // User is inactive - hold toast (latest per session)
+        heldToastsRef.current.set(toast.sessionId, toast);
+        setHeldCount(heldToastsRef.current.size);
+      } else {
+        // User is active - show toast immediately
+        showToast(toast);
+      }
     }
-    clearTimerRef.current = setTimeout(() => {
-      setActiveToast(null);
-    }, TOAST_ACTIVE_DURATION_MS);
-  }, [items, config, onShowToast]);
+  }, [items, config, isUserActive, currentSessionId, showToast, autoDismiss]);
 
   // Polling for inbox refresh
   useEffect(() => {
@@ -175,5 +287,6 @@ export function useNotifications(
     attachToActiveToast,
     mostRecentUnread,
     toastCount,
+    heldCount,
   };
 }

--- a/src/tui/app.tsx
+++ b/src/tui/app.tsx
@@ -10,7 +10,7 @@
 
 import { createCliRenderer } from '@opentui/core';
 import { createRoot, useKeyboard } from '@opentui/react';
-import { useState, useEffect, useCallback, useReducer, Fragment } from 'react';
+import { useState, useEffect, useCallback, useReducer, Fragment, useMemo } from 'react';
 import { Toaster } from '@opentui-ui/toast/react';
 
 // Terminal component
@@ -1159,7 +1159,37 @@ function App({ relayConfig, onQuit }: AppProps) {
     },
   });
 
-  // Notification toasts hook
+  // ========== Activity Tracking for Notifications ==========
+
+  // Track last activity time for idle detection
+  const [lastActivityAt, setLastActivityAt] = useState(Date.now());
+  const [activityTick, setActivityTick] = useState(0); // Forces re-evaluation
+
+  // Callback to update activity timestamp (passed to Terminal)
+  const handleTerminalActivity = useCallback(() => {
+    setLastActivityAt(Date.now());
+  }, []);
+
+  // Re-evaluate isUserActive periodically (every 1 second)
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setActivityTick((t) => t + 1);
+    }, 1000);
+    return () => clearInterval(interval);
+  }, []);
+
+  // Compute whether user is active based on view and last activity
+  const holdWhenIdleMs = DEFAULT_NOTIFICATION_CONFIG.toast.holdWhenIdleMs || 15000;
+  const isUserActive = useMemo(() => {
+    // Always "active" when not in terminal view (browsing projects/workspaces)
+    if (state.view !== 'terminal') return true;
+    // In terminal view, check if activity is recent
+    return Date.now() - lastActivityAt < holdWhenIdleMs;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [state.view, lastActivityAt, holdWhenIdleMs, activityTick]);
+
+  // ========== Notification Toasts ==========
+
   const handleShowToast = useCallback((notification: ToastNotification) => {
     const description = notification.preview
       ? `${notification.preview}\n[Shift+Tab to attach]`
@@ -1177,8 +1207,13 @@ function App({ relayConfig, onQuit }: AppProps) {
     onAttachSession: (sessionId) => {
       handleAttachSession({ sessionId });
     },
-    pollIntervalMs: 5000, // Poll every 5 seconds
+    onMarkRead: async (itemId) => {
+      await markInboxRead(itemId);
+    },
+    pollIntervalMs: 5000,
     onRefreshInbox: refreshInbox,
+    isUserActive,
+    currentSessionId: state.attachedSession?.id,
   });
 
   // ========== Keyboard Handlers ==========
@@ -1581,6 +1616,7 @@ function App({ relayConfig, onQuit }: AppProps) {
           onKicked={handleTerminalKicked}
           onError={handleTerminalError}
           interceptShiftTab={!!notifications.activeToast}
+          onActivity={handleTerminalActivity}
         />
       </Fragment>
     );

--- a/src/tui/app.tsx
+++ b/src/tui/app.tsx
@@ -1161,8 +1161,11 @@ function App({ relayConfig, onQuit }: AppProps) {
 
   // Notification toasts hook
   const handleShowToast = useCallback((notification: ToastNotification) => {
+    const description = notification.preview
+      ? `${notification.preview}\n[Shift+Tab to attach]`
+      : '[Shift+Tab to attach]';
     toast.info(`${notification.icon} ${notification.title}`, {
-      description: notification.preview,
+      description,
       duration: 8000,
     });
   }, []);

--- a/src/tui/app.tsx
+++ b/src/tui/app.tsx
@@ -1618,6 +1618,8 @@ function App({ relayConfig, onQuit }: AppProps) {
           interceptShiftTab={!!notifications.activeToast}
           onActivity={handleTerminalActivity}
         />
+        {/* Flow modal overlay (e.g. "steal session" confirm) */}
+        <FlowTUI flow={flow} />
       </Fragment>
     );
   }

--- a/src/tui/app.tsx
+++ b/src/tui/app.tsx
@@ -38,6 +38,12 @@ import { ProjectListTUI } from '../shared/components/ProjectList.tui.js';
 import { InboxTUI } from '../shared/components/Inbox.tui.js';
 import { useInbox } from '../shared/components/Inbox.js';
 import { clearInbox, markInboxRead } from '../lib/tmux-lite/cli.js';
+import { toast } from '@opentui-ui/toast';
+import {
+  useNotifications,
+  type ToastNotification,
+  DEFAULT_NOTIFICATION_CONFIG,
+} from '../shared/notifications/index.js';
 
 // Local state and config
 import {
@@ -1153,6 +1159,25 @@ function App({ relayConfig, onQuit }: AppProps) {
     },
   });
 
+  // Notification toasts hook
+  const handleShowToast = useCallback((notification: ToastNotification) => {
+    toast.info(`${notification.icon} ${notification.title}`, {
+      description: notification.preview,
+      duration: 8000,
+    });
+  }, []);
+
+  const notifications = useNotifications({
+    items: state.inbox,
+    config: DEFAULT_NOTIFICATION_CONFIG,
+    onShowToast: handleShowToast,
+    onAttachSession: (sessionId) => {
+      handleAttachSession({ sessionId });
+    },
+    pollIntervalMs: 5000, // Poll every 5 seconds
+    onRefreshInbox: refreshInbox,
+  });
+
   // ========== Keyboard Handlers ==========
 
   useKeyboard(async (key) => {
@@ -1385,6 +1410,12 @@ function App({ relayConfig, onQuit }: AppProps) {
     // Inbox shortcut (global) - open full-screen inbox view
     if (key.raw === 'i') {
       dispatch({ type: 'SET_VIEW', view: 'inbox' });
+      return;
+    }
+
+    // Toast-only attach hotkey (Shift+Tab)
+    if (key.shift && key.name === 'tab' && notifications.activeToast) {
+      notifications.attachToActiveToast();
       return;
     }
 

--- a/src/tui/app.tsx
+++ b/src/tui/app.tsx
@@ -1184,6 +1184,13 @@ function App({ relayConfig, onQuit }: AppProps) {
   // ========== Keyboard Handlers ==========
 
   useKeyboard(async (key) => {
+    // Toast-only attach hotkey (Shift+Tab) - check FIRST, even in terminal view
+    // This allows attaching to a different session while in a terminal
+    if (key.shift && key.name === 'tab' && notifications.activeToast) {
+      notifications.attachToActiveToast();
+      return;
+    }
+
     // Don't handle keys when in terminal view (Terminal component handles input)
     if (state.view === 'terminal') {
       return;
@@ -1416,12 +1423,6 @@ function App({ relayConfig, onQuit }: AppProps) {
       return;
     }
 
-    // Toast-only attach hotkey (Shift+Tab)
-    if (key.shift && key.name === 'tab' && notifications.activeToast) {
-      notifications.attachToActiveToast();
-      return;
-    }
-
     // Inbox view keyboard handling
     if (state.view === 'inbox') {
       if (key.name === 'escape') {
@@ -1579,6 +1580,7 @@ function App({ relayConfig, onQuit }: AppProps) {
           onExit={handleTerminalExit}
           onKicked={handleTerminalKicked}
           onError={handleTerminalError}
+          interceptShiftTab={!!notifications.activeToast}
         />
       </Fragment>
     );

--- a/src/tui/components/Terminal.tsx
+++ b/src/tui/components/Terminal.tsx
@@ -57,6 +57,8 @@ export interface TerminalProps {
   onError: (error: string) => void;
   /** When true, Shift+Tab is intercepted by parent for toast attach */
   interceptShiftTab?: boolean;
+  /** Called when user interacts with terminal (for activity tracking) */
+  onActivity?: () => void;
 }
 
 type TerminalStatus = 'connecting' | 'connected' | 'disconnected' | 'error';
@@ -96,7 +98,7 @@ function getTerminalSize() {
   };
 }
 
-export function Terminal({ session, onDetach, onExit, onKicked, onError, interceptShiftTab }: TerminalProps) {
+export function Terminal({ session, onDetach, onExit, onKicked, onError, interceptShiftTab, onActivity }: TerminalProps) {
   const [status, setStatus] = useState<TerminalStatus>('connecting');
   const [errorMsg, setErrorMsg] = useState<string>('');
   const [termSize, setTermSize] = useState(getTerminalSize);
@@ -165,6 +167,9 @@ export function Terminal({ session, onDetach, onExit, onKicked, onError, interce
       const text = e.text ?? '';
       if (text.length === 0) return;
 
+      // Track user activity for notification hold/flush
+      onActivity?.();
+
       const payload = wrapPaste(text, bracketedPasteRef.current.isEnabled);
 
       const frame = encodePTY(Buffer.from(payload));
@@ -178,7 +183,7 @@ export function Terminal({ session, onDetach, onExit, onKicked, onError, interce
     return () => {
       renderer.keyInput.off('paste', handlePaste);
     };
-  }, [renderer]);
+  }, [renderer, onActivity]);
 
   // Track when terminal ref changes to flush pending data
   const [terminalMounted, setTerminalMounted] = useState(false);
@@ -400,6 +405,9 @@ export function Terminal({ session, onDetach, onExit, onKicked, onError, interce
 
     const socket = socketRef.current;
     if (!socket) return;
+
+    // Track user activity for notification hold/flush
+    onActivity?.();
 
     // Check for Ctrl+Esc (detach) - key.name is 'escape' with ctrl modifier
     if (key.name === 'escape' && key.ctrl) {

--- a/src/tui/components/Terminal.tsx
+++ b/src/tui/components/Terminal.tsx
@@ -55,6 +55,8 @@ export interface TerminalProps {
   onExit: (code: number) => void;
   onKicked: () => void;
   onError: (error: string) => void;
+  /** When true, Shift+Tab is intercepted by parent for toast attach */
+  interceptShiftTab?: boolean;
 }
 
 type TerminalStatus = 'connecting' | 'connected' | 'disconnected' | 'error';
@@ -94,7 +96,7 @@ function getTerminalSize() {
   };
 }
 
-export function Terminal({ session, onDetach, onExit, onKicked, onError }: TerminalProps) {
+export function Terminal({ session, onDetach, onExit, onKicked, onError, interceptShiftTab }: TerminalProps) {
   const [status, setStatus] = useState<TerminalStatus>('connecting');
   const [errorMsg, setErrorMsg] = useState<string>('');
   const [termSize, setTermSize] = useState(getTerminalSize);
@@ -437,7 +439,10 @@ export function Terminal({ session, onDetach, onExit, onKicked, onError }: Termi
       const charCode = key.name.toLowerCase().charCodeAt(0) - 96;
       data = String.fromCharCode(charCode);
     } else if (key.shift && key.name === 'tab') {
-      // Shift+Tab (backtab) - send CSI Z
+      // Shift+Tab (backtab) - send CSI Z, unless intercepted by parent for toast
+      if (interceptShiftTab) {
+        return; // Parent handles this for toast attach
+      }
       data = '\x1b[Z';
     } else if (hasModifier && key.name && specialKeys[key.name]) {
       // Special keys with modifiers - construct proper CSI sequence

--- a/src/tui/state.ts
+++ b/src/tui/state.ts
@@ -189,13 +189,30 @@ export async function loadWorkspaces(projectName: string): Promise<WorkspaceStat
 }
 
 /**
- * Load inbox items
+ * Load inbox items with unread count bounded by active sessions.
+ * Returns the number of unique active sessions that have unread notifications,
+ * not the total number of unread items. This prevents the count from growing
+ * unboundedly and caps it at one per active session.
  */
 export async function loadInbox(): Promise<{ items: InboxItem[]; unreadCount: number }> {
   try {
-    const items = await getInbox();
-    const unreadCount = items.filter(i => !i.read).length;
-    return { items, unreadCount };
+    const [items, activeSessions] = await Promise.all([
+      getInbox(),
+      listSessions(),
+    ]);
+    
+    // Build a set of active session IDs
+    const activeSessionIds = new Set(activeSessions.map(s => s.id));
+    
+    // Count unique sessions that have unread items AND are still active
+    const activeSessionsWithUnread = new Set<string>();
+    for (const item of items) {
+      if (!item.read && activeSessionIds.has(item.sessionId)) {
+        activeSessionsWithUnread.add(item.sessionId);
+      }
+    }
+    
+    return { items, unreadCount: activeSessionsWithUnread.size };
   } catch {
     // Server might not be running
     return { items: [], unreadCount: 0 };

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -3,6 +3,65 @@
  */
 
 /**
+ * Notification type toggles
+ */
+export interface NotificationTypeConfig {
+  /** Notify on process exit (default: true) */
+  exit: boolean;
+  /** Notify when terminal goes idle after activity (default: true) */
+  idle: boolean;
+  /** Notify on terminal bell (default: true) */
+  bell: boolean;
+  /** Notify on terminal title change (default: true) */
+  title: boolean;
+  /** Notify on OSC sequences (9, 99, 777) (default: true) */
+  osc: boolean;
+}
+
+/**
+ * Toast notification settings
+ */
+export interface NotificationToastConfig {
+  /** Whether toast notifications are enabled (default: true) */
+  enabled: boolean;
+}
+
+/**
+ * Notification configuration
+ */
+export interface NotificationConfig {
+  /** Whether notifications are enabled globally (default: true) */
+  enabled: boolean;
+  /** Minimum command duration (ms) before notifying on completion (default: 10000) */
+  minCommandDurationMs: number;
+  /** Which notification types are enabled */
+  types: NotificationTypeConfig;
+  /** Toast notification settings */
+  toast: NotificationToastConfig;
+}
+
+/**
+ * Default notification type config
+ */
+export const DEFAULT_NOTIFICATION_TYPES: NotificationTypeConfig = {
+  exit: true,
+  idle: true,
+  bell: true,
+  title: true,
+  osc: true,
+};
+
+/**
+ * Default notification config
+ */
+export const DEFAULT_NOTIFICATION_CONFIG: NotificationConfig = {
+  enabled: true,
+  minCommandDurationMs: 10000,
+  types: { ...DEFAULT_NOTIFICATION_TYPES },
+  toast: { enabled: true },
+};
+
+/**
  * Linear team info stored in config
  */
 export interface LinearTeamInfo {
@@ -30,6 +89,8 @@ export interface GlobalConfig {
   linearTeams?: LinearTeamInfo[];
   /** Default Linear team key for new projects */
   linearDefaultTeam?: string;
+  /** Notification settings */
+  notifications?: NotificationConfig;
 }
 
 /**
@@ -88,6 +149,7 @@ export const DEFAULT_GLOBAL_CONFIG: GlobalConfig = {
   projectsDir: '', // Will be set to ~/gitspace at runtime
   defaultBaseBranch: 'main',
   staleDays: 30,
+  notifications: { ...DEFAULT_NOTIFICATION_CONFIG },
 };
 
 /**

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -24,6 +24,8 @@ export interface NotificationTypeConfig {
 export interface NotificationToastConfig {
   /** Whether toast notifications are enabled (default: true) */
   enabled: boolean;
+  /** Hold toasts when user is idle for this duration (ms). 0 = disabled. (default: 15000) */
+  holdWhenIdleMs: number;
 }
 
 /**
@@ -58,7 +60,7 @@ export const DEFAULT_NOTIFICATION_CONFIG: NotificationConfig = {
   enabled: true,
   minCommandDurationMs: 10000,
   types: { ...DEFAULT_NOTIFICATION_TYPES },
-  toast: { enabled: true },
+  toast: { enabled: true, holdWhenIdleMs: 15000 },
 };
 
 /**

--- a/src/web/bun.lock
+++ b/src/web/bun.lock
@@ -12,6 +12,7 @@
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
         "react-router-dom": "^7.11.0",
+        "sonner": "^1.7.0",
       },
       "devDependencies": {
         "@eslint/js": "^9.39.1",
@@ -507,6 +508,8 @@
     "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
 
     "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
+
+    "sonner": ["sonner@1.7.4", "", { "peerDependencies": { "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc", "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc" } }, "sha512-DIS8z4PfJRbIyfVFDVnK9rO3eYDtse4Omcm6bt0oEr5/jtLgysmjuBl1frJ9E/EQZrFmKx2A8m/s5s9CRXIzhw=="],
 
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 

--- a/src/web/package.json
+++ b/src/web/package.json
@@ -16,7 +16,8 @@
     "ghostty-web": "^0.4.0",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
-    "react-router-dom": "^7.11.0"
+    "react-router-dom": "^7.11.0",
+    "sonner": "^1.7.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.1",

--- a/src/web/src/App.tsx
+++ b/src/web/src/App.tsx
@@ -1,5 +1,5 @@
 /** @jsxImportSource react */
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useRef, useCallback } from "react";
 import { Terminal, type TerminalHandle } from "./components/Terminal";
 import { TerminalControls } from "./components/TerminalControls";
 import { useTerminal } from "./hooks/useTerminal";
@@ -7,6 +7,7 @@ import { useRelayConnection } from "./hooks/useRelayConnection";
 import { useVisualViewport } from "./hooks/useVisualViewport";
 import { parseInviteFromHash } from "./lib/invite";
 import { applyDeviceClasses, isMobileLayout, isTouchDevice } from "./utils/device";
+import { Toaster, toast } from "sonner";
 
 // Import shared components and hooks
 import {
@@ -21,6 +22,11 @@ import { SpacesBrowserWeb } from "../../shared/components/SpacesBrowser.web.js";
 import { FlowWeb } from "../../shared/components/Flow.web.js";
 import { useInbox } from "../../shared/components/Inbox.js";
 import { InboxWeb } from "../../shared/components/Inbox.web.js";
+import {
+  useNotifications,
+  type ToastNotification,
+  DEFAULT_NOTIFICATION_CONFIG,
+} from "../../shared/notifications/index.js";
 
 type View = "machines" | "terminal";
 
@@ -206,6 +212,36 @@ export default function App() {
       terminal.attachSession({ sessionId });
     },
     onClose: () => setShowInbox(false),
+  });
+
+  // Notification toasts hook
+  const handleShowToast = useCallback((notification: ToastNotification) => {
+    toast(notification.title, {
+      description: notification.preview,
+      icon: notification.icon,
+      duration: 8000,
+      action: {
+        label: "Attach",
+        onClick: () => {
+          terminal.attachSession({ sessionId: notification.sessionId });
+        },
+      },
+    });
+  }, [terminal]);
+
+  const notifications = useNotifications({
+    items: terminal.inbox,
+    config: DEFAULT_NOTIFICATION_CONFIG,
+    onShowToast: handleShowToast,
+    onAttachSession: (sessionId) => {
+      terminal.attachSession({ sessionId });
+    },
+    pollIntervalMs: 5000, // Poll every 5 seconds
+    onRefreshInbox: async () => {
+      if (terminal.status === "established") {
+        terminal.requestInbox();
+      }
+    },
   });
 
   // Request workspaces when connection is established and view is "terminal"
@@ -399,6 +435,25 @@ export default function App() {
     return () => window.removeEventListener("keydown", handleKeyDown);
   }, [view, terminal.status, terminal.mode, terminal.detachSession]);
 
+  // Global hotkey for toast-only attach (Shift+Tab)
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      // Skip if in an input field
+      if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) {
+        return;
+      }
+
+      // Shift+Tab: attach to active toast's session
+      if (e.shiftKey && e.key === "Tab" && notifications.activeToast) {
+        e.preventDefault();
+        notifications.attachToActiveToast();
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [notifications.activeToast, notifications.attachToActiveToast]);
+
   // ========== Spaces Browser View (browsing mode) ==========
   if (view === "terminal" && terminal.status === "established" && terminal.mode === "browsing") {
     // Show inbox if open
@@ -407,6 +462,7 @@ export default function App() {
         <>
           <InboxWeb {...inboxProps} />
           <FlowWeb flow={flow} />
+          <Toaster theme="dark" position="top-right" richColors />
         </>
       );
     }
@@ -457,6 +513,7 @@ export default function App() {
           </div>
         </div>
         <FlowWeb flow={flow} />
+        <Toaster theme="dark" position="top-right" richColors />
       </>
     );
   }
@@ -474,52 +531,55 @@ export default function App() {
     };
 
     return (
-      <div className="h-screen w-screen flex flex-col bg-gray-900">
-        <div className="bg-gray-800 px-4 py-2 flex items-center justify-between border-b border-gray-700 min-h-[52px] gap-2">
-          <div className="flex items-center gap-2 sm:gap-4 min-w-0 flex-1">
-            <button
-              onClick={terminal.detachSession}
-              className="text-sm text-gray-400 hover:text-white active:text-blue-400 py-2 pr-2 -ml-2 min-h-[44px] flex items-center flex-shrink-0"
-            >
-              ← <span className="hidden sm:inline ml-1">Workspaces</span>
-            </button>
-            <div className="text-sm text-gray-400 truncate">
-              <span className="text-green-400">●</span>{" "}
-              <span className="hidden sm:inline">{selectedMachine?.label || selectedMachine?.machineId}</span>
-              {terminal.attachedSessionName && (
-                <span className="text-gray-300">
-                  <span className="hidden sm:inline text-gray-500 mx-1">/</span>
-                  {terminal.attachedSessionName.split(':').pop()}
-                </span>
-              )}
+      <>
+        <div className="h-screen w-screen flex flex-col bg-gray-900">
+          <div className="bg-gray-800 px-4 py-2 flex items-center justify-between border-b border-gray-700 min-h-[52px] gap-2">
+            <div className="flex items-center gap-2 sm:gap-4 min-w-0 flex-1">
+              <button
+                onClick={terminal.detachSession}
+                className="text-sm text-gray-400 hover:text-white active:text-blue-400 py-2 pr-2 -ml-2 min-h-[44px] flex items-center flex-shrink-0"
+              >
+                ← <span className="hidden sm:inline ml-1">Workspaces</span>
+              </button>
+              <div className="text-sm text-gray-400 truncate">
+                <span className="text-green-400">●</span>{" "}
+                <span className="hidden sm:inline">{selectedMachine?.label || selectedMachine?.machineId}</span>
+                {terminal.attachedSessionName && (
+                  <span className="text-gray-300">
+                    <span className="hidden sm:inline text-gray-500 mx-1">/</span>
+                    {terminal.attachedSessionName.split(':').pop()}
+                  </span>
+                )}
+              </div>
+            </div>
+            <div className="flex items-center gap-2 flex-shrink-0">
+              <span className="text-xs text-gray-500 hidden sm:inline">Ctrl+Esc</span>
+              <button
+                onClick={terminal.detachSession}
+                className="px-3 py-2 text-sm bg-gray-700 hover:bg-gray-600 active:bg-gray-500 rounded text-white min-h-[44px]"
+              >
+                Detach
+              </button>
             </div>
           </div>
-          <div className="flex items-center gap-2 flex-shrink-0">
-            <span className="text-xs text-gray-500 hidden sm:inline">Ctrl+Esc</span>
-            <button
-              onClick={terminal.detachSession}
-              className="px-3 py-2 text-sm bg-gray-700 hover:bg-gray-600 active:bg-gray-500 rounded text-white min-h-[44px]"
-            >
-              Detach
-            </button>
+          <div className={`flex-1 ${showMobileControls ? 'terminal-with-controls' : ''}`}>
+            <Terminal
+              ref={terminalRef}
+              onData={terminal.send}
+              setWriteCallback={terminal.setWriteCallback}
+              onResize={terminal.resize}
+            />
           </div>
+          {/* Mobile controls toolbar */}
+          {showMobileControls && (
+            <TerminalControls
+              onSendData={handleSendData}
+              onFocusTerminal={handleFocusTerminal}
+            />
+          )}
         </div>
-        <div className={`flex-1 ${showMobileControls ? 'terminal-with-controls' : ''}`}>
-          <Terminal
-            ref={terminalRef}
-            onData={terminal.send}
-            setWriteCallback={terminal.setWriteCallback}
-            onResize={terminal.resize}
-          />
-        </div>
-        {/* Mobile controls toolbar */}
-        {showMobileControls && (
-          <TerminalControls
-            onSendData={handleSendData}
-            onFocusTerminal={handleFocusTerminal}
-          />
-        )}
-      </div>
+        <Toaster theme="dark" position="top-right" richColors />
+      </>
     );
   }
 
@@ -535,22 +595,25 @@ export default function App() {
     }[terminal.status];
 
     return (
-      <div className="h-screen w-screen flex flex-col items-center justify-center bg-gray-900 px-4">
-        <div className="text-center">
-          <div className="text-lg text-white mb-2 break-words">
-            Connecting to {selectedMachine?.label || selectedMachine?.machineId}
+      <>
+        <div className="h-screen w-screen flex flex-col items-center justify-center bg-gray-900 px-4">
+          <div className="text-center">
+            <div className="text-lg text-white mb-2 break-words">
+              Connecting to {selectedMachine?.label || selectedMachine?.machineId}
+            </div>
+            <div className="text-sm text-gray-400">{statusMessage}</div>
+            {terminal.status === "error" && (
+              <button
+                onClick={handleBackToMachines}
+                className="mt-4 px-6 py-3 text-base bg-gray-700 hover:bg-gray-600 active:bg-gray-500 rounded-lg text-white min-h-[48px]"
+              >
+                Back to Machines
+              </button>
+            )}
           </div>
-          <div className="text-sm text-gray-400">{statusMessage}</div>
-          {terminal.status === "error" && (
-            <button
-              onClick={handleBackToMachines}
-              className="mt-4 px-6 py-3 text-base bg-gray-700 hover:bg-gray-600 active:bg-gray-500 rounded-lg text-white min-h-[48px]"
-            >
-              Back to Machines
-            </button>
-          )}
         </div>
-      </div>
+        <Toaster theme="dark" position="top-right" richColors />
+      </>
     );
   }
 
@@ -642,6 +705,7 @@ export default function App() {
         </div>
       </div>
       <FlowWeb flow={flow} />
+      <Toaster theme="dark" position="top-right" richColors />
     </>
   );
 }

--- a/src/web/src/App.tsx
+++ b/src/web/src/App.tsx
@@ -1,5 +1,5 @@
 /** @jsxImportSource react */
-import { useState, useEffect, useRef, useCallback } from "react";
+import { useState, useEffect, useRef, useCallback, useMemo } from "react";
 import { Terminal, type TerminalHandle } from "./components/Terminal";
 import { TerminalControls } from "./components/TerminalControls";
 import { useTerminal } from "./hooks/useTerminal";
@@ -214,7 +214,37 @@ export default function App() {
     onClose: () => setShowInbox(false),
   });
 
-  // Notification toasts hook
+  // ========== Activity Tracking for Notifications ==========
+
+  // Track last activity time for idle detection
+  const [lastActivityAt, setLastActivityAt] = useState(Date.now());
+  const [activityTick, setActivityTick] = useState(0); // Forces re-evaluation
+
+  // Callback to update activity timestamp (passed to Terminal)
+  const handleTerminalActivity = useCallback(() => {
+    setLastActivityAt(Date.now());
+  }, []);
+
+  // Re-evaluate isUserActive periodically (every 1 second)
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setActivityTick((t) => t + 1);
+    }, 1000);
+    return () => clearInterval(interval);
+  }, []);
+
+  // Compute whether user is active based on view and last activity
+  const holdWhenIdleMs = DEFAULT_NOTIFICATION_CONFIG.toast.holdWhenIdleMs || 15000;
+  const isUserActive = useMemo(() => {
+    // Always "active" when not in attached terminal mode
+    if (view !== "terminal" || terminal.mode !== "attached") return true;
+    // In attached mode, check if activity is recent
+    return Date.now() - lastActivityAt < holdWhenIdleMs;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [view, terminal.mode, lastActivityAt, holdWhenIdleMs, activityTick]);
+
+  // ========== Notification Toasts ==========
+
   const handleShowToast = useCallback((notification: ToastNotification) => {
     const description = notification.preview
       ? `${notification.preview} · Shift+Tab to attach`
@@ -239,12 +269,17 @@ export default function App() {
     onAttachSession: (sessionId) => {
       terminal.attachSession({ sessionId });
     },
-    pollIntervalMs: 5000, // Poll every 5 seconds
+    onMarkRead: async (itemId) => {
+      terminal.markInboxItemRead(itemId);
+    },
+    pollIntervalMs: 5000,
     onRefreshInbox: async () => {
       if (terminal.status === "established") {
         terminal.requestInbox();
       }
     },
+    isUserActive,
+    currentSessionId: terminal.attachedSessionId ?? undefined,
   });
 
   // Request workspaces when connection is established and view is "terminal"
@@ -571,6 +606,7 @@ export default function App() {
               onData={terminal.send}
               setWriteCallback={terminal.setWriteCallback}
               onResize={terminal.resize}
+              onActivity={handleTerminalActivity}
             />
           </div>
           {/* Mobile controls toolbar */}

--- a/src/web/src/App.tsx
+++ b/src/web/src/App.tsx
@@ -216,8 +216,11 @@ export default function App() {
 
   // Notification toasts hook
   const handleShowToast = useCallback((notification: ToastNotification) => {
+    const description = notification.preview
+      ? `${notification.preview} · Shift+Tab to attach`
+      : 'Shift+Tab to attach';
     toast(notification.title, {
-      description: notification.preview,
+      description,
       icon: notification.icon,
       duration: 8000,
       action: {

--- a/src/web/src/components/Terminal.tsx
+++ b/src/web/src/components/Terminal.tsx
@@ -5,6 +5,8 @@ interface Props {
   onData: (data: Uint8Array) => void;
   setWriteCallback: (fn: (data: Uint8Array) => void) => void;
   onResize?: (cols: number, rows: number) => void;
+  /** Called when user interacts with terminal (for activity tracking) */
+  onActivity?: () => void;
 }
 
 /** Methods exposed via ref for external control */
@@ -20,13 +22,14 @@ const SCROLL_ACCUMULATOR_THRESHOLD = 30; // pixels of accumulated delta before s
 const TAP_MOVE_THRESHOLD = 10; // max movement to still count as a tap
 
 export const Terminal = forwardRef<TerminalHandle, Props>(function Terminal(
-  { onData, setWriteCallback, onResize },
+  { onData, setWriteCallback, onResize, onActivity },
   ref
 ) {
   const containerRef = useRef<HTMLDivElement>(null);
   const terminalRef = useRef<GhosttyTerminal | null>(null);
   const initializedRef = useRef(false);
   const onDataRef = useRef(onData);
+  const onActivityRef = useRef(onActivity);
 
   // Touch state with accumulated delta pattern
   const touchStateRef = useRef<{
@@ -39,10 +42,14 @@ export const Terminal = forwardRef<TerminalHandle, Props>(function Terminal(
     hasSelection: boolean; // whether user is selecting text
   } | null>(null);
 
-  // Keep ref up to date
+  // Keep refs up to date
   useEffect(() => {
     onDataRef.current = onData;
   }, [onData]);
+
+  useEffect(() => {
+    onActivityRef.current = onActivity;
+  }, [onActivity]);
 
   // Expose methods via ref for external control (e.g., from TerminalControls)
   useImperativeHandle(
@@ -109,6 +116,7 @@ export const Terminal = forwardRef<TerminalHandle, Props>(function Terminal(
 
       // Wire up input
       term.onData((data: string) => {
+        onActivityRef.current?.(); // Track user activity
         onDataRef.current(new TextEncoder().encode(data));
       });
 
@@ -193,8 +201,9 @@ export const Terminal = forwardRef<TerminalHandle, Props>(function Terminal(
           touchStateRef.current &&
           touchStateRef.current.totalMovement < TAP_MOVE_THRESHOLD;
 
-        // If it was a tap, focus the terminal
+        // If it was a tap, focus the terminal and track activity
         if (wasTap && terminalRef.current) {
+          onActivityRef.current?.(); // Track user activity
           terminalRef.current.focus();
         }
 


### PR DESCRIPTION
## Summary
- Add cross-platform notification/inbox system with toast alerts (TUI + Web) and Shift+Tab quick attach.
- Add shell hook installer (`gssh notifications install/uninstall/status`) to emit OSC markers for command start/done and exit codes.
- Bound unread count to active sessions and prune notifications on session exit; show steal-session confirm overlay while in terminal view.

## Notes
- Shift+Tab uses the existing two-step steal confirmation when session is already attached.
- `src/version.generated.js` is treated as generated and ignored.

## Testing
- `bun test`
- `bun run typecheck`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI notifications command (install/uninstall/hook/status) and shell integration.
  * Activity-aware toast notifications across TUI and Web, with Shift+Tab attach flow.
  * Idle tracking and configurable notification options; unread counts now reflect active sessions only.
  * Terminal components wired to surface activity events.

* **Tests**
  * Comprehensive unit and integration tests for notification policy, hooks, CLI hooks, and UI behavior.

* **Chores**
  * Updated ignores and package deps for web/toast and test tooling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->