### PR TITLE
Add visual feedback for lifecycle scripts and long-running operations

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -20,7 +20,7 @@
         "clipboardy": "^5.0.2",
         "commander": "^12.0.0",
         "conf": "^12.0.0",
-        "ghostty-opentui": "^1.3.11",
+        "ghostty-opentui": "^1.3.12",
         "open": "^11.0.0",
         "ora": "^8.0.1",
         "react": "^19.2.3",
@@ -38,10 +38,10 @@
         "typescript": "^5.3.3",
       },
       "optionalDependencies": {
-        "@gitspace/darwin-arm64": "0.2.0-rc.5",
-        "@gitspace/darwin-x64": "0.2.0-rc.5",
-        "@gitspace/linux-arm64": "0.2.0-rc.5",
-        "@gitspace/linux-x64": "0.2.0-rc.5",
+        "@gitspace/darwin-arm64": "0.2.0-rc.9",
+        "@gitspace/darwin-x64": "0.2.0-rc.9",
+        "@gitspace/linux-arm64": "0.2.0-rc.9",
+        "@gitspace/linux-x64": "0.2.0-rc.9",
       },
     },
   },
@@ -65,7 +65,7 @@
 
     "@eslint/js": ["@eslint/js@8.57.1", "", {}, "sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q=="],
 
-    "@gitspace/darwin-arm64": ["@gitspace/darwin-arm64@0.2.0-rc.5", "", { "os": "darwin", "cpu": "arm64", "bin": { "gssh-darwin-arm64": "bin/gssh" } }, "sha512-jeFMG2y/Ztvlfc9BHm1M4yyTR1P5bDtdpA40DVNSSdhGv4NpsGPifVBo5GUwEQOAO9QTHFuxkdAl+LK5dYS9yQ=="],
+    "@gitspace/darwin-arm64": ["@gitspace/darwin-arm64@0.2.0-rc.9", "", { "os": "darwin", "cpu": "arm64", "bin": { "gssh-darwin-arm64": "bin/gssh" } }, "sha512-izzHMx3qom7tAXqPI/BcW5GKino2YizOXWvQsK+pTatIwsXuW8gRqnTCn5SU2ecfOvEArh8qnNPy8lMiBmz+5g=="],
 
     "@graphql-typed-document-node/core": ["@graphql-typed-document-node/core@3.2.0", "", { "peerDependencies": { "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0" } }, "sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ=="],
 
@@ -393,7 +393,7 @@
 
     "get-stream": ["get-stream@9.0.1", "", { "dependencies": { "@sec-ant/readable-stream": "^0.4.1", "is-stream": "^4.0.1" } }, "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA=="],
 
-    "ghostty-opentui": ["ghostty-opentui@1.3.11", "", { "dependencies": { "strip-ansi": "^7.1.2" }, "peerDependencies": { "@opentui/core": "*" }, "optionalPeers": ["@opentui/core"] }, "sha512-taKOhQD65dip/GBi2eDicyS6Z+m7T6CAWyUcFUVP3nX+JKTCiOwfncGqhnqtSa8VE3mG6VHaPzIimDVN7pdD6w=="],
+    "ghostty-opentui": ["ghostty-opentui@1.3.12", "", { "dependencies": { "strip-ansi": "^7.1.2" }, "peerDependencies": { "@opentui/core": "*" }, "optionalPeers": ["@opentui/core"] }, "sha512-ei++1SUPuIlr50OTWirBQCoO12DkjR8Ao4XdIZ2wNA1DuDTkZ+jA0BQygvpRhmW/zb46cHC49UHX2BdAQMB8dg=="],
 
     "gifwrap": ["gifwrap@0.10.1", "", { "dependencies": { "image-q": "^4.0.0", "omggif": "^1.0.10" } }, "sha512-2760b1vpJHNmLzZ/ubTtNnEx5WApN/PYWJvXvgS+tL1egTTthayFYIQQNi136FLEDcN/IyEY2EcGpIITD6eYUw=="],
 

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "clipboardy": "^5.0.2",
     "commander": "^12.0.0",
     "conf": "^12.0.0",
-    "ghostty-opentui": "^1.3.11",
+    "ghostty-opentui": "^1.3.12",
     "open": "^11.0.0",
     "ora": "^8.0.1",
     "react": "^19.2.3",

--- a/src/core/git.ts
+++ b/src/core/git.ts
@@ -106,6 +106,16 @@ export async function checkLocalBranch(
 }
 
 /**
+ * Options for creating a worktree
+ */
+export interface CreateWorktreeOptions {
+  /** Whether the branch exists on the remote */
+  existsRemotely?: boolean;
+  /** Callback to report progress (for TUI loading indicator) */
+  onProgress?: (message: string) => void;
+}
+
+/**
  * Create a git worktree
  */
 export async function createWorktree(
@@ -113,8 +123,14 @@ export async function createWorktree(
   workspacePath: string,
   branchName: string,
   baseBranch: string,
-  existsRemotely?: boolean
+  existsRemotelyOrOptions?: boolean | CreateWorktreeOptions
 ): Promise<void> {
+  // Handle both old signature (boolean) and new signature (options object)
+  const options: CreateWorktreeOptions = typeof existsRemotelyOrOptions === 'boolean'
+    ? { existsRemotely: existsRemotelyOrOptions }
+    : existsRemotelyOrOptions ?? {};
+  const { existsRemotely, onProgress } = options;
+
   try {
     // Check if worktree path already exists
     if (existsSync(workspacePath)) {
@@ -126,10 +142,12 @@ export async function createWorktree(
     }
 
     // Fetch latest changes
+    onProgress?.('Fetching latest changes...');
     logger.debug('Fetching latest changes...');
     await execAsync('git fetch --all --prune', { cwd: repoPath });
 
     // Pull latest base branch
+    onProgress?.(`Updating ${baseBranch}...`);
     try {
       await execAsync(`git pull --ff-only origin ${escapeShellArg(baseBranch)}`, {
         cwd: repoPath,
@@ -141,6 +159,7 @@ export async function createWorktree(
     // Determine how to create the worktree
     if (existsRemotely) {
       // Branch exists on remote, create from remote branch
+      onProgress?.(`Creating worktree from ${branchName}...`);
       logger.debug(`Creating worktree from remote branch: ${branchName}`);
       await execAsync(
         `git worktree add ${escapeShellArg(workspacePath)} -b ${escapeShellArg(branchName)} ${escapeShellArg(`origin/${branchName}`)}`,
@@ -148,6 +167,7 @@ export async function createWorktree(
       );
     } else if (await checkLocalBranch(repoPath, branchName)) {
       // Branch exists locally, attach worktree to it
+      onProgress?.(`Creating worktree from ${branchName}...`);
       logger.debug(`Creating worktree from local branch: ${branchName}`);
       await execAsync(`git worktree add ${escapeShellArg(workspacePath)} ${escapeShellArg(branchName)}`, {
         cwd: repoPath,
@@ -155,6 +175,7 @@ export async function createWorktree(
     } else {
       // Branch doesn't exist, create new from base
       // Use --no-track to avoid setting upstream to baseBranch (user should push -u to set correct upstream)
+      onProgress?.(`Creating new branch ${branchName}...`);
       logger.debug(`Creating new branch from ${baseBranch}: ${branchName}`);
       await execAsync(
         `git worktree add -b ${escapeShellArg(branchName)} ${escapeShellArg(workspacePath)} ${escapeShellArg(`origin/${baseBranch}`)} --no-track`,

--- a/src/core/workspace.ts
+++ b/src/core/workspace.ts
@@ -38,6 +38,16 @@ export interface DeleteWorkspaceOptions {
   nonInteractive?: boolean;
   /** Keep the local branch after removing worktree */
   keepBranch?: boolean;
+  /**
+   * Callback to receive ANSI output from remove scripts (for TUI/Web terminal display).
+   * Called with raw output from stdout/stderr.
+   */
+  onScriptOutput?: (data: Buffer) => void;
+  /**
+   * Callback to report progress on deletion steps (for TUI loading indicator).
+   * Called with a human-readable message for each step.
+   */
+  onProgress?: (message: string) => void;
 }
 
 /**
@@ -93,6 +103,9 @@ export async function deleteWorkspaceCore(
     if (await isServerRunning()) {
       const sessions = await listSessions();
       const workspaceSessions = sessions.filter(s => s.cwd === workspacePath);
+      if (workspaceSessions.length > 0) {
+        options.onProgress?.(`Killing ${workspaceSessions.length} session(s)...`);
+      }
       for (const session of workspaceSessions) {
         try {
           await killSession(session.id);
@@ -111,12 +124,16 @@ export async function deleteWorkspaceCore(
   try {
     const projectConfig = readProjectConfig(projectName);
     const removeScriptsDir = getScriptsPhaseDir(projectName, 'remove');
+    options.onProgress?.('Running cleanup scripts...');
     await runScriptsInTerminal(
       removeScriptsDir,
       workspacePath,
       workspaceName,
       projectConfig.repository,
-      { nonInteractive: options.nonInteractive }
+      {
+        nonInteractive: options.nonInteractive,
+        onOutput: options.onScriptOutput,
+      }
     );
   } catch (e) {
     // Scripts are best-effort, log but continue
@@ -124,6 +141,7 @@ export async function deleteWorkspaceCore(
   }
 
   // Remove worktree
+  options.onProgress?.('Removing worktree...');
   try {
     await removeWorktree(baseDir, workspacePath, true);
   } catch (e) {
@@ -133,6 +151,7 @@ export async function deleteWorkspaceCore(
 
   // Try to delete the local branch
   if (!options.keepBranch && info?.branch) {
+    options.onProgress?.(`Deleting branch ${info.branch}...`);
     try {
       await deleteLocalBranch(baseDir, info.branch, true);
       result.branchDeleted = true;
@@ -155,6 +174,11 @@ export interface DeleteProjectOptions {
    * When true, remove scripts run with stdin closed.
    */
   nonInteractive?: boolean;
+  /**
+   * Callback to report progress on deletion steps (for TUI loading indicator).
+   * Called with a human-readable message for each step.
+   */
+  onProgress?: (message: string) => void;
 }
 
 /**
@@ -209,11 +233,14 @@ export async function deleteProjectCore(
   }
 
   // Delete each workspace (this handles session teardown and remove scripts)
-  for (const workspaceName of workspaceNames) {
+  for (let i = 0; i < workspaceNames.length; i++) {
+    const workspaceName = workspaceNames[i];
+    options.onProgress?.(`Removing workspace ${i + 1}/${workspaceNames.length}: ${workspaceName}...`);
     try {
       const wsResult = await deleteWorkspaceCore(projectName, workspaceName, {
         nonInteractive: options.nonInteractive,
         keepBranch: true, // Don't try to delete branches, we're removing the whole repo
+        onProgress: options.onProgress,
       });
       if (wsResult.success) {
         result.workspacesDeleted++;
@@ -229,6 +256,7 @@ export async function deleteProjectCore(
   }
 
   // Remove entire project directory
+  options.onProgress?.('Removing project directory...');
   try {
     rmSync(projectDir, { recursive: true, force: true });
   } catch (e) {

--- a/src/lib/remote-session/protocol.ts
+++ b/src/lib/remote-session/protocol.ts
@@ -194,6 +194,21 @@ export interface InboxMarkedReadResponse {
   id: string;
 }
 
+/** Script output during attach_session (streams lifecycle script output) */
+export interface ScriptOutputResponse {
+  type: "script_output";
+  /** Current script phase (pre, setup, select, remove) */
+  phase: "pre" | "setup" | "select" | "remove";
+  /** ANSI output data (base64 encoded for binary safety) */
+  data: string;
+  /** Whether scripts are complete */
+  done?: boolean;
+  /** Exit code if scripts failed (only when done=true) */
+  exitCode?: number;
+  /** Error message if scripts failed (only when done=true) */
+  error?: string;
+}
+
 // ============================================================================
 // Union Types
 // ============================================================================
@@ -223,7 +238,8 @@ export type MachineToClientMessage =
   | WorkspaceDeletedResponse
   | InboxListResponse
   | InboxClearedResponse
-  | InboxMarkedReadResponse;
+  | InboxMarkedReadResponse
+  | ScriptOutputResponse;
 
 /** All remote session messages */
 export type RemoteSessionMessage =

--- a/src/lib/remote-session/session-handler.ts
+++ b/src/lib/remote-session/session-handler.ts
@@ -37,6 +37,7 @@ import { readProjectConfig } from "../../core/config";
 
 // Import script execution
 import { runWorkspaceScripts } from "../../utils/run-workspace-scripts";
+import { logger } from "../../utils/logger.js";
 
 /**
  * Session state for a connected client
@@ -343,12 +344,15 @@ export class RemoteSessionHandler {
           workspaceName: workspace.id,
           repository: config.repository,
           interactive: false, // Remote context - scripts can't prompt for input
-          onOutput: async (data) => {
+          onOutput: (data) => {
             // Stream script output to client (base64 encode for binary safety)
-            await this.sendMessage(session, sendResponse, {
+            // Use void + catch to avoid unhandled promise rejections since this callback isn't awaited
+            void this.sendMessage(session, sendResponse, {
               type: 'script_output',
               phase: currentPhase,
               data: data.toString('base64'),
+            }).catch((error) => {
+              logger.debug(`[remote-session] Failed to stream script output: ${error instanceof Error ? error.message : String(error)}`);
             });
           },
           onPhaseStart: (phase) => {

--- a/src/lib/remote-session/session-handler.ts
+++ b/src/lib/remote-session/session-handler.ts
@@ -329,23 +329,54 @@ export class RemoteSessionHandler {
           return;
         }
 
-        // Run setup or select scripts for the workspace
+        // Run setup or select scripts for the workspace with output streaming
         const config = readProjectConfig(workspace.projectName);
 
         console.log(`[remote-session] Running workspace scripts for: ${workspace.id}`);
+
+        // Track current phase for script_output messages
+        let currentPhase: 'pre' | 'setup' | 'select' = 'pre';
+
         const scriptResult = await runWorkspaceScripts({
           projectName: workspace.projectName,
           workspacePath: workspace.path,
           workspaceName: workspace.id,
           repository: config.repository,
           interactive: false, // Remote context - scripts can't prompt for input
+          onOutput: async (data) => {
+            // Stream script output to client (base64 encode for binary safety)
+            await this.sendMessage(session, sendResponse, {
+              type: 'script_output',
+              phase: currentPhase,
+              data: data.toString('base64'),
+            });
+          },
+          onPhaseStart: (phase) => {
+            currentPhase = phase;
+          },
         });
 
         if (!scriptResult.success) {
           console.error(`[remote-session] ${scriptResult.phase} scripts failed:`, scriptResult.error);
+          // Send final script_output with error info
+          await this.sendMessage(session, sendResponse, {
+            type: 'script_output',
+            phase: scriptResult.phase,
+            data: '',
+            done: true,
+            error: scriptResult.error,
+          });
           await this.sendError(session, sendResponse, "SCRIPT_FAILED", `Workspace scripts failed during ${scriptResult.phase} phase: ${scriptResult.error}`);
           return;
         }
+
+        // Send final script_output indicating success
+        await this.sendMessage(session, sendResponse, {
+          type: 'script_output',
+          phase: currentPhase,
+          data: '',
+          done: true,
+        });
 
         // Create session name: use provided name or auto-generate
         let sessionName: string;

--- a/src/tui/app.tsx
+++ b/src/tui/app.tsx
@@ -13,8 +13,9 @@ import { createRoot, useKeyboard } from '@opentui/react';
 import { useState, useEffect, useCallback, useReducer, Fragment, useMemo, useRef } from 'react';
 import { Toaster } from '@opentui-ui/toast/react';
 
-// Terminal component
+// Terminal components
 import { Terminal, useTerminalSession } from './components/Terminal.js';
+import { ScriptTerminal, type ScriptTerminalHandle } from './components/ScriptTerminal.js';
 import type { Session } from '../lib/tmux-lite/protocol.js';
 import { listSessions, createSession, ensureServer, killSession } from '../lib/tmux-lite/cli.js';
 import { getSessionSocketPath } from '../lib/tmux-lite/protocol.js';
@@ -79,7 +80,7 @@ import { existsSync, mkdirSync, writeFileSync } from 'fs';
 import { join } from 'path';
 
 // Script execution
-import { runWorkspaceScripts } from '../utils/run-workspace-scripts.js';
+import { runWorkspaceScripts, type ScriptPhase } from '../utils/run-workspace-scripts.js';
 import type { LinearIssue } from '../types/workspace.js';
 
 // Project creation
@@ -111,7 +112,7 @@ type WorkspaceFlowState =
   | { type: 'linear-select'; issues: LinearIssue[]; selectedIndex: number }
   | { type: 'manual-name-input'; inputValue: string; error: string | null }
   | { type: 'manual-branch-input'; workspaceName: string; inputValue: string }
-  | { type: 'creating'; workspaceName: string };
+  | { type: 'creating'; workspaceName: string; message?: string };
 
 /** Project flow states - explicit state machine for project creation */
 type ProjectFlowState =
@@ -187,8 +188,29 @@ const ASCII_LINES = [
 // App State
 // ============================================================================
 
-type AppView = 'machines' | 'projects' | 'workspaces' | 'terminal' | 'inbox';
+type AppView = 'machines' | 'projects' | 'workspaces' | 'terminal' | 'inbox' | 'scripts';
 type PanelFocus = 'projects' | 'workspaces';
+
+/** Info about what to do after scripts complete */
+interface ScriptCompletionAction {
+  /** Create a new session after scripts complete */
+  type: 'create-session';
+  sessionName: string;
+  workspacePath: string;
+}
+
+/** State for script runner view */
+interface ScriptRunnerState {
+  phase: ScriptPhase | 'remove';
+  workspaceName: string;
+  workspacePath: string;
+  projectName: string;
+  isRunning: boolean;
+  error?: string;
+  exitCode?: number;
+  /** What to do when scripts complete successfully */
+  onComplete?: ScriptCompletionAction;
+}
 
 interface AppState {
   view: AppView;
@@ -202,6 +224,8 @@ interface AppState {
   isLoading: boolean;
   error: string | null;
   attachedSession: Session | null;
+  /** Script runner state for 'scripts' view */
+  scriptRunner: ScriptRunnerState | null;
 }
 
 type AppAction =
@@ -215,7 +239,10 @@ type AppAction =
   | { type: 'SET_LOADING'; loading: boolean }
   | { type: 'SET_ERROR'; error: string | null }
   | { type: 'SWITCH_PANEL' }
-  | { type: 'SET_ATTACHED_SESSION'; session: Session | null };
+  | { type: 'SET_ATTACHED_SESSION'; session: Session | null }
+  | { type: 'SET_SCRIPT_RUNNER'; scriptRunner: ScriptRunnerState | null }
+  | { type: 'UPDATE_SCRIPT_PHASE'; phase: ScriptPhase | 'remove' }
+  | { type: 'SCRIPT_COMPLETE'; success: boolean; error?: string; exitCode?: number };
 
 function appReducer(state: AppState, action: AppAction): AppState {
   switch (action.type) {
@@ -249,6 +276,24 @@ function appReducer(state: AppState, action: AppAction): AppState {
       return { ...state, panelFocus: state.panelFocus === 'projects' ? 'workspaces' : 'projects' };
     case 'SET_ATTACHED_SESSION':
       return { ...state, attachedSession: action.session };
+    case 'SET_SCRIPT_RUNNER':
+      return { ...state, scriptRunner: action.scriptRunner };
+    case 'UPDATE_SCRIPT_PHASE':
+      return state.scriptRunner
+        ? { ...state, scriptRunner: { ...state.scriptRunner, phase: action.phase } }
+        : state;
+    case 'SCRIPT_COMPLETE':
+      return state.scriptRunner
+        ? {
+            ...state,
+            scriptRunner: {
+              ...state.scriptRunner,
+              isRunning: false,
+              error: action.success ? undefined : action.error,
+              exitCode: action.exitCode,
+            },
+          }
+        : state;
     default:
       return state;
   }
@@ -299,10 +344,14 @@ function App({ relayConfig, onQuit }: AppProps) {
     isLoading: true,
     error: null,
     attachedSession: null,
+    scriptRunner: null,
   });
 
   // Track when we're switching sessions (to prevent detach handler from navigating away)
   const sessionSwitchingRef = useRef(false);
+
+  // Ref for ScriptTerminal to feed output data
+  const scriptTerminalRef = useRef<ScriptTerminalHandle>(null);
 
   // Shared Flow hook (for non-workspace flows)
   const flow = useFlow({
@@ -404,11 +453,14 @@ function App({ relayConfig, onQuit }: AppProps) {
       confirmText: project.name,
       warning: 'This will delete all workspaces in this project!',
       onConfirm: async () => {
-        flow.showLoading({ title: 'Deleting', message: 'Removing project...' });
+        flow.showLoading({ title: 'Deleting', message: 'Preparing...' });
 
         try {
           const result = await deleteProjectCore(project.name, {
             nonInteractive: true, // TUI is non-interactive for scripts
+            onProgress: (message) => {
+              flow.showLoading({ title: 'Deleting', message });
+            },
           });
 
           if (!result.success && result.errors.length > 0) {
@@ -496,41 +548,79 @@ function App({ relayConfig, onQuit }: AppProps) {
             // Always use project:workspace:session format for proper parsing
             const sessionSuffix = name || String(Date.now());
             const sessionName = `${state.currentProject}:${workspace.name}:${sessionSuffix}`;
-            try {
-              const config = readProjectConfig(state.currentProject!);
+            const config = readProjectConfig(state.currentProject!);
 
-              // Run workspace scripts (pre+setup for first time, select for existing)
-              const scriptResult = await runWorkspaceScripts({
-                projectName: state.currentProject!,
-                workspacePath: workspace.path,
+            // Set up script runner state and switch to scripts view
+            dispatch({
+              type: 'SET_SCRIPT_RUNNER',
+              scriptRunner: {
+                phase: 'pre', // Will be updated as scripts run
                 workspaceName: workspace.name,
-                repository: config.repository,
-                interactive: false, // TUI context - scripts can't prompt for input
-              });
+                workspacePath: workspace.path,
+                projectName: state.currentProject!,
+                isRunning: true,
+                onComplete: {
+                  type: 'create-session',
+                  sessionName,
+                  workspacePath: workspace.path,
+                },
+              },
+            });
+            dispatch({ type: 'SET_VIEW', view: 'scripts' });
 
-              if (!scriptResult.success) {
+            // Run workspace scripts with output streaming
+            const scriptResult = await runWorkspaceScripts({
+              projectName: state.currentProject!,
+              workspacePath: workspace.path,
+              workspaceName: workspace.name,
+              repository: config.repository,
+              interactive: false, // TUI context - scripts can't prompt for input
+              onOutput: (data) => {
+                // Feed output to ScriptTerminal via ref
+                scriptTerminalRef.current?.feed(data);
+              },
+              onPhaseStart: (phase) => {
+                dispatch({ type: 'UPDATE_SCRIPT_PHASE', phase });
+              },
+            });
+
+            // Handle script completion
+            if (scriptResult.success) {
+              dispatch({ type: 'SCRIPT_COMPLETE', success: true });
+              // Create session and attach
+              try {
+                const session = await createSession(sessionName, workspace.path);
+                sessionSwitchingRef.current = true;
+                dispatch({ type: 'SET_SCRIPT_RUNNER', scriptRunner: null });
+                dispatch({ type: 'SET_ATTACHED_SESSION', session });
+                dispatch({ type: 'SET_VIEW', view: 'terminal' });
+                setTimeout(() => { sessionSwitchingRef.current = false; }, 200);
+              } catch (err) {
+                dispatch({ type: 'SET_SCRIPT_RUNNER', scriptRunner: null });
+                dispatch({ type: 'SET_VIEW', view: 'projects' });
+                flow.showMessage({
+                  title: 'Session Failed',
+                  message: err instanceof Error ? err.message : 'Failed to create session',
+                  variant: 'error',
+                });
+              }
+            } else {
+              dispatch({
+                type: 'SCRIPT_COMPLETE',
+                success: false,
+                error: scriptResult.error,
+              });
+              // Show error and wait for user to acknowledge
+              // After a short delay, go back to projects view
+              setTimeout(() => {
+                dispatch({ type: 'SET_SCRIPT_RUNNER', scriptRunner: null });
+                dispatch({ type: 'SET_VIEW', view: 'projects' });
                 flow.showMessage({
                   title: 'Script Failed',
                   message: `Workspace scripts failed during ${scriptResult.phase} phase: ${scriptResult.error}`,
                   variant: 'error',
                 });
-                return;
-              }
-
-              const session = await createSession(sessionName, workspace.path);
-              // Mark that we're switching sessions (prevents detach handler from navigating away)
-              sessionSwitchingRef.current = true;
-              // Attach to newly created session
-              dispatch({ type: 'SET_ATTACHED_SESSION', session });
-              dispatch({ type: 'SET_VIEW', view: 'terminal' });
-              // Clear flag after a short delay (allows old Terminal to cleanup)
-              setTimeout(() => { sessionSwitchingRef.current = false; }, 200);
-            } catch (err) {
-              flow.showMessage({
-                title: 'Session Failed',
-                message: err instanceof Error ? err.message : 'Failed to create session',
-                variant: 'error',
-              });
+              }, 2000); // Show error in terminal for 2 seconds
             }
           },
         });
@@ -592,11 +682,14 @@ function App({ relayConfig, onQuit }: AppProps) {
       warning: workspace.sessions.length > 0 ? `This will kill ${workspace.sessions.length} active session(s)!` : undefined,
       onConfirm: async () => {
         if (!state.currentProject) return;
-        flow.showLoading({ title: 'Deleting', message: 'Removing workspace...' });
+        flow.showLoading({ title: 'Deleting', message: 'Preparing...' });
 
         try {
           const result = await deleteWorkspaceCore(state.currentProject, workspace.name, {
             nonInteractive: true, // TUI is non-interactive for scripts
+            onProgress: (message) => {
+              flow.showLoading({ title: 'Deleting', message });
+            },
           });
 
           if (!result.success) {
@@ -673,7 +766,12 @@ function App({ relayConfig, onQuit }: AppProps) {
       setWorkspaceFlow({ type: 'creating', workspaceName });
 
       // Create worktree
-      await createWorktree(baseDir, workspacePath, branchName, config.baseBranch, existsRemotely);
+      await createWorktree(baseDir, workspacePath, branchName, config.baseBranch, {
+        existsRemotely,
+        onProgress: (message) => {
+          setWorkspaceFlow({ type: 'creating', workspaceName, message });
+        },
+      });
 
       // Save Linear issue if present
       if (linearIssue) {
@@ -686,31 +784,68 @@ function App({ relayConfig, onQuit }: AppProps) {
         }
       }
 
-      // Run workspace scripts (pre+setup for new workspace)
+      // Set up script runner and show scripts view for workspace setup
+      setWorkspaceFlow({ type: 'closed' });
+      const sessionName = `${state.currentProject}:${workspaceName}:${Date.now()}`;
+
+      dispatch({
+        type: 'SET_SCRIPT_RUNNER',
+        scriptRunner: {
+          phase: 'pre',
+          workspaceName,
+          workspacePath,
+          projectName: state.currentProject,
+          isRunning: true,
+          onComplete: {
+            type: 'create-session',
+            sessionName,
+            workspacePath,
+          },
+        },
+      });
+      dispatch({ type: 'SET_VIEW', view: 'scripts' });
+
+      // Run workspace scripts (pre+setup for new workspace) with output streaming
       const scriptResult = await runWorkspaceScripts({
         projectName: state.currentProject,
         workspacePath,
         workspaceName,
         repository: config.repository,
         interactive: false, // TUI context - scripts can't prompt for input
+        onOutput: (data) => {
+          scriptTerminalRef.current?.feed(data);
+        },
+        onPhaseStart: (phase) => {
+          dispatch({ type: 'UPDATE_SCRIPT_PHASE', phase });
+        },
       });
 
       if (!scriptResult.success) {
-        setWorkspaceFlow({ type: 'closed' });
-        flow.showMessage({
-          title: 'Script Failed',
-          message: `Workspace scripts failed during ${scriptResult.phase} phase: ${scriptResult.error}`,
-          variant: 'error',
+        dispatch({
+          type: 'SCRIPT_COMPLETE',
+          success: false,
+          error: scriptResult.error,
         });
+        // Show error for 2 seconds then go back
+        setTimeout(() => {
+          dispatch({ type: 'SET_SCRIPT_RUNNER', scriptRunner: null });
+          dispatch({ type: 'SET_VIEW', view: 'projects' });
+          flow.showMessage({
+            title: 'Script Failed',
+            message: `Workspace scripts failed during ${scriptResult.phase} phase: ${scriptResult.error}`,
+            variant: 'error',
+          });
+        }, 2000);
         return;
       }
 
-      setWorkspaceFlow({ type: 'closed' });
+      dispatch({ type: 'SCRIPT_COMPLETE', success: true });
       await refreshWorkspaces();
 
       // Create session and attach
       await ensureServer();
-      const session = await createSession(`${state.currentProject}:${workspaceName}:${Date.now()}`, workspacePath);
+      const session = await createSession(sessionName, workspacePath);
+      dispatch({ type: 'SET_SCRIPT_RUNNER', scriptRunner: null });
       dispatch({ type: 'SET_ATTACHED_SESSION', session });
       dispatch({ type: 'SET_VIEW', view: 'terminal' });
     } catch (err) {
@@ -1318,6 +1453,11 @@ function App({ relayConfig, onQuit }: AppProps) {
       return;
     }
 
+    // Don't handle keys when in scripts view (output-only, no interaction)
+    if (state.view === 'scripts') {
+      return;
+    }
+
     // Handle project creation flow (custom state machine)
     if (projectFlow.type !== 'closed') {
       if (key.name === 'escape') {
@@ -1802,6 +1942,23 @@ function App({ relayConfig, onQuit }: AppProps) {
     );
   }
 
+  // Scripts view (running lifecycle scripts)
+  if (state.view === 'scripts' && state.scriptRunner) {
+    return (
+      <Fragment>
+        <Toaster position="top-right" />
+        <ScriptTerminal
+          ref={scriptTerminalRef}
+          phase={state.scriptRunner.phase}
+          workspaceName={state.scriptRunner.workspaceName}
+          isRunning={state.scriptRunner.isRunning}
+          error={state.scriptRunner.error}
+          exitCode={state.scriptRunner.exitCode}
+        />
+      </Fragment>
+    );
+  }
+
   // Inbox view (full-screen)
   if (state.view === 'inbox') {
     return (
@@ -1947,7 +2104,7 @@ function WorkspaceFlowModal({ flow }: { flow: WorkspaceFlowState }) {
         {flow.type === 'creating' && (
           <>
             <text fg={COLORS.title} height={1}>Creating Workspace</text>
-            <text fg={COLORS.loading} height={1} marginTop={1}>Creating {flow.workspaceName}...</text>
+            <text fg={COLORS.loading} height={1} marginTop={1}>{flow.message ?? `Creating ${flow.workspaceName}...`}</text>
           </>
         )}
 

--- a/src/tui/components/ScriptTerminal.tsx
+++ b/src/tui/components/ScriptTerminal.tsx
@@ -1,0 +1,213 @@
+/**
+ * ScriptTerminal - TUI Component for displaying lifecycle script output
+ *
+ * Shows ANSI output from scripts (pre, setup, select, remove) in a read-only terminal.
+ * Uses ghostty-opentui for rendering with mouse selection support.
+ */
+
+import { useState, useRef, useCallback, useEffect, useImperativeHandle, forwardRef } from 'react';
+import { extend, useRenderer } from '@opentui/react';
+import type { ScrollBoxRenderable, MouseEvent } from '@opentui/core';
+import { GhosttyTerminalRenderable } from 'ghostty-opentui/terminal-buffer';
+import { toast } from '@opentui-ui/toast';
+import { copyToClipboard } from '../../utils/clipboard.js';
+import type { ScriptPhase } from '../../utils/run-workspace-scripts.js';
+
+// Register the ghostty-terminal component
+extend({ 'ghostty-terminal': GhosttyTerminalRenderable });
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface ScriptTerminalProps {
+  /** Current phase being executed */
+  phase: ScriptPhase | 'remove';
+  /** Workspace name (shown in header) */
+  workspaceName: string;
+  /** Whether scripts are still running */
+  isRunning: boolean;
+  /** Error message if scripts failed */
+  error?: string;
+  /** Exit code from failed script */
+  exitCode?: number;
+}
+
+export interface ScriptTerminalHandle {
+  /** Feed output data to the terminal */
+  feed: (data: Buffer) => void;
+}
+
+// ============================================================================
+// Colors
+// ============================================================================
+
+const COLORS = {
+  statusBar: '#333333',
+  phase: '#00FF88',
+  textDim: '#888888',
+  runningHint: '#FFAA00',
+  error: '#FF4444',
+  success: '#00FF88',
+};
+
+// Phase display names
+const PHASE_NAMES: Record<ScriptPhase | 'remove', string> = {
+  pre: 'Pre Scripts',
+  setup: 'Setup Scripts',
+  select: 'Select Scripts',
+  remove: 'Remove Scripts',
+};
+
+// ============================================================================
+// Helper to get terminal size
+// ============================================================================
+
+function getTerminalSize() {
+  let cols = process.stdout.columns || 0;
+  let rows = process.stdout.rows || 0;
+  if (cols <= 0 || rows <= 0) {
+    const size = (process.stdout as { getWindowSize?: () => number[] }).getWindowSize?.();
+    if (Array.isArray(size) && size.length >= 2) {
+      cols = size[0];
+      rows = size[1];
+    }
+  }
+  // Reserve 1 row for header
+  return {
+    cols: cols > 0 ? cols : 80,
+    rows: (rows > 0 ? rows : 24) - 1,
+  };
+}
+
+// ============================================================================
+// ScriptTerminal Component
+// ============================================================================
+
+export const ScriptTerminal = forwardRef<ScriptTerminalHandle, ScriptTerminalProps>(
+  function ScriptTerminal(
+    {
+      phase,
+      workspaceName,
+      isRunning,
+      error,
+      exitCode,
+    },
+    ref
+  ) {
+    const [termSize, setTermSize] = useState(getTerminalSize);
+    const renderer = useRenderer();
+
+    const terminalRef = useRef<GhosttyTerminalRenderable | null>(null);
+    const scrollBoxRef = useRef<ScrollBoxRenderable | null>(null);
+    const outputBufferRef = useRef<Buffer>(Buffer.alloc(0));
+
+    // Handle window resize
+    useEffect(() => {
+      const onResize = () => {
+        setTermSize(getTerminalSize());
+      };
+      process.on('SIGWINCH', onResize);
+      return () => {
+        process.removeListener('SIGWINCH', onResize);
+      };
+    }, []);
+
+    // Handle mouse up to detect selection completion and copy to clipboard
+    const handleMouseUp = useCallback(async (event: MouseEvent) => {
+      if (event.isSelecting && terminalRef.current) {
+        const selectedText = terminalRef.current.getSelectedText();
+        if (selectedText && selectedText.length > 0) {
+          try {
+            await copyToClipboard(selectedText);
+            toast.success('Copied to clipboard');
+          } catch {
+            toast.error('Failed to copy to clipboard');
+          }
+          renderer.clearSelection();
+        }
+      }
+    }, [renderer]);
+
+    // Feed data to terminal - exposed via ref
+    const feed = useCallback((data: Buffer) => {
+      outputBufferRef.current = Buffer.concat([outputBufferRef.current, data]);
+      // Feed to terminal if mounted
+      if (terminalRef.current) {
+        terminalRef.current.feed(data);
+      }
+    }, []);
+
+    // Expose feed method via ref
+    useImperativeHandle(ref, () => ({
+      feed,
+    }), [feed]);
+
+    // Status text
+    const statusText = isRunning
+      ? 'Running...'
+      : error
+        ? `Failed (exit ${exitCode})`
+        : 'Complete';
+
+    const statusColor = isRunning
+      ? COLORS.runningHint
+      : error
+        ? COLORS.error
+        : COLORS.success;
+
+    return (
+      <box flexDirection="column" flexGrow={1}>
+        {/* Header */}
+        <box
+          height={1}
+          width="100%"
+          backgroundColor={COLORS.statusBar}
+          flexDirection="row"
+          paddingLeft={1}
+          paddingRight={1}
+        >
+          <box flexGrow={1} flexDirection="row">
+            <text fg={COLORS.phase}>{PHASE_NAMES[phase]}</text>
+            <text fg={COLORS.textDim}> - {workspaceName}</text>
+          </box>
+          <text fg={statusColor}>{statusText}</text>
+        </box>
+
+        {/* Terminal output */}
+        <scrollbox
+          ref={(el: ScrollBoxRenderable | null) => {
+            scrollBoxRef.current = el;
+          }}
+          flexGrow={1}
+          viewportCulling={true}
+          stickyScroll={true}
+          stickyStart="bottom"
+          onMouseUp={handleMouseUp}
+        >
+          <ghostty-terminal
+            ref={(el: GhosttyTerminalRenderable | null) => {
+              const wasNull = terminalRef.current === null;
+              terminalRef.current = el;
+              // Feed any buffered output when terminal mounts
+              if (el && wasNull && outputBufferRef.current.length > 0) {
+                el.feed(outputBufferRef.current);
+              }
+            }}
+            persistent={true}
+            showCursor={false}
+            cols={termSize.cols}
+            rows={termSize.rows}
+          />
+        </scrollbox>
+
+        {/* Error message if failed */}
+        {error && !isRunning && (
+          <box height={1} width="100%" backgroundColor="#331111" paddingLeft={1}>
+            <text fg={COLORS.error}>{error}</text>
+          </box>
+        )}
+      </box>
+    );
+  }
+);

--- a/src/utils/__tests__/run-scripts.test.ts
+++ b/src/utils/__tests__/run-scripts.test.ts
@@ -303,4 +303,59 @@ echo "$SPACE_SECRET_TOKEN" >> "${outputFile}"
       // Should not throw
     });
   });
+
+  describe('onOutput callback', () => {
+    it('should call onOutput with script stdout in nonInteractive mode', async () => {
+      const scriptPath = join(scriptsDir, '01-output.sh');
+      writeFileSync(scriptPath, `#!/bin/bash
+echo "Hello from script"
+echo "Line 2"
+`);
+      chmodSync(scriptPath, 0o755);
+
+      const chunks: Buffer[] = [];
+      await runScriptsInTerminal(scriptsDir, workspacePath, 'test-workspace', 'test/repo', {
+        nonInteractive: true,
+        onOutput: (data) => chunks.push(data),
+      });
+
+      const output = Buffer.concat(chunks).toString();
+      expect(output).toContain('Hello from script');
+      expect(output).toContain('Line 2');
+    });
+
+    it('should call onOutput with script stderr in nonInteractive mode', async () => {
+      const scriptPath = join(scriptsDir, '01-stderr.sh');
+      writeFileSync(scriptPath, `#!/bin/bash
+echo "Error message" >&2
+`);
+      chmodSync(scriptPath, 0o755);
+
+      const chunks: Buffer[] = [];
+      await runScriptsInTerminal(scriptsDir, workspacePath, 'test-workspace', 'test/repo', {
+        nonInteractive: true,
+        onOutput: (data) => chunks.push(data),
+      });
+
+      const output = Buffer.concat(chunks).toString();
+      expect(output).toContain('Error message');
+    });
+
+    it('should not call onOutput in interactive mode (stdio: inherit)', async () => {
+      const scriptPath = join(scriptsDir, '01-simple.sh');
+      writeFileSync(scriptPath, `#!/bin/bash
+echo "Output"
+`);
+      chmodSync(scriptPath, 0o755);
+
+      const chunks: Buffer[] = [];
+      await runScriptsInTerminal(scriptsDir, workspacePath, 'test-workspace', 'test/repo', {
+        nonInteractive: false, // Interactive mode
+        onOutput: (data) => chunks.push(data),
+      });
+
+      // In interactive mode, stdio is inherited, so onOutput won't be called
+      expect(chunks).toHaveLength(0);
+    });
+  });
 });

--- a/src/utils/run-scripts.ts
+++ b/src/utils/run-scripts.ts
@@ -60,6 +60,11 @@ export interface RunScriptsOptions {
    * - Prevents scripts from blocking indefinitely
    */
   nonInteractive?: boolean;
+  /**
+   * Callback to receive ANSI output as it arrives (for TUI/Web terminal display).
+   * Called with raw output from stdout/stderr. Only works when nonInteractive is true.
+   */
+  onOutput?: (data: Buffer) => void;
 }
 
 /**
@@ -125,10 +130,17 @@ export async function runScriptsInTerminal(
       });
 
       // Capture output in non-interactive mode for logging on failure
+      // Also stream to onOutput callback if provided (for TUI/Web terminal display)
       let output = '';
       if (options?.nonInteractive && child.stdout && child.stderr) {
-        child.stdout.on('data', (data: Buffer) => { output += data.toString(); });
-        child.stderr.on('data', (data: Buffer) => { output += data.toString(); });
+        child.stdout.on('data', (data: Buffer) => {
+          output += data.toString();
+          options?.onOutput?.(data);
+        });
+        child.stderr.on('data', (data: Buffer) => {
+          output += data.toString();
+          options?.onOutput?.(data);
+        });
       }
 
       child.on('close', (code: number | null) => {

--- a/src/utils/run-workspace-scripts.ts
+++ b/src/utils/run-workspace-scripts.ts
@@ -19,6 +19,15 @@ export interface RunWorkspaceScriptsOptions {
   repository: string;
   /** If true, scripts can prompt for input. If false (default), stdin is closed. */
   interactive?: boolean;
+  /**
+   * Callback to receive ANSI output as it arrives (for TUI/Web terminal display).
+   * Called with raw output from stdout/stderr.
+   */
+  onOutput?: (data: Buffer) => void;
+  /**
+   * Callback when a new phase starts (for displaying phase name in UI).
+   */
+  onPhaseStart?: (phase: ScriptPhase) => void;
 }
 
 export type RunWorkspaceScriptsResult =
@@ -36,7 +45,15 @@ export type RunWorkspaceScriptsResult =
 export async function runWorkspaceScripts(
   options: RunWorkspaceScriptsOptions
 ): Promise<RunWorkspaceScriptsResult> {
-  const { projectName, workspacePath, workspaceName, repository, interactive = false } = options;
+  const {
+    projectName,
+    workspacePath,
+    workspaceName,
+    repository,
+    interactive = false,
+    onOutput,
+    onPhaseStart,
+  } = options;
 
   // Read project config for bundle values and secrets
   const config = readProjectConfig(projectName);
@@ -45,6 +62,7 @@ export async function runWorkspaceScripts(
   const scriptOptions: RunScriptsOptions = {
     bundleValues: config.bundleValues,
     nonInteractive: !interactive,
+    onOutput,
   };
 
   // Fetch secrets from OS keychain if we have secret keys
@@ -59,6 +77,7 @@ export async function runWorkspaceScripts(
     // Run select scripts for existing workspace
     const selectScriptsDir = getScriptsPhaseDir(projectName, 'select');
     try {
+      onPhaseStart?.('select');
       await runScriptsInTerminal(selectScriptsDir, workspacePath, workspaceName, repository, scriptOptions);
       return { success: true };
     } catch (error) {
@@ -70,10 +89,12 @@ export async function runWorkspaceScripts(
     let preScriptsSucceeded = false;
 
     try {
+      onPhaseStart?.('pre');
       const preScriptsDir = getScriptsPhaseDir(projectName, 'pre');
       await runScriptsInTerminal(preScriptsDir, workspacePath, workspaceName, repository, scriptOptions);
       preScriptsSucceeded = true;
 
+      onPhaseStart?.('setup');
       const setupScriptsDir = getScriptsPhaseDir(projectName, 'setup');
       await runScriptsInTerminal(setupScriptsDir, workspacePath, workspaceName, repository, scriptOptions);
 

--- a/src/web/src/hooks/useTerminal.ts
+++ b/src/web/src/hooks/useTerminal.ts
@@ -104,6 +104,7 @@ export function useTerminal() {
   const modeRef = useRef<SessionMode>("browsing"); // For use in callbacks
   const utf8BufferRef = useRef<Uint8Array>(new Uint8Array(0)); // Buffer for incomplete UTF-8 sequences
   const handleDataMessageRef = useRef<((data: string) => void) | null>(null); // For use in handleMessage
+  const scriptOutputBufferRef = useRef<Uint8Array[]>([]); // Buffer for script output before terminal mounts
 
   const connect = useCallback(async (params: ConnectionParams) => {
     try {
@@ -432,9 +433,14 @@ export function useTerminal() {
   /**
    * Write PTY data to terminal with UTF-8 boundary handling
    * Buffers incomplete UTF-8 sequences to prevent garbled output
+   * Also buffers data if terminal hasn't mounted yet (script output during attach)
    */
   const writePtyData = useCallback((data: Uint8Array) => {
-    if (!writeCallbackRef.current) return;
+    if (!writeCallbackRef.current) {
+      // Buffer data until terminal mounts (for script output during attach)
+      scriptOutputBufferRef.current.push(data);
+      return;
+    }
 
     // Combine with any buffered incomplete UTF-8 bytes
     let combined: Uint8Array;
@@ -679,7 +685,15 @@ export function useTerminal() {
 
   const setWriteCallback = useCallback((fn: (data: Uint8Array) => void) => {
     writeCallbackRef.current = fn;
-  }, []);
+    // Flush any buffered script output that arrived before terminal mounted
+    if (scriptOutputBufferRef.current.length > 0) {
+      console.log(`[useTerminal] Flushing ${scriptOutputBufferRef.current.length} buffered script output chunks`);
+      for (const chunk of scriptOutputBufferRef.current) {
+        writePtyData(chunk);
+      }
+      scriptOutputBufferRef.current = [];
+    }
+  }, [writePtyData]);
 
   const disconnect = useCallback(() => {
     wsRef.current?.close();
@@ -687,6 +701,7 @@ export function useTerminal() {
     sessionKeysRef.current = null;
     handshakeStateRef.current = null;
     utf8BufferRef.current = new Uint8Array(0); // Clear UTF-8 buffer
+    scriptOutputBufferRef.current = []; // Clear script output buffer
     setStatus("disconnected");
     setMode("browsing");
     modeRef.current = "browsing";

--- a/src/web/src/hooks/useTerminal.ts
+++ b/src/web/src/hooks/useTerminal.ts
@@ -58,6 +58,14 @@ export interface SessionInfo {
   exitCode?: number;
 }
 
+/** Script execution state (during workspace attach) */
+export interface ScriptState {
+  phase: 'pre' | 'setup' | 'select' | 'remove';
+  isRunning: boolean;
+  error?: string;
+  exitCode?: number;
+}
+
 /** Project information from machine */
 export interface ProjectInfo {
   name: string;
@@ -85,6 +93,7 @@ export function useTerminal() {
   const [selectedProjectName, setSelectedProjectName] = useState<string | null>(null);
   const [inbox, setInbox] = useState<InboxItem[]>([]);
   const [inboxUnreadCount, setInboxUnreadCount] = useState(0);
+  const [scriptState, setScriptState] = useState<ScriptState | null>(null);
 
   const wsRef = useRef<WebSocket | null>(null);
   const identityRef = useRef<Identity | null>(null);
@@ -421,6 +430,37 @@ export function useTerminal() {
   }, [requestWorkspaces]);
 
   /**
+   * Write PTY data to terminal with UTF-8 boundary handling
+   * Buffers incomplete UTF-8 sequences to prevent garbled output
+   */
+  const writePtyData = useCallback((data: Uint8Array) => {
+    if (!writeCallbackRef.current) return;
+
+    // Combine with any buffered incomplete UTF-8 bytes
+    let combined: Uint8Array;
+    if (utf8BufferRef.current.length > 0) {
+      combined = new Uint8Array(utf8BufferRef.current.length + data.length);
+      combined.set(utf8BufferRef.current, 0);
+      combined.set(data, utf8BufferRef.current.length);
+      utf8BufferRef.current = new Uint8Array(0);
+    } else {
+      combined = data;
+    }
+
+    // Find UTF-8 boundary
+    const boundary = findUtf8Boundary(combined);
+    if (boundary < combined.length) {
+      // Buffer incomplete sequence for next time
+      utf8BufferRef.current = combined.slice(boundary);
+      combined = combined.slice(0, boundary);
+    }
+
+    if (combined.length > 0) {
+      writeCallbackRef.current(combined);
+    }
+  }, []);
+
+  /**
    * Handle a decrypted browse response (workspace_list, session_list, etc.)
    */
   const handleBrowseResponse = useCallback((msg: Record<string, unknown>) => {
@@ -497,45 +537,50 @@ export function useTerminal() {
         requestInbox();
         break;
 
+      case "script_output": {
+        // Handle script output streaming during attach_session
+        const phase = msg.phase as ScriptState['phase'];
+        const done = msg.done as boolean | undefined;
+        const error = msg.error as string | undefined;
+        const exitCode = msg.exitCode as number | undefined;
+
+        // Update script state
+        if (done) {
+          if (error) {
+            setScriptState({ phase, isRunning: false, error, exitCode });
+          } else {
+            // Scripts completed successfully - clear state (attach response will follow)
+            setScriptState(null);
+          }
+        } else {
+          setScriptState({ phase, isRunning: true });
+        }
+
+        // Decode base64 output data and write to terminal
+        const data = msg.data as string;
+        if (data && data.length > 0) {
+          const ptyData = Uint8Array.from(atob(data), c => c.charCodeAt(0));
+          writePtyData(ptyData);
+        }
+        break;
+      }
+
       case "error":
         console.error("Machine error:", msg.code, msg.message);
+        // If we were running scripts, mark as failed
+        if (scriptState?.isRunning) {
+          setScriptState({
+            ...scriptState,
+            isRunning: false,
+            error: msg.message as string,
+          });
+        }
         break;
 
       default:
         console.log("Unknown browse response:", msg.type);
     }
-  }, [requestWorkspaces, requestSessions, requestInbox]);
-
-  /**
-   * Write PTY data to terminal with UTF-8 boundary handling
-   * Buffers incomplete UTF-8 sequences to prevent garbled output
-   */
-  const writePtyData = useCallback((data: Uint8Array) => {
-    if (!writeCallbackRef.current) return;
-
-    // Combine with any buffered incomplete UTF-8 bytes
-    let combined: Uint8Array;
-    if (utf8BufferRef.current.length > 0) {
-      combined = new Uint8Array(utf8BufferRef.current.length + data.length);
-      combined.set(utf8BufferRef.current, 0);
-      combined.set(data, utf8BufferRef.current.length);
-      utf8BufferRef.current = new Uint8Array(0);
-    } else {
-      combined = data;
-    }
-
-    // Find UTF-8 boundary
-    const boundary = findUtf8Boundary(combined);
-    if (boundary < combined.length) {
-      // Buffer incomplete sequence for next time
-      utf8BufferRef.current = combined.slice(boundary);
-      combined = combined.slice(0, boundary);
-    }
-
-    if (combined.length > 0) {
-      writeCallbackRef.current(combined);
-    }
-  }, []);
+  }, [requestWorkspaces, requestSessions, requestInbox, writePtyData, scriptState]);
 
   const handleDataMessage = useCallback(async (base64Data: string) => {
     const sessionKeys = sessionKeysRef.current;
@@ -653,6 +698,7 @@ export function useTerminal() {
     setSelectedProjectName(null);
     setInbox([]);
     setInboxUnreadCount(0);
+    setScriptState(null);
   }, []);
 
   return {
@@ -695,5 +741,8 @@ export function useTerminal() {
     requestInbox,
     clearInboxItem,
     markInboxItemRead,
+
+    // Script execution state (during attach)
+    scriptState,
   };
 }


### PR DESCRIPTION
## Summary
- Display lifecycle scripts (pre, setup, select, remove) in a terminal view as they run, showing ANSI output with copy/paste support
- Add progress callbacks to show step-by-step status in loading spinners during workspace/project deletion and worktree creation

## Test plan
- [ ] Create a new workspace and verify script output displays in terminal view during pre/setup phases
- [ ] Select an existing workspace and verify select scripts show in terminal view
- [ ] Delete a workspace and verify progress messages update ("Killing sessions...", "Running cleanup scripts...", "Removing worktree...", etc.)
- [ ] Delete a project with multiple workspaces and verify progress shows each workspace being removed
- [ ] Connect via web UI and verify script output streams correctly over WebSocket

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a scripts view with a read-only terminal for running workspace scripts, showing live output, phase/status, and copy-to-clipboard support; prevents input while scripts run.
* **Improvements**
  * Real-time streaming of script output and richer progress messages during project/workspace operations and session flows.
* **Tests**
  * Added tests covering script output callback behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->