### PR TITLE
Fix TUI terminal cursor/scroll sync and cap scrollback

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
   },
   "packageManager": "pnpm@10.12.1+sha512.f0dda8580f0ee9481c5c79a1d927b9164f2c478e90992ad268bbb2465a736984391d6333d2c327913578b2804af33474ca554ba29c04a8b13060a717675ae3ac",
   "patchedDependencies": {
-    "@opentui/core@0.1.72": "patches/@opentui%2Fcore@0.1.72.patch"
+    "@opentui/core@0.1.72": "patches/@opentui%2Fcore@0.1.72.patch",
+    "ghostty-opentui@1.3.12": "patches/ghostty-opentui@1.3.12.patch"
   }
 }

--- a/patches/ghostty-opentui@1.3.12.patch
+++ b/patches/ghostty-opentui@1.3.12.patch
@@ -1,0 +1,26 @@
+diff --git a/dist/terminal-buffer.js b/dist/terminal-buffer.js
+index 40a50209b2c790405664a711c78df4f3c9890b25..e2c348bb03e9ecca0e78192d0e6fa7e42046e281 100644
+--- a/dist/terminal-buffer.js
++++ b/dist/terminal-buffer.js
+@@ -427,7 +427,7 @@ export class GhosttyTerminalRenderable extends TextBufferRenderable {
+             // Build cursor info if enabled
+             const cursor = this._showCursor ? {
+                 x: data.cursor[0],
+-                y: data.cursor[1],
++                y: Math.max(0, (data.totalLines - data.rows) + data.cursor[1] - data.offset),
+                 style: this._cursorStyle,
+             } : undefined;
+             const styledText = terminalDataToStyledText(data, this._highlights, cursor);
+diff --git a/src/terminal-buffer.ts b/src/terminal-buffer.ts
+index 96e8dae07c30329b79cc8e4ec0054f0b48a42ea1..30f5f37a049416627934a3120fd0f33da12b0103 100644
+--- a/src/terminal-buffer.ts
++++ b/src/terminal-buffer.ts
+@@ -568,7 +568,7 @@ export class GhosttyTerminalRenderable extends TextBufferRenderable {
+       // Build cursor info if enabled
+       const cursor = this._showCursor ? {
+         x: data.cursor[0],
+-        y: data.cursor[1],
++        y: Math.max(0, (data.totalLines - data.rows) + data.cursor[1] - data.offset),
+         style: this._cursorStyle,
+       } : undefined
+       

--- a/src/lib/tmux-lite/server.ts
+++ b/src/lib/tmux-lite/server.ts
@@ -40,7 +40,7 @@ const PTY_CHUNK_SIZE = 512 * 1024;
 
 // Max scrollback lines to include in serialized state during attach
 // This is a limit - if less scrollback exists, we'll send what's available
-const SERIALIZE_SCROLLBACK_LINES = 1_000;
+const SERIALIZE_SCROLLBACK_LINES = 10_000;
 
 const rawArgs = process.argv.slice(2);
 if (rawArgs.includes("--test")) {
@@ -1049,9 +1049,9 @@ function createSession(name: string | undefined, cwd: string): Session {
   const xterm = new XTerminal({
     cols,
     rows,
-    // Keep stored scrollback bounded to avoid slow attach+render on large sessions.
+    // Keep stored scrollback bounded; match ghostty-web default (10k).
     // Note: attach serialization is additionally capped by SERIALIZE_SCROLLBACK_LINES.
-    scrollback: 2_000,
+    scrollback: 10_000,
     allowProposedApi: true,
   });
 

--- a/src/tui/components/Terminal.tsx
+++ b/src/tui/components/Terminal.tsx
@@ -78,6 +78,8 @@ const COLORS = {
   error: '#FF4444',
 };
 
+const SCROLLBACK_LIMIT = 2_000;
+
 // ============================================================================
 // Terminal Component
 // ============================================================================
@@ -120,6 +122,7 @@ export function Terminal({ session, onDetach, onExit, onKicked, onError, interce
   const pendingPtyDataRef = useRef<Buffer[]>([]); // Buffer PTY data until "attached" received
   const lastSizeRef = useRef({ cols: 0, rows: 0 });
   const statusRef = useRef<TerminalStatus>(status);
+  const followScrollTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // Track bracketed paste mode (DECSET 2004) as requested by the remote program.
   const bracketedPasteRef = useRef(new BracketedPasteModeTracker());
@@ -156,6 +159,53 @@ export function Terminal({ session, onDetach, onExit, onKicked, onError, interce
 
   const updateBracketedPasteMode = useCallback((chunk: Buffer) => {
     bracketedPasteRef.current.update(chunk);
+  }, []);
+
+  const scrollToCursorIfFollowing = useCallback(() => {
+    const scrollBox = scrollBoxRef.current;
+    const terminal = terminalRef.current;
+    if (!scrollBox || !terminal) return;
+
+    const maxScrollTop = Math.max(0, scrollBox.scrollHeight - scrollBox.viewport.height);
+    const isAtBottom = scrollBox.scrollTop >= maxScrollTop - 1;
+    if (!isAtBottom) return;
+
+    let cursor: [number, number];
+    try {
+      cursor = terminal.getCursor();
+    } catch {
+      return;
+    }
+
+    const lineCount = terminal.lineCount ?? 0;
+    if (lineCount <= 0) return;
+
+    if (lineCount > SCROLLBACK_LIMIT) {
+      // Drop saved scrollback locally while keeping current screen.
+      // This caps client-side history without affecting the PTY/server state.
+      terminal.feed(Buffer.from("\x1b[3J"));
+    }
+
+    const cursorLine = Math.max(0, lineCount - terminal.rows + cursor[1]);
+    const scrollPos = terminal.getScrollPositionForLine(cursorLine);
+    scrollBox.scrollTo(scrollPos);
+  }, []);
+
+  const scheduleScrollFollow = useCallback(() => {
+    if (followScrollTimeoutRef.current) return;
+    followScrollTimeoutRef.current = setTimeout(() => {
+      followScrollTimeoutRef.current = null;
+      scrollToCursorIfFollowing();
+    }, 0);
+  }, [scrollToCursorIfFollowing]);
+
+  useEffect(() => {
+    return () => {
+      if (followScrollTimeoutRef.current) {
+        clearTimeout(followScrollTimeoutRef.current);
+        followScrollTimeoutRef.current = null;
+      }
+    };
   }, []);
 
   // Handle paste events from OpenTUI (bracketed paste on the *local* terminal).
@@ -197,8 +247,15 @@ export function Terminal({ session, onDetach, onExit, onKicked, onError, interce
       const combined = Buffer.concat(pendingPtyDataRef.current);
       pendingPtyDataRef.current = [];
       terminalRef.current.feed(combined);
+      scheduleScrollFollow();
     }
-  }, [terminalMounted]);
+  }, [scheduleScrollFollow, terminalMounted]);
+
+  // Align scroll position after initial snapshot render
+  useEffect(() => {
+    if (!terminalMounted || !initialData) return;
+    scheduleScrollFollow();
+  }, [initialData, scheduleScrollFollow, terminalMounted]);
 
   // Send resize to session
   const sendResize = useCallback((force = false) => {
@@ -224,7 +281,8 @@ export function Terminal({ session, onDetach, onExit, onKicked, onError, interce
       terminalRef.current.cols = cols;
       terminalRef.current.rows = rows;
     }
-  }, []);
+    scheduleScrollFollow();
+  }, [scheduleScrollFollow]);
 
   // Connect to session socket
   useEffect(() => {
@@ -324,6 +382,7 @@ export function Terminal({ session, onDetach, onExit, onKicked, onError, interce
                   if (combined.length > 0) {
                     debugLog(`Feeding ${combined.length} bytes to ghostty`, combined);
                     terminalRef.current.feed(combined);
+                    scheduleScrollFollow();
                   }
                 } else {
                   // Terminal not yet mounted - buffer for later
@@ -486,7 +545,7 @@ export function Terminal({ session, onDetach, onExit, onKicked, onError, interce
   const handleMouseUp = useCallback(async (event: MouseEvent) => {
     // Check if we were selecting (isSelecting is set during drag selection)
     if (event.isSelecting && terminalRef.current) {
-      const selectedText = terminalRef.current.getSelectedText();
+      const selectedText = (terminalRef.current as any).getSelectedText?.();
       if (selectedText && selectedText.length > 0) {
         try {
           await copyToClipboard(selectedText);


### PR DESCRIPTION
## Summary
- fix TUI cursor visibility/position drift in `ghostty-opentui` + `scrollbox` by following the cursor line only while the view is at the sticky bottom position
- cap terminal history growth to keep attached TUI performance stable (local compaction threshold `2_000`) and align tmux-lite server/snapshot caps to explicit `10_000`
- add and register a Bun patch for `ghostty-opentui@1.3.12` that corrects cursor line mapping when scrollback is present

## Notes
- upstream issue filed for the cursor mapping bug: https://github.com/remorses/ghostty-opentui/issues/4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed terminal cursor positioning to properly account for scroll offset

* **New Features**
  * Added automatic scroll-to-cursor following when at bottom of scrollback
  * Enhanced text selection and clipboard operations
  * Improved input handling with modal awareness and activity tracking

* **Improvements**
  * Increased scrollback history limits to preserve significantly more terminal output

<!-- end of auto-generated comment: release notes by coderabbit.ai -->