### PR TITLE
Fix PageUp/PageDown handling between local scrollback and PTY

### DIFF
--- a/src/app.web.tsx
+++ b/src/app.web.tsx
@@ -47,6 +47,9 @@ import {
 
 type View = "machines" | "terminal";
 
+const PAGE_UP = '\x1b[5~';
+const PAGE_DOWN = '\x1b[6~';
+
 export default function App() {
   const [view, setView] = useState<View>("machines");
   const [selectedMachine, setSelectedMachine] = useState<MachineInfo | null>(null);
@@ -762,6 +765,14 @@ export default function App() {
   if (view === "terminal" && terminal.status === "established" && terminal.mode === "attached") {
     // Handler for sending data from mobile controls (already processed)
     const handleSendData = (data: string) => {
+      if (data === PAGE_UP && terminalRef.current?.pageUp()) {
+        return;
+      }
+
+      if (data === PAGE_DOWN && terminalRef.current?.pageDown()) {
+        return;
+      }
+
       terminal.send(new TextEncoder().encode(data));
     };
 

--- a/src/components/SessionTerminal.tui.tsx
+++ b/src/components/SessionTerminal.tui.tsx
@@ -264,6 +264,8 @@ export function SessionTerminal({
       if (
         scrollBox &&
         shouldConsumePageNavigationInScrollbox({
+          direction: 'up',
+          scrollTop: scrollBox.scrollTop,
           scrollHeight: scrollBox.scrollHeight,
           viewportHeight: scrollBox.viewport.height,
         })
@@ -278,6 +280,8 @@ export function SessionTerminal({
       if (
         scrollBox &&
         shouldConsumePageNavigationInScrollbox({
+          direction: 'down',
+          scrollTop: scrollBox.scrollTop,
           scrollHeight: scrollBox.scrollHeight,
           viewportHeight: scrollBox.viewport.height,
         })

--- a/src/components/SessionTerminal.tui.tsx
+++ b/src/components/SessionTerminal.tui.tsx
@@ -12,6 +12,10 @@ import { findUtf8Boundary } from '../utils/utf8.js';
 import { BracketedPasteModeTracker, wrapPaste } from './terminal-bracketed-paste.tui.js';
 import { toast } from '@opentui-ui/toast';
 import { copyToClipboard } from '../utils/clipboard.js';
+import {
+  getPageNavigationEscapeSequence,
+  shouldConsumePageNavigationInScrollbox,
+} from './session-terminal-page-navigation.js';
 
 extend({ 'ghostty-terminal': GhosttyTerminalRenderable });
 
@@ -256,13 +260,31 @@ export function SessionTerminal({
     }
 
     if (key.name === 'pageup') {
-      scrollBoxRef.current?.scrollBy(-1, 'viewport');
-      return;
+      const scrollBox = scrollBoxRef.current;
+      if (
+        scrollBox &&
+        shouldConsumePageNavigationInScrollbox({
+          scrollHeight: scrollBox.scrollHeight,
+          viewportHeight: scrollBox.viewport.height,
+        })
+      ) {
+        scrollBox.scrollBy(-1, 'viewport');
+        return;
+      }
     }
 
     if (key.name === 'pagedown') {
-      scrollBoxRef.current?.scrollBy(1, 'viewport');
-      return;
+      const scrollBox = scrollBoxRef.current;
+      if (
+        scrollBox &&
+        shouldConsumePageNavigationInScrollbox({
+          scrollHeight: scrollBox.scrollHeight,
+          viewportHeight: scrollBox.viewport.height,
+        })
+      ) {
+        scrollBox.scrollBy(1, 'viewport');
+        return;
+      }
     }
 
     if (key.name === 'escape' && key.ctrl) {
@@ -298,6 +320,10 @@ export function SessionTerminal({
       } else if (code.length === 1) {
         data = `\x1b[1;${modifier}${code}`;
       }
+    } else if (key.name === 'pageup') {
+      data = getPageNavigationEscapeSequence('up');
+    } else if (key.name === 'pagedown') {
+      data = getPageNavigationEscapeSequence('down');
     } else if (key.sequence) {
       data = key.sequence;
     } else if (key.raw) {

--- a/src/components/SessionTerminal.web.tsx
+++ b/src/components/SessionTerminal.web.tsx
@@ -1,5 +1,9 @@
-import { useEffect, useRef, useImperativeHandle, forwardRef } from "react";
+import { useEffect, useRef, useImperativeHandle, forwardRef, useCallback } from "react";
 import { init, Terminal as GhosttyTerminal, FitAddon } from "ghostty-web";
+import {
+  canConsumePageNavigationInViewport,
+  type PageDirection,
+} from './session-terminal-page-navigation.js';
 
 interface Props {
   onData: (data: Uint8Array) => void;
@@ -20,6 +24,19 @@ export interface SessionTerminalHandle {
   sendData: (data: string) => void;
   isFocused: () => boolean;
   getSize: () => { cols: number; rows: number } | null;
+  pageUp: () => boolean;
+  pageDown: () => boolean;
+}
+
+interface TerminalViewportLike {
+  viewportY?: number;
+  rows?: number;
+  scrollLines: (lines: number) => void;
+  buffer?: {
+    active?: {
+      baseY?: number;
+    };
+  };
 }
 
 // Touch scrolling constants (agentboard-inspired accumulated delta pattern)
@@ -73,6 +90,30 @@ export const SessionTerminal = forwardRef<SessionTerminalHandle, Props>(function
     allowTouchScrollRef.current = allowTouchScroll;
   }, [allowTouchScroll]);
 
+  const tryConsumePageNavigation = useCallback((direction: PageDirection): boolean => {
+    const terminal = terminalRef.current as unknown as TerminalViewportLike | null;
+    if (!terminal) {
+      return false;
+    }
+
+    const viewportY = terminal.viewportY ?? 0;
+    const baseY = terminal.buffer?.active?.baseY ?? 0;
+    const canConsume = canConsumePageNavigationInViewport({
+      direction,
+      viewportY,
+      baseY,
+    });
+
+    if (!canConsume) {
+      return false;
+    }
+
+    const linesPerPage = Math.max(1, (terminal.rows ?? 1) - 1);
+    terminal.scrollLines(direction === 'up' ? -linesPerPage : linesPerPage);
+    onActivityRef.current?.();
+    return true;
+  }, []);
+
   // Expose methods via ref for external control (e.g., from TerminalControls)
   useImperativeHandle(
     ref,
@@ -102,8 +143,10 @@ export const SessionTerminal = forwardRef<SessionTerminalHandle, Props>(function
         }
         return { cols: term.cols, rows: term.rows };
       },
+      pageUp: () => tryConsumePageNavigation('up'),
+      pageDown: () => tryConsumePageNavigation('down'),
     }),
-    []
+    [tryConsumePageNavigation]
   );
 
   useEffect(() => {
@@ -164,6 +207,22 @@ export const SessionTerminal = forwardRef<SessionTerminalHandle, Props>(function
             event.preventDefault();
             event.stopPropagation();
             onDataRef.current(new TextEncoder().encode('\x1b[Z'));
+            return;
+          }
+
+          if (event.key === 'PageUp') {
+            if (tryConsumePageNavigation('up')) {
+              event.preventDefault();
+              event.stopPropagation();
+            }
+            return;
+          }
+
+          if (event.key === 'PageDown') {
+            if (tryConsumePageNavigation('down')) {
+              event.preventDefault();
+              event.stopPropagation();
+            }
           }
         };
         container.addEventListener('keydown', handleKeyDown, true);
@@ -301,7 +360,7 @@ export const SessionTerminal = forwardRef<SessionTerminalHandle, Props>(function
         setWriteCallback(null);
       }
     };
-  }, [setWriteCallback]);
+  }, [setWriteCallback, tryConsumePageNavigation]);
 
   return (
     <div

--- a/src/components/session-terminal-page-navigation.ts
+++ b/src/components/session-terminal-page-navigation.ts
@@ -1,6 +1,8 @@
 export type PageDirection = 'up' | 'down';
 
 interface ScrollboxPageNavigationState {
+  direction: PageDirection;
+  scrollTop: number;
   scrollHeight: number;
   viewportHeight: number;
 }
@@ -12,10 +14,21 @@ interface ViewportPageNavigationState {
 }
 
 export function shouldConsumePageNavigationInScrollbox({
+  direction,
+  scrollTop,
   scrollHeight,
   viewportHeight,
 }: ScrollboxPageNavigationState): boolean {
-  return scrollHeight > viewportHeight;
+  const maxScrollTop = Math.max(0, scrollHeight - viewportHeight);
+  if (maxScrollTop <= 0) {
+    return false;
+  }
+
+  if (direction === 'up') {
+    return scrollTop > 0;
+  }
+
+  return scrollTop < maxScrollTop;
 }
 
 export function canConsumePageNavigationInViewport({
@@ -24,10 +37,10 @@ export function canConsumePageNavigationInViewport({
   baseY,
 }: ViewportPageNavigationState): boolean {
   if (direction === 'up') {
-    return baseY > 0 || viewportY > 0;
+    return viewportY < baseY;
   }
 
-  return viewportY < baseY;
+  return viewportY > 0;
 }
 
 export function getPageNavigationEscapeSequence(direction: PageDirection): string {

--- a/src/components/session-terminal-page-navigation.ts
+++ b/src/components/session-terminal-page-navigation.ts
@@ -1,0 +1,35 @@
+export type PageDirection = 'up' | 'down';
+
+interface ScrollboxPageNavigationState {
+  scrollHeight: number;
+  viewportHeight: number;
+}
+
+interface ViewportPageNavigationState {
+  direction: PageDirection;
+  viewportY: number;
+  baseY: number;
+}
+
+export function shouldConsumePageNavigationInScrollbox({
+  scrollHeight,
+  viewportHeight,
+}: ScrollboxPageNavigationState): boolean {
+  return scrollHeight > viewportHeight;
+}
+
+export function canConsumePageNavigationInViewport({
+  direction,
+  viewportY,
+  baseY,
+}: ViewportPageNavigationState): boolean {
+  if (direction === 'up') {
+    return baseY > 0 || viewportY > 0;
+  }
+
+  return viewportY < baseY;
+}
+
+export function getPageNavigationEscapeSequence(direction: PageDirection): string {
+  return direction === 'up' ? '\x1b[5~' : '\x1b[6~';
+}

--- a/src/tui/__tests__/session-terminal-page-navigation.test.ts
+++ b/src/tui/__tests__/session-terminal-page-navigation.test.ts
@@ -6,32 +6,81 @@ import {
 } from '../../components/session-terminal-page-navigation.js'
 
 describe('session terminal page navigation helpers', () => {
-  it('consumes page navigation only when scrollbox has overflow', () => {
-    expect(shouldConsumePageNavigationInScrollbox({ scrollHeight: 100, viewportHeight: 20 })).toBe(true)
-    expect(shouldConsumePageNavigationInScrollbox({ scrollHeight: 20, viewportHeight: 20 })).toBe(false)
-    expect(shouldConsumePageNavigationInScrollbox({ scrollHeight: 10, viewportHeight: 20 })).toBe(false)
+  it('consumes scrollbox page navigation only when scroll can move', () => {
+    expect(
+      shouldConsumePageNavigationInScrollbox({
+        direction: 'up',
+        scrollTop: 10,
+        scrollHeight: 100,
+        viewportHeight: 20,
+      })
+    ).toBe(true)
+
+    expect(
+      shouldConsumePageNavigationInScrollbox({
+        direction: 'up',
+        scrollTop: 0,
+        scrollHeight: 100,
+        viewportHeight: 20,
+      })
+    ).toBe(false)
+
+    expect(
+      shouldConsumePageNavigationInScrollbox({
+        direction: 'down',
+        scrollTop: 10,
+        scrollHeight: 100,
+        viewportHeight: 20,
+      })
+    ).toBe(true)
+
+    expect(
+      shouldConsumePageNavigationInScrollbox({
+        direction: 'down',
+        scrollTop: 80,
+        scrollHeight: 100,
+        viewportHeight: 20,
+      })
+    ).toBe(false)
+
+    expect(
+      shouldConsumePageNavigationInScrollbox({
+        direction: 'down',
+        scrollTop: 0,
+        scrollHeight: 20,
+        viewportHeight: 20,
+      })
+    ).toBe(false)
   })
 
   it('detects when viewport can consume page up/down', () => {
     expect(
       canConsumePageNavigationInViewport({
         direction: 'up',
+        viewportY: 50,
+        baseY: 200,
+      })
+    ).toBe(true)
+
+    expect(
+      canConsumePageNavigationInViewport({
+        direction: 'down',
+        viewportY: 1,
+        baseY: 200,
+      })
+    ).toBe(true)
+
+    expect(
+      canConsumePageNavigationInViewport({
+        direction: 'down',
         viewportY: 0,
         baseY: 200,
       })
-    ).toBe(true)
+    ).toBe(false)
 
     expect(
       canConsumePageNavigationInViewport({
-        direction: 'down',
-        viewportY: 75,
-        baseY: 200,
-      })
-    ).toBe(true)
-
-    expect(
-      canConsumePageNavigationInViewport({
-        direction: 'down',
+        direction: 'up',
         viewportY: 200,
         baseY: 200,
       })

--- a/src/tui/__tests__/session-terminal-page-navigation.test.ts
+++ b/src/tui/__tests__/session-terminal-page-navigation.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'bun:test'
+import {
+  canConsumePageNavigationInViewport,
+  getPageNavigationEscapeSequence,
+  shouldConsumePageNavigationInScrollbox,
+} from '../../components/session-terminal-page-navigation.js'
+
+describe('session terminal page navigation helpers', () => {
+  it('consumes page navigation only when scrollbox has overflow', () => {
+    expect(shouldConsumePageNavigationInScrollbox({ scrollHeight: 100, viewportHeight: 20 })).toBe(true)
+    expect(shouldConsumePageNavigationInScrollbox({ scrollHeight: 20, viewportHeight: 20 })).toBe(false)
+    expect(shouldConsumePageNavigationInScrollbox({ scrollHeight: 10, viewportHeight: 20 })).toBe(false)
+  })
+
+  it('detects when viewport can consume page up/down', () => {
+    expect(
+      canConsumePageNavigationInViewport({
+        direction: 'up',
+        viewportY: 0,
+        baseY: 200,
+      })
+    ).toBe(true)
+
+    expect(
+      canConsumePageNavigationInViewport({
+        direction: 'down',
+        viewportY: 75,
+        baseY: 200,
+      })
+    ).toBe(true)
+
+    expect(
+      canConsumePageNavigationInViewport({
+        direction: 'down',
+        viewportY: 200,
+        baseY: 200,
+      })
+    ).toBe(false)
+  })
+
+  it('returns standard escape sequences for page keys', () => {
+    expect(getPageNavigationEscapeSequence('up')).toBe('\x1b[5~')
+    expect(getPageNavigationEscapeSequence('down')).toBe('\x1b[6~')
+  })
+})


### PR DESCRIPTION
## Summary
- Make TUI session terminals consume PgUp/PgDn only when local scrollback exists, and otherwise forward keys to the PTY.
- Add matching web terminal behavior for physical keyboard navigation and expose imperative page navigation methods for shared controls.
- Route mobile PgUp/PgDn controls through the same consume-or-forward logic and add regression tests for page navigation helpers.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches terminal input/scrollback handling across TUI and web, so regressions could break key forwarding or scrolling behavior, but changes are localized and covered by new unit tests.
> 
> **Overview**
> Fixes PageUp/PageDown behavior so terminals only use these keys for **local scrollback navigation** when scrolling is possible, and otherwise forward the standard escape sequences to the remote PTY.
> 
> Adds shared helpers in `session-terminal-page-navigation.ts`, updates both `SessionTerminal.tui` and `SessionTerminal.web` to use consume-or-forward logic (including new imperative `pageUp`/`pageDown` methods and physical-key interception on web), and routes mobile PgUp/PgDn controls through the same path in `app.web.tsx` with new regression tests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 14955d4636f9ac4c2f75e4a79190c33ba576057a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Page Up / Page Down keyboard support for terminal output, enabling page-by-page navigation in both web and terminal UI.
  * Terminal API now exposes pageUp/pageDown actions for programmatic control.

* **Tests**
  * Added unit tests covering page-navigation behavior and key-sequence handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->