### PR TITLE
Improve workspace delete lifecycle script handling

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -39,10 +39,10 @@
         "typescript": "^5.9.3",
       },
       "optionalDependencies": {
-        "@gitspace/darwin-arm64": "0.2.0-rc.12",
-        "@gitspace/darwin-x64": "0.2.0-rc.12",
-        "@gitspace/linux-arm64": "0.2.0-rc.12",
-        "@gitspace/linux-x64": "0.2.0-rc.12",
+        "@gitspace/darwin-arm64": "0.2.0-rc.15",
+        "@gitspace/darwin-x64": "0.2.0-rc.15",
+        "@gitspace/linux-arm64": "0.2.0-rc.15",
+        "@gitspace/linux-x64": "0.2.0-rc.15",
       },
     },
   },
@@ -63,7 +63,7 @@
 
     "@eslint/js": ["@eslint/js@8.57.1", "", {}, "sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q=="],
 
-    "@gitspace/darwin-arm64": ["@gitspace/darwin-arm64@0.2.0-rc.12", "", { "os": "darwin", "cpu": "arm64", "bin": { "gssh-darwin-arm64": "bin/gssh" } }, "sha512-FUCz7f6EThB1/epRZ+X3SV7wDq/m4mFRDy2AVXGurVK6OWAA+D8tddUYeGmxvYT9+PXEZDATu5ukBh2RKpr5OQ=="],
+    "@gitspace/darwin-arm64": ["@gitspace/darwin-arm64@0.2.0-rc.15", "", { "os": "darwin", "cpu": "arm64", "bin": { "gssh-darwin-arm64": "bin/gssh" } }, "sha512-gjqsRdz2f7cOOTbj97wmQ4Z0nh7jWUVN4Dxj1N/Ex4fp6dJ8qu2d5izbsCHWVIPX4uN+gK/qqzxuwLwCdaEqlQ=="],
 
     "@graphql-typed-document-node/core": ["@graphql-typed-document-node/core@3.2.0", "", { "peerDependencies": { "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0" } }, "sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ=="],
 

--- a/src/app.tui.tsx
+++ b/src/app.tui.tsx
@@ -2576,11 +2576,9 @@ export async function launchTUI(
   relayConfig?: RelayConfig,
   options: { ignoreKeychainAndSkipSecrets?: boolean } = {}
 ): Promise<void> {
-  if (!relayConfig) {
-    await initializeSecretRuntime({
-      ignoreKeychainAndSkipSecrets: options.ignoreKeychainAndSkipSecrets,
-    });
-  }
+  await initializeSecretRuntime({
+    ignoreKeychainAndSkipSecrets: options.ignoreKeychainAndSkipSecrets,
+  });
 
   const renderer = await createCliRenderer({
     exitOnCtrlC: false,

--- a/src/app.tui.tsx
+++ b/src/app.tui.tsx
@@ -87,6 +87,7 @@ import { useUserActivity } from './hooks/index.js';
 import { useBundleRefreshAttachFlow } from './session/index.js';
 import { useAttachController } from './app/session/useAttachController.js';
 import { useWorkspaceDeleteFlow } from './app/session/useWorkspaceDeleteFlow.js';
+import { initializeSecretRuntime } from './core/secret-runtime.js';
 import {
   resolveInboxCommand,
   resolveMachineListCommand,
@@ -2571,7 +2572,16 @@ function StatusBar({ hint }: { hint: string }) {
 /** @deprecated Use RelayConfig instead */
 export type TUIRelayConfig = RelayConfig;
 
-export async function launchTUI(relayConfig?: RelayConfig): Promise<void> {
+export async function launchTUI(
+  relayConfig?: RelayConfig,
+  options: { ignoreKeychainAndSkipSecrets?: boolean } = {}
+): Promise<void> {
+  if (!relayConfig) {
+    await initializeSecretRuntime({
+      ignoreKeychainAndSkipSecrets: options.ignoreKeychainAndSkipSecrets,
+    });
+  }
+
   const renderer = await createCliRenderer({
     exitOnCtrlC: false,
     targetFps: 30,

--- a/src/app.tui.tsx
+++ b/src/app.tui.tsx
@@ -86,6 +86,7 @@ import { useLocalSession } from './hooks/useLocalSession.tui.js';
 import { useUserActivity } from './hooks/index.js';
 import { useBundleRefreshAttachFlow } from './session/index.js';
 import { useAttachController } from './app/session/useAttachController.js';
+import { useWorkspaceDeleteFlow } from './app/session/useWorkspaceDeleteFlow.js';
 import {
   resolveInboxCommand,
   resolveMachineListCommand,
@@ -438,6 +439,27 @@ function App({ relayConfig, onQuit }: AppProps) {
     },
   });
 
+  const { deleteWorkspaceWithPrompt } = useWorkspaceDeleteFlow({
+    flow,
+    deleteWorkspace: deleteLocalWorkspace,
+    onBeforeDelete: ({ target }) => {
+      setScriptWorkspaceName(target.workspaceName);
+      dispatch({ type: 'SET_VIEW', view: 'scripts' });
+    },
+    onDeleteSuccess: async () => {
+      dispatch({ type: 'SET_VIEW', view: 'projects' });
+      await refreshWorkspaces();
+    },
+    onDeleteError: async ({ message }) => {
+      dispatch({ type: 'SET_VIEW', view: 'projects' });
+      flow.showMessage({
+        title: 'Delete Failed',
+        message,
+        variant: 'error',
+      });
+    },
+  });
+
   // Daemon status hook (tmux-lite and serve)
   const { status: daemonStatus } = useDaemonStatus({ pollInterval: 5000 });
 
@@ -600,26 +622,14 @@ function App({ relayConfig, onQuit }: AppProps) {
       warning: workspace.sessionCount > 0 ? `This will kill ${workspace.sessionCount} active session(s)!` : undefined,
       onConfirm: async () => {
         if (!currentProject) return;
-        flow.showLoading({ title: 'Deleting', message: 'Preparing...' });
-
-        try {
-          await deleteLocalWorkspace(currentProject, workspace.id);
-        } catch (error) {
-          console.error('[tui] Failed to delete workspace:', error);
-          flow.close();
-          flow.showMessage({
-            title: 'Delete Failed',
-            message: error instanceof Error ? error.message : `Failed to delete workspace "${workspace.name}".`,
-            variant: 'error',
-          });
-          return;
-        }
-
-        flow.close();
-        await refreshWorkspaces();
+        await deleteWorkspaceWithPrompt({
+          projectName: currentProject,
+          workspaceId: workspace.id,
+          workspaceName: workspace.name,
+        });
       },
     });
-  }, [currentProject, flow, refreshWorkspaces]);
+  }, [currentProject, flow, deleteWorkspaceWithPrompt]);
 
   // Delete session
   const handleDeleteSession = useCallback((sessionId: string, sessionName: string) => {

--- a/src/app.web.tsx
+++ b/src/app.web.tsx
@@ -18,6 +18,7 @@ import { applyDeviceClasses, isMobileLayout, isTouchDevice } from "./utils/devic
 import { useUserActivity } from "./hooks/index.js";
 import { useBundleRefreshAttachFlow } from './session/useBundleRefreshAttachFlow.js';
 import { useAttachController } from './app/session/useAttachController.js';
+import { useWorkspaceDeleteFlow } from './app/session/useWorkspaceDeleteFlow.js';
 
 // Import shared components and hooks
 import {
@@ -174,6 +175,29 @@ export default function App() {
     },
   });
 
+  const { deleteWorkspaceWithPrompt } = useWorkspaceDeleteFlow({
+    flow,
+    deleteWorkspace: terminal.deleteWorkspace,
+    onBeforeDelete: ({ target }) => {
+      setShowInbox(false);
+      setScriptWorkspaceName(target.workspaceName);
+      setShowScriptTerminal(true);
+    },
+    onDeleteSuccess: async () => {
+      setShowScriptTerminal(false);
+      terminal.requestWorkspaces();
+      terminal.requestSessions();
+    },
+    onDeleteError: async ({ message }) => {
+      setShowScriptTerminal(false);
+      flow.showMessage({
+        title: 'Delete Failed',
+        message,
+        variant: 'error',
+      });
+    },
+  });
+
   useEffect(() => {
     let mounted = true;
     void browserPreferencesService.getNotificationConfig().then((config) => {
@@ -263,7 +287,8 @@ export default function App() {
       terminal.commandError.code === 'SCRIPT_FAILED' ||
       terminal.commandError.code === 'PRE_SCRIPT_FAILED' ||
       terminal.commandError.code === 'SETUP_SCRIPT_FAILED' ||
-      terminal.commandError.code === 'SELECT_SCRIPT_FAILED';
+      terminal.commandError.code === 'SELECT_SCRIPT_FAILED' ||
+      terminal.commandError.code === 'REMOVE_SCRIPT_FAILED';
 
     if (isScriptFailure) {
       if (!terminal.scriptState) {
@@ -594,8 +619,12 @@ export default function App() {
             message: `Are you sure you want to delete workspace "${selected.workspace.name}"?`,
             confirmText: selected.workspace.name,
             warning: sessionCount > 0 ? `This will kill ${sessionCount} active session(s)!` : undefined,
-            onConfirm: () => {
-              terminal.deleteWorkspace(selected.workspace.projectName, selected.workspace.id);
+            onConfirm: async () => {
+              await deleteWorkspaceWithPrompt({
+                projectName: selected.workspace.projectName,
+                workspaceId: selected.workspace.id,
+                workspaceName: selected.workspace.name,
+              });
             },
           });
         }
@@ -607,7 +636,16 @@ export default function App() {
 
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [view, terminal.status, terminal.mode, showInbox, showScriptTerminal, spacesBrowserProps, flow]);
+  }, [
+    view,
+    terminal.status,
+    terminal.mode,
+    showInbox,
+    showScriptTerminal,
+    spacesBrowserProps,
+    flow,
+    deleteWorkspaceWithPrompt,
+  ]);
 
   // Attached terminal mode keyboard handler (Ctrl+Esc to detach)
   useEffect(() => {

--- a/src/app.web.tsx
+++ b/src/app.web.tsx
@@ -72,6 +72,7 @@ export default function App() {
   const terminalRef = useRef<SessionTerminalHandle>(null);
   const lastScriptErrorRef = useRef<string | null>(null);
   const lastCommandErrorRef = useRef<string | null>(null);
+  const suppressDeleteScriptFailureModalRef = useRef(false);
 
   // Invite params from URL
   const [inviteParams, setInviteParams] = useState<{
@@ -179,16 +180,23 @@ export default function App() {
     flow,
     deleteWorkspace: terminal.deleteWorkspace,
     onBeforeDelete: ({ target }) => {
+      suppressDeleteScriptFailureModalRef.current = true;
       setShowInbox(false);
       setScriptWorkspaceName(target.workspaceName);
       setShowScriptTerminal(true);
     },
     onDeleteSuccess: async () => {
+      suppressDeleteScriptFailureModalRef.current = false;
       setShowScriptTerminal(false);
       terminal.requestWorkspaces();
       terminal.requestSessions();
     },
+    onDeleteCancelled: async () => {
+      suppressDeleteScriptFailureModalRef.current = false;
+      setShowScriptTerminal(false);
+    },
     onDeleteError: async ({ message }) => {
+      suppressDeleteScriptFailureModalRef.current = false;
       setShowScriptTerminal(false);
       flow.showMessage({
         title: 'Delete Failed',
@@ -259,6 +267,11 @@ export default function App() {
       return;
     }
 
+    if (suppressDeleteScriptFailureModalRef.current) {
+      lastScriptErrorRef.current = scriptError;
+      return;
+    }
+
     if (lastScriptErrorRef.current === scriptError) {
       return;
     }
@@ -282,6 +295,13 @@ export default function App() {
       return;
     }
     lastCommandErrorRef.current = key;
+
+    if (
+      terminal.commandError.code === 'REMOVE_SCRIPT_FAILED' &&
+      suppressDeleteScriptFailureModalRef.current
+    ) {
+      return;
+    }
 
     const isScriptFailure =
       terminal.commandError.code === 'SCRIPT_FAILED' ||

--- a/src/app.web.tsx
+++ b/src/app.web.tsx
@@ -395,12 +395,10 @@ export default function App() {
   const spacesBrowserProps = useSpacesBrowser({
     workspaces: terminal.workspaces,
     sessions: terminal.sessions,
-    onRequestSessions: terminal.requestSessions,
+    onRequestSessions: () => terminal.requestSessions(),
     onAttachSession: handleAttachSession,
     onRefresh: terminal.requestWorkspaces,
-    onRefreshSessions: (workspaceIds) => {
-      workspaceIds.forEach(id => terminal.requestSessions(id));
-    },
+    onRefreshSessions: () => terminal.requestSessions(),
     onBack: handleBackToMachines,
     machineName: selectedMachine?.label || selectedMachine?.machineId,
   });
@@ -471,6 +469,7 @@ export default function App() {
     if (view === "terminal" && terminal.status === "established" && terminal.mode === "browsing") {
       terminal.requestProjects();
       terminal.requestWorkspaces();
+      terminal.requestSessions();
       terminal.requestNotificationConfig();
     }
   }, [
@@ -479,6 +478,7 @@ export default function App() {
     terminal.mode,
     terminal.requestProjects,
     terminal.requestWorkspaces,
+    terminal.requestSessions,
     terminal.requestNotificationConfig,
   ]);
 

--- a/src/app.web.tsx
+++ b/src/app.web.tsx
@@ -50,6 +50,13 @@ type View = "machines" | "terminal";
 
 const PAGE_UP = '\x1b[5~';
 const PAGE_DOWN = '\x1b[6~';
+const DELETE_ERROR_CODES = new Set([
+  'REMOVE_SCRIPT_FAILED',
+  'DELETE_FAILED',
+  'WORKSPACE_NOT_FOUND',
+  'RESOURCE_NOT_FOUND',
+  'NOT_FOUND',
+]);
 
 export default function App() {
   const [view, setView] = useState<View>("machines");
@@ -297,8 +304,9 @@ export default function App() {
     lastCommandErrorRef.current = key;
 
     if (
-      terminal.commandError.code === 'REMOVE_SCRIPT_FAILED' &&
-      suppressDeleteScriptFailureModalRef.current
+      suppressDeleteScriptFailureModalRef.current &&
+      terminal.commandError.code &&
+      DELETE_ERROR_CODES.has(terminal.commandError.code)
     ) {
       return;
     }

--- a/src/app/session/useWorkspaceDeleteFlow.ts
+++ b/src/app/session/useWorkspaceDeleteFlow.ts
@@ -1,0 +1,156 @@
+import { useCallback } from 'react';
+import type { UseFlowReturn } from '../../components/Flow.js';
+import type { DeleteWorkspaceParams } from '../../session/backend.js';
+
+export interface WorkspaceDeleteTarget {
+  projectName: string;
+  workspaceId: string;
+  workspaceName: string;
+}
+
+export interface WorkspaceDeleteContext {
+  target: WorkspaceDeleteTarget;
+  params: DeleteWorkspaceParams;
+  isRetry: boolean;
+}
+
+export interface WorkspaceDeleteErrorContext extends WorkspaceDeleteContext {
+  error: unknown;
+  message: string;
+}
+
+export interface UseWorkspaceDeleteFlowOptions {
+  flow: Pick<UseFlowReturn, 'showLoading' | 'showConfirm' | 'showMessage' | 'close'>;
+  deleteWorkspace: (
+    projectName: string,
+    workspaceId: string,
+    params?: DeleteWorkspaceParams
+  ) => Promise<void>;
+  onBeforeDelete?: (context: WorkspaceDeleteContext) => void | Promise<void>;
+  onDeleteSuccess?: (context: WorkspaceDeleteContext) => void | Promise<void>;
+  onDeleteCancelled?: (context: WorkspaceDeleteContext) => void | Promise<void>;
+  onDeleteError?: (context: WorkspaceDeleteErrorContext) => void | Promise<void>;
+}
+
+export interface UseWorkspaceDeleteFlowResult {
+  deleteWorkspaceWithPrompt: (target: WorkspaceDeleteTarget) => Promise<boolean>;
+}
+
+function getErrorCode(error: unknown): string | undefined {
+  if (!error || typeof error !== 'object') {
+    return undefined;
+  }
+
+  const candidate = error as { code?: unknown };
+  return typeof candidate.code === 'string' ? candidate.code : undefined;
+}
+
+function toErrorMessage(error: unknown): string {
+  if (error instanceof Error && error.message) {
+    return error.message;
+  }
+
+  if (typeof error === 'string' && error.length > 0) {
+    return error;
+  }
+
+  return 'Failed to delete workspace';
+}
+
+function promptRemoveScriptFailure(
+  flow: UseWorkspaceDeleteFlowOptions['flow'],
+  workspaceName: string,
+  message: string
+): Promise<boolean> {
+  return new Promise<boolean>((resolve) => {
+    flow.showConfirm({
+      title: 'Remove Scripts Failed',
+      message:
+        `Cleanup scripts failed for workspace "${workspaceName}".\n\n${message}\n\nRemove anyway and skip cleanup scripts?`,
+      variant: 'warning',
+      confirmLabel: 'Remove anyway',
+      cancelLabel: 'Keep workspace',
+      onConfirm: () => resolve(true),
+      onCancel: () => resolve(false),
+    });
+  });
+}
+
+export function useWorkspaceDeleteFlow(
+  options: UseWorkspaceDeleteFlowOptions
+): UseWorkspaceDeleteFlowResult {
+  const {
+    flow,
+    deleteWorkspace,
+    onBeforeDelete,
+    onDeleteSuccess,
+    onDeleteCancelled,
+    onDeleteError,
+  } = options;
+
+  const executeDelete = useCallback(async (
+    target: WorkspaceDeleteTarget,
+    params: DeleteWorkspaceParams,
+    isRetry: boolean
+  ): Promise<boolean> => {
+    const context: WorkspaceDeleteContext = {
+      target,
+      params,
+      isRetry,
+    };
+
+    await onBeforeDelete?.(context);
+    flow.showLoading({
+      title: 'Deleting Workspace',
+      message:
+        params.scriptPolicy === 'skip'
+          ? 'Removing workspace without cleanup scripts...'
+          : `Running cleanup scripts for "${target.workspaceName}"...`,
+    });
+
+    try {
+      await deleteWorkspace(target.projectName, target.workspaceId, params);
+      flow.close();
+      await onDeleteSuccess?.(context);
+      return true;
+    } catch (error) {
+      const message = toErrorMessage(error);
+      const code = getErrorCode(error);
+
+      if (code === 'REMOVE_SCRIPT_FAILED' && params.scriptPolicy !== 'skip') {
+        const removeAnyway = await promptRemoveScriptFailure(flow, target.workspaceName, message);
+        if (!removeAnyway) {
+          await onDeleteCancelled?.(context);
+          return false;
+        }
+
+        return executeDelete(target, { scriptPolicy: 'skip' }, true);
+      }
+
+      flow.close();
+      if (onDeleteError) {
+        await onDeleteError({
+          ...context,
+          error,
+          message,
+        });
+      } else {
+        flow.showMessage({
+          title: 'Delete Failed',
+          message,
+          variant: 'error',
+        });
+      }
+
+      return false;
+    }
+  }, [deleteWorkspace, flow, onBeforeDelete, onDeleteCancelled, onDeleteError, onDeleteSuccess]);
+
+  const deleteWorkspaceWithPrompt = useCallback(async (target: WorkspaceDeleteTarget): Promise<boolean> => {
+    return executeDelete(target, { scriptPolicy: 'auto' }, false);
+  }, [executeDelete]);
+
+  return {
+    deleteWorkspaceWithPrompt,
+  };
+}

--- a/src/commands/remove.ts
+++ b/src/commands/remove.ts
@@ -126,10 +126,12 @@ export async function removeWorkspace(
 
 	if (!result.success && result.errorCode === 'REMOVE_SCRIPT_FAILED') {
 		logger.warning(result.error || 'Remove scripts failed')
-		const removeAnyway = await promptConfirm(
-			`Remove workspace "${workspaceName}" anyway and skip cleanup scripts?`,
-			false
-		)
+		const removeAnyway = options.force
+			? true
+			: await promptConfirm(
+				`Remove workspace "${workspaceName}" anyway and skip cleanup scripts?`,
+				false
+			)
 
 		if (!removeAnyway) {
 			logger.info('Cancelled')

--- a/src/commands/remove.ts
+++ b/src/commands/remove.ts
@@ -114,10 +114,30 @@ export async function removeWorkspace(
 
 	// Delegate to core deletion logic (interactive mode for CLI)
 	logger.info('Removing workspace...')
-	const result = await deleteWorkspaceCore(currentProject, workspaceName, {
-		nonInteractive: false, // CLI is interactive
-		keepBranch: options.keepBranch,
-	})
+	const runDelete = async (scriptPolicy: 'enforce' | 'skip') => {
+		return deleteWorkspaceCore(currentProject, workspaceName, {
+			nonInteractive: false, // CLI is interactive
+			keepBranch: options.keepBranch,
+			removeScriptPolicy: scriptPolicy,
+		})
+	}
+
+	let result = await runDelete('enforce')
+
+	if (!result.success && result.errorCode === 'REMOVE_SCRIPT_FAILED') {
+		logger.warning(result.error || 'Remove scripts failed')
+		const removeAnyway = await promptConfirm(
+			`Remove workspace "${workspaceName}" anyway and skip cleanup scripts?`,
+			false
+		)
+
+		if (!removeAnyway) {
+			logger.info('Cancelled')
+			return
+		}
+
+		result = await runDelete('skip')
+	}
 
 	if (!result.success) {
 		throw new SpacesError(

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -1304,9 +1304,15 @@ export async function serveStart(options: {
   const entries = readAccessList();
   accessList.import(entries);
 
-  await initializeSecretRuntime({
-    ignoreKeychainAndSkipSecrets: options.ignoreKeychainAndSkipSecrets,
-  });
+  try {
+    await initializeSecretRuntime({
+      ignoreKeychainAndSkipSecrets: options.ignoreKeychainAndSkipSecrets,
+    });
+  } catch (error) {
+    stopStatusServer();
+    cleanupServeFiles();
+    throw error;
+  }
 
   // Get config
   const machineIdentity = readMachineIdentity();

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -61,6 +61,7 @@ import {
   ensureServeDaemonDir,
   type StatusResponse,
 } from '../serve/daemon.js';
+import { initializeSecretRuntime } from '../core/secret-runtime.js';
 
 /** Package version for daemon status */
 const PACKAGE_VERSION = '1.0.0';
@@ -463,6 +464,7 @@ function stopCloudflared(): void {
 export async function serve(options: {
   relay?: string;
   relayPubkey?: string;
+  ignoreKeychainAndSkipSecrets?: boolean;
 } = {}): Promise<void> {
   // Step 1: Load machine identity
   if (!keypairExists()) {
@@ -502,6 +504,10 @@ export async function serve(options: {
   const accessList = new AccessControlList();
   const entries = readAccessList();
   accessList.import(entries);
+
+  await initializeSecretRuntime({
+    ignoreKeychainAndSkipSecrets: options.ignoreKeychainAndSkipSecrets,
+  });
 
   // Step 3: Check for gitspace.sh hosting or explicit relay
   const hostConfig = readHostConfig();
@@ -1156,6 +1162,7 @@ export async function serveStart(options: {
   relayPubkey?: string;
   passwordStdin?: boolean;
   foreground?: boolean;
+  ignoreKeychainAndSkipSecrets?: boolean;
 } = {}): Promise<void> {
   // Check if already running
   if (isServeRunning()) {
@@ -1234,6 +1241,9 @@ export async function serveStart(options: {
     const serveArgs = ['serve', 'start', '--foreground'];
     if (options.relay) serveArgs.push('--relay', options.relay);
     if (options.relayPubkey) serveArgs.push('--relay-pubkey', options.relayPubkey);
+    if (options.ignoreKeychainAndSkipSecrets) {
+      serveArgs.push('--ignore-keychain-and-skip-secrets');
+    }
     serveArgs.push('--password-stdin');
 
     // Build command: compiled binary runs directly, dev mode uses bun
@@ -1293,6 +1303,10 @@ export async function serveStart(options: {
   const accessList = new AccessControlList();
   const entries = readAccessList();
   accessList.import(entries);
+
+  await initializeSecretRuntime({
+    ignoreKeychainAndSkipSecrets: options.ignoreKeychainAndSkipSecrets,
+  });
 
   // Get config
   const machineIdentity = readMachineIdentity();

--- a/src/components/RemoteMachineScreen.tui.tsx
+++ b/src/components/RemoteMachineScreen.tui.tsx
@@ -1,4 +1,4 @@
-import { Fragment, useEffect, useMemo, useState } from 'react';
+import { Fragment, useEffect, useMemo, useRef, useState } from 'react';
 import type { PasteEvent } from '@opentui/core';
 import { useKeyboard, useRenderer } from '@opentui/react';
 import type { Identity } from '../types/identity.js';
@@ -23,7 +23,9 @@ import {
   resolveSessionBrowserCommand,
 } from '../app/input/sessionCommands.js';
 import { SessionTerminal } from './SessionTerminal.tui.js';
+import { ScriptTerminal, type ScriptTerminalHandle } from './ScriptTerminal.tui.js';
 import { getKeyboardInputChunk, normalizeInputText } from '../tui/input-text.js';
+import { useWorkspaceDeleteFlow } from '../app/session/useWorkspaceDeleteFlow.js';
 
 const COLORS = {
   statusBar: '#333333',
@@ -52,6 +54,9 @@ export function RemoteMachineScreen({ machine, relayUrl, identity, onBack }: Rem
   const remote = useRemoteTerminal();
   const renderer = useRenderer();
   const [showInbox, setShowInbox] = useState(false);
+  const [showScriptTerminal, setShowScriptTerminal] = useState(false);
+  const [scriptWorkspaceName, setScriptWorkspaceName] = useState('workspace');
+  const scriptTerminalRef = useRef<ScriptTerminalHandle | null>(null);
   const flow = useFlow({
     onError: (error) => {
       remote.disconnect();
@@ -86,6 +91,43 @@ export function RemoteMachineScreen({ machine, relayUrl, identity, onBack }: Rem
     },
   });
 
+  const { deleteWorkspaceWithPrompt } = useWorkspaceDeleteFlow({
+    flow,
+    deleteWorkspace: remote.deleteWorkspace,
+    onBeforeDelete: ({ target }) => {
+      setShowInbox(false);
+      setScriptWorkspaceName(target.workspaceName);
+      setShowScriptTerminal(true);
+    },
+    onDeleteSuccess: async () => {
+      setShowScriptTerminal(false);
+      remote.requestWorkspaces();
+      remote.requestSessions();
+    },
+    onDeleteError: async ({ message }) => {
+      setShowScriptTerminal(false);
+      flow.showMessage({
+        title: 'Delete Failed',
+        message,
+        variant: 'error',
+      });
+    },
+  });
+
+  useEffect(() => {
+    if (!showScriptTerminal || remote.mode !== 'browsing') {
+      return;
+    }
+
+    remote.setWriteCallback((data) => {
+      scriptTerminalRef.current?.feed(data);
+    });
+
+    return () => {
+      remote.setWriteCallback(null);
+    };
+  }, [remote.mode, remote.setWriteCallback, showScriptTerminal]);
+
   useEffect(() => {
     void remote.connect({
       relayUrl,
@@ -107,6 +149,12 @@ export function RemoteMachineScreen({ machine, relayUrl, identity, onBack }: Rem
     remote.requestWorkspaces();
     remote.requestNotificationConfig();
   }, [remote.mode, remote.status]);
+
+  useEffect(() => {
+    if (remote.mode === 'attached') {
+      setShowScriptTerminal(false);
+    }
+  }, [remote.mode]);
 
   const spacesBrowserProps = useSpacesBrowser({
     workspaces: remote.workspaces,
@@ -228,6 +276,16 @@ export function RemoteMachineScreen({ machine, relayUrl, identity, onBack }: Rem
       return;
     }
 
+    if (showScriptTerminal) {
+      if (
+        !remote.scriptState?.isRunning &&
+        (key.name === 'escape' || key.name === 'n' || key.raw === 'n')
+      ) {
+        setShowScriptTerminal(false);
+      }
+      return;
+    }
+
     if (showInbox) {
       const command = resolveInboxCommand({
         name: key.name,
@@ -323,7 +381,11 @@ export function RemoteMachineScreen({ machine, relayUrl, identity, onBack }: Rem
               ? `This kills ${selected.workspace.sessionCount} active session(s).`
               : undefined,
           onConfirm: () => {
-            remote.deleteWorkspace(selected.workspace.projectName, selected.workspace.id);
+            void deleteWorkspaceWithPrompt({
+              projectName: selected.workspace.projectName,
+              workspaceId: selected.workspace.id,
+              workspaceName: selected.workspace.name,
+            });
           },
         });
       }
@@ -354,6 +416,24 @@ export function RemoteMachineScreen({ machine, relayUrl, identity, onBack }: Rem
           onDetach={remote.detachSession}
           setWriteCallback={remote.setWriteCallback}
         />
+      </Fragment>
+    );
+  }
+
+  if (showScriptTerminal && remote.status === 'established' && remote.mode === 'browsing') {
+    const isRunning = remote.scriptState?.isRunning ?? true;
+    return (
+      <Fragment>
+        <ScriptTerminal
+          ref={scriptTerminalRef}
+          phase={remote.scriptState?.phase ?? 'remove'}
+          workspaceName={scriptWorkspaceName}
+          isRunning={isRunning}
+          error={remote.scriptState?.error}
+          exitCode={remote.scriptState?.exitCode}
+        />
+        <FlowTUI flow={flow} />
+        <StatusBar hint={isRunning ? '[Running scripts...]' : '[Esc/n] Back to workspaces'} />
       </Fragment>
     );
   }

--- a/src/components/RemoteMachineScreen.tui.tsx
+++ b/src/components/RemoteMachineScreen.tui.tsx
@@ -147,6 +147,7 @@ export function RemoteMachineScreen({ machine, relayUrl, identity, onBack }: Rem
     }
     remote.requestProjects();
     remote.requestWorkspaces();
+    remote.requestSessions();
     remote.requestNotificationConfig();
   }, [remote.mode, remote.status]);
 
@@ -159,14 +160,10 @@ export function RemoteMachineScreen({ machine, relayUrl, identity, onBack }: Rem
   const spacesBrowserProps = useSpacesBrowser({
     workspaces: remote.workspaces,
     sessions: remote.sessions,
-    onRequestSessions: remote.requestSessions,
+    onRequestSessions: () => remote.requestSessions(),
     onAttachSession: attachController.attachFromSelection,
     onRefresh: remote.requestWorkspaces,
-    onRefreshSessions: (workspaceIds) => {
-      for (const workspaceId of workspaceIds) {
-        remote.requestSessions(workspaceId);
-      }
-    },
+    onRefreshSessions: () => remote.requestSessions(),
     onBack,
     machineName: machine.label || machine.machineId,
   });

--- a/src/components/SessionTerminal.web.tsx
+++ b/src/components/SessionTerminal.web.tsx
@@ -4,6 +4,7 @@ import {
   canConsumePageNavigationInViewport,
   type PageDirection,
 } from './session-terminal-page-navigation.js';
+import { isIOSDevice } from '../utils/device.web.js';
 
 interface Props {
   onData: (data: Uint8Array) => void;
@@ -43,6 +44,24 @@ interface TerminalViewportLike {
 const SCROLL_THRESHOLD = 10; // pixels before we consider it a scroll vs tap
 const SCROLL_ACCUMULATOR_THRESHOLD = 30; // pixels of accumulated delta before sending scroll
 const TAP_MOVE_THRESHOLD = 10; // max movement to still count as a tap
+
+function configureMobileHelperTextarea(textarea: HTMLTextAreaElement): void {
+  textarea.setAttribute('autocorrect', 'on');
+  textarea.setAttribute('autocomplete', 'on');
+  textarea.setAttribute('autocapitalize', 'none');
+  textarea.setAttribute('inputmode', 'text');
+  textarea.setAttribute('enterkeyhint', 'enter');
+  textarea.spellcheck = true;
+}
+
+function shouldHandleIosWordInput(event: InputEvent): boolean {
+  const inputType = event.inputType;
+  return (
+    inputType === 'insertText' ||
+    inputType === 'insertReplacementText' ||
+    inputType === 'insertFromComposition'
+  );
+}
 
 export const SessionTerminal = forwardRef<SessionTerminalHandle, Props>(function SessionTerminal(
   { onData, setWriteCallback, onResize, onActivity, allowTapFocus = true, allowTouchScroll = true },
@@ -227,6 +246,63 @@ export const SessionTerminal = forwardRef<SessionTerminalHandle, Props>(function
         };
         container.addEventListener('keydown', handleKeyDown, true);
 
+        const isIOS = isIOSDevice();
+        const helperTextarea = container.querySelector('.xterm-helper-textarea') as HTMLTextAreaElement | null;
+        let isComposing = false;
+
+        const handleHelperFocus = () => {
+          if (!isIOS || !helperTextarea) {
+            return;
+          }
+          configureMobileHelperTextarea(helperTextarea);
+        };
+
+        const handleCompositionStart = () => {
+          if (!isIOS) {
+            return;
+          }
+          isComposing = true;
+        };
+
+        const handleCompositionEnd = () => {
+          if (!isIOS) {
+            return;
+          }
+          isComposing = false;
+        };
+
+        const handleInputFallback = (event: Event) => {
+          if (!isIOS || !helperTextarea || isComposing) {
+            return;
+          }
+
+          const inputEvent = event as InputEvent;
+          if (!shouldHandleIosWordInput(inputEvent)) {
+            return;
+          }
+
+          // xterm usually consumes normal key input and clears helper value.
+          // Keep this as an iOS fallback for word-level commits (swipe/predictive text).
+          const value = helperTextarea.value;
+          if (value.length <= 1) {
+            return;
+          }
+
+          onActivityRef.current?.();
+          onDataRef.current(new TextEncoder().encode(value));
+          helperTextarea.value = '';
+        };
+
+        if (helperTextarea) {
+          if (isIOS) {
+            configureMobileHelperTextarea(helperTextarea);
+          }
+          helperTextarea.addEventListener('focus', handleHelperFocus);
+          helperTextarea.addEventListener('compositionstart', handleCompositionStart);
+          helperTextarea.addEventListener('compositionend', handleCompositionEnd);
+          helperTextarea.addEventListener('input', handleInputFallback);
+        }
+
         const handlePreventTouchFocus = (e: Event) => {
           if (!allowTapFocusRef.current) {
             e.stopPropagation();
@@ -337,6 +413,12 @@ export const SessionTerminal = forwardRef<SessionTerminalHandle, Props>(function
 
         teardown = () => {
           container.removeEventListener('keydown', handleKeyDown, true);
+          if (helperTextarea) {
+            helperTextarea.removeEventListener('focus', handleHelperFocus);
+            helperTextarea.removeEventListener('compositionstart', handleCompositionStart);
+            helperTextarea.removeEventListener('compositionend', handleCompositionEnd);
+            helperTextarea.removeEventListener('input', handleInputFallback);
+          }
           container.removeEventListener('touchend', handlePreventTouchFocus, true);
           container.removeEventListener('touchstart', handleTouchStart);
           container.removeEventListener('touchmove', handleTouchMove);

--- a/src/components/SpacesBrowser.tsx
+++ b/src/components/SpacesBrowser.tsx
@@ -49,11 +49,11 @@ export type TreeItemWithState = TreeItem & {
 export interface UseSpacesBrowserProps {
   workspaces: WorkspaceInfo[];
   sessions: SessionInfo[];
-  onRequestSessions: (workspaceId: string) => void;
+  onRequestSessions: (workspaceId?: string) => void;
   onAttachSession: (params: { sessionId?: string; workspaceId?: string }) => void | Promise<void>;
   onRefresh: () => void | Promise<void>;
-  /** Called to refresh sessions for specific workspaces (e.g., on manual refresh) */
-  onRefreshSessions?: (workspaceIds: string[]) => void | Promise<void>;
+  /** Called to refresh sessions after workspace refresh (full refresh by default). */
+  onRefreshSessions?: () => void | Promise<void>;
   onBack: () => void;
   /** Called when user wants to create a new workspace */
   onCreateWorkspace?: () => void;
@@ -233,17 +233,14 @@ export function useSpacesBrowser(props: UseSpacesBrowserProps): UseSpacesBrowser
   }, [tree.length]);
 
   const toggleWorkspace = useCallback((workspaceId: string) => {
-    console.log('[SpacesBrowser hook] toggleWorkspace called:', workspaceId);
     setExpandedWorkspaces(prev => {
       const next = new Set(prev);
       if (next.has(workspaceId)) {
-        console.log('[SpacesBrowser hook] Collapsing workspace:', workspaceId);
         next.delete(workspaceId);
       } else {
-        console.log('[SpacesBrowser hook] Expanding workspace:', workspaceId);
         next.add(workspaceId);
-        // Request sessions when expanding
-        onRequestSessions(workspaceId);
+        // Request a full sessions refresh when expanding.
+        onRequestSessions();
       }
       return next;
     });
@@ -282,11 +279,11 @@ export function useSpacesBrowser(props: UseSpacesBrowserProps): UseSpacesBrowser
 
   const refresh = useCallback(async () => {
     await onRefresh();
-    // Also refresh sessions for all expanded workspaces
-    if (onRefreshSessions && expandedWorkspaces.size > 0) {
-      await onRefreshSessions(Array.from(expandedWorkspaces));
+    // Also refresh sessions (shared full refresh policy)
+    if (onRefreshSessions) {
+      await onRefreshSessions();
     }
-  }, [onRefresh, onRefreshSessions, expandedWorkspaces]);
+  }, [onRefresh, onRefreshSessions]);
 
   const back = useCallback(() => {
     onBack();

--- a/src/core/__tests__/workspace-lifecycle.test.ts
+++ b/src/core/__tests__/workspace-lifecycle.test.ts
@@ -5,6 +5,7 @@ let planResult: any
 let syncParseError: string | undefined
 let syncCalls = 0
 let runCalls = 0
+let skipSecretDependentScripts = false
 
 mock.module('../bundle-refresh', () => ({
   checkAndRefreshBundle: async () => true,
@@ -32,7 +33,7 @@ mock.module('../../utils/secrets', () => ({
 }))
 
 mock.module('../secret-runtime', () => ({
-  shouldSkipSecretDependentScripts: () => false,
+  shouldSkipSecretDependentScripts: () => skipSecretDependentScripts,
 }))
 
 mock.module('../../utils/run-workspace-scripts', () => ({
@@ -45,6 +46,7 @@ mock.module('../../utils/run-workspace-scripts', () => ({
 mock.module('../../utils/logger', () => ({
   logger: {
     info: () => {},
+    warning: () => {},
   },
 }))
 
@@ -55,6 +57,7 @@ describe('prepareWorkspaceForSession bundle checks', () => {
     syncCalls = 0
     runCalls = 0
     syncParseError = undefined
+    skipSecretDependentScripts = false
     detectResult = {
       hasBundle: true,
       hasChanged: false,
@@ -135,6 +138,22 @@ describe('prepareWorkspaceForSession bundle checks', () => {
     expect(result.success).toBe(false)
     expect('bundleNeedsRefresh' in result && result.bundleNeedsRefresh).toBe(true)
     expect(syncCalls).toBe(0)
+    expect(runCalls).toBe(0)
+  })
+
+  it('syncs bundle state and skips scripts when secret loading is disabled', async () => {
+    skipSecretDependentScripts = true
+
+    const result = await prepareWorkspaceForSession({
+      projectName: 'test-project',
+      workspacePath: '/tmp/test-workspace',
+      workspaceName: 'test-workspace',
+      repository: 'owner/repo',
+      bundleMode: 'error-if-changed',
+    })
+
+    expect(result.success).toBe(true)
+    expect(syncCalls).toBe(1)
     expect(runCalls).toBe(0)
   })
 })

--- a/src/core/__tests__/workspace-lifecycle.test.ts
+++ b/src/core/__tests__/workspace-lifecycle.test.ts
@@ -31,6 +31,10 @@ mock.module('../../utils/secrets', () => ({
   preloadProjectSecrets: async () => {},
 }))
 
+mock.module('../secret-runtime', () => ({
+  shouldSkipSecretDependentScripts: () => false,
+}))
+
 mock.module('../../utils/run-workspace-scripts', () => ({
   runWorkspaceScripts: async () => {
     runCalls += 1

--- a/src/core/secret-runtime.ts
+++ b/src/core/secret-runtime.ts
@@ -80,10 +80,6 @@ export async function initializeSecretRuntime(
   }
 }
 
-export function isIgnoringKeychainAndSkippingSecrets(): boolean {
-  return state.ignoreKeychainAndSkipSecrets;
-}
-
 export function shouldSkipSecretDependentScripts(
   projectName: string,
   configuredSecretKeys?: string[]
@@ -104,10 +100,6 @@ export function shouldSkipSecretDependentScripts(
     const config = readProjectConfig(projectName);
     return (config.bundleSecretKeys ?? []).length > 0;
   } catch {
-    return false;
+    return true;
   }
-}
-
-export function isSecretRuntimeInitialized(): boolean {
-  return state.initialized;
 }

--- a/src/core/secret-runtime.ts
+++ b/src/core/secret-runtime.ts
@@ -1,0 +1,113 @@
+import { getAllProjectNames, readProjectConfig } from './config.js';
+import { logger } from '../utils/logger.js';
+import { preloadProjectSecrets } from '../utils/secrets.js';
+import { SpacesError } from '../types/errors.js';
+
+interface SecretRuntimeState {
+  ignoreKeychainAndSkipSecrets: boolean;
+  initialized: boolean;
+  projectsWithSecrets: Set<string>;
+}
+
+const state: SecretRuntimeState = {
+  ignoreKeychainAndSkipSecrets: false,
+  initialized: false,
+  projectsWithSecrets: new Set<string>(),
+};
+
+function collectProjectsWithSecrets(): Array<{ projectName: string; keys: string[] }> {
+  const projects = getAllProjectNames();
+  const result: Array<{ projectName: string; keys: string[] }> = [];
+
+  for (const projectName of projects) {
+    try {
+      const config = readProjectConfig(projectName);
+      const keys = config.bundleSecretKeys ?? [];
+      if (keys.length > 0) {
+        result.push({ projectName, keys });
+      }
+    } catch (error) {
+      logger.debug(
+        `[secrets] Failed reading project config for ${projectName}: ${error instanceof Error ? error.message : String(error)}`
+      );
+    }
+  }
+
+  return result;
+}
+
+export interface InitializeSecretRuntimeOptions {
+  ignoreKeychainAndSkipSecrets?: boolean;
+}
+
+export async function initializeSecretRuntime(
+  options: InitializeSecretRuntimeOptions = {}
+): Promise<void> {
+  const ignore = options.ignoreKeychainAndSkipSecrets ?? false;
+  state.ignoreKeychainAndSkipSecrets = ignore;
+
+  const projectsWithSecrets = collectProjectsWithSecrets();
+  state.projectsWithSecrets = new Set(projectsWithSecrets.map((entry) => entry.projectName));
+
+  if (ignore) {
+    state.initialized = true;
+    if (projectsWithSecrets.length > 0) {
+      logger.warning(
+        'Ignoring keychain and skipping secret-dependent scripts (use with caution).'
+      );
+    }
+    return;
+  }
+
+  if (projectsWithSecrets.length === 0) {
+    state.initialized = true;
+    return;
+  }
+
+  try {
+    for (const entry of projectsWithSecrets) {
+      await preloadProjectSecrets(entry.projectName, entry.keys);
+    }
+    state.initialized = true;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new SpacesError(
+      `Failed to preload keychain secrets at startup: ${message}\n\n` +
+        'Unlock keychain access and retry, or run with --ignore-keychain-and-skip-secrets to continue without secret-dependent scripts.',
+      'USER_ERROR',
+      1
+    );
+  }
+}
+
+export function isIgnoringKeychainAndSkippingSecrets(): boolean {
+  return state.ignoreKeychainAndSkipSecrets;
+}
+
+export function shouldSkipSecretDependentScripts(
+  projectName: string,
+  configuredSecretKeys?: string[]
+): boolean {
+  if (!state.ignoreKeychainAndSkipSecrets) {
+    return false;
+  }
+
+  if (configuredSecretKeys && configuredSecretKeys.length > 0) {
+    return true;
+  }
+
+  if (state.projectsWithSecrets.has(projectName)) {
+    return true;
+  }
+
+  try {
+    const config = readProjectConfig(projectName);
+    return (config.bundleSecretKeys ?? []).length > 0;
+  } catch {
+    return false;
+  }
+}
+
+export function isSecretRuntimeInitialized(): boolean {
+  return state.initialized;
+}

--- a/src/core/workspace-lifecycle.ts
+++ b/src/core/workspace-lifecycle.ts
@@ -12,6 +12,7 @@ import {
 import { readProjectConfig } from './config.js';
 import { logger } from '../utils/logger.js';
 import { preloadProjectSecrets } from '../utils/secrets.js';
+import { shouldSkipSecretDependentScripts } from './secret-runtime.js';
 import {
   runWorkspaceScripts,
   type RunWorkspaceScriptsResult,
@@ -80,6 +81,15 @@ export async function prepareWorkspaceForSession(
     scriptPolicy = 'auto',
   } = options;
 
+  const projectConfig = readProjectConfig(projectName);
+
+  if (shouldSkipSecretDependentScripts(projectName, projectConfig.bundleSecretKeys)) {
+    logger.warning(
+      `Skipping workspace scripts for "${workspaceName}" because --ignore-keychain-and-skip-secrets is enabled.`
+    );
+    return { success: true };
+  }
+
   const bundleReady = await ensureBundleReady({
     projectName,
     workspacePath,
@@ -94,8 +104,6 @@ export async function prepareWorkspaceForSession(
       bundleNeedsRefresh: bundleReady.bundleNeedsRefresh,
     };
   }
-
-  const projectConfig = readProjectConfig(projectName);
 
   if (projectConfig.bundleSecretKeys && projectConfig.bundleSecretKeys.length > 0) {
     await preloadProjectSecrets(projectName, projectConfig.bundleSecretKeys);

--- a/src/core/workspace-lifecycle.ts
+++ b/src/core/workspace-lifecycle.ts
@@ -84,6 +84,20 @@ export async function prepareWorkspaceForSession(
   const projectConfig = readProjectConfig(projectName);
 
   if (shouldSkipSecretDependentScripts(projectName, projectConfig.bundleSecretKeys)) {
+    const bundleReady = await ensureBundleReady({
+      projectName,
+      workspacePath,
+      mode: 'skip',
+    });
+
+    if (!bundleReady.success) {
+      return {
+        success: false,
+        phase: 'pre',
+        error: bundleReady.error,
+      };
+    }
+
     logger.warning(
       `Skipping workspace scripts for "${workspaceName}" because --ignore-keychain-and-skip-secrets is enabled.`
     );

--- a/src/core/workspace.ts
+++ b/src/core/workspace.ts
@@ -49,6 +49,13 @@ export interface DeleteWorkspaceOptions {
    * Called with a human-readable message for each step.
    */
   onProgress?: (message: string) => void;
+  /**
+   * Controls remove-script behavior:
+   * - enforce: fail deletion when remove scripts fail
+   * - best-effort: log remove script failures and continue deletion
+   * - skip: do not run remove scripts
+   */
+  removeScriptPolicy?: 'enforce' | 'best-effort' | 'skip';
 }
 
 /**
@@ -60,7 +67,9 @@ export interface DeleteWorkspaceResult {
   branch?: string;
   branchDeleted: boolean;
   sessionsKilled: number;
+  errorCode?: 'WORKSPACE_NOT_FOUND' | 'REMOVE_SCRIPT_FAILED' | 'WORKTREE_REMOVE_FAILED';
   error?: string;
+  removeScriptError?: string;
 }
 
 /**
@@ -89,9 +98,12 @@ export async function deleteWorkspaceCore(
 
   // Validate workspace exists before attempting deletion
   if (!existsSync(workspacePath)) {
+    result.errorCode = 'WORKSPACE_NOT_FOUND';
     result.error = `Workspace "${workspaceName}" does not exist`;
     return result;
   }
+
+  const removeScriptPolicy = options.removeScriptPolicy ?? 'enforce';
 
   // Get workspace info before deletion
   const info = await getWorktreeInfo(workspacePath);
@@ -122,29 +134,40 @@ export async function deleteWorkspaceCore(
   }
 
   // Run remove scripts (cleanup before deletion)
-  try {
-    const projectConfig = readProjectConfig(projectName);
-    const removeScriptsDir = join(workspacePath, '.gitspace', 'scripts', 'remove');
-    const bundleSecrets = projectConfig.bundleSecretKeys && projectConfig.bundleSecretKeys.length > 0
-      ? await getProjectSecrets(projectName, projectConfig.bundleSecretKeys)
-      : undefined;
+  if (removeScriptPolicy !== 'skip') {
+    try {
+      const projectConfig = readProjectConfig(projectName);
+      const removeScriptsDir = join(workspacePath, '.gitspace', 'scripts', 'remove');
+      const bundleSecrets = projectConfig.bundleSecretKeys && projectConfig.bundleSecretKeys.length > 0
+        ? await getProjectSecrets(projectName, projectConfig.bundleSecretKeys)
+        : undefined;
 
-    options.onProgress?.('Running cleanup scripts...');
-    await runScriptsInTerminal(
-      removeScriptsDir,
-      workspacePath,
-      workspaceName,
-      projectConfig.repository,
-      {
-        bundleValues: projectConfig.bundleValues,
-        bundleSecrets,
-        nonInteractive: options.nonInteractive,
-        onOutput: options.onScriptOutput,
+      options.onProgress?.('Running cleanup scripts...');
+      await runScriptsInTerminal(
+        removeScriptsDir,
+        workspacePath,
+        workspaceName,
+        projectConfig.repository,
+        {
+          bundleValues: projectConfig.bundleValues,
+          bundleSecrets,
+          nonInteractive: options.nonInteractive,
+          onOutput: options.onScriptOutput,
+        }
+      );
+    } catch (e) {
+      const message = e instanceof Error ? e.message : String(e);
+      if (removeScriptPolicy === 'enforce') {
+        result.errorCode = 'REMOVE_SCRIPT_FAILED';
+        result.removeScriptError = message;
+        result.error = `Remove scripts failed: ${message}`;
+        return result;
       }
-    );
-  } catch (e) {
-    // Scripts are best-effort, log but continue
-    logger.debug(`Remove scripts failed for ${workspaceName}: ${e}`);
+
+      logger.debug(`Remove scripts failed for ${workspaceName}: ${e}`);
+    }
+  } else {
+    options.onProgress?.('Skipping cleanup scripts...');
   }
 
   // Remove worktree
@@ -152,6 +175,7 @@ export async function deleteWorkspaceCore(
   try {
     await removeWorktree(baseDir, workspacePath, true);
   } catch (e) {
+    result.errorCode = 'WORKTREE_REMOVE_FAILED';
     result.error = e instanceof Error ? e.message : 'Failed to remove worktree';
     return result;
   }
@@ -264,6 +288,7 @@ export async function deleteProjectCore(
         nonInteractive: options.nonInteractive,
         keepBranch: true, // Don't try to delete branches, we're removing the whole repo
         onProgress: options.onProgress,
+        removeScriptPolicy: 'best-effort',
       });
       if (wsResult.success) {
         result.workspacesDeleted++;

--- a/src/core/workspace.ts
+++ b/src/core/workspace.ts
@@ -21,6 +21,7 @@ import {
 } from './git.js';
 import { runScriptsInTerminal } from '../utils/run-scripts.js';
 import { getProjectSecrets } from '../utils/secrets.js';
+import { shouldSkipSecretDependentScripts } from './secret-runtime.js';
 import { logger } from '../utils/logger.js';
 import {
   listSessions,
@@ -104,6 +105,19 @@ export async function deleteWorkspaceCore(
   }
 
   const removeScriptPolicy = options.removeScriptPolicy ?? 'enforce';
+  let projectConfig: ReturnType<typeof readProjectConfig> | null = null;
+  try {
+    projectConfig = readProjectConfig(projectName);
+  } catch (error) {
+    logger.debug(
+      `Failed to read project config for ${projectName} while preparing delete: ${error instanceof Error ? error.message : String(error)}`
+    );
+  }
+  const skipSecretScripts = shouldSkipSecretDependentScripts(
+    projectName,
+    projectConfig?.bundleSecretKeys
+  );
+  const effectiveRemoveScriptPolicy = skipSecretScripts ? 'skip' : removeScriptPolicy;
 
   // Get workspace info before deletion
   const info = await getWorktreeInfo(workspacePath);
@@ -134,12 +148,12 @@ export async function deleteWorkspaceCore(
   }
 
   // Run remove scripts (cleanup before deletion)
-  if (removeScriptPolicy !== 'skip') {
+  if (effectiveRemoveScriptPolicy !== 'skip') {
     try {
-      const projectConfig = readProjectConfig(projectName);
+      const config = projectConfig ?? readProjectConfig(projectName);
       const removeScriptsDir = join(workspacePath, '.gitspace', 'scripts', 'remove');
-      const bundleSecrets = projectConfig.bundleSecretKeys && projectConfig.bundleSecretKeys.length > 0
-        ? await getProjectSecrets(projectName, projectConfig.bundleSecretKeys)
+      const bundleSecrets = config.bundleSecretKeys && config.bundleSecretKeys.length > 0
+        ? await getProjectSecrets(projectName, config.bundleSecretKeys)
         : undefined;
 
       options.onProgress?.('Running cleanup scripts...');
@@ -147,9 +161,9 @@ export async function deleteWorkspaceCore(
         removeScriptsDir,
         workspacePath,
         workspaceName,
-        projectConfig.repository,
+        config.repository,
         {
-          bundleValues: projectConfig.bundleValues,
+          bundleValues: config.bundleValues,
           bundleSecrets,
           nonInteractive: options.nonInteractive,
           onOutput: options.onScriptOutput,
@@ -157,7 +171,7 @@ export async function deleteWorkspaceCore(
       );
     } catch (e) {
       const message = e instanceof Error ? e.message : String(e);
-      if (removeScriptPolicy === 'enforce') {
+      if (effectiveRemoveScriptPolicy === 'enforce') {
         result.errorCode = 'REMOVE_SCRIPT_FAILED';
         result.removeScriptError = message;
         result.error = `Remove scripts failed: ${message}`;
@@ -167,7 +181,11 @@ export async function deleteWorkspaceCore(
       logger.debug(`Remove scripts failed for ${workspaceName}: ${e}`);
     }
   } else {
-    options.onProgress?.('Skipping cleanup scripts...');
+    if (skipSecretScripts) {
+      options.onProgress?.('Skipping cleanup scripts (secret loading disabled)...');
+    } else {
+      options.onProgress?.('Skipping cleanup scripts...');
+    }
   }
 
   // Remove worktree

--- a/src/hooks/__tests__/useLocalSession.tui.test.ts
+++ b/src/hooks/__tests__/useLocalSession.tui.test.ts
@@ -1,7 +1,12 @@
 import { afterAll, beforeAll, describe, expect, it, mock } from 'bun:test'
 import { act, renderHook } from '@testing-library/react'
 import { Window } from 'happy-dom'
-import type { AttachSessionParams, BackendEvent, SessionBackend } from '../../session/index.js'
+import type {
+  AttachSessionParams,
+  BackendEvent,
+  DeleteWorkspaceParams,
+  SessionBackend,
+} from '../../session/index.js'
 import type { NotificationConfig } from '../../notifications/types.js'
 import type { BundleRefreshPlan, BundleRefreshSubmission } from '../../types/bundle-refresh.js'
 import { SpacesError } from '../../types/errors.js'
@@ -83,7 +88,11 @@ class FakeLocalBackend implements SessionBackend {
 
   async killSession(_sessionId: string): Promise<void> {}
 
-  async deleteWorkspace(_projectName: string, _workspaceId: string): Promise<void> {}
+  async deleteWorkspace(
+    _projectName: string,
+    _workspaceId: string,
+    _params?: DeleteWorkspaceParams
+  ): Promise<void> {}
 
   async getBundleRefreshPlan(
     _projectName: string,

--- a/src/hooks/useLocalSession.tui.ts
+++ b/src/hooks/useLocalSession.tui.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef } from 'react';
 import {
   useSessionEngine,
   type AttachSessionParams,
+  type DeleteWorkspaceParams,
   type BundleRefreshPlan,
   type BundleRefreshSubmission,
   type BackendKey,
@@ -253,9 +254,13 @@ export function useLocalSession(options: UseLocalSessionOptions = {}) {
     }, { strict: true });
   }, [backendKey, runWithBackend]);
 
-  const deleteWorkspace = useCallback(async (projectName: string, workspaceId: string) => {
+  const deleteWorkspace = useCallback(async (
+    projectName: string,
+    workspaceId: string,
+    params?: DeleteWorkspaceParams
+  ) => {
     await runWithBackend(async (sessionEngine) => {
-      await sessionEngine.deleteWorkspace(backendKey, projectName, workspaceId);
+      await sessionEngine.deleteWorkspace(backendKey, projectName, workspaceId, params);
       await sessionEngine.listWorkspaces(backendKey);
       await sessionEngine.listSessions(backendKey);
     }, { strict: true });

--- a/src/index.ts
+++ b/src/index.ts
@@ -431,6 +431,7 @@ serveCommand
 	.description('Start the serve daemon')
 	.option('--relay <url>', 'Override default relay URL')
 	.option('--relay-pubkey <pubkey>', 'Relay public key for explicit trust (base64)')
+	.option('--ignore-keychain-and-skip-secrets', 'Skip keychain preload and skip secret-dependent scripts')
 	.option('--password-stdin', 'Read password from stdin')
 	.option('--foreground', 'Run in foreground (don\'t daemonize)')
 	.action(async (options) => {
@@ -468,6 +469,7 @@ serveCommand
 serveCommand
 	.option('--relay <url>', 'Override default relay URL')
 	.option('--relay-pubkey <pubkey>', 'Relay public key for explicit trust (base64)')
+	.option('--ignore-keychain-and-skip-secrets', 'Skip keychain preload and skip secret-dependent scripts')
 	.action(async (options) => {
 		await checkFirstTimeSetup()
 		try {
@@ -971,26 +973,42 @@ process.on('unhandledRejection', (reason) => {
 // Parse command line arguments
 // Check for global relay options (TUI mode with relay)
 const args = process.argv.slice(2)
-const hasRelayOption = args.includes('--relay')
-const hasOnlyRelayOptions = args.every(arg =>
-	arg === '--relay' ||
-	(args[args.indexOf('--relay') + 1] === arg)
-)
+let relayUrlFromArgs: string | undefined
+let ignoreKeychainAndSkipSecrets = false
+let hasOnlyTuiOptions = true
+
+for (let i = 0; i < args.length; i += 1) {
+	const arg = args[i]
+	if (arg === '--relay') {
+		const value = args[i + 1]
+		if (!value || value.startsWith('--')) {
+			hasOnlyTuiOptions = false
+			break
+		}
+		relayUrlFromArgs = value
+		i += 1
+		continue
+	}
+
+	if (arg === '--ignore-keychain-and-skip-secrets') {
+		ignoreKeychainAndSkipSecrets = true
+		continue
+	}
+
+	hasOnlyTuiOptions = false
+	break
+}
 
 // If no args provided or only relay options, launch TUI
-if (process.argv.length === 2 || (hasRelayOption && hasOnlyRelayOptions)) {
-	// Extract options manually instead of using commander.parse() which shows help
-	const relayIndex = args.indexOf('--relay')
-	const relayUrl = relayIndex >= 0 ? args[relayIndex + 1] : undefined
-
+if (process.argv.length === 2 || hasOnlyTuiOptions) {
 	// Build relay config if provided (auth now via challenge-response, not token)
-	const relayConfig = relayUrl ? {
-		url: relayUrl,
+	const relayConfig = relayUrlFromArgs ? {
+		url: relayUrlFromArgs,
 	} : undefined
 
 	// Launch TUI
 	checkFirstTimeSetup()
-		.then(() => launchTUI(relayConfig))
+		.then(() => launchTUI(relayConfig, { ignoreKeychainAndSkipSecrets }))
 		.catch((error) => {
 			if (error instanceof SpacesError) {
 				logger.error(error.message)

--- a/src/lib/remote-session/protocol.ts
+++ b/src/lib/remote-session/protocol.ts
@@ -178,6 +178,7 @@ export interface ErrorResponse {
   type: "error";
   code: string;
   message: string;
+  workspaceId?: string;
 }
 
 /** Project information */

--- a/src/lib/remote-session/protocol.ts
+++ b/src/lib/remote-session/protocol.ts
@@ -120,7 +120,7 @@ export interface ApplyBundleRefreshRequest {
 
 /** Workspace information */
 export interface WorkspaceInfo {
-  id: string;           // Workspace directory name
+  id: string;           // Canonical workspace id: project:workspace
   name: string;         // Display name
   path: string;         // Full path
   projectName: string;  // Parent project name

--- a/src/lib/remote-session/protocol.ts
+++ b/src/lib/remote-session/protocol.ts
@@ -68,6 +68,7 @@ export interface DeleteWorkspaceRequest {
   type: "delete_workspace";
   workspaceId: string;
   projectName: string;  // Needed to locate workspace
+  scriptPolicy?: 'auto' | 'skip';
 }
 
 /** Request inbox items */

--- a/src/lib/remote-session/session-handler.ts
+++ b/src/lib/remote-session/session-handler.ts
@@ -193,7 +193,13 @@ export class RemoteSessionHandler {
           await this.sendError(session, sendResponse, "PERMISSION_DENIED", "Requires full access to delete workspaces");
           return;
         }
-        await this.handleDeleteWorkspace(session, msg.projectName, msg.workspaceId, sendResponse);
+        await this.handleDeleteWorkspace(
+          session,
+          msg.projectName,
+          msg.workspaceId,
+          msg.scriptPolicy,
+          sendResponse
+        );
         break;
 
       case "get_inbox":
@@ -566,18 +572,53 @@ export class RemoteSessionHandler {
     session: RemoteClientSession,
     projectName: string,
     workspaceId: string,
+    scriptPolicy: 'auto' | 'skip' | undefined,
     sendResponse: (data: Uint8Array) => void
   ): Promise<void> {
+    let emittedDone = false;
+    const emitDone = async (error?: string) => {
+      await this.sendMessage(session, sendResponse, {
+        type: 'script_output',
+        phase: 'remove',
+        data: '',
+        done: true,
+        error,
+      });
+      emittedDone = true;
+    };
+
     try {
       const result = await deleteWorkspaceCore(projectName, workspaceId, {
         nonInteractive: true, // Remote context - scripts can't prompt for input
+        removeScriptPolicy: scriptPolicy === 'skip' ? 'skip' : 'enforce',
+        onScriptOutput: (data) => {
+          void this.sendMessage(session, sendResponse, {
+            type: 'script_output',
+            phase: 'remove',
+            data: data.toString('base64'),
+          }).catch((error) => {
+            logger.debug(`[remote-session] Failed to stream remove script output: ${error instanceof Error ? error.message : String(error)}`);
+          });
+        },
       });
 
       if (!result.success) {
-        const errorCode = result.error?.includes("not found") ? "NOT_FOUND" : "DELETE_FAILED";
-        await this.sendError(session, sendResponse, errorCode, result.error || "Failed to delete workspace");
+        const message = result.error || 'Failed to delete workspace';
+        await emitDone(message);
+
+        if (result.errorCode === 'REMOVE_SCRIPT_FAILED') {
+          await this.sendError(session, sendResponse, 'REMOVE_SCRIPT_FAILED', message);
+          return;
+        }
+
+        const errorCode = result.errorCode === 'WORKSPACE_NOT_FOUND' || message.includes('not exist')
+          ? 'NOT_FOUND'
+          : 'DELETE_FAILED';
+        await this.sendError(session, sendResponse, errorCode, message);
         return;
       }
+
+      await emitDone();
 
       await this.sendMessage(session, sendResponse, {
         type: "workspace_deleted",
@@ -585,6 +626,10 @@ export class RemoteSessionHandler {
       });
     } catch (e) {
       console.error("[remote-session] Failed to delete workspace:", e);
+      if (!emittedDone) {
+        const message = e instanceof Error ? e.message : String(e);
+        await emitDone(message);
+      }
       await this.sendError(session, sendResponse, "DELETE_FAILED", "Failed to delete workspace");
     }
   }

--- a/src/lib/remote-session/session-handler.ts
+++ b/src/lib/remote-session/session-handler.ts
@@ -202,7 +202,16 @@ export class RemoteSessionHandler {
       case "delete_workspace":
         // Security: Requires management permission
         if (!canManage(session.accessType)) {
-          await this.sendError(session, sendResponse, "PERMISSION_DENIED", "Requires full access to delete workspaces");
+          const normalizedWorkspaceId = msg.workspaceId.startsWith(`${msg.projectName}:`)
+            ? msg.workspaceId.slice(msg.projectName.length + 1)
+            : msg.workspaceId;
+          await this.sendError(
+            session,
+            sendResponse,
+            "PERMISSION_DENIED",
+            "Requires full access to delete workspaces",
+            { workspaceId: `${msg.projectName}:${normalizedWorkspaceId}` }
+          );
           return;
         }
         await this.handleDeleteWorkspace(

--- a/src/lib/remote-session/session-handler.ts
+++ b/src/lib/remote-session/session-handler.ts
@@ -588,6 +588,7 @@ export class RemoteSessionHandler {
     const normalizedWorkspaceId = workspaceId.startsWith(`${projectName}:`)
       ? workspaceId.slice(projectName.length + 1)
       : workspaceId;
+    const canonicalWorkspaceId = `${projectName}:${normalizedWorkspaceId}`;
     let emittedDone = false;
     const emitDone = async (error?: string) => {
       await this.sendMessage(session, sendResponse, {
@@ -620,14 +621,18 @@ export class RemoteSessionHandler {
         await emitDone(message);
 
         if (result.errorCode === 'REMOVE_SCRIPT_FAILED') {
-          await this.sendError(session, sendResponse, 'REMOVE_SCRIPT_FAILED', message);
+          await this.sendError(session, sendResponse, 'REMOVE_SCRIPT_FAILED', message, {
+            workspaceId: canonicalWorkspaceId,
+          });
           return;
         }
 
         const errorCode = result.errorCode === 'WORKSPACE_NOT_FOUND' || message.includes('not exist')
           ? 'NOT_FOUND'
           : 'DELETE_FAILED';
-        await this.sendError(session, sendResponse, errorCode, message);
+        await this.sendError(session, sendResponse, errorCode, message, {
+          workspaceId: canonicalWorkspaceId,
+        });
         return;
       }
 
@@ -635,7 +640,7 @@ export class RemoteSessionHandler {
 
       await this.sendMessage(session, sendResponse, {
         type: "workspace_deleted",
-        workspaceId: `${projectName}:${normalizedWorkspaceId}`,
+        workspaceId: canonicalWorkspaceId,
       });
     } catch (e) {
       console.error("[remote-session] Failed to delete workspace:", e);
@@ -643,7 +648,9 @@ export class RemoteSessionHandler {
         const message = e instanceof Error ? e.message : String(e);
         await emitDone(message);
       }
-      await this.sendError(session, sendResponse, "DELETE_FAILED", "Failed to delete workspace");
+      await this.sendError(session, sendResponse, "DELETE_FAILED", "Failed to delete workspace", {
+        workspaceId: canonicalWorkspaceId,
+      });
     }
   }
 
@@ -852,12 +859,14 @@ export class RemoteSessionHandler {
     session: RemoteClientSession,
     sendResponse: (data: Uint8Array) => void,
     code: string,
-    message: string
+    message: string,
+    options?: { workspaceId?: string }
   ): Promise<void> {
     await this.sendMessage(session, sendResponse, {
       type: "error",
       code,
       message,
+      workspaceId: options?.workspaceId,
     });
   }
 

--- a/src/lib/remote-session/session-handler.ts
+++ b/src/lib/remote-session/session-handler.ts
@@ -39,6 +39,7 @@ import {
   getBundleRefreshPlan,
   applyBundleRefreshSubmission,
 } from '../../core/bundle-refresh.js';
+import { buildSessionName } from '../../session/session-name.js';
 
 import { logger } from "../../utils/logger.js";
 
@@ -85,6 +86,17 @@ function canAttachSession(
     return grantedSessionId === targetSessionId;
   }
   return false;
+}
+
+function toCanonicalWorkspaceId(workspace: { projectName: string; id: string }): string {
+  return `${workspace.projectName}:${workspace.id}`;
+}
+
+function matchesWorkspaceId(
+  workspace: { projectName: string; id: string },
+  workspaceId: string
+): boolean {
+  return workspace.id === workspaceId || toCanonicalWorkspaceId(workspace) === workspaceId;
 }
 
 /**
@@ -294,7 +306,10 @@ export class RemoteSessionHandler {
 
     await this.sendMessage(session, sendResponse, {
       type: "workspace_list",
-      workspaces,
+      workspaces: workspaces.map((workspace) => ({
+        ...workspace,
+        id: toCanonicalWorkspaceId(workspace),
+      })),
     });
   }
 
@@ -323,7 +338,7 @@ export class RemoteSessionHandler {
             // Note: Session cwd is set once at creation time and does NOT change
             // as users navigate within the shell.
             const ws = workspacePathMap.get(s.cwd);
-            return ws?.id === workspaceId;
+            return ws ? matchesWorkspaceId(ws, workspaceId) : false;
           })
           .map(s => {
             // Find workspace info by cwd
@@ -331,7 +346,7 @@ export class RemoteSessionHandler {
             return {
               id: s.id,
               name: s.name,
-              workspaceId: ws?.id ?? "unknown",
+              workspaceId: ws ? toCanonicalWorkspaceId(ws) : "unknown",
               attached: s.attached,
               createdAt: s.createdAt,
               processTitle: s.processTitle,
@@ -376,6 +391,7 @@ export class RemoteSessionHandler {
 
       // If no session ID, create new session in workspace
       if (!msg.sessionId && msg.workspaceId) {
+        const requestedWorkspaceId = msg.workspaceId;
         // Security: Creating new sessions requires full/manage access
         if (!canManage(session.accessType)) {
           await this.sendError(session, sendResponse, "PERMISSION_DENIED", "Requires full access to create sessions");
@@ -384,7 +400,7 @@ export class RemoteSessionHandler {
 
         // Find the workspace path
         const workspaces = await scanWorkspaces();
-        const workspace = workspaces.find(w => w.id === msg.workspaceId);
+        const workspace = workspaces.find((w) => matchesWorkspaceId(w, requestedWorkspaceId));
 
         if (!workspace) {
           await this.sendError(session, sendResponse, "NOT_FOUND", "Workspace not found");
@@ -452,21 +468,14 @@ export class RemoteSessionHandler {
           done: true,
         });
 
-        // Create session name: use provided name or auto-generate
-        let sessionName: string;
-        if (msg.sessionName) {
-          // Use provided name with project:workspace prefix
-          sessionName = `${workspace.projectName}:${workspace.id}:${msg.sessionName}`;
-          console.log(`[remote-session] Using provided session name: ${sessionName}`);
-        } else {
-          // Auto-generate: project:workspace:N
-          const sessions = await listSessions();
-          const existingCount = sessions.filter(s =>
-            s.name.startsWith(`${workspace.projectName}:${workspace.id}:`)
-          ).length;
-          sessionName = `${workspace.projectName}:${workspace.id}:${existingCount + 1}`;
-          console.log(`[remote-session] Auto-generated session name: ${sessionName}`);
-        }
+        const sessions = await listSessions();
+        const sessionName = buildSessionName({
+          projectName: workspace.projectName,
+          workspaceName: workspace.id,
+          requestedName: msg.sessionName,
+          sessions,
+        });
+        console.log(`[remote-session] Selected session name: ${sessionName}`);
 
         targetSession = await createSession(sessionName, workspace.path);
         console.log(`[remote-session] Created session: ${targetSession.name} (id: ${targetSession.id})`)
@@ -501,7 +510,8 @@ export class RemoteSessionHandler {
       });
     } catch (e) {
       console.error("[remote-session] Failed to attach session:", e);
-      await this.sendError(session, sendResponse, "ATTACH_FAILED", "Failed to attach to session");
+      const detail = e instanceof Error ? e.message : String(e);
+      await this.sendError(session, sendResponse, "ATTACH_FAILED", `Failed to attach to session: ${detail}`);
     }
   }
 
@@ -549,7 +559,7 @@ export class RemoteSessionHandler {
       const workspacePathMap = new Map(workspaces.map(w => [w.path, w]));
       const targetSession = sessions.find(s => s.id === sessionId);
       const workspace = targetSession ? workspacePathMap.get(targetSession.cwd) : undefined;
-      const workspaceId = workspace?.id ?? "unknown";
+      const workspaceId = workspace ? toCanonicalWorkspaceId(workspace) : "unknown";
 
       await killSession(sessionId);
       // Wait a bit for the server to process the kill
@@ -575,6 +585,9 @@ export class RemoteSessionHandler {
     scriptPolicy: 'auto' | 'skip' | undefined,
     sendResponse: (data: Uint8Array) => void
   ): Promise<void> {
+    const normalizedWorkspaceId = workspaceId.startsWith(`${projectName}:`)
+      ? workspaceId.slice(projectName.length + 1)
+      : workspaceId;
     let emittedDone = false;
     const emitDone = async (error?: string) => {
       await this.sendMessage(session, sendResponse, {
@@ -588,7 +601,7 @@ export class RemoteSessionHandler {
     };
 
     try {
-      const result = await deleteWorkspaceCore(projectName, workspaceId, {
+      const result = await deleteWorkspaceCore(projectName, normalizedWorkspaceId, {
         nonInteractive: true, // Remote context - scripts can't prompt for input
         removeScriptPolicy: scriptPolicy === 'skip' ? 'skip' : 'enforce',
         onScriptOutput: (data) => {
@@ -622,7 +635,7 @@ export class RemoteSessionHandler {
 
       await this.sendMessage(session, sendResponse, {
         type: "workspace_deleted",
-        workspaceId,
+        workspaceId: `${projectName}:${normalizedWorkspaceId}`,
       });
     } catch (e) {
       console.error("[remote-session] Failed to delete workspace:", e);

--- a/src/session/__tests__/backend-manager.test.ts
+++ b/src/session/__tests__/backend-manager.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'bun:test';
 import { BackendManager } from '../backend-manager';
-import type { AttachSessionParams, BackendDescriptor, SessionBackend } from '../backend';
+import type {
+  AttachSessionParams,
+  BackendDescriptor,
+  DeleteWorkspaceParams,
+  SessionBackend,
+} from '../backend';
 import type { BackendEvent } from '../events';
 import type { BundleRefreshPlan, BundleRefreshSubmission } from '../../types/bundle-refresh';
 
@@ -38,7 +43,11 @@ class FakeBackend implements SessionBackend {
   async attachSession(_params: AttachSessionParams): Promise<void> {}
   async detachSession(): Promise<void> {}
   async killSession(_sessionId: string): Promise<void> {}
-  async deleteWorkspace(_projectName: string, _workspaceId: string): Promise<void> {}
+  async deleteWorkspace(
+    _projectName: string,
+    _workspaceId: string,
+    _params?: DeleteWorkspaceParams
+  ): Promise<void> {}
   async getBundleRefreshPlan(_projectName: string, _workspaceId: string): Promise<BundleRefreshPlan> {
     throw new Error('not implemented');
   }

--- a/src/session/__tests__/local-session-backend.test.ts
+++ b/src/session/__tests__/local-session-backend.test.ts
@@ -1063,4 +1063,34 @@ describe('LocalSessionBackend', () => {
       error: 'Remove scripts failed: cleanup failed',
     });
   });
+
+  it('preserves workspace delete error code and throws typed error', async () => {
+    const events: BackendEvent[] = [];
+
+    const deps: Partial<LocalSessionBackendDependencies> = {
+      deleteWorkspaceCore: async (_projectName, workspaceId) => ({
+        success: false,
+        workspaceName: workspaceId,
+        branchDeleted: false,
+        sessionsKilled: 0,
+        errorCode: 'WORKSPACE_NOT_FOUND',
+        error: 'Workspace "ws-missing" does not exist',
+      }),
+    };
+
+    const backend = new LocalSessionBackend({ deps });
+    backend.onEvent((event) => events.push(event));
+
+    await expect(backend.deleteWorkspace('alpha', 'ws-missing')).rejects.toMatchObject({
+      name: 'WorkspaceDeleteError',
+      code: 'WORKSPACE_NOT_FOUND',
+      message: 'Workspace "ws-missing" does not exist',
+    });
+
+    expect(events).toContainEqual({
+      type: 'command_error',
+      code: 'WORKSPACE_NOT_FOUND',
+      message: 'Workspace "ws-missing" does not exist',
+    });
+  });
 });

--- a/src/session/__tests__/local-session-backend.test.ts
+++ b/src/session/__tests__/local-session-backend.test.ts
@@ -974,4 +974,93 @@ describe('LocalSessionBackend', () => {
 
     expect(prepareCalls).toBe(1);
   });
+
+  it('streams remove script output and emits completion when deleting workspace', async () => {
+    const events: BackendEvent[] = [];
+
+    const deps: Partial<LocalSessionBackendDependencies> = {
+      deleteWorkspaceCore: async (_projectName, workspaceId, options) => {
+        options?.onScriptOutput?.(Buffer.from(`remove:${workspaceId}`));
+        return {
+          success: true,
+          workspaceName: workspaceId,
+          branchDeleted: false,
+          sessionsKilled: 0,
+        };
+      },
+    };
+
+    const backend = new LocalSessionBackend({ deps });
+    backend.onEvent((event) => events.push(event));
+
+    await backend.deleteWorkspace('alpha', 'alpha:ws-1');
+
+    expect(events).toContainEqual({
+      type: 'script_output',
+      phase: 'remove',
+      data: new TextEncoder().encode('remove:ws-1'),
+    });
+    expect(events).toContainEqual({
+      type: 'script_output',
+      phase: 'remove',
+      data: new Uint8Array(0),
+      done: true,
+    });
+  });
+
+  it('allows retrying delete with scriptPolicy skip after remove script failure', async () => {
+    const events: BackendEvent[] = [];
+    const observedPolicies: Array<'enforce' | 'best-effort' | 'skip' | undefined> = [];
+
+    const deps: Partial<LocalSessionBackendDependencies> = {
+      deleteWorkspaceCore: async (_projectName, workspaceId, options) => {
+        observedPolicies.push(options?.removeScriptPolicy);
+        if (options?.removeScriptPolicy === 'skip') {
+          return {
+            success: true,
+            workspaceName: workspaceId,
+            branchDeleted: false,
+            sessionsKilled: 0,
+          };
+        }
+
+        options?.onScriptOutput?.(Buffer.from('cleanup failed'));
+        return {
+          success: false,
+          workspaceName: workspaceId,
+          branchDeleted: false,
+          sessionsKilled: 0,
+          errorCode: 'REMOVE_SCRIPT_FAILED',
+          error: 'Remove scripts failed: cleanup failed',
+          removeScriptError: 'cleanup failed',
+        };
+      },
+    };
+
+    const backend = new LocalSessionBackend({ deps });
+    backend.onEvent((event) => events.push(event));
+
+    await expect(backend.deleteWorkspace('alpha', 'ws-1')).rejects.toMatchObject({
+      message: 'Remove scripts failed: cleanup failed',
+      code: 'REMOVE_SCRIPT_FAILED',
+    });
+
+    await expect(
+      backend.deleteWorkspace('alpha', 'ws-1', { scriptPolicy: 'skip' })
+    ).resolves.toBeUndefined();
+
+    expect(observedPolicies).toEqual(['enforce', 'skip']);
+    expect(events).toContainEqual({
+      type: 'command_error',
+      code: 'REMOVE_SCRIPT_FAILED',
+      message: 'Remove scripts failed: cleanup failed',
+    });
+    expect(events).toContainEqual({
+      type: 'script_output',
+      phase: 'remove',
+      data: new Uint8Array(0),
+      done: true,
+      error: 'Remove scripts failed: cleanup failed',
+    });
+  });
 });

--- a/src/session/__tests__/remote-session-backend.test.ts
+++ b/src/session/__tests__/remote-session-backend.test.ts
@@ -676,6 +676,38 @@ describe('RemoteSessionBackend', () => {
     });
   });
 
+  it('times out pending workspace delete when no response arrives', async () => {
+    const socket = createFakeSocket();
+
+    const backend = new RemoteSessionBackend({
+      descriptor: {
+        key: buildRemoteBackendKey('wss://relay.test/ws', 'machine-1'),
+        kind: 'remote',
+        label: 'Machine 1',
+        relayUrl: 'wss://relay.test/ws',
+        machineId: 'machine-1',
+      },
+      socket,
+      socketAdapter,
+      identity,
+      machineId: 'machine-1',
+      signer: (message) => ({ ...message, signature: { sig: 'x' } }),
+      crypto: cryptoAdapter,
+      handshake: handshakeAdapter,
+    });
+
+    await connectAndHandshake(backend, socket);
+
+    const deletePromise = backend.deleteWorkspace('alpha', 'alpha:ws-timeout', {
+      timeoutMs: 5,
+    });
+
+    await expect(deletePromise).rejects.toMatchObject({
+      name: 'WorkspaceDeleteError',
+      code: 'DELETE_TIMEOUT',
+    });
+  });
+
   it('ignores workspace_deleted for a different workspace', async () => {
     const socket = createFakeSocket();
 

--- a/src/session/__tests__/remote-session-backend.test.ts
+++ b/src/session/__tests__/remote-session-backend.test.ts
@@ -564,4 +564,83 @@ describe('RemoteSessionBackend', () => {
       sessionId: 'existing-session',
     });
   });
+
+  it('waits for workspace_deleted when deleting a workspace', async () => {
+    const socket = createFakeSocket();
+
+    const backend = new RemoteSessionBackend({
+      descriptor: {
+        key: buildRemoteBackendKey('wss://relay.test/ws', 'machine-1'),
+        kind: 'remote',
+        label: 'Machine 1',
+        relayUrl: 'wss://relay.test/ws',
+        machineId: 'machine-1',
+      },
+      socket,
+      socketAdapter,
+      identity,
+      machineId: 'machine-1',
+      signer: (message) => ({ ...message, signature: { sig: 'x' } }),
+      crypto: cryptoAdapter,
+      handshake: handshakeAdapter,
+    });
+
+    await connectAndHandshake(backend, socket);
+
+    const deletePromise = backend.deleteWorkspace('alpha', 'ws-1', { scriptPolicy: 'skip' });
+    await Bun.sleep(0);
+    const deleteCommand = decodeRelayDataCommand(cryptoAdapter, socket.sent[socket.sent.length - 1]);
+    expect(deleteCommand).toEqual({
+      type: 'delete_workspace',
+      projectName: 'alpha',
+      workspaceId: 'ws-1',
+      scriptPolicy: 'skip',
+    });
+
+    socket.handlers?.onMessage(
+      makeRelayDataPayload(cryptoAdapter, {
+        type: 'workspace_deleted',
+        workspaceId: 'ws-1',
+      })
+    );
+
+    await expect(deletePromise).resolves.toBeUndefined();
+  });
+
+  it('rejects workspace delete when backend returns an error', async () => {
+    const socket = createFakeSocket();
+
+    const backend = new RemoteSessionBackend({
+      descriptor: {
+        key: buildRemoteBackendKey('wss://relay.test/ws', 'machine-1'),
+        kind: 'remote',
+        label: 'Machine 1',
+        relayUrl: 'wss://relay.test/ws',
+        machineId: 'machine-1',
+      },
+      socket,
+      socketAdapter,
+      identity,
+      machineId: 'machine-1',
+      signer: (message) => ({ ...message, signature: { sig: 'x' } }),
+      crypto: cryptoAdapter,
+      handshake: handshakeAdapter,
+    });
+
+    await connectAndHandshake(backend, socket);
+
+    const deletePromise = backend.deleteWorkspace('alpha', 'ws-1');
+    socket.handlers?.onMessage(
+      makeRelayDataPayload(cryptoAdapter, {
+        type: 'error',
+        code: 'REMOVE_SCRIPT_FAILED',
+        message: 'Remove scripts failed: cleanup failed',
+      })
+    );
+
+    await expect(deletePromise).rejects.toMatchObject({
+      message: 'Remove scripts failed: cleanup failed',
+      code: 'REMOVE_SCRIPT_FAILED',
+    });
+  });
 });

--- a/src/session/__tests__/remote-session-backend.test.ts
+++ b/src/session/__tests__/remote-session-backend.test.ts
@@ -674,4 +674,103 @@ describe('RemoteSessionBackend', () => {
       code: 'DELETE_FAILED',
     });
   });
+
+  it('ignores workspace_deleted for a different workspace', async () => {
+    const socket = createFakeSocket();
+
+    const backend = new RemoteSessionBackend({
+      descriptor: {
+        key: buildRemoteBackendKey('wss://relay.test/ws', 'machine-1'),
+        kind: 'remote',
+        label: 'Machine 1',
+        relayUrl: 'wss://relay.test/ws',
+        machineId: 'machine-1',
+      },
+      socket,
+      socketAdapter,
+      identity,
+      machineId: 'machine-1',
+      signer: (message) => ({ ...message, signature: { sig: 'x' } }),
+      crypto: cryptoAdapter,
+      handshake: handshakeAdapter,
+    });
+
+    await connectAndHandshake(backend, socket);
+
+    const deletePromise = backend.deleteWorkspace('alpha', 'alpha:ws-target');
+    socket.handlers?.onMessage(
+      makeRelayDataPayload(cryptoAdapter, {
+        type: 'workspace_deleted',
+        workspaceId: 'alpha:ws-other',
+      })
+    );
+
+    const statusAfterMismatch = await Promise.race([
+      deletePromise.then(() => 'resolved', () => 'rejected'),
+      Bun.sleep(0).then(() => 'pending'),
+    ]);
+    expect(statusAfterMismatch).toBe('pending');
+
+    socket.handlers?.onMessage(
+      makeRelayDataPayload(cryptoAdapter, {
+        type: 'workspace_deleted',
+        workspaceId: 'alpha:ws-target',
+      })
+    );
+
+    await expect(deletePromise).resolves.toBeUndefined();
+  });
+
+  it('ignores delete error for a different workspace id', async () => {
+    const socket = createFakeSocket();
+
+    const backend = new RemoteSessionBackend({
+      descriptor: {
+        key: buildRemoteBackendKey('wss://relay.test/ws', 'machine-1'),
+        kind: 'remote',
+        label: 'Machine 1',
+        relayUrl: 'wss://relay.test/ws',
+        machineId: 'machine-1',
+      },
+      socket,
+      socketAdapter,
+      identity,
+      machineId: 'machine-1',
+      signer: (message) => ({ ...message, signature: { sig: 'x' } }),
+      crypto: cryptoAdapter,
+      handshake: handshakeAdapter,
+    });
+
+    await connectAndHandshake(backend, socket);
+
+    const deletePromise = backend.deleteWorkspace('alpha', 'alpha:ws-target');
+    socket.handlers?.onMessage(
+      makeRelayDataPayload(cryptoAdapter, {
+        type: 'error',
+        code: 'DELETE_FAILED',
+        message: 'wrong workspace error',
+        workspaceId: 'alpha:ws-other',
+      })
+    );
+
+    const statusAfterMismatch = await Promise.race([
+      deletePromise.then(() => 'resolved', () => 'rejected'),
+      Bun.sleep(0).then(() => 'pending'),
+    ]);
+    expect(statusAfterMismatch).toBe('pending');
+
+    socket.handlers?.onMessage(
+      makeRelayDataPayload(cryptoAdapter, {
+        type: 'error',
+        code: 'DELETE_FAILED',
+        message: 'target workspace error',
+        workspaceId: 'alpha:ws-target',
+      })
+    );
+
+    await expect(deletePromise).rejects.toMatchObject({
+      message: 'target workspace error',
+      code: 'DELETE_FAILED',
+    });
+  });
 });

--- a/src/session/__tests__/remote-session-backend.test.ts
+++ b/src/session/__tests__/remote-session-backend.test.ts
@@ -643,4 +643,35 @@ describe('RemoteSessionBackend', () => {
       code: 'REMOVE_SCRIPT_FAILED',
     });
   });
+
+  it('rejects pending workspace delete immediately when socket closes', async () => {
+    const socket = createFakeSocket();
+
+    const backend = new RemoteSessionBackend({
+      descriptor: {
+        key: buildRemoteBackendKey('wss://relay.test/ws', 'machine-1'),
+        kind: 'remote',
+        label: 'Machine 1',
+        relayUrl: 'wss://relay.test/ws',
+        machineId: 'machine-1',
+      },
+      socket,
+      socketAdapter,
+      identity,
+      machineId: 'machine-1',
+      signer: (message) => ({ ...message, signature: { sig: 'x' } }),
+      crypto: cryptoAdapter,
+      handshake: handshakeAdapter,
+    });
+
+    await connectAndHandshake(backend, socket);
+
+    const deletePromise = backend.deleteWorkspace('alpha', 'ws-1');
+    socket.handlers?.onClose();
+
+    await expect(deletePromise).rejects.toMatchObject({
+      message: 'Remote session disconnected',
+      code: 'DELETE_FAILED',
+    });
+  });
 });

--- a/src/session/__tests__/remote-session-backend.test.ts
+++ b/src/session/__tests__/remote-session-backend.test.ts
@@ -635,6 +635,7 @@ describe('RemoteSessionBackend', () => {
         type: 'error',
         code: 'REMOVE_SCRIPT_FAILED',
         message: 'Remove scripts failed: cleanup failed',
+        workspaceId: 'ws-1',
       })
     );
 
@@ -770,6 +771,88 @@ describe('RemoteSessionBackend', () => {
 
     await expect(deletePromise).rejects.toMatchObject({
       message: 'target workspace error',
+      code: 'DELETE_FAILED',
+    });
+  });
+
+  it('rejects delete on permission error when workspace id is provided', async () => {
+    const socket = createFakeSocket();
+
+    const backend = new RemoteSessionBackend({
+      descriptor: {
+        key: buildRemoteBackendKey('wss://relay.test/ws', 'machine-1'),
+        kind: 'remote',
+        label: 'Machine 1',
+        relayUrl: 'wss://relay.test/ws',
+        machineId: 'machine-1',
+      },
+      socket,
+      socketAdapter,
+      identity,
+      machineId: 'machine-1',
+      signer: (message) => ({ ...message, signature: { sig: 'x' } }),
+      crypto: cryptoAdapter,
+      handshake: handshakeAdapter,
+    });
+
+    await connectAndHandshake(backend, socket);
+
+    const deletePromise = backend.deleteWorkspace('alpha', 'alpha:ws-target');
+    socket.handlers?.onMessage(
+      makeRelayDataPayload(cryptoAdapter, {
+        type: 'error',
+        code: 'PERMISSION_DENIED',
+        message: 'Requires full access to delete workspaces',
+        workspaceId: 'alpha:ws-target',
+      })
+    );
+
+    await expect(deletePromise).rejects.toMatchObject({
+      message: 'Requires full access to delete workspaces',
+      code: 'PERMISSION_DENIED',
+    });
+  });
+
+  it('does not reject delete for unrelated error without workspace id', async () => {
+    const socket = createFakeSocket();
+
+    const backend = new RemoteSessionBackend({
+      descriptor: {
+        key: buildRemoteBackendKey('wss://relay.test/ws', 'machine-1'),
+        kind: 'remote',
+        label: 'Machine 1',
+        relayUrl: 'wss://relay.test/ws',
+        machineId: 'machine-1',
+      },
+      socket,
+      socketAdapter,
+      identity,
+      machineId: 'machine-1',
+      signer: (message) => ({ ...message, signature: { sig: 'x' } }),
+      crypto: cryptoAdapter,
+      handshake: handshakeAdapter,
+    });
+
+    await connectAndHandshake(backend, socket);
+
+    const deletePromise = backend.deleteWorkspace('alpha', 'alpha:ws-target');
+    socket.handlers?.onMessage(
+      makeRelayDataPayload(cryptoAdapter, {
+        type: 'error',
+        code: 'NOT_FOUND',
+        message: 'Session not found',
+      })
+    );
+
+    const statusAfterUnrelatedError = await Promise.race([
+      deletePromise.then(() => 'resolved', () => 'rejected'),
+      Bun.sleep(0).then(() => 'pending'),
+    ]);
+    expect(statusAfterUnrelatedError).toBe('pending');
+
+    socket.handlers?.onClose();
+    await expect(deletePromise).rejects.toMatchObject({
+      message: 'Remote session disconnected',
       code: 'DELETE_FAILED',
     });
   });

--- a/src/session/__tests__/session-name.test.ts
+++ b/src/session/__tests__/session-name.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'bun:test';
+import { buildSessionName } from '../session-name.js';
+
+describe('buildSessionName', () => {
+  it('returns first available numeric suffix for auto naming', () => {
+    const name = buildSessionName({
+      projectName: 'alpha',
+      workspaceName: 'ws-1',
+      sessions: [
+        { name: 'alpha:ws-1:1' },
+        { name: 'alpha:ws-1:3' },
+        { name: 'alpha:ws-2:1' },
+      ],
+    });
+
+    expect(name).toBe('alpha:ws-1:2');
+  });
+
+  it('throws when requested name already exists in workspace', () => {
+    expect(() =>
+      buildSessionName({
+        projectName: 'alpha',
+        workspaceName: 'ws-1',
+        requestedName: 'debug',
+        sessions: [{ name: 'alpha:ws-1:debug' }],
+      })
+    ).toThrow('already exists');
+  });
+});

--- a/src/session/__tests__/session-name.test.ts
+++ b/src/session/__tests__/session-name.test.ts
@@ -17,13 +17,19 @@ describe('buildSessionName', () => {
   });
 
   it('throws when requested name already exists in workspace', () => {
-    expect(() =>
+    try {
       buildSessionName({
         projectName: 'alpha',
         workspaceName: 'ws-1',
         requestedName: 'debug',
         sessions: [{ name: 'alpha:ws-1:debug' }],
-      })
-    ).toThrow('already exists');
+      });
+      expect.unreachable('Expected duplicate session name error');
+    } catch (error) {
+      expect(error).toMatchObject({
+        name: 'SessionNameExistsError',
+        code: 'SESSION_ALREADY_EXISTS',
+      });
+    }
   });
 });

--- a/src/session/__tests__/useRemoteSessionClient.test.ts
+++ b/src/session/__tests__/useRemoteSessionClient.test.ts
@@ -2,7 +2,11 @@ import { afterAll, beforeAll, describe, expect, it } from 'bun:test'
 import { act, renderHook } from '@testing-library/react'
 import { Window } from 'happy-dom'
 import type { NotificationConfig } from '../../notifications/types.js'
-import type { AttachSessionParams, BackendDescriptor } from '../backend.js'
+import type {
+  AttachSessionParams,
+  BackendDescriptor,
+  DeleteWorkspaceParams,
+} from '../backend.js'
 import type { BackendEvent } from '../events.js'
 import { buildRemoteBackendKey } from '../backend-key.js'
 import type { RemoteSessionPtyBackend } from '../useRemoteSessionClient.js'
@@ -115,7 +119,11 @@ class FakeRemoteBackend implements RemoteSessionPtyBackend {
     this.killCalls.push(sessionId)
   }
 
-  async deleteWorkspace(projectName: string, workspaceId: string): Promise<void> {
+  async deleteWorkspace(
+    projectName: string,
+    workspaceId: string,
+    _params?: DeleteWorkspaceParams
+  ): Promise<void> {
     this.deleteCalls.push({ projectName, workspaceId })
   }
 

--- a/src/session/backend.ts
+++ b/src/session/backend.ts
@@ -25,6 +25,10 @@ export interface AttachSessionParams {
   scriptPolicy?: 'auto' | 'skip';
 }
 
+export interface DeleteWorkspaceParams {
+  scriptPolicy?: 'auto' | 'skip';
+}
+
 /**
  * Canonical backend contract used by shared session engine.
  */
@@ -42,7 +46,11 @@ export interface SessionBackend {
   detachSession(): Promise<void>;
 
   killSession(sessionId: string): Promise<void>;
-  deleteWorkspace(projectName: string, workspaceId: string): Promise<void>;
+  deleteWorkspace(
+    projectName: string,
+    workspaceId: string,
+    params?: DeleteWorkspaceParams
+  ): Promise<void>;
 
   getBundleRefreshPlan(projectName: string, workspaceId: string): Promise<BundleRefreshPlan>;
   applyBundleRefresh(

--- a/src/session/backend.ts
+++ b/src/session/backend.ts
@@ -27,6 +27,11 @@ export interface AttachSessionParams {
 
 export interface DeleteWorkspaceParams {
   scriptPolicy?: 'auto' | 'skip';
+  /**
+   * Optional timeout for delete completion when waiting on remote responses.
+   * Ignored by local backend.
+   */
+  timeoutMs?: number;
 }
 
 /**

--- a/src/session/backends/local-session-backend.ts
+++ b/src/session/backends/local-session-backend.ts
@@ -44,7 +44,11 @@ import type {
 import type { BackendEvent } from '../events.js';
 import type { NotificationConfig } from '../../notifications/types.js';
 import type { BundleRefreshPlan, BundleRefreshSubmission } from '../../types/bundle-refresh.js';
-import { SpacesError } from '../../types/errors.js';
+import {
+  SpacesError,
+  WorkspaceDeleteError,
+  type WorkspaceDeleteErrorCode,
+} from '../../types/errors.js';
 
 export interface LocalSessionBackendDependencies {
   listSessions: typeof listSessions;
@@ -142,6 +146,24 @@ function toError(error: unknown, fallback: string): Error {
     return error;
   }
   return new SpacesError(fallback, 'SYSTEM_ERROR', 2);
+}
+
+function toWorkspaceDeleteErrorCode(error: unknown): WorkspaceDeleteErrorCode | undefined {
+  if (!error || typeof error !== 'object' || !('code' in error)) {
+    return undefined;
+  }
+
+  const code = (error as { code?: unknown }).code;
+  if (
+    code === 'REMOVE_SCRIPT_FAILED' ||
+    code === 'WORKSPACE_NOT_FOUND' ||
+    code === 'WORKTREE_REMOVE_FAILED' ||
+    code === 'DELETE_FAILED'
+  ) {
+    return code;
+  }
+
+  return undefined;
 }
 
 function getDefaultTerminalSize(): { cols: number; rows: number } {
@@ -578,9 +600,7 @@ export class LocalSessionBackend implements SessionBackend {
       });
 
       if (!result.success) {
-        const errorCode = result.errorCode === 'REMOVE_SCRIPT_FAILED'
-          ? 'REMOVE_SCRIPT_FAILED'
-          : 'DELETE_FAILED';
+        const errorCode: WorkspaceDeleteErrorCode = result.errorCode ?? 'DELETE_FAILED';
         const message = result.error ?? `Failed to delete workspace ${resolvedWorkspaceId}`;
 
         this.emit({
@@ -598,9 +618,7 @@ export class LocalSessionBackend implements SessionBackend {
         });
         emittedDone = true;
 
-        const error = new Error(message) as Error & { code?: string };
-        error.code = errorCode;
-        throw error;
+        throw new WorkspaceDeleteError(message, errorCode);
       }
 
       this.emit({
@@ -613,6 +631,7 @@ export class LocalSessionBackend implements SessionBackend {
     } catch (error) {
       if (!emittedDone) {
         const message = error instanceof Error ? error.message : String(error);
+        const errorCode = toWorkspaceDeleteErrorCode(error) ?? 'DELETE_FAILED';
         this.emit({
           type: 'script_output',
           phase: 'remove',
@@ -622,9 +641,13 @@ export class LocalSessionBackend implements SessionBackend {
         });
         this.emit({
           type: 'command_error',
-          code: 'DELETE_FAILED',
+          code: errorCode,
           message,
         });
+
+        if (!(error instanceof WorkspaceDeleteError)) {
+          throw new WorkspaceDeleteError(message, errorCode);
+        }
       }
       throw error;
     }

--- a/src/session/backends/local-session-backend.ts
+++ b/src/session/backends/local-session-backend.ts
@@ -37,6 +37,7 @@ import { findUtf8Boundary } from '../../utils/utf8.js';
 import type {
   AttachSessionParams,
   BackendDescriptor,
+  DeleteWorkspaceParams,
   SessionBackend,
 } from '../backend.js';
 import type { BackendEvent } from '../events.js';
@@ -550,18 +551,79 @@ export class LocalSessionBackend implements SessionBackend {
     await this.deps.killSession(sessionId);
   }
 
-  async deleteWorkspace(projectName: string, workspaceId: string): Promise<void> {
+  async deleteWorkspace(
+    projectName: string,
+    workspaceId: string,
+    params: DeleteWorkspaceParams = {}
+  ): Promise<void> {
     const resolvedWorkspaceId = resolveWorkspaceName(projectName, workspaceId);
-    const result = await this.deps.deleteWorkspaceCore(projectName, resolvedWorkspaceId, {
-      nonInteractive: true,
-    });
+    const scriptPolicy = params.scriptPolicy ?? 'auto';
+    let emittedDone = false;
 
-    if (!result.success) {
-      throw new SpacesError(
-        result.error ?? `Failed to delete workspace ${resolvedWorkspaceId}`,
-        'USER_ERROR',
-        1
-      );
+    try {
+      const result = await this.deps.deleteWorkspaceCore(projectName, resolvedWorkspaceId, {
+        nonInteractive: true,
+        removeScriptPolicy: scriptPolicy === 'skip' ? 'skip' : 'enforce',
+        onScriptOutput: (data) => {
+          this.emitPtyData(data);
+          this.emit({
+            type: 'script_output',
+            phase: 'remove',
+            data,
+          });
+        },
+      });
+
+      if (!result.success) {
+        const errorCode = result.errorCode === 'REMOVE_SCRIPT_FAILED'
+          ? 'REMOVE_SCRIPT_FAILED'
+          : 'DELETE_FAILED';
+        const message = result.error ?? `Failed to delete workspace ${resolvedWorkspaceId}`;
+
+        this.emit({
+          type: 'command_error',
+          code: errorCode,
+          message,
+        });
+
+        this.emit({
+          type: 'script_output',
+          phase: 'remove',
+          data: new Uint8Array(0),
+          done: true,
+          error: message,
+        });
+        emittedDone = true;
+
+        const error = new Error(message) as Error & { code?: string };
+        error.code = errorCode;
+        throw error;
+      }
+
+      this.emit({
+        type: 'script_output',
+        phase: 'remove',
+        data: new Uint8Array(0),
+        done: true,
+      });
+      emittedDone = true;
+    } catch (error) {
+      if (!emittedDone) {
+        const message = error instanceof Error ? error.message : String(error);
+        this.emit({
+          type: 'script_output',
+          phase: 'remove',
+          data: new Uint8Array(0),
+          done: true,
+          error: message,
+        });
+        this.emit({
+          type: 'command_error',
+          code: 'DELETE_FAILED',
+          message,
+        });
+      }
+      throw error;
     }
   }
 

--- a/src/session/backends/local-session-backend.ts
+++ b/src/session/backends/local-session-backend.ts
@@ -34,6 +34,7 @@ import {
 } from '../../core/bundle-refresh.js';
 import { createBufferedSocketWriter } from '../../utils/bun-socket-writer.js';
 import { findUtf8Boundary } from '../../utils/utf8.js';
+import { buildSessionName } from '../session-name.js';
 import type {
   AttachSessionParams,
   BackendDescriptor,
@@ -506,10 +507,12 @@ export class LocalSessionBackend implements SessionBackend {
       });
 
       const sessions = await this.deps.listSessions();
-      const sessionPrefix = `${workspace.projectName}:${workspace.id}:`;
-      const count = sessions.filter((session) => session.name.startsWith(sessionPrefix)).length;
-      const suffix = params.sessionName ?? String(count + 1);
-      const fullName = `${sessionPrefix}${suffix}`;
+      const fullName = buildSessionName({
+        projectName: workspace.projectName,
+        workspaceName: workspace.id,
+        requestedName: params.sessionName,
+        sessions,
+      });
       targetSession = await this.deps.createSession(fullName, workspace.path);
     } else {
       throw new SpacesError('attachSession requires sessionId or workspaceId', 'USER_ERROR', 1);

--- a/src/session/backends/remote-session-backend.ts
+++ b/src/session/backends/remote-session-backend.ts
@@ -227,6 +227,38 @@ function concatUint8Array(parts: Uint8Array[]): Uint8Array {
   return combined;
 }
 
+function workspaceIdsMatch(expected: string, actual: string | undefined): boolean {
+  if (!actual) {
+    return false;
+  }
+
+  if (expected === actual) {
+    return true;
+  }
+
+  const expectedSeparator = expected.indexOf(':');
+  const actualSeparator = actual.indexOf(':');
+
+  if (expectedSeparator > 0 && actualSeparator <= 0) {
+    return expected.slice(expectedSeparator + 1) === actual;
+  }
+
+  if (expectedSeparator <= 0 && actualSeparator > 0) {
+    return expected === actual.slice(actualSeparator + 1);
+  }
+
+  return false;
+}
+
+function isDeleteErrorCode(code: string | undefined): boolean {
+  return (
+    code === 'REMOVE_SCRIPT_FAILED' ||
+    code === 'DELETE_FAILED' ||
+    code === 'WORKSPACE_NOT_FOUND' ||
+    code === 'NOT_FOUND'
+  );
+}
+
 export class RemoteSessionBackend<TSocket, THandshakeState, TServerHello, TServerAuth>
   implements SessionBackend {
   readonly descriptor: BackendDescriptor;
@@ -267,6 +299,7 @@ export class RemoteSessionBackend<TSocket, THandshakeState, TServerHello, TServe
     | null = null;
   private pendingDeleteWorkspace:
     | {
+        workspaceId: string;
         resolve: () => void;
         reject: (error: Error) => void;
       }
@@ -403,6 +436,7 @@ export class RemoteSessionBackend<TSocket, THandshakeState, TServerHello, TServe
 
     return new Promise<void>((resolve, reject) => {
       this.pendingDeleteWorkspace = {
+        workspaceId,
         resolve,
         reject,
       };
@@ -830,7 +864,9 @@ export class RemoteSessionBackend<TSocket, THandshakeState, TServerHello, TServe
       }
       case 'error':
         this.rejectPendingBundleRefreshRequests(message.message);
-        this.rejectPendingWorkspaceDelete(message.code, message.message);
+        if (message.workspaceId || isDeleteErrorCode(message.code)) {
+          this.rejectPendingWorkspaceDelete(message.code, message.message, message.workspaceId);
+        }
         this.emit({
           type: 'command_error',
           code: message.code,
@@ -919,9 +955,13 @@ export class RemoteSessionBackend<TSocket, THandshakeState, TServerHello, TServe
     }
   }
 
-  private resolveWorkspaceDelete(_workspaceId: string): void {
+  private resolveWorkspaceDelete(workspaceId: string): void {
     const pending = this.pendingDeleteWorkspace;
     if (!pending) {
+      return;
+    }
+
+    if (!workspaceIdsMatch(pending.workspaceId, workspaceId)) {
       return;
     }
 
@@ -929,9 +969,18 @@ export class RemoteSessionBackend<TSocket, THandshakeState, TServerHello, TServe
     pending.resolve();
   }
 
-  private rejectPendingWorkspaceDelete(code: string | undefined, message: string): void {
+  private rejectPendingWorkspaceDelete(
+    code: string | undefined,
+    message: string,
+    workspaceId?: string,
+    force = false
+  ): void {
     const pending = this.pendingDeleteWorkspace;
     if (!pending) {
+      return;
+    }
+
+    if (!force && workspaceId && !workspaceIdsMatch(pending.workspaceId, workspaceId)) {
       return;
     }
 
@@ -1026,7 +1075,7 @@ export class RemoteSessionBackend<TSocket, THandshakeState, TServerHello, TServe
     this.pendingPtyChunks = [];
     this.pendingUtf8Bytes = new Uint8Array(0);
     this.rejectPendingBundleRefreshRequests('Remote session disconnected');
-    this.rejectPendingWorkspaceDelete('DELETE_FAILED', 'Remote session disconnected');
+    this.rejectPendingWorkspaceDelete('DELETE_FAILED', 'Remote session disconnected', undefined, true);
     this.connectPromise = null;
     this.connectResolve = null;
     this.connectReject = null;

--- a/src/session/backends/remote-session-backend.ts
+++ b/src/session/backends/remote-session-backend.ts
@@ -27,6 +27,7 @@ import type { NotificationConfig } from '../../notifications/types.js';
 import type {
   AttachSessionParams,
   BackendDescriptor,
+  DeleteWorkspaceParams,
   SessionBackend,
 } from '../backend.js';
 import type { BackendEvent } from '../events.js';
@@ -264,6 +265,13 @@ export class RemoteSessionBackend<TSocket, THandshakeState, TServerHello, TServe
         timeout: ReturnType<typeof setTimeout>;
       }
     | null = null;
+  private pendingDeleteWorkspace:
+    | {
+        resolve: () => void;
+        reject: (error: Error) => void;
+        timeout: ReturnType<typeof setTimeout>;
+      }
+    | null = null;
   private ptyOutputHandler: ((data: Uint8Array) => void) | null = null;
   private pendingPtyChunks: Uint8Array[] = [];
   private pendingUtf8Bytes = new Uint8Array(0);
@@ -378,13 +386,47 @@ export class RemoteSessionBackend<TSocket, THandshakeState, TServerHello, TServe
     await this.sendCommand(command);
   }
 
-  async deleteWorkspace(projectName: string, workspaceId: string): Promise<void> {
+  async deleteWorkspace(
+    projectName: string,
+    workspaceId: string,
+    params: DeleteWorkspaceParams = {}
+  ): Promise<void> {
+    if (this.pendingDeleteWorkspace) {
+      throw new Error('Workspace delete request already in progress');
+    }
+
     const command: DeleteWorkspaceRequest = {
       type: 'delete_workspace',
       projectName,
       workspaceId,
+      scriptPolicy: params.scriptPolicy,
     };
-    await this.sendCommand(command);
+
+    return new Promise<void>((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        if (!this.pendingDeleteWorkspace) {
+          return;
+        }
+        this.pendingDeleteWorkspace = null;
+        reject(new Error('Timed out deleting workspace'));
+      }, 15000);
+
+      this.pendingDeleteWorkspace = {
+        resolve,
+        reject,
+        timeout,
+      };
+
+      void this.sendCommand(command).catch((error) => {
+        const pending = this.pendingDeleteWorkspace;
+        if (!pending) {
+          return;
+        }
+        clearTimeout(pending.timeout);
+        this.pendingDeleteWorkspace = null;
+        reject(error instanceof Error ? error : new Error(String(error)));
+      });
+    });
   }
 
   async getBundleRefreshPlan(projectName: string, workspaceId: string): Promise<BundleRefreshPlan> {
@@ -770,6 +812,7 @@ export class RemoteSessionBackend<TSocket, THandshakeState, TServerHello, TServe
         );
         return;
       case 'workspace_deleted':
+        this.resolveWorkspaceDelete(message.workspaceId);
         await this.listWorkspaces();
         return;
       case 'inbox_list':
@@ -800,6 +843,7 @@ export class RemoteSessionBackend<TSocket, THandshakeState, TServerHello, TServe
       }
       case 'error':
         this.rejectPendingBundleRefreshRequests(message.message);
+        this.rejectPendingWorkspaceDelete(message.code, message.message);
         this.emit({
           type: 'command_error',
           code: message.code,
@@ -888,6 +932,30 @@ export class RemoteSessionBackend<TSocket, THandshakeState, TServerHello, TServe
     }
   }
 
+  private resolveWorkspaceDelete(_workspaceId: string): void {
+    const pending = this.pendingDeleteWorkspace;
+    if (!pending) {
+      return;
+    }
+
+    clearTimeout(pending.timeout);
+    this.pendingDeleteWorkspace = null;
+    pending.resolve();
+  }
+
+  private rejectPendingWorkspaceDelete(code: string | undefined, message: string): void {
+    const pending = this.pendingDeleteWorkspace;
+    if (!pending) {
+      return;
+    }
+
+    clearTimeout(pending.timeout);
+    this.pendingDeleteWorkspace = null;
+    const error = new Error(message) as Error & { code?: string };
+    error.code = code;
+    pending.reject(error);
+  }
+
   private emitPtyData(data: Uint8Array): void {
     if (!this.ptyOutputHandler) {
       this.pendingPtyChunks.push(data);
@@ -973,6 +1041,7 @@ export class RemoteSessionBackend<TSocket, THandshakeState, TServerHello, TServe
     this.pendingPtyChunks = [];
     this.pendingUtf8Bytes = new Uint8Array(0);
     this.rejectPendingBundleRefreshRequests('Remote session disconnected');
+    this.rejectPendingWorkspaceDelete('DELETE_FAILED', 'Remote session disconnected');
     this.connectPromise = null;
     this.connectResolve = null;
     this.connectReject = null;

--- a/src/session/backends/remote-session-backend.ts
+++ b/src/session/backends/remote-session-backend.ts
@@ -24,6 +24,10 @@ import {
 import type { BundleRefreshPlan, BundleRefreshSubmission } from '../../types/bundle-refresh.js';
 import { findUtf8Boundary } from '../../utils/utf8.js';
 import type { NotificationConfig } from '../../notifications/types.js';
+import {
+  WorkspaceDeleteError,
+  type WorkspaceDeleteErrorCode,
+} from '../../types/errors.js';
 import type {
   AttachSessionParams,
   BackendDescriptor,
@@ -33,6 +37,7 @@ import type {
 import type { BackendEvent } from '../events.js';
 
 const DEFAULT_CONTROL_STREAM_ID = 1;
+const DEFAULT_DELETE_WORKSPACE_TIMEOUT_MS = 30000;
 
 interface RelayDataMessage {
   type: 'data';
@@ -250,6 +255,23 @@ function workspaceIdsMatch(expected: string, actual: string | undefined): boolea
   return false;
 }
 
+function toWorkspaceDeleteErrorCode(code: string | undefined): WorkspaceDeleteErrorCode {
+  if (
+    code === 'REMOVE_SCRIPT_FAILED' ||
+    code === 'WORKSPACE_NOT_FOUND' ||
+    code === 'WORKTREE_REMOVE_FAILED' ||
+    code === 'DELETE_FAILED' ||
+    code === 'NOT_FOUND' ||
+    code === 'RESOURCE_NOT_FOUND' ||
+    code === 'PERMISSION_DENIED' ||
+    code === 'DELETE_TIMEOUT'
+  ) {
+    return code;
+  }
+
+  return 'DELETE_FAILED';
+}
+
 export class RemoteSessionBackend<TSocket, THandshakeState, TServerHello, TServerAuth>
   implements SessionBackend {
   readonly descriptor: BackendDescriptor;
@@ -293,6 +315,7 @@ export class RemoteSessionBackend<TSocket, THandshakeState, TServerHello, TServe
         workspaceId: string;
         resolve: () => void;
         reject: (error: Error) => void;
+        timeout: ReturnType<typeof setTimeout>;
       }
     | null = null;
   private ptyOutputHandler: ((data: Uint8Array) => void) | null = null;
@@ -424,12 +447,32 @@ export class RemoteSessionBackend<TSocket, THandshakeState, TServerHello, TServe
       workspaceId,
       scriptPolicy: params.scriptPolicy,
     };
+    const timeoutMs =
+      typeof params.timeoutMs === 'number' && Number.isFinite(params.timeoutMs) && params.timeoutMs > 0
+        ? params.timeoutMs
+        : DEFAULT_DELETE_WORKSPACE_TIMEOUT_MS;
 
     return new Promise<void>((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        const pending = this.pendingDeleteWorkspace;
+        if (!pending || !workspaceIdsMatch(pending.workspaceId, workspaceId)) {
+          return;
+        }
+
+        this.pendingDeleteWorkspace = null;
+        pending.reject(
+          new WorkspaceDeleteError(
+            `Timed out waiting for workspace deletion response (${workspaceId})`,
+            'DELETE_TIMEOUT'
+          )
+        );
+      }, timeoutMs);
+
       this.pendingDeleteWorkspace = {
         workspaceId,
         resolve,
         reject,
+        timeout,
       };
 
       void this.sendCommand(command).catch((error) => {
@@ -437,8 +480,10 @@ export class RemoteSessionBackend<TSocket, THandshakeState, TServerHello, TServe
         if (!pending) {
           return;
         }
+        clearTimeout(pending.timeout);
         this.pendingDeleteWorkspace = null;
-        reject(error instanceof Error ? error : new Error(String(error)));
+        const message = error instanceof Error ? error.message : String(error);
+        pending.reject(new WorkspaceDeleteError(message, 'DELETE_FAILED'));
       });
     });
   }
@@ -956,6 +1001,7 @@ export class RemoteSessionBackend<TSocket, THandshakeState, TServerHello, TServe
       return;
     }
 
+    clearTimeout(pending.timeout);
     this.pendingDeleteWorkspace = null;
     pending.resolve();
   }
@@ -975,10 +1021,9 @@ export class RemoteSessionBackend<TSocket, THandshakeState, TServerHello, TServe
       return;
     }
 
+    clearTimeout(pending.timeout);
     this.pendingDeleteWorkspace = null;
-    const error = new Error(message) as Error & { code?: string };
-    error.code = code;
-    pending.reject(error);
+    pending.reject(new WorkspaceDeleteError(message, toWorkspaceDeleteErrorCode(code)));
   }
 
   private emitPtyData(data: Uint8Array): void {

--- a/src/session/backends/remote-session-backend.ts
+++ b/src/session/backends/remote-session-backend.ts
@@ -250,15 +250,6 @@ function workspaceIdsMatch(expected: string, actual: string | undefined): boolea
   return false;
 }
 
-function isDeleteErrorCode(code: string | undefined): boolean {
-  return (
-    code === 'REMOVE_SCRIPT_FAILED' ||
-    code === 'DELETE_FAILED' ||
-    code === 'WORKSPACE_NOT_FOUND' ||
-    code === 'NOT_FOUND'
-  );
-}
-
 export class RemoteSessionBackend<TSocket, THandshakeState, TServerHello, TServerAuth>
   implements SessionBackend {
   readonly descriptor: BackendDescriptor;
@@ -864,7 +855,7 @@ export class RemoteSessionBackend<TSocket, THandshakeState, TServerHello, TServe
       }
       case 'error':
         this.rejectPendingBundleRefreshRequests(message.message);
-        if (message.workspaceId || isDeleteErrorCode(message.code)) {
+        if (message.workspaceId) {
           this.rejectPendingWorkspaceDelete(message.code, message.message, message.workspaceId);
         }
         this.emit({

--- a/src/session/backends/remote-session-backend.ts
+++ b/src/session/backends/remote-session-backend.ts
@@ -269,7 +269,6 @@ export class RemoteSessionBackend<TSocket, THandshakeState, TServerHello, TServe
     | {
         resolve: () => void;
         reject: (error: Error) => void;
-        timeout: ReturnType<typeof setTimeout>;
       }
     | null = null;
   private ptyOutputHandler: ((data: Uint8Array) => void) | null = null;
@@ -403,18 +402,9 @@ export class RemoteSessionBackend<TSocket, THandshakeState, TServerHello, TServe
     };
 
     return new Promise<void>((resolve, reject) => {
-      const timeout = setTimeout(() => {
-        if (!this.pendingDeleteWorkspace) {
-          return;
-        }
-        this.pendingDeleteWorkspace = null;
-        reject(new Error('Timed out deleting workspace'));
-      }, 15000);
-
       this.pendingDeleteWorkspace = {
         resolve,
         reject,
-        timeout,
       };
 
       void this.sendCommand(command).catch((error) => {
@@ -422,7 +412,6 @@ export class RemoteSessionBackend<TSocket, THandshakeState, TServerHello, TServe
         if (!pending) {
           return;
         }
-        clearTimeout(pending.timeout);
         this.pendingDeleteWorkspace = null;
         reject(error instanceof Error ? error : new Error(String(error)));
       });
@@ -557,12 +546,8 @@ export class RemoteSessionBackend<TSocket, THandshakeState, TServerHello, TServe
         this.sendRelayConnectMessage();
       },
       onClose: () => {
-        this.isConnected = false;
-        this.mode = 'browsing';
-        this.attachedSessionId = null;
-        this.sessionKeys = null;
-        this.handshakeState = null;
         this.rejectConnect(new Error('Socket closed before handshake completed'));
+        this.resetState();
         this.emit({ type: 'status', status: 'disconnected' });
       },
       onMessage: (raw) => {
@@ -573,6 +558,8 @@ export class RemoteSessionBackend<TSocket, THandshakeState, TServerHello, TServe
       },
       onError: (error) => {
         this.rejectConnect(error);
+        this.rejectPendingBundleRefreshRequests(error.message);
+        this.rejectPendingWorkspaceDelete('DELETE_FAILED', error.message);
         this.emit({ type: 'status', status: 'error', error: error.message });
       },
     });
@@ -938,7 +925,6 @@ export class RemoteSessionBackend<TSocket, THandshakeState, TServerHello, TServe
       return;
     }
 
-    clearTimeout(pending.timeout);
     this.pendingDeleteWorkspace = null;
     pending.resolve();
   }
@@ -949,7 +935,6 @@ export class RemoteSessionBackend<TSocket, THandshakeState, TServerHello, TServe
       return;
     }
 
-    clearTimeout(pending.timeout);
     this.pendingDeleteWorkspace = null;
     const error = new Error(message) as Error & { code?: string };
     error.code = code;

--- a/src/session/index.ts
+++ b/src/session/index.ts
@@ -4,6 +4,7 @@ export type {
   BackendDescriptor,
   SessionBackend,
   AttachSessionParams,
+  DeleteWorkspaceParams,
 } from './backend.js';
 
 export type {

--- a/src/session/session-name.ts
+++ b/src/session/session-name.ts
@@ -1,3 +1,5 @@
+import { SessionNameExistsError } from '../types/errors.js';
+
 export interface ExistingSessionName {
   name: string;
 }
@@ -20,7 +22,7 @@ export function buildSessionName(options: BuildSessionNameOptions): string {
   if (requestedName && requestedName.length > 0) {
     const fullName = `${prefix}${requestedName}`;
     if (sessions.some((session) => session.name === fullName)) {
-      throw new Error(
+      throw new SessionNameExistsError(
         `Session name "${requestedName}" already exists in workspace "${workspaceName}"`
       );
     }

--- a/src/session/session-name.ts
+++ b/src/session/session-name.ts
@@ -1,0 +1,48 @@
+export interface ExistingSessionName {
+  name: string;
+}
+
+interface BuildSessionNameOptions {
+  projectName: string;
+  workspaceName: string;
+  requestedName?: string;
+  sessions: ExistingSessionName[];
+}
+
+function getSessionPrefix(projectName: string, workspaceName: string): string {
+  return `${projectName}:${workspaceName}:`;
+}
+
+export function buildSessionName(options: BuildSessionNameOptions): string {
+  const { projectName, workspaceName, requestedName, sessions } = options;
+  const prefix = getSessionPrefix(projectName, workspaceName);
+
+  if (requestedName && requestedName.length > 0) {
+    const fullName = `${prefix}${requestedName}`;
+    if (sessions.some((session) => session.name === fullName)) {
+      throw new Error(
+        `Session name "${requestedName}" already exists in workspace "${workspaceName}"`
+      );
+    }
+    return fullName;
+  }
+
+  const usedNumericSuffixes = new Set<number>();
+  for (const session of sessions) {
+    if (!session.name.startsWith(prefix)) {
+      continue;
+    }
+    const suffix = session.name.slice(prefix.length);
+    const parsed = Number.parseInt(suffix, 10);
+    if (!Number.isNaN(parsed) && parsed > 0) {
+      usedNumericSuffixes.add(parsed);
+    }
+  }
+
+  let candidate = 1;
+  while (usedNumericSuffixes.has(candidate)) {
+    candidate += 1;
+  }
+
+  return `${prefix}${candidate}`;
+}

--- a/src/session/useRemoteSessionClient.ts
+++ b/src/session/useRemoteSessionClient.ts
@@ -9,6 +9,7 @@ import type { NotificationConfig } from '../notifications/types.js';
 import type {
   AttachSessionParams,
   BackendKey,
+  DeleteWorkspaceParams,
   SessionBackend,
 } from './backend.js';
 import type { ScriptRuntimeState, BackendSessionState } from './types.js';
@@ -62,7 +63,11 @@ export interface UseRemoteSessionClientReturn<ConnectParams> {
   selectProject: (projectName: string | null) => void;
 
   killSession: (sessionId: string) => void;
-  deleteWorkspace: (projectName: string, workspaceId: string) => void;
+  deleteWorkspace: (
+    projectName: string,
+    workspaceId: string,
+    params?: DeleteWorkspaceParams
+  ) => Promise<void>;
   getBundleRefreshPlan: (projectName: string, workspaceId: string) => Promise<BundleRefreshPlan>;
   applyBundleRefresh: (
     projectName: string,
@@ -125,12 +130,12 @@ export function useRemoteSessionClient<ConnectParams>(
   }, [activeBackendState, mapConnectionStatus]);
 
   const withActiveBackend = useCallback(
-    async (fn: (backendKey: BackendKey) => Promise<void>) => {
+    async <T>(fn: (backendKey: BackendKey) => Promise<T>): Promise<T | null> => {
       const backendKey = activeBackendKeyRef.current;
       if (!backendKey) {
-        return;
+        return null;
       }
-      await fn(backendKey);
+      return fn(backendKey);
     },
     []
   );
@@ -216,10 +221,17 @@ export function useRemoteSessionClient<ConnectParams>(
     void withActiveBackend((backendKey) => engine.killSession(backendKey, sessionId));
   }, [engine, withActiveBackend]);
 
-  const deleteWorkspace = useCallback((projectName: string, workspaceId: string) => {
-    void withActiveBackend((backendKey) =>
-      engine.deleteWorkspace(backendKey, projectName, workspaceId)
+  const deleteWorkspace = useCallback(async (
+    projectName: string,
+    workspaceId: string,
+    params?: DeleteWorkspaceParams
+  ) => {
+    const result = await withActiveBackend((backendKey) =>
+      engine.deleteWorkspace(backendKey, projectName, workspaceId, params)
     );
+    if (result === null) {
+      throw new Error('No active backend connection');
+    }
   }, [engine, withActiveBackend]);
 
   const getBundleRefreshPlan = useCallback(

--- a/src/session/useSessionEngine.ts
+++ b/src/session/useSessionEngine.ts
@@ -1,6 +1,11 @@
 import { useCallback, useEffect, useMemo, useReducer, useRef } from 'react';
 import type { NotificationConfig } from '../notifications/types.js';
-import type { BackendKey, SessionBackend, AttachSessionParams } from './backend.js';
+import type {
+  BackendKey,
+  SessionBackend,
+  AttachSessionParams,
+  DeleteWorkspaceParams,
+} from './backend.js';
 import type {
   BundleRefreshPlan,
   BundleRefreshSubmission,
@@ -205,8 +210,41 @@ export function useSessionEngine() {
     await withBackend(backendKey, (backend) => backend.killSession(sessionId));
   }, [withBackend]);
 
-  const deleteWorkspace = useCallback(async (backendKey: BackendKey, projectName: string, workspaceId: string) => {
-    await withBackend(backendKey, (backend) => backend.deleteWorkspace(projectName, workspaceId));
+  const deleteWorkspace = useCallback(async (
+    backendKey: BackendKey,
+    projectName: string,
+    workspaceId: string,
+    params?: DeleteWorkspaceParams
+  ) => {
+    dispatch({
+      type: 'SET_COMMAND_ERROR',
+      backendKey,
+      commandError: null,
+    });
+    dispatch({
+      type: 'SET_SCRIPT_STATE',
+      backendKey,
+      scriptState: {
+        phase: 'remove',
+        isRunning: true,
+      },
+    });
+    try {
+      await withBackend(backendKey, (backend) => backend.deleteWorkspace(projectName, workspaceId, params));
+    } catch (error) {
+      const code =
+        typeof error === 'object' && error !== null && 'code' in error
+          ? (error as { code?: unknown }).code
+          : undefined;
+      if (code !== 'REMOVE_SCRIPT_FAILED') {
+        dispatch({
+          type: 'SET_SCRIPT_STATE',
+          backendKey,
+          scriptState: null,
+        });
+      }
+      throw error;
+    }
   }, [withBackend]);
 
   const getBundleRefreshPlan = useCallback(async (

--- a/src/types/errors.ts
+++ b/src/types/errors.ts
@@ -211,7 +211,11 @@ export type WorkspaceDeleteErrorCode =
   | 'REMOVE_SCRIPT_FAILED'
   | 'WORKSPACE_NOT_FOUND'
   | 'WORKTREE_REMOVE_FAILED'
-  | 'DELETE_FAILED';
+  | 'DELETE_FAILED'
+  | 'NOT_FOUND'
+  | 'RESOURCE_NOT_FOUND'
+  | 'PERMISSION_DENIED'
+  | 'DELETE_TIMEOUT';
 
 /**
  * Error thrown when workspace deletion fails in session backends.

--- a/src/types/errors.ts
+++ b/src/types/errors.ts
@@ -206,3 +206,44 @@ export class InvalidPublicKeyError extends SpacesError {
     this.name = 'InvalidPublicKeyError';
   }
 }
+
+export type WorkspaceDeleteErrorCode =
+  | 'REMOVE_SCRIPT_FAILED'
+  | 'WORKSPACE_NOT_FOUND'
+  | 'WORKTREE_REMOVE_FAILED'
+  | 'DELETE_FAILED';
+
+/**
+ * Error thrown when workspace deletion fails in session backends.
+ * Keeps machine-parseable delete codes for retry/UX handling.
+ */
+export class WorkspaceDeleteError extends Error {
+  public readonly code: WorkspaceDeleteErrorCode;
+
+  constructor(message: string, code: WorkspaceDeleteErrorCode) {
+    super(message);
+    this.name = 'WorkspaceDeleteError';
+    this.code = code;
+
+    if (typeof Error.captureStackTrace === 'function') {
+      Error.captureStackTrace(this, this.constructor);
+    }
+  }
+}
+
+/**
+ * Error thrown when a requested session name already exists.
+ */
+export class SessionNameExistsError extends Error {
+  public readonly code: 'SESSION_ALREADY_EXISTS';
+
+  constructor(message: string) {
+    super(message);
+    this.name = 'SessionNameExistsError';
+    this.code = 'SESSION_ALREADY_EXISTS';
+
+    if (typeof Error.captureStackTrace === 'function') {
+      Error.captureStackTrace(this, this.constructor);
+    }
+  }
+}

--- a/src/utils/__tests__/workspace-setup.integration.test.ts
+++ b/src/utils/__tests__/workspace-setup.integration.test.ts
@@ -171,6 +171,15 @@ function setupRemoveScript(workspacePath: string, outputFile: string): void {
   );
 }
 
+function setupFailingRemoveScript(workspacePath: string, outputFile: string): void {
+  const removeDir = join(workspacePath, '.gitspace', 'scripts', 'remove');
+  mkdirSync(removeDir, { recursive: true });
+  writeExecutable(
+    join(removeDir, '01-remove.sh'),
+    `#!/bin/bash\necho "remove-fail" >> "${outputFile}"\nexit 7\n`
+  );
+}
+
 describe('workspace setup integration', () => {
   beforeEach(() => {
     testDir = join(tmpdir(), `workspace-setup-integration-${Date.now()}-${Math.random().toString(36).slice(2)}`);
@@ -559,5 +568,35 @@ describe('workspace setup integration', () => {
 
     expect(mockProjectConfig.bundleWorkspaceState[wsTargetName]).toBeUndefined();
     expect(mockProjectConfig.bundleWorkspaceState[wsOtherName]).toBeDefined();
+  });
+
+  it('fails deletion when remove scripts fail unless skip policy is used', async () => {
+    const { deleteWorkspaceCore } = await loadWorkspaceCoreModule();
+
+    const workspaceName = 'ws-remove-fail';
+    const workspacePath = join(workspacesDir, workspaceName);
+    mkdirSync(workspacePath, { recursive: true });
+
+    const removeOutput = join(testDir, 'remove-fail.log');
+    setupFailingRemoveScript(workspacePath, removeOutput);
+
+    const firstAttempt = await deleteWorkspaceCore('test-project', workspaceName, {
+      nonInteractive: true,
+      keepBranch: true,
+    });
+
+    expect(firstAttempt.success).toBe(false);
+    expect(firstAttempt.errorCode).toBe('REMOVE_SCRIPT_FAILED');
+    expect(existsSync(workspacePath)).toBe(true);
+    expect((await Bun.file(removeOutput).text()).trim()).toBe('remove-fail');
+
+    const secondAttempt = await deleteWorkspaceCore('test-project', workspaceName, {
+      nonInteractive: true,
+      keepBranch: true,
+      removeScriptPolicy: 'skip',
+    });
+
+    expect(secondAttempt.success).toBe(true);
+    expect(existsSync(workspacePath)).toBe(false);
   });
 });

--- a/src/utils/__tests__/workspace-setup.integration.test.ts
+++ b/src/utils/__tests__/workspace-setup.integration.test.ts
@@ -32,6 +32,7 @@ function setupModuleMocks(): void {
     getProjectBaseDir: () => baseDir,
     getProjectWorkspacesDir: () => workspacesDir,
     getProjectDir: () => testDir,
+    getAllProjectNames: () => ['test-project'],
     readGlobalConfig: () => ({ currentProject: 'test-project' }),
     updateGlobalConfig: () => {},
   }));

--- a/src/utils/__tests__/workspace-setup.integration.test.ts
+++ b/src/utils/__tests__/workspace-setup.integration.test.ts
@@ -113,6 +113,10 @@ function setupModuleMocks(): void {
       debug: () => {},
     },
   }));
+
+  mock.module('../../core/secret-runtime', () => ({
+    shouldSkipSecretDependentScripts: () => false,
+  }));
 }
 
 async function loadBundleRefreshModule() {


### PR DESCRIPTION
## Summary
- Route workspace delete through a shared delete flow hook so TUI, web, and remote TUI all show `ScriptTerminal` output for the `remove` phase.
- Change workspace delete semantics to enforce remove scripts by default, surface `REMOVE_SCRIPT_FAILED`, and allow explicit retry with `scriptPolicy: 'skip'` after user confirmation; keep project delete best-effort.
- Extend local/remote session backends and remote protocol to stream remove-phase script output, propagate delete errors consistently, and support async delete completion.
- Add tests for remove-phase output streaming, remote delete completion/error behavior, and core delete policy behavior when remove scripts fail.

## Testing
- bun run typecheck
- bun test src/session/__tests__/local-session-backend.test.ts
- bun test src/session/__tests__/remote-session-backend.test.ts
- bun test src/hooks/__tests__/useLocalSession.tui.test.ts
- bun test src/session/__tests__/useRemoteSessionClient.test.ts
- bun test src/session/__tests__/backend-manager.test.ts src/utils/__tests__/workspace-setup.integration.test.ts

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core workspace deletion, remote protocol/backend state, and secret-loading behavior; bugs could cause failed deletes, skipped cleanup scripts, or stuck/incorrect remote delete completion handling.
> 
> **Overview**
> **Workspace deletion is refactored into a shared, retryable flow** via new `useWorkspaceDeleteFlow`, used by web/TUI/remote TUI to show remove-phase script progress and, on `REMOVE_SCRIPT_FAILED`, prompt to retry deletion with `scriptPolicy: 'skip'`.
> 
> Deletion semantics are tightened: `deleteWorkspaceCore` now **enforces cleanup scripts by default**, returns typed `errorCode`s, supports `removeScriptPolicy`, and can stream script output; local/remote session backends + remote protocol now accept `DeleteWorkspaceParams`, stream remove output, wait for async delete completion with timeouts, and propagate workspace-scoped errors. Adds `secret-runtime` initialization + CLI flags to optionally skip keychain preload and secret-dependent scripts, introduces shared `buildSessionName`, improves iOS terminal word input, and updates tests accordingly (plus bumps `@gitspace/*` optional deps).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5292d732a30a4276d480c4fbd398279008b46255. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Interactive, resilient workspace deletion with prompts on cleanup-script failures, optional skip-and-retry, streaming script progress in an integrated terminal, and automatic workspace/session refresh on success.
  * Deterministic session naming to avoid collisions.
  * iOS keyboard input improvements in the terminal.

* **Bug Fixes**
  * More reliable remote session and workspace ID handling and improved deletion/error signaling.

* **Chores**
  * New CLI flag --ignore-keychain-and-skip-secrets to opt out of secret preload and skip secret-dependent scripts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->