### PR TITLE
Unify keychain secrets and keep delete scripts visible

### DIFF
--- a/src/app.tui.tsx
+++ b/src/app.tui.tsx
@@ -87,7 +87,10 @@ import { useUserActivity } from './hooks/index.js';
 import { useBundleRefreshAttachFlow } from './session/index.js';
 import { useAttachController } from './app/session/useAttachController.js';
 import { useWorkspaceDeleteFlow } from './app/session/useWorkspaceDeleteFlow.js';
-import { initializeSecretRuntime } from './core/secret-runtime.js';
+import {
+  consumeLegacyCleanupReminderForTui,
+  initializeSecretRuntime,
+} from './core/secret-runtime.js';
 import {
   resolveInboxCommand,
   resolveMachineListCommand,
@@ -2590,6 +2593,12 @@ export async function launchTUI(
   // Clean exit handler
   const handleQuit = () => {
     renderer.destroy();
+
+    const legacyReminder = consumeLegacyCleanupReminderForTui();
+    if (legacyReminder) {
+      logger.warning(legacyReminder);
+    }
+
     process.exit(0);
   };
 

--- a/src/app.tui.tsx
+++ b/src/app.tui.tsx
@@ -1325,9 +1325,13 @@ function App({ relayConfig, onQuit }: AppProps) {
   // ========== Keyboard Handlers ==========
 
   useKeyboard(async (key) => {
+    const localScriptTerminalRunning =
+      state.view === 'scripts' &&
+      localScriptState?.isRunning === true;
+
     // Handle flow modals FIRST - even in terminal view
     // This ensures y/n work in confirmation modals when terminal is underneath
-    if (flow.isOpen) {
+    if (flow.isOpen && !localScriptTerminalRunning) {
       // Handle confirm modal with y/n shortcuts
       if (flow.flow.type === 'confirm') {
         if (key.raw === 'y' || key.name === 'return') {
@@ -2062,7 +2066,7 @@ function App({ relayConfig, onQuit }: AppProps) {
           error={localScriptState?.error}
           exitCode={localScriptState?.exitCode}
         />
-        <FlowTUI flow={flow} />
+        {!isRunning && <FlowTUI flow={flow} />}
         <StatusBar hint={isRunning ? '[Running scripts...]' : '[Esc/n] Back to workspaces'} />
       </Fragment>
     );

--- a/src/app.tui.tsx
+++ b/src/app.tui.tsx
@@ -1327,7 +1327,7 @@ function App({ relayConfig, onQuit }: AppProps) {
   useKeyboard(async (key) => {
     const localScriptTerminalRunning =
       state.view === 'scripts' &&
-      localScriptState?.isRunning === true;
+      (localScriptState?.isRunning ?? true);
 
     // Handle flow modals FIRST - even in terminal view
     // This ensures y/n work in confirmation modals when terminal is underneath

--- a/src/app.web.tsx
+++ b/src/app.web.tsx
@@ -747,18 +747,19 @@ export default function App() {
     terminal.mode === 'browsing' &&
     showScriptTerminal
   ) {
+    const isRunning = terminal.scriptState?.isRunning ?? true;
     return (
       <>
         <ScriptTerminal
           phase={terminal.scriptState?.phase ?? 'pre'}
           workspaceName={scriptWorkspaceName}
-          isRunning={terminal.scriptState?.isRunning ?? true}
+          isRunning={isRunning}
           error={terminal.scriptState?.error}
           exitCode={terminal.scriptState?.exitCode}
           setWriteCallback={terminal.setWriteCallback}
           onBack={() => setShowScriptTerminal(false)}
         />
-        <FlowWeb flow={flow} />
+        {!isRunning && <FlowWeb flow={flow} />}
         <Toaster theme="dark" position="top-right" richColors />
       </>
     );

--- a/src/app/session/useWorkspaceDeleteFlow.ts
+++ b/src/app/session/useWorkspaceDeleteFlow.ts
@@ -30,6 +30,7 @@ export interface UseWorkspaceDeleteFlowOptions {
   onDeleteSuccess?: (context: WorkspaceDeleteContext) => void | Promise<void>;
   onDeleteCancelled?: (context: WorkspaceDeleteContext) => void | Promise<void>;
   onDeleteError?: (context: WorkspaceDeleteErrorContext) => void | Promise<void>;
+  showLoadingDuringDelete?: boolean;
 }
 
 export interface UseWorkspaceDeleteFlowResult {
@@ -86,6 +87,7 @@ export function useWorkspaceDeleteFlow(
     onDeleteSuccess,
     onDeleteCancelled,
     onDeleteError,
+    showLoadingDuringDelete = false,
   } = options;
 
   const executeDelete = useCallback(async (
@@ -100,13 +102,17 @@ export function useWorkspaceDeleteFlow(
     };
 
     await onBeforeDelete?.(context);
-    flow.showLoading({
-      title: 'Deleting Workspace',
-      message:
-        params.scriptPolicy === 'skip'
-          ? 'Removing workspace without cleanup scripts...'
-          : `Running cleanup scripts for "${target.workspaceName}"...`,
-    });
+    if (showLoadingDuringDelete) {
+      flow.showLoading({
+        title: 'Deleting Workspace',
+        message:
+          params.scriptPolicy === 'skip'
+            ? 'Removing workspace without cleanup scripts...'
+            : `Running cleanup scripts for "${target.workspaceName}"...`,
+      });
+    } else {
+      flow.close();
+    }
 
     try {
       await deleteWorkspace(target.projectName, target.workspaceId, params);
@@ -144,7 +150,15 @@ export function useWorkspaceDeleteFlow(
 
       return false;
     }
-  }, [deleteWorkspace, flow, onBeforeDelete, onDeleteCancelled, onDeleteError, onDeleteSuccess]);
+  }, [
+    deleteWorkspace,
+    flow,
+    onBeforeDelete,
+    onDeleteCancelled,
+    onDeleteError,
+    onDeleteSuccess,
+    showLoadingDuringDelete,
+  ]);
 
   const deleteWorkspaceWithPrompt = useCallback(async (target: WorkspaceDeleteTarget): Promise<boolean> => {
     return executeDelete(target, { scriptPolicy: 'auto' }, false);

--- a/src/commands/migrate.ts
+++ b/src/commands/migrate.ts
@@ -1,0 +1,39 @@
+import { getAllProjectNames } from '../core/config.js';
+import { logger } from '../utils/logger.js';
+import { promptConfirm } from '../utils/prompts.js';
+import { cleanupLegacySecretEntries } from '../utils/secrets.js';
+
+export interface CleanupLegacyOptions {
+  yes?: boolean;
+}
+
+export async function migrateCleanupLegacy(
+  options: CleanupLegacyOptions = {}
+): Promise<void> {
+  const projectNames = getAllProjectNames();
+
+  if (!options.yes) {
+    const confirmed = await promptConfirm(
+      'Delete legacy keychain entries (project:* and global)? Unified secrets are kept.',
+      false
+    );
+
+    if (!confirmed) {
+      logger.info('Cancelled');
+      return;
+    }
+  }
+
+  const result = await cleanupLegacySecretEntries(projectNames);
+
+  if (result.errors.length > 0) {
+    logger.warning(`Legacy cleanup completed with ${result.errors.length} error(s).`);
+    for (const error of result.errors) {
+      logger.error(`  ${error}`);
+    }
+  }
+
+  logger.success(
+    `Legacy cleanup complete. Deleted ${result.deleted} entries (${result.missing} already absent).`
+  );
+}

--- a/src/commands/migrate.ts
+++ b/src/commands/migrate.ts
@@ -40,6 +40,10 @@ export async function migrateCleanupLegacy(
     for (const error of result.errors) {
       logger.error(`  ${error}`);
     }
+    logger.info(
+      `Legacy cleanup finished with issues. Deleted ${result.deleted} entries (${result.missing} already absent).`
+    );
+    return;
   }
 
   logger.success(

--- a/src/commands/migrate.ts
+++ b/src/commands/migrate.ts
@@ -1,4 +1,4 @@
-import { getAllProjectNames } from '../core/config.js';
+import { getSecretMigrationInputs } from '../core/secret-runtime.js';
 import { logger } from '../utils/logger.js';
 import { promptConfirm } from '../utils/prompts.js';
 import { cleanupLegacySecretEntries } from '../utils/secrets.js';
@@ -10,11 +10,11 @@ export interface CleanupLegacyOptions {
 export async function migrateCleanupLegacy(
   options: CleanupLegacyOptions = {}
 ): Promise<void> {
-  const projectNames = getAllProjectNames();
+  const migrationInputs = getSecretMigrationInputs();
 
   if (!options.yes) {
     const confirmed = await promptConfirm(
-      'Delete legacy keychain entries (project:* and global)? Unified secrets are kept.',
+      'Delete legacy keychain entries (project:*, global, and old per-key entries)? Unified secrets are kept.',
       false
     );
 
@@ -24,7 +24,10 @@ export async function migrateCleanupLegacy(
     }
   }
 
-  const result = await cleanupLegacySecretEntries(projectNames);
+  const result = await cleanupLegacySecretEntries(migrationInputs.projectNames, {
+    projectLegacyKeys: migrationInputs.projectSecretKeys,
+    globalLegacyKeys: migrationInputs.globalSecretKeys,
+  });
 
   if (result.errors.length > 0) {
     logger.warning(`Legacy cleanup completed with ${result.errors.length} error(s).`);

--- a/src/commands/migrate.ts
+++ b/src/commands/migrate.ts
@@ -1,7 +1,7 @@
 import { getSecretMigrationInputs } from '../core/secret-runtime.js';
 import { logger } from '../utils/logger.js';
 import { promptConfirm } from '../utils/prompts.js';
-import { cleanupLegacySecretEntries } from '../utils/secrets.js';
+import { cleanupLegacySecretEntries, preloadAllSecrets } from '../utils/secrets.js';
 
 export interface CleanupLegacyOptions {
   yes?: boolean;
@@ -23,6 +23,12 @@ export async function migrateCleanupLegacy(
       return;
     }
   }
+
+  // Ensure legacy entries are copied into unified storage before cleanup.
+  await preloadAllSecrets(migrationInputs.projectNames, {
+    projectLegacyKeys: migrationInputs.projectSecretKeys,
+    globalLegacyKeys: migrationInputs.globalSecretKeys,
+  });
 
   const result = await cleanupLegacySecretEntries(migrationInputs.projectNames, {
     projectLegacyKeys: migrationInputs.projectSecretKeys,

--- a/src/components/RemoteMachineScreen.tui.tsx
+++ b/src/components/RemoteMachineScreen.tui.tsx
@@ -247,7 +247,9 @@ export function RemoteMachineScreen({ machine, relayUrl, identity, onBack }: Rem
   }, [flow, renderer]);
 
   useKeyboard(async (key) => {
-    const scriptTerminalRunning = showScriptTerminal && remote.scriptState?.isRunning === true;
+    const scriptTerminalRunning =
+      showScriptTerminal &&
+      (remote.scriptState?.isRunning ?? true);
 
     if (flow.isOpen && !scriptTerminalRunning) {
       if (flow.flow.type === 'confirm') {

--- a/src/components/RemoteMachineScreen.tui.tsx
+++ b/src/components/RemoteMachineScreen.tui.tsx
@@ -89,6 +89,32 @@ export function RemoteMachineScreen({ machine, relayUrl, identity, onBack }: Rem
       }
       return remote.selectedProjectName;
     },
+    onBeforeAttach: ({ target, params }) => {
+      if (target === 'workspace' && params.workspaceId) {
+        setShowInbox(false);
+        setScriptWorkspaceName(params.workspaceId.split(':').slice(-1)[0] ?? params.workspaceId);
+        setShowScriptTerminal(true);
+      }
+    },
+    onAttachCancelled: ({ target }) => {
+      if (target === 'workspace') {
+        setShowScriptTerminal(false);
+      }
+    },
+    onAttachError: ({ target, message }) => {
+      const isWorkspaceScriptFailure = message.startsWith('Workspace scripts failed during');
+      const hasScriptRuntimeState = Boolean(remote.scriptState);
+
+      if (target === 'workspace' && (!isWorkspaceScriptFailure || !hasScriptRuntimeState)) {
+        setShowScriptTerminal(false);
+      }
+
+      flow.showMessage({
+        title: isWorkspaceScriptFailure ? 'Workspace Script Failed' : 'Session Failed',
+        message,
+        variant: 'error',
+      });
+    },
   });
 
   const { deleteWorkspaceWithPrompt } = useWorkspaceDeleteFlow({
@@ -221,7 +247,9 @@ export function RemoteMachineScreen({ machine, relayUrl, identity, onBack }: Rem
   }, [flow, renderer]);
 
   useKeyboard(async (key) => {
-    if (flow.isOpen) {
+    const scriptTerminalRunning = showScriptTerminal && remote.scriptState?.isRunning === true;
+
+    if (flow.isOpen && !scriptTerminalRunning) {
       if (flow.flow.type === 'confirm') {
         if (key.raw === 'y' || key.name === 'return') {
           await flow.handleConfirm();
@@ -429,7 +457,7 @@ export function RemoteMachineScreen({ machine, relayUrl, identity, onBack }: Rem
           error={remote.scriptState?.error}
           exitCode={remote.scriptState?.exitCode}
         />
-        <FlowTUI flow={flow} />
+        {!isRunning && <FlowTUI flow={flow} />}
         <StatusBar hint={isRunning ? '[Running scripts...]' : '[Esc/n] Back to workspaces'} />
       </Fragment>
     );

--- a/src/core/secret-runtime.ts
+++ b/src/core/secret-runtime.ts
@@ -1,18 +1,20 @@
 import { getAllProjectNames, readProjectConfig } from './config.js';
 import { logger } from '../utils/logger.js';
-import { preloadProjectSecrets } from '../utils/secrets.js';
+import { preloadAllSecrets } from '../utils/secrets.js';
 import { SpacesError } from '../types/errors.js';
 
 interface SecretRuntimeState {
   ignoreKeychainAndSkipSecrets: boolean;
-  initialized: boolean;
   projectsWithSecrets: Set<string>;
+  legacyEntriesDetected: boolean;
+  legacyReminderConsumed: boolean;
 }
 
 const state: SecretRuntimeState = {
   ignoreKeychainAndSkipSecrets: false,
-  initialized: false,
   projectsWithSecrets: new Set<string>(),
+  legacyEntriesDetected: false,
+  legacyReminderConsumed: false,
 };
 
 function collectProjectsWithSecrets(): Array<{ projectName: string; keys: string[] }> {
@@ -45,12 +47,14 @@ export async function initializeSecretRuntime(
 ): Promise<void> {
   const ignore = options.ignoreKeychainAndSkipSecrets ?? false;
   state.ignoreKeychainAndSkipSecrets = ignore;
+  state.legacyEntriesDetected = false;
+  state.legacyReminderConsumed = false;
 
   const projectsWithSecrets = collectProjectsWithSecrets();
   state.projectsWithSecrets = new Set(projectsWithSecrets.map((entry) => entry.projectName));
+  const projectNames = projectsWithSecrets.map((entry) => entry.projectName);
 
   if (ignore) {
-    state.initialized = true;
     if (projectsWithSecrets.length > 0) {
       logger.warning(
         'Ignoring keychain and skipping secret-dependent scripts (use with caution).'
@@ -59,16 +63,9 @@ export async function initializeSecretRuntime(
     return;
   }
 
-  if (projectsWithSecrets.length === 0) {
-    state.initialized = true;
-    return;
-  }
-
   try {
-    for (const entry of projectsWithSecrets) {
-      await preloadProjectSecrets(entry.projectName, entry.keys);
-    }
-    state.initialized = true;
+    const preloadResult = await preloadAllSecrets(projectNames);
+    state.legacyEntriesDetected = preloadResult.legacyEntriesDetected;
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     throw new SpacesError(
@@ -78,6 +75,15 @@ export async function initializeSecretRuntime(
       1
     );
   }
+}
+
+export function consumeLegacyCleanupReminderForTui(): string | null {
+  if (!state.legacyEntriesDetected || state.legacyReminderConsumed) {
+    return null;
+  }
+
+  state.legacyReminderConsumed = true;
+  return 'Legacy keychain entries are still present. Run `gssh migrate cleanup-legacy` once you are confident the unified keychain storage is stable.';
 }
 
 export function shouldSkipSecretDependentScripts(

--- a/src/core/secret-runtime.ts
+++ b/src/core/secret-runtime.ts
@@ -92,27 +92,6 @@ const state: SecretRuntimeState = {
   legacyReminderConsumed: false,
 };
 
-function collectProjectsWithSecrets(): Array<{ projectName: string; keys: string[] }> {
-  const projects = getAllProjectNames();
-  const result: Array<{ projectName: string; keys: string[] }> = [];
-
-  for (const projectName of projects) {
-    try {
-      const config = readProjectConfig(projectName);
-      const keys = config.bundleSecretKeys ?? [];
-      if (keys.length > 0) {
-        result.push({ projectName, keys });
-      }
-    } catch (error) {
-      logger.debug(
-        `[secrets] Failed reading project config for ${projectName}: ${error instanceof Error ? error.message : String(error)}`
-      );
-    }
-  }
-
-  return result;
-}
-
 export interface InitializeSecretRuntimeOptions {
   ignoreKeychainAndSkipSecrets?: boolean;
 }
@@ -125,12 +104,11 @@ export async function initializeSecretRuntime(
   state.legacyEntriesDetected = false;
   state.legacyReminderConsumed = false;
 
-  const projectsWithSecrets = collectProjectsWithSecrets();
-  state.projectsWithSecrets = new Set(projectsWithSecrets.map((entry) => entry.projectName));
   const migrationInputs = getSecretMigrationInputs();
+  state.projectsWithSecrets = new Set(Object.keys(migrationInputs.projectSecretKeys));
 
   if (ignore) {
-    if (projectsWithSecrets.length > 0) {
+    if (state.projectsWithSecrets.size > 0) {
       logger.warning(
         'Ignoring keychain and skipping secret-dependent scripts (use with caution).'
       );

--- a/src/core/secret-runtime.ts
+++ b/src/core/secret-runtime.ts
@@ -1,4 +1,6 @@
-import { getAllProjectNames, readProjectConfig } from './config.js';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { getAllProjectNames, getSpacesDir, readProjectConfig } from './config.js';
 import { logger } from '../utils/logger.js';
 import { preloadAllSecrets } from '../utils/secrets.js';
 import { SpacesError } from '../types/errors.js';
@@ -8,6 +10,79 @@ interface SecretRuntimeState {
   projectsWithSecrets: Set<string>;
   legacyEntriesDetected: boolean;
   legacyReminderConsumed: boolean;
+}
+
+export interface SecretMigrationInputs {
+  projectNames: string[];
+  projectSecretKeys: Record<string, string[]>;
+  globalSecretKeys: string[];
+}
+
+function readHostSubdomains(): string[] {
+  const hostPath = join(getSpacesDir(), 'host.json');
+  if (!existsSync(hostPath)) {
+    return [];
+  }
+
+  try {
+    const parsed = JSON.parse(readFileSync(hostPath, 'utf-8')) as {
+      subdomain?: unknown;
+      subdomains?: unknown;
+    };
+
+    const found = new Set<string>();
+    if (typeof parsed.subdomain === 'string' && parsed.subdomain.length > 0) {
+      found.add(parsed.subdomain);
+    }
+
+    if (Array.isArray(parsed.subdomains)) {
+      for (const candidate of parsed.subdomains) {
+        if (typeof candidate === 'string' && candidate.length > 0) {
+          found.add(candidate);
+        }
+      }
+    }
+
+    return [...found];
+  } catch {
+    return [];
+  }
+}
+
+export function getSecretMigrationInputs(): SecretMigrationInputs {
+  const projectNames = getAllProjectNames();
+  const projectSecretKeys: Record<string, string[]> = {};
+  const globalSecretKeys = new Set<string>([
+    'GITSPACE_TOKEN',
+    'linear-api-key',
+    'relay:signingPrivateKey',
+  ]);
+
+  for (const projectName of projectNames) {
+    globalSecretKeys.add(`linear-api-key-${projectName}`);
+
+    try {
+      const config = readProjectConfig(projectName);
+      const keys = [...new Set(config.bundleSecretKeys ?? [])];
+      if (keys.length > 0) {
+        projectSecretKeys[projectName] = keys;
+      }
+    } catch (error) {
+      logger.debug(
+        `[secrets] Failed reading project config for ${projectName}: ${error instanceof Error ? error.message : String(error)}`
+      );
+    }
+  }
+
+  for (const subdomain of readHostSubdomains()) {
+    globalSecretKeys.add(`TUNNEL_TOKEN_${subdomain}`);
+  }
+
+  return {
+    projectNames,
+    projectSecretKeys,
+    globalSecretKeys: [...globalSecretKeys],
+  };
 }
 
 const state: SecretRuntimeState = {
@@ -52,7 +127,7 @@ export async function initializeSecretRuntime(
 
   const projectsWithSecrets = collectProjectsWithSecrets();
   state.projectsWithSecrets = new Set(projectsWithSecrets.map((entry) => entry.projectName));
-  const projectNames = projectsWithSecrets.map((entry) => entry.projectName);
+  const migrationInputs = getSecretMigrationInputs();
 
   if (ignore) {
     if (projectsWithSecrets.length > 0) {
@@ -64,7 +139,10 @@ export async function initializeSecretRuntime(
   }
 
   try {
-    const preloadResult = await preloadAllSecrets(projectNames);
+    const preloadResult = await preloadAllSecrets(migrationInputs.projectNames, {
+      projectLegacyKeys: migrationInputs.projectSecretKeys,
+      globalLegacyKeys: migrationInputs.globalSecretKeys,
+    });
     state.legacyEntriesDetected = preloadResult.legacyEntriesDetected;
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);

--- a/src/core/workspace.ts
+++ b/src/core/workspace.ts
@@ -193,9 +193,29 @@ export async function deleteWorkspaceCore(
   try {
     await removeWorktree(baseDir, workspacePath, true);
   } catch (e) {
-    result.errorCode = 'WORKTREE_REMOVE_FAILED';
-    result.error = e instanceof Error ? e.message : 'Failed to remove worktree';
-    return result;
+    const message = e instanceof Error ? e.message : String(e);
+    const isNotWorkingTreeError = /not a working tree/i.test(message);
+
+    if (isNotWorkingTreeError) {
+      logger.debug(
+        `Worktree metadata missing for ${workspaceName}; removing directory directly.`
+      );
+
+      try {
+        rmSync(workspacePath, { recursive: true, force: true });
+      } catch (rmError) {
+        result.errorCode = 'WORKTREE_REMOVE_FAILED';
+        result.error =
+          rmError instanceof Error
+            ? rmError.message
+            : 'Failed to remove orphaned workspace directory';
+        return result;
+      }
+    } else {
+      result.errorCode = 'WORKTREE_REMOVE_FAILED';
+      result.error = message || 'Failed to remove worktree';
+      return result;
+    }
   }
 
   // Try to delete the local branch

--- a/src/index.ts
+++ b/src/index.ts
@@ -56,6 +56,7 @@ import { hostReserve, hostRelease, hostList, hostSetPrimary, hostStatus } from '
 import { startTmux, stopTmux, statusTmux, listTmux, newTmux, attachTmux, killTmux } from './commands/tmux.js'
 import { showStatus } from './commands/status.js'
 import { configNotifications, linearSetup, linearShow, linearClear } from './commands/config.js'
+import { migrateCleanupLegacy } from './commands/migrate.js'
 import { notificationsInstall, notificationsUninstall, notificationsHook, notificationsStatus } from './commands/notifications.js'
 import { bundleRefresh, bundleStatus } from './commands/bundle.js'
 
@@ -718,6 +719,27 @@ configLinearCommand
 		await checkFirstTimeSetup()
 		try {
 			await linearClear(options)
+		} catch (error) {
+			handleError(error)
+		}
+	})
+
+// ============================================================================
+// Migration Commands
+// ============================================================================
+
+const migrateCommand = program
+	.command('migrate')
+	.description('Migration and cleanup utilities')
+
+migrateCommand
+	.command('cleanup-legacy')
+	.description('Delete legacy keychain entries kept for backwards compatibility')
+	.option('-y, --yes', 'Skip confirmation prompt')
+	.action(async (options) => {
+		await checkFirstTimeSetup()
+		try {
+			await migrateCleanupLegacy(options)
 		} catch (error) {
 			handleError(error)
 		}

--- a/src/session/useBundleRefreshAttachFlow.ts
+++ b/src/session/useBundleRefreshAttachFlow.ts
@@ -394,10 +394,8 @@ export function useBundleRefreshAttachFlow(
             return false;
           }
 
-          currentOptions.flow.showLoading({
-            title: 'Bundle Refresh',
-            message: 'Retrying session attach...',
-          });
+          // Ensure lifecycle script output is visible in ScriptTerminal during retry.
+          currentOptions.flow.close();
           await Promise.resolve(currentOptions.attachSession(pending.params));
           currentOptions.flow.close();
           return true;
@@ -436,10 +434,8 @@ export function useBundleRefreshAttachFlow(
 
         await currentOptions.applyBundleRefresh(projectName, pending.workspaceId, submission);
 
-        currentOptions.flow.showLoading({
-          title: 'Bundle Refresh',
-          message: 'Retrying session attach...',
-        });
+        // Ensure lifecycle script output is visible in ScriptTerminal during retry.
+        currentOptions.flow.close();
 
         await Promise.resolve(currentOptions.attachSession(pending.params));
         currentOptions.flow.close();
@@ -476,10 +472,8 @@ export function useBundleRefreshAttachFlow(
       }
 
       try {
-        currentOptions.flow.showLoading({
-          title: 'Attaching Session',
-          message: 'Retrying without workspace scripts...',
-        });
+        // Do not block ScriptTerminal with loading overlays while attach retries.
+        currentOptions.flow.close();
         await Promise.resolve(currentOptions.attachSession({
           ...pending.params,
           scriptPolicy: 'skip',

--- a/src/utils/__tests__/workspace-setup.integration.test.ts
+++ b/src/utils/__tests__/workspace-setup.integration.test.ts
@@ -19,6 +19,7 @@ let mockProjectConfig: any;
 let secretStore: Record<string, string>;
 let onboardingQueue: Array<any>;
 let capturedOnboardingBatches: OnboardingStep[][];
+let mockRemoveWorktreeError: string | null;
 let oldTmuxSocket: string | undefined;
 let oldTmuxSessionDir: string | undefined;
 let oldTmuxPidFile: string | undefined;
@@ -48,6 +49,9 @@ function setupModuleMocks(): void {
       lastCommit: '',
     }),
     removeWorktree: async (_baseDir: string, workspacePath: string) => {
+      if (mockRemoveWorktreeError) {
+        throw new Error(mockRemoveWorktreeError);
+      }
       if (existsSync(workspacePath)) {
         rmSync(workspacePath, { recursive: true, force: true });
       }
@@ -205,6 +209,7 @@ describe('workspace setup integration', () => {
     secretStore = {};
     onboardingQueue = [];
     capturedOnboardingBatches = [];
+    mockRemoveWorktreeError = null;
 
     // Guard rails: isolate tmux-lite env in case a future code path accidentally
     // reaches tmux-lite helpers.
@@ -602,6 +607,27 @@ describe('workspace setup integration', () => {
     });
 
     expect(secondAttempt.success).toBe(true);
+    expect(existsSync(workspacePath)).toBe(false);
+  });
+
+  it('falls back to removing workspace directory when git reports not a working tree', async () => {
+    const { deleteWorkspaceCore } = await loadWorkspaceCoreModule();
+
+    const workspaceName = 'ws-orphan';
+    const workspacePath = join(workspacesDir, workspaceName);
+    mkdirSync(workspacePath, { recursive: true });
+
+    mockRemoveWorktreeError = `fatal: '${workspacePath}' is not a working tree`;
+
+    const result = await deleteWorkspaceCore('test-project', workspaceName, {
+      nonInteractive: true,
+      keepBranch: true,
+      removeScriptPolicy: 'skip',
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.error).toBeUndefined();
+    expect(result.errorCode).toBeUndefined();
     expect(existsSync(workspacePath)).toBe(false);
   });
 });

--- a/src/utils/secrets.ts
+++ b/src/utils/secrets.ts
@@ -20,7 +20,14 @@ const GLOBAL_SECRETS_KEY = 'global';
 interface UnifiedSecretsBlob {
   global: Record<string, string>;
   projects: Record<string, Record<string, string>>;
+  metadata: {
+    schemaVersion: number;
+    legacyMigrationComplete: boolean;
+    legacyEntriesRetained: boolean;
+  };
 }
+
+const UNIFIED_SECRETS_SCHEMA_VERSION = 2;
 
 // In-memory cache for unified secrets blob
 let unifiedSecretsCache: UnifiedSecretsBlob | null = null;
@@ -34,6 +41,11 @@ function createEmptyBlob(): UnifiedSecretsBlob {
   return {
     global: {},
     projects: {},
+    metadata: {
+      schemaVersion: UNIFIED_SECRETS_SCHEMA_VERSION,
+      legacyMigrationComplete: false,
+      legacyEntriesRetained: false,
+    },
   };
 }
 
@@ -60,6 +72,7 @@ function parseUnifiedSecretsBlob(raw: string | null): UnifiedSecretsBlob {
     const parsed = JSON.parse(raw) as {
       global?: unknown;
       projects?: unknown;
+      metadata?: unknown;
     };
 
     const projects: Record<string, Record<string, string>> = {};
@@ -69,27 +82,34 @@ function parseUnifiedSecretsBlob(raw: string | null): UnifiedSecretsBlob {
       }
     }
 
+    const metadata =
+      parsed.metadata && typeof parsed.metadata === 'object'
+        ? (parsed.metadata as {
+            schemaVersion?: unknown;
+            legacyMigrationComplete?: unknown;
+            legacyEntriesRetained?: unknown;
+          })
+        : {};
+
     return {
       global: normalizeRecord(parsed.global),
       projects,
+      metadata: {
+        schemaVersion:
+          typeof metadata.schemaVersion === 'number' && Number.isFinite(metadata.schemaVersion)
+            ? metadata.schemaVersion
+            : UNIFIED_SECRETS_SCHEMA_VERSION,
+        legacyMigrationComplete: metadata.legacyMigrationComplete === true,
+        legacyEntriesRetained: metadata.legacyEntriesRetained === true,
+      },
     };
   } catch {
     return createEmptyBlob();
   }
 }
 
-function hasAnySecrets(blob: UnifiedSecretsBlob): boolean {
-  if (Object.keys(blob.global).length > 0) {
-    return true;
-  }
-
-  for (const secrets of Object.values(blob.projects)) {
-    if (Object.keys(secrets).length > 0) {
-      return true;
-    }
-  }
-
-  return false;
+function isLegacyMigrationComplete(blob: UnifiedSecretsBlob): boolean {
+  return blob.metadata.legacyMigrationComplete === true;
 }
 
 async function loadUnifiedSecretsBlob(): Promise<UnifiedSecretsBlob> {
@@ -103,24 +123,28 @@ async function loadUnifiedSecretsBlob(): Promise<UnifiedSecretsBlob> {
   });
 
   unifiedSecretsCache = parseUnifiedSecretsBlob(raw);
+  if (unifiedSecretsCache.metadata.legacyMigrationComplete) {
+    legacyEntriesDetected = unifiedSecretsCache.metadata.legacyEntriesRetained;
+  }
   return unifiedSecretsCache;
 }
 
 async function saveUnifiedSecretsBlob(blob: UnifiedSecretsBlob): Promise<void> {
-  unifiedSecretsCache = blob;
-
-  if (!hasAnySecrets(blob)) {
-    await Bun.secrets.delete({
-      service: SERVICE_NAME,
-      name: UNIFIED_SECRETS_KEY,
-    });
-    return;
-  }
+  const normalized: UnifiedSecretsBlob = {
+    global: { ...blob.global },
+    projects: { ...blob.projects },
+    metadata: {
+      schemaVersion: UNIFIED_SECRETS_SCHEMA_VERSION,
+      legacyMigrationComplete: blob.metadata.legacyMigrationComplete === true,
+      legacyEntriesRetained: blob.metadata.legacyEntriesRetained === true,
+    },
+  };
+  unifiedSecretsCache = normalized;
 
   await Bun.secrets.set({
     service: SERVICE_NAME,
     name: UNIFIED_SECRETS_KEY,
-    value: JSON.stringify(blob),
+    value: JSON.stringify(normalized),
   });
 }
 
@@ -132,6 +156,7 @@ export function clearSecretsCache(): void {
   unifiedSecretsCache = null;
   legacyProjectBlobChecked.clear();
   legacyGlobalBlobChecked = false;
+  legacyEntriesDetected = false;
 }
 
 // ============================================================================
@@ -252,6 +277,10 @@ export async function getProjectSecret(
     return current[key];
   }
 
+  if (isLegacyMigrationComplete(blob)) {
+    return null;
+  }
+
   // Try legacy project blob format: project:<name>
   if (!legacyProjectBlobChecked.has(projectName)) {
     const legacyBlob = await loadLegacyProjectBlob(projectName);
@@ -313,7 +342,7 @@ export async function getProjectSecrets(
   let secrets = blob.projects[projectName] || {};
   let changed = false;
 
-  if (Object.keys(secrets).length === 0 && !legacyProjectBlobChecked.has(projectName)) {
+  if (!isLegacyMigrationComplete(blob) && !legacyProjectBlobChecked.has(projectName)) {
     const legacyBlob = await loadLegacyProjectBlob(projectName);
     if (legacyBlob.hasLegacyEntry) {
       secrets = mergeSecrets(secrets, legacyBlob.secrets);
@@ -327,6 +356,10 @@ export async function getProjectSecrets(
   for (const key of keys) {
     if (key in secrets) {
       result[key] = secrets[key];
+      continue;
+    }
+
+    if (isLegacyMigrationComplete(blob)) {
       continue;
     }
 
@@ -437,6 +470,10 @@ export async function getSecret(key: string): Promise<string | null> {
     return secrets[key];
   }
 
+  if (isLegacyMigrationComplete(blob)) {
+    return null;
+  }
+
   // Try legacy global blob format: global
   if (!legacyGlobalBlobChecked) {
     const legacyBlob = await loadLegacyGlobalBlob();
@@ -485,34 +522,81 @@ export interface PreloadAllSecretsResult {
   importedLegacyGlobalEntry: boolean;
 }
 
+export interface PreloadAllSecretsOptions {
+  globalLegacyKeys?: string[];
+  projectLegacyKeys?: Record<string, string[]>;
+}
+
 /**
  * Preload all secrets for the process into memory.
  * This is intended to be called once at startup (serve + TUI).
  */
-export async function preloadAllSecrets(projectNames: string[]): Promise<PreloadAllSecretsResult> {
+export async function preloadAllSecrets(
+  projectNames: string[],
+  options: PreloadAllSecretsOptions = {}
+): Promise<PreloadAllSecretsResult> {
   const blob = await loadUnifiedSecretsBlob();
+
+  if (isLegacyMigrationComplete(blob)) {
+    legacyEntriesDetected = blob.metadata.legacyEntriesRetained;
+    return {
+      legacyEntriesDetected,
+      importedLegacyProjectEntries: 0,
+      importedLegacyGlobalEntry: false,
+    };
+  }
+
   let importedLegacyProjectEntries = 0;
   let importedLegacyGlobalEntry = false;
   let changed = false;
+  let detectedLegacyEntries = false;
 
-  const uniqueProjects = [...new Set(projectNames)];
-  for (const projectName of uniqueProjects) {
+  const projectLegacyKeys = options.projectLegacyKeys ?? {};
+  const globalLegacyKeys = [...new Set(options.globalLegacyKeys ?? [])];
+
+  const projectNamesToCheck = [...new Set([...projectNames, ...Object.keys(projectLegacyKeys)])];
+
+  for (const projectName of projectNamesToCheck) {
     const legacyProject = await loadLegacyProjectBlob(projectName);
     if (!legacyProject.hasLegacyEntry) {
-      continue;
+      // continue with per-key migration below
+    } else {
+      detectedLegacyEntries = true;
+      importedLegacyProjectEntries += 1;
+      const current = blob.projects[projectName] || {};
+      const merged = mergeSecrets(current, legacyProject.secrets);
+      if (JSON.stringify(current) !== JSON.stringify(merged)) {
+        blob.projects[projectName] = merged;
+        changed = true;
+      }
     }
 
-    importedLegacyProjectEntries += 1;
-    const current = blob.projects[projectName] || {};
-    const merged = mergeSecrets(current, legacyProject.secrets);
-    if (JSON.stringify(current) !== JSON.stringify(merged)) {
-      blob.projects[projectName] = merged;
-      changed = true;
+    const oldKeys = [...new Set(projectLegacyKeys[projectName] ?? [])];
+    for (const key of oldKeys) {
+      const oldValue = await Bun.secrets.get({
+        service: SERVICE_NAME,
+        name: `${projectName}:${key}`,
+      });
+
+      if (!oldValue) {
+        continue;
+      }
+
+      detectedLegacyEntries = true;
+      const currentProjectSecrets = blob.projects[projectName] || {};
+      if (currentProjectSecrets[key] !== oldValue) {
+        blob.projects[projectName] = {
+          ...currentProjectSecrets,
+          [key]: oldValue,
+        };
+        changed = true;
+      }
     }
   }
 
   const legacyGlobal = await loadLegacyGlobalBlob();
   if (legacyGlobal.hasLegacyEntry) {
+    detectedLegacyEntries = true;
     importedLegacyGlobalEntry = true;
     const merged = mergeSecrets(blob.global, legacyGlobal.secrets);
     if (JSON.stringify(blob.global) !== JSON.stringify(merged)) {
@@ -520,6 +604,29 @@ export async function preloadAllSecrets(projectNames: string[]): Promise<Preload
       changed = true;
     }
   }
+
+  for (const key of globalLegacyKeys) {
+    const oldValue = await Bun.secrets.get({
+      service: SERVICE_NAME,
+      name: key,
+    });
+
+    if (!oldValue) {
+      continue;
+    }
+
+    detectedLegacyEntries = true;
+    if (blob.global[key] !== oldValue) {
+      blob.global[key] = oldValue;
+      changed = true;
+    }
+  }
+
+  blob.metadata.legacyMigrationComplete = true;
+  blob.metadata.legacyEntriesRetained = detectedLegacyEntries;
+  changed = true;
+
+  legacyEntriesDetected = detectedLegacyEntries;
 
   if (changed) {
     await saveUnifiedSecretsBlob(blob);
@@ -542,6 +649,11 @@ export interface CleanupLegacySecretsResult {
   errors: string[];
 }
 
+export interface CleanupLegacySecretsOptions {
+  globalLegacyKeys?: string[];
+  projectLegacyKeys?: Record<string, string[]>;
+}
+
 /**
  * Remove legacy keychain entries now that unified secrets are in use.
  * This only removes legacy blob entries (`project:*`, `global`).
@@ -550,7 +662,8 @@ export interface CleanupLegacySecretsResult {
  * unified secrets storage has been stable for several releases.
  */
 export async function cleanupLegacySecretEntries(
-  projectNames: string[]
+  projectNames: string[],
+  options: CleanupLegacySecretsOptions = {}
 ): Promise<CleanupLegacySecretsResult> {
   const result: CleanupLegacySecretsResult = {
     deleted: 0,
@@ -558,7 +671,21 @@ export async function cleanupLegacySecretEntries(
     errors: [],
   };
 
-  const entries = [GLOBAL_SECRETS_KEY, ...[...new Set(projectNames)].map((name) => getProjectSecretsKey(name))];
+  const projectLegacyKeys = options.projectLegacyKeys ?? {};
+  const globalLegacyKeys = options.globalLegacyKeys ?? [];
+
+  const entries = new Set<string>([
+    GLOBAL_SECRETS_KEY,
+    ...[...new Set(projectNames)].map((name) => getProjectSecretsKey(name)),
+    ...globalLegacyKeys,
+  ]);
+
+  for (const [projectName, keys] of Object.entries(projectLegacyKeys)) {
+    for (const key of keys) {
+      entries.add(`${projectName}:${key}`);
+    }
+  }
+
   for (const name of entries) {
     try {
       const deleted = await Bun.secrets.delete({

--- a/src/utils/secrets.ts
+++ b/src/utils/secrets.ts
@@ -1,28 +1,137 @@
 /**
- * Secure secrets management using Bun.secrets API
- * Stores secrets in the OS keychain (macOS Keychain, Linux libsecret, Windows Credential Manager)
+ * Secure secrets management using Bun.secrets API.
  *
- * All project secrets are stored in a single keychain entry per project (as JSON).
- * All global secrets are stored in a single keychain entry (as JSON).
- * This ensures only ONE keychain prompt per operation, regardless of how many secrets are needed.
+ * Current format: a SINGLE unified keychain entry containing both global
+ * and project-scoped secret maps.
+ *
+ * Legacy formats still supported for reads/migration:
+ * - project blobs: project:<name>
+ * - global blob: global
+ * - very old per-secret keys: <project>:<key> and <key>
  */
 
 const SERVICE_NAME = 'com.gitspace';
 
 // Keychain entry names
+const UNIFIED_SECRETS_KEY = 'secrets';
 const PROJECT_SECRETS_PREFIX = 'project:';
 const GLOBAL_SECRETS_KEY = 'global';
 
-// In-memory cache for loaded secret blobs
-// Maps keychain entry name -> parsed secrets object
-const secretsBlobCache = new Map<string, Record<string, string>>();
+interface UnifiedSecretsBlob {
+  global: Record<string, string>;
+  projects: Record<string, Record<string, string>>;
+}
+
+// In-memory cache for unified secrets blob
+let unifiedSecretsCache: UnifiedSecretsBlob | null = null;
+
+// Process-level marker used for reminders about legacy cleanup.
+let legacyEntriesDetected = false;
+const legacyProjectBlobChecked = new Set<string>();
+let legacyGlobalBlobChecked = false;
+
+function createEmptyBlob(): UnifiedSecretsBlob {
+  return {
+    global: {},
+    projects: {},
+  };
+}
+
+function normalizeRecord(value: unknown): Record<string, string> {
+  if (!value || typeof value !== 'object') {
+    return {};
+  }
+
+  const output: Record<string, string> = {};
+  for (const [key, raw] of Object.entries(value as Record<string, unknown>)) {
+    if (typeof raw === 'string') {
+      output[key] = raw;
+    }
+  }
+  return output;
+}
+
+function parseUnifiedSecretsBlob(raw: string | null): UnifiedSecretsBlob {
+  if (!raw) {
+    return createEmptyBlob();
+  }
+
+  try {
+    const parsed = JSON.parse(raw) as {
+      global?: unknown;
+      projects?: unknown;
+    };
+
+    const projects: Record<string, Record<string, string>> = {};
+    if (parsed.projects && typeof parsed.projects === 'object') {
+      for (const [projectName, projectSecrets] of Object.entries(parsed.projects as Record<string, unknown>)) {
+        projects[projectName] = normalizeRecord(projectSecrets);
+      }
+    }
+
+    return {
+      global: normalizeRecord(parsed.global),
+      projects,
+    };
+  } catch {
+    return createEmptyBlob();
+  }
+}
+
+function hasAnySecrets(blob: UnifiedSecretsBlob): boolean {
+  if (Object.keys(blob.global).length > 0) {
+    return true;
+  }
+
+  for (const secrets of Object.values(blob.projects)) {
+    if (Object.keys(secrets).length > 0) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+async function loadUnifiedSecretsBlob(): Promise<UnifiedSecretsBlob> {
+  if (unifiedSecretsCache) {
+    return unifiedSecretsCache;
+  }
+
+  const raw = await Bun.secrets.get({
+    service: SERVICE_NAME,
+    name: UNIFIED_SECRETS_KEY,
+  });
+
+  unifiedSecretsCache = parseUnifiedSecretsBlob(raw);
+  return unifiedSecretsCache;
+}
+
+async function saveUnifiedSecretsBlob(blob: UnifiedSecretsBlob): Promise<void> {
+  unifiedSecretsCache = blob;
+
+  if (!hasAnySecrets(blob)) {
+    await Bun.secrets.delete({
+      service: SERVICE_NAME,
+      name: UNIFIED_SECRETS_KEY,
+    });
+    return;
+  }
+
+  await Bun.secrets.set({
+    service: SERVICE_NAME,
+    name: UNIFIED_SECRETS_KEY,
+    value: JSON.stringify(blob),
+  });
+}
 
 /**
  * Clear the in-memory secrets cache
  * Useful for long-running processes that need fresh values
  */
 export function clearSecretsCache(): void {
-  secretsBlobCache.clear();
+  unifiedSecretsCache = null;
+  legacyProjectBlobChecked.clear();
+  legacyGlobalBlobChecked = false;
 }
 
 // ============================================================================
@@ -36,38 +145,64 @@ function getProjectSecretsKey(projectName: string): string {
   return `${PROJECT_SECRETS_PREFIX}${projectName}`;
 }
 
-/**
- * Load the secrets blob for a project from keychain (or cache)
- * This is the only function that accesses the keychain for project secrets
- */
-async function loadProjectSecretsBlob(projectName: string): Promise<Record<string, string>> {
-  const keychainKey = getProjectSecretsKey(projectName);
-
-  // Check cache first
-  if (secretsBlobCache.has(keychainKey)) {
-    return secretsBlobCache.get(keychainKey)!;
-  }
-
-  // Load from keychain (triggers one OS prompt)
+async function loadLegacyProjectBlob(projectName: string): Promise<{
+  hasLegacyEntry: boolean;
+  secrets: Record<string, string>;
+}> {
+  legacyProjectBlobChecked.add(projectName);
   const raw = await Bun.secrets.get({
     service: SERVICE_NAME,
-    name: keychainKey,
+    name: getProjectSecretsKey(projectName),
   });
 
-  // Parse JSON or return empty object
-  let secrets: Record<string, string> = {};
-  if (raw) {
-    try {
-      secrets = JSON.parse(raw);
-    } catch {
-      // Invalid JSON, start fresh
-      secrets = {};
-    }
+  if (!raw) {
+    return { hasLegacyEntry: false, secrets: {} };
   }
 
-  // Cache the loaded blob
-  secretsBlobCache.set(keychainKey, secrets);
-  return secrets;
+  legacyEntriesDetected = true;
+  try {
+    return { hasLegacyEntry: true, secrets: normalizeRecord(JSON.parse(raw)) };
+  } catch {
+    return { hasLegacyEntry: true, secrets: {} };
+  }
+}
+
+async function loadLegacyGlobalBlob(): Promise<{
+  hasLegacyEntry: boolean;
+  secrets: Record<string, string>;
+}> {
+  legacyGlobalBlobChecked = true;
+  const raw = await Bun.secrets.get({
+    service: SERVICE_NAME,
+    name: GLOBAL_SECRETS_KEY,
+  });
+
+  if (!raw) {
+    return { hasLegacyEntry: false, secrets: {} };
+  }
+
+  legacyEntriesDetected = true;
+  try {
+    return { hasLegacyEntry: true, secrets: normalizeRecord(JSON.parse(raw)) };
+  } catch {
+    return { hasLegacyEntry: true, secrets: {} };
+  }
+}
+
+function mergeSecrets(
+  existing: Record<string, string>,
+  legacy: Record<string, string>
+): Record<string, string> {
+  // New-format values win if both are present.
+  return { ...legacy, ...existing };
+}
+
+/**
+ * Load project secrets from the unified blob.
+ */
+async function loadProjectSecretsBlob(projectName: string): Promise<Record<string, string>> {
+  const blob = await loadUnifiedSecretsBlob();
+  return { ...(blob.projects[projectName] || {}) };
 }
 
 /**
@@ -77,25 +212,13 @@ async function saveProjectSecretsBlob(
   projectName: string,
   secrets: Record<string, string>
 ): Promise<void> {
-  const keychainKey = getProjectSecretsKey(projectName);
-
-  // Update cache
-  secretsBlobCache.set(keychainKey, secrets);
-
-  // Save to keychain
+  const blob = await loadUnifiedSecretsBlob();
   if (Object.keys(secrets).length === 0) {
-    // Delete the entry if no secrets remain
-    await Bun.secrets.delete({
-      service: SERVICE_NAME,
-      name: keychainKey,
-    });
+    delete blob.projects[projectName];
   } else {
-    await Bun.secrets.set({
-      service: SERVICE_NAME,
-      name: keychainKey,
-      value: JSON.stringify(secrets),
-    });
+    blob.projects[projectName] = { ...secrets };
   }
+  await saveUnifiedSecretsBlob(blob);
 }
 
 /**
@@ -121,11 +244,24 @@ export async function getProjectSecret(
   projectName: string,
   key: string
 ): Promise<string | null> {
-  const secrets = await loadProjectSecretsBlob(projectName);
+  const blob = await loadUnifiedSecretsBlob();
+  const current = blob.projects[projectName] || {};
 
   // Found in new format
-  if (secrets[key] !== undefined) {
-    return secrets[key];
+  if (current[key] !== undefined) {
+    return current[key];
+  }
+
+  // Try legacy project blob format: project:<name>
+  if (!legacyProjectBlobChecked.has(projectName)) {
+    const legacyBlob = await loadLegacyProjectBlob(projectName);
+    if (legacyBlob.hasLegacyEntry) {
+      blob.projects[projectName] = mergeSecrets(current, legacyBlob.secrets);
+      await saveUnifiedSecretsBlob(blob);
+      if (blob.projects[projectName][key] !== undefined) {
+        return blob.projects[projectName][key];
+      }
+    }
   }
 
   // Try old format: ${projectName}:${key}
@@ -136,15 +272,12 @@ export async function getProjectSecret(
   });
 
   if (oldValue) {
-    // Migrate to new format automatically
-    secrets[key] = oldValue;
-    await saveProjectSecretsBlob(projectName, secrets);
-
-    // Delete old entry
-    await Bun.secrets.delete({
-      service: SERVICE_NAME,
-      name: oldKeychainName,
-    });
+    legacyEntriesDetected = true;
+    blob.projects[projectName] = {
+      ...(blob.projects[projectName] || {}),
+      [key]: oldValue,
+    };
+    await saveUnifiedSecretsBlob(blob);
 
     return oldValue;
   }
@@ -176,13 +309,47 @@ export async function getProjectSecrets(
   projectName: string,
   keys: string[]
 ): Promise<Record<string, string>> {
-  const secrets = await loadProjectSecretsBlob(projectName);
+  const blob = await loadUnifiedSecretsBlob();
+  let secrets = blob.projects[projectName] || {};
+  let changed = false;
+
+  if (Object.keys(secrets).length === 0 && !legacyProjectBlobChecked.has(projectName)) {
+    const legacyBlob = await loadLegacyProjectBlob(projectName);
+    if (legacyBlob.hasLegacyEntry) {
+      secrets = mergeSecrets(secrets, legacyBlob.secrets);
+      blob.projects[projectName] = secrets;
+      changed = true;
+    }
+  }
+
   const result: Record<string, string> = {};
 
   for (const key of keys) {
     if (key in secrets) {
       result[key] = secrets[key];
+      continue;
     }
+
+    // Legacy per-secret fallback (very old format)
+    const oldKeychainName = `${projectName}:${key}`;
+    const oldValue = await Bun.secrets.get({
+      service: SERVICE_NAME,
+      name: oldKeychainName,
+    });
+
+    if (oldValue) {
+      legacyEntriesDetected = true;
+      result[key] = oldValue;
+      blob.projects[projectName] = {
+        ...(blob.projects[projectName] || {}),
+        [key]: oldValue,
+      };
+      changed = true;
+    }
+  }
+
+  if (changed) {
+    await saveUnifiedSecretsBlob(blob);
   }
 
   return result;
@@ -219,12 +386,9 @@ export async function deleteProjectSecrets(
  * Used when removing a project entirely
  */
 export async function deleteAllProjectSecrets(projectName: string): Promise<void> {
-  const keychainKey = getProjectSecretsKey(projectName);
-  secretsBlobCache.delete(keychainKey);
-  await Bun.secrets.delete({
-    service: SERVICE_NAME,
-    name: keychainKey,
-  });
+  const blob = await loadUnifiedSecretsBlob();
+  delete blob.projects[projectName];
+  await saveUnifiedSecretsBlob(blob);
 }
 
 // ============================================================================
@@ -232,58 +396,20 @@ export async function deleteAllProjectSecrets(projectName: string): Promise<void
 // ============================================================================
 
 /**
- * Load the global secrets blob from keychain (or cache)
- * This is the only function that accesses the keychain for global secrets
+ * Load global secrets from the unified blob.
  */
 async function loadGlobalSecretsBlob(): Promise<Record<string, string>> {
-  // Check cache first
-  if (secretsBlobCache.has(GLOBAL_SECRETS_KEY)) {
-    return secretsBlobCache.get(GLOBAL_SECRETS_KEY)!;
-  }
-
-  // Load from keychain (triggers one OS prompt)
-  const raw = await Bun.secrets.get({
-    service: SERVICE_NAME,
-    name: GLOBAL_SECRETS_KEY,
-  });
-
-  // Parse JSON or return empty object
-  let secrets: Record<string, string> = {};
-  if (raw) {
-    try {
-      secrets = JSON.parse(raw);
-    } catch {
-      // Invalid JSON, start fresh
-      secrets = {};
-    }
-  }
-
-  // Cache the loaded blob
-  secretsBlobCache.set(GLOBAL_SECRETS_KEY, secrets);
-  return secrets;
+  const blob = await loadUnifiedSecretsBlob();
+  return { ...blob.global };
 }
 
 /**
  * Save the global secrets blob to keychain
  */
 async function saveGlobalSecretsBlob(secrets: Record<string, string>): Promise<void> {
-  // Update cache
-  secretsBlobCache.set(GLOBAL_SECRETS_KEY, secrets);
-
-  // Save to keychain
-  if (Object.keys(secrets).length === 0) {
-    // Delete the entry if no secrets remain
-    await Bun.secrets.delete({
-      service: SERVICE_NAME,
-      name: GLOBAL_SECRETS_KEY,
-    });
-  } else {
-    await Bun.secrets.set({
-      service: SERVICE_NAME,
-      name: GLOBAL_SECRETS_KEY,
-      value: JSON.stringify(secrets),
-    });
-  }
+  const blob = await loadUnifiedSecretsBlob();
+  blob.global = { ...secrets };
+  await saveUnifiedSecretsBlob(blob);
 }
 
 /**
@@ -303,11 +429,24 @@ export async function setSecret(key: string, value: string): Promise<void> {
  * format for seamless migration from older versions.
  */
 export async function getSecret(key: string): Promise<string | null> {
-  const secrets = await loadGlobalSecretsBlob();
+  const blob = await loadUnifiedSecretsBlob();
+  const secrets = blob.global;
 
   // Found in new format
   if (secrets[key] !== undefined) {
     return secrets[key];
+  }
+
+  // Try legacy global blob format: global
+  if (!legacyGlobalBlobChecked) {
+    const legacyBlob = await loadLegacyGlobalBlob();
+    if (legacyBlob.hasLegacyEntry) {
+      blob.global = mergeSecrets(blob.global, legacyBlob.secrets);
+      await saveUnifiedSecretsBlob(blob);
+      if (blob.global[key] !== undefined) {
+        return blob.global[key];
+      }
+    }
   }
 
   // Try old format: direct key name
@@ -317,15 +456,9 @@ export async function getSecret(key: string): Promise<string | null> {
   });
 
   if (oldValue) {
-    // Migrate to new format automatically
-    secrets[key] = oldValue;
-    await saveGlobalSecretsBlob(secrets);
-
-    // Delete old entry
-    await Bun.secrets.delete({
-      service: SERVICE_NAME,
-      name: key,
-    });
+    legacyEntriesDetected = true;
+    blob.global[key] = oldValue;
+    await saveUnifiedSecretsBlob(blob);
 
     return oldValue;
   }
@@ -344,6 +477,105 @@ export async function deleteSecret(key: string): Promise<boolean> {
   delete secrets[key];
   await saveGlobalSecretsBlob(secrets);
   return true;
+}
+
+export interface PreloadAllSecretsResult {
+  legacyEntriesDetected: boolean;
+  importedLegacyProjectEntries: number;
+  importedLegacyGlobalEntry: boolean;
+}
+
+/**
+ * Preload all secrets for the process into memory.
+ * This is intended to be called once at startup (serve + TUI).
+ */
+export async function preloadAllSecrets(projectNames: string[]): Promise<PreloadAllSecretsResult> {
+  const blob = await loadUnifiedSecretsBlob();
+  let importedLegacyProjectEntries = 0;
+  let importedLegacyGlobalEntry = false;
+  let changed = false;
+
+  const uniqueProjects = [...new Set(projectNames)];
+  for (const projectName of uniqueProjects) {
+    const legacyProject = await loadLegacyProjectBlob(projectName);
+    if (!legacyProject.hasLegacyEntry) {
+      continue;
+    }
+
+    importedLegacyProjectEntries += 1;
+    const current = blob.projects[projectName] || {};
+    const merged = mergeSecrets(current, legacyProject.secrets);
+    if (JSON.stringify(current) !== JSON.stringify(merged)) {
+      blob.projects[projectName] = merged;
+      changed = true;
+    }
+  }
+
+  const legacyGlobal = await loadLegacyGlobalBlob();
+  if (legacyGlobal.hasLegacyEntry) {
+    importedLegacyGlobalEntry = true;
+    const merged = mergeSecrets(blob.global, legacyGlobal.secrets);
+    if (JSON.stringify(blob.global) !== JSON.stringify(merged)) {
+      blob.global = merged;
+      changed = true;
+    }
+  }
+
+  if (changed) {
+    await saveUnifiedSecretsBlob(blob);
+  }
+
+  return {
+    legacyEntriesDetected,
+    importedLegacyProjectEntries,
+    importedLegacyGlobalEntry,
+  };
+}
+
+export function hasLegacyEntriesInProcess(): boolean {
+  return legacyEntriesDetected;
+}
+
+export interface CleanupLegacySecretsResult {
+  deleted: number;
+  missing: number;
+  errors: string[];
+}
+
+/**
+ * Remove legacy keychain entries now that unified secrets are in use.
+ * This only removes legacy blob entries (`project:*`, `global`).
+ *
+ * TODO(v0.3+): remove legacy blob reads and this cleanup path once
+ * unified secrets storage has been stable for several releases.
+ */
+export async function cleanupLegacySecretEntries(
+  projectNames: string[]
+): Promise<CleanupLegacySecretsResult> {
+  const result: CleanupLegacySecretsResult = {
+    deleted: 0,
+    missing: 0,
+    errors: [],
+  };
+
+  const entries = [GLOBAL_SECRETS_KEY, ...[...new Set(projectNames)].map((name) => getProjectSecretsKey(name))];
+  for (const name of entries) {
+    try {
+      const deleted = await Bun.secrets.delete({
+        service: SERVICE_NAME,
+        name,
+      });
+      if (deleted) {
+        result.deleted += 1;
+      } else {
+        result.missing += 1;
+      }
+    } catch (error) {
+      result.errors.push(`${name}: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+
+  return result;
 }
 
 // ============================================================================

--- a/src/utils/secrets.ts
+++ b/src/utils/secrets.ts
@@ -584,7 +584,7 @@ export async function preloadAllSecrets(
 
       detectedLegacyEntries = true;
       const currentProjectSecrets = blob.projects[projectName] || {};
-      if (currentProjectSecrets[key] !== oldValue) {
+      if (currentProjectSecrets[key] === undefined) {
         blob.projects[projectName] = {
           ...currentProjectSecrets,
           [key]: oldValue,
@@ -616,7 +616,7 @@ export async function preloadAllSecrets(
     }
 
     detectedLegacyEntries = true;
-    if (blob.global[key] !== oldValue) {
+    if (blob.global[key] === undefined) {
       blob.global[key] = oldValue;
       changed = true;
     }
@@ -700,6 +700,15 @@ export async function cleanupLegacySecretEntries(
     } catch (error) {
       result.errors.push(`${name}: ${error instanceof Error ? error.message : String(error)}`);
     }
+  }
+
+  if (result.errors.length === 0) {
+    const blob = await loadUnifiedSecretsBlob();
+    if (blob.metadata.legacyEntriesRetained) {
+      blob.metadata.legacyEntriesRetained = false;
+      await saveUnifiedSecretsBlob(blob);
+    }
+    legacyEntriesDetected = false;
   }
 
   return result;


### PR DESCRIPTION
## Summary
- Keep remove/cleanup script output visible by preventing the delete flow from opening a blocking loading modal over `ScriptTerminal`.
- Move runtime secrets to a single unified keychain blob and preload once at startup for TUI/serve, while still reading legacy entries for compatibility.
- Add `gssh migrate cleanup-legacy` and a one-time TUI-process reminder on quit when legacy keychain entries are still present.

## Testing
- bun run typecheck
- bun test src/session/__tests__/remote-session-backend.test.ts src/session/__tests__/local-session-backend.test.ts
- bun test src/core/__tests__/workspace-lifecycle.test.ts src/utils/__tests__/workspace-setup.integration.test.ts

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches keychain secret persistence/migration and deletion flows; mistakes could cause lost/incorrect secrets or unexpected cleanup behavior across upgrades.
> 
> **Overview**
> Unifies secrets storage into a single `Bun.secrets` “unified” blob, adds startup preloading/migration from legacy keychain entries, and introduces `gssh migrate cleanup-legacy` plus a one-time TUI quit reminder when legacy entries are still present.
> 
> Improves UX around lifecycle scripts by preventing blocking flow overlays during script execution/retry (TUI/Web `ScriptTerminal`, attach retry in `useBundleRefreshAttachFlow`, and optional loading behavior in `useWorkspaceDeleteFlow`). Workspace deletion is also made more robust by falling back to direct directory removal when git reports the worktree is “not a working tree”, with an added integration test.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3ec789a5c7e457f60b7e048e6f1ef163414bbbba. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New CLI command to clean up legacy secret entries and a one-time legacy-cleanup reminder shown on quit.
  * Option to show a loading indicator during workspace deletion.

* **Bug Fixes**
  * Improved workspace deletion fallback when worktree removal fails.
  * Flow UI no longer steals input or blocks terminal output while scripts run; retry/attach flows close overlays to keep terminal visible.

* **Chores**
  * Consolidated secrets into a unified, migration-ready storage model.

* **Tests**
  * Added integration test for workspace deletion fallback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->