### PR TITLE
Add wide events, process management, and processes config editor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 lerna-debug.log*
+.events/
 
 # Testing
 coverage/

--- a/.gitspace/events.json
+++ b/.gitspace/events.json
@@ -1,0 +1,11 @@
+{
+  "savedFilters": [
+    {
+      "name": "Sample process events",
+      "filter": {
+        "processName": "sample-events"
+      },
+      "sinceMinutes": 60
+    }
+  ]
+}

--- a/.gitspace/processes.json
+++ b/.gitspace/processes.json
@@ -1,0 +1,23 @@
+{
+  "processes": [
+    {
+      "name": "sample-events",
+      "command": "bun",
+      "args": ["scripts/sample-events.ts"],
+      "autostart": false,
+      "events": {
+        "keepRawOutput": false,
+        "correlationField": "requestId",
+        "aggregateMode": "stream",
+        "updateIntervalMs": 200,
+        "maxTimeline": 50
+      },
+      "restart": {
+        "policy": "always",
+        "maxAttempts": 10,
+        "backoffMs": 2000,
+        "maxBackoffMs": 15000
+      }
+    }
+  ]
+}

--- a/scripts/sample-events.ts
+++ b/scripts/sample-events.ts
@@ -1,0 +1,263 @@
+type EventLevel = "info" | "warn" | "error";
+
+type SampleEvent = {
+  event: string;
+  eventId: string;
+  level: EventLevel;
+  timestamp: string;
+  message: string;
+  requestId: string;
+  traceId?: string;
+  spanId?: string;
+  parentSpanId?: string;
+  durationMs?: number;
+};
+
+type TaskDefinition = {
+  name: string;
+  startMessage: string;
+  finishMessage: string;
+  errorMessage: string;
+};
+
+type ScheduledEvent = {
+  offsetMs: number;
+  event: string;
+  message: string;
+  level?: EventLevel;
+  spanId: string;
+  parentSpanId?: string;
+  durationMs?: number;
+};
+
+const TASKS: TaskDefinition[] = [
+  {
+    name: "auth.check",
+    startMessage: "Validating token",
+    finishMessage: "Token validated",
+    errorMessage: "Token validation failed",
+  },
+  {
+    name: "db.query",
+    startMessage: "Querying primary database",
+    finishMessage: "Query complete",
+    errorMessage: "Database timeout",
+  },
+  {
+    name: "cache.lookup",
+    startMessage: "Cache lookup",
+    finishMessage: "Cache response",
+    errorMessage: "Cache lookup failed",
+  },
+  {
+    name: "worker.dispatch",
+    startMessage: "Dispatching queue worker",
+    finishMessage: "Worker acknowledged",
+    errorMessage: "Worker dispatch stalled",
+  },
+  {
+    name: "billing.capture",
+    startMessage: "Capturing payment",
+    finishMessage: "Payment captured",
+    errorMessage: "Payment capture failed",
+  },
+  {
+    name: "inventory.reserve",
+    startMessage: "Reserving inventory",
+    finishMessage: "Inventory reserved",
+    errorMessage: "Inventory reservation failed",
+  },
+  {
+    name: "feature.flag",
+    startMessage: "Evaluating feature flags",
+    finishMessage: "Flags applied",
+    errorMessage: "Flag evaluation failed",
+  },
+  {
+    name: "webhook.emit",
+    startMessage: "Emitting webhook",
+    finishMessage: "Webhook delivered",
+    errorMessage: "Webhook delivery failed",
+  },
+];
+
+const REQUEST_DURATION_RANGE_MS = [6000, 18000] as const;
+const REQUEST_INTERVAL_RANGE_MS = [2000, 4000] as const;
+const TASK_COUNT_RANGE = [4, 8] as const;
+const FAILURE_RATE = 0.22;
+
+function randomId(prefix: string): string {
+  return `${prefix}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+function randomBetween(min: number, max: number): number {
+  return Math.floor(Math.random() * (max - min + 1)) + min;
+}
+
+function shuffle<T>(items: T[]): T[] {
+  const copy = [...items];
+  for (let i = copy.length - 1; i > 0; i -= 1) {
+    const j = randomBetween(0, i);
+    [copy[i], copy[j]] = [copy[j], copy[i]];
+  }
+  return copy;
+}
+
+function pickOne<T>(items: T[]): T {
+  return items[randomBetween(0, items.length - 1)];
+}
+
+function emitEvent(payload: SampleEvent): void {
+  console.log(`@event ${JSON.stringify(payload)}`);
+}
+
+function buildEvent(params: {
+  requestId: string;
+  traceId: string;
+  spanId: string;
+  parentSpanId?: string;
+  event: string;
+  message: string;
+  level?: EventLevel;
+  durationMs?: number;
+}): SampleEvent {
+  const now = new Date();
+  return {
+    event: params.event,
+    eventId: randomId("evt"),
+    level: params.level ?? "info",
+    timestamp: now.toISOString(),
+    message: params.message,
+    requestId: params.requestId,
+    traceId: params.traceId,
+    spanId: params.spanId,
+    parentSpanId: params.parentSpanId,
+    durationMs: params.durationMs,
+  };
+}
+
+function scheduleEvents(params: {
+  requestId: string;
+  traceId: string;
+  events: ScheduledEvent[];
+}): void {
+  const { requestId, traceId, events } = params;
+  const sorted = [...events].sort((a, b) => a.offsetMs - b.offsetMs);
+  for (const event of sorted) {
+    setTimeout(() => {
+      emitEvent(buildEvent({
+        requestId,
+        traceId,
+        spanId: event.spanId,
+        parentSpanId: event.parentSpanId,
+        event: event.event,
+        message: event.message,
+        level: event.level,
+        durationMs: event.durationMs,
+      }));
+    }, event.offsetMs);
+  }
+}
+
+function emitRequestSequence(): void {
+  const requestId = randomId("req");
+  const traceId = randomId("trace");
+  const rootSpanId = randomId("span");
+  const totalDuration = randomBetween(...REQUEST_DURATION_RANGE_MS);
+  const willFail = Math.random() < FAILURE_RATE;
+  const failureOffset = willFail
+    ? randomBetween(Math.floor(totalDuration * 0.4), Math.floor(totalDuration * 0.85))
+    : totalDuration;
+  const finalOffset = willFail
+    ? failureOffset + randomBetween(120, 480)
+    : totalDuration + randomBetween(200, 600);
+
+  const scheduled: ScheduledEvent[] = [
+    {
+      offsetMs: 0,
+      event: "request.start",
+      message: "Request started",
+      spanId: rootSpanId,
+    },
+  ];
+
+  const taskCount = randomBetween(...TASK_COUNT_RANGE);
+  const selectedTasks = shuffle(TASKS).slice(0, taskCount);
+  const taskWindowEnd = Math.max(600, failureOffset - 600);
+
+  for (const task of selectedTasks) {
+    const spanId = randomId("span");
+    const startOffset = randomBetween(200, taskWindowEnd);
+    if (willFail && startOffset > failureOffset - 200) {
+      continue;
+    }
+
+    const duration = randomBetween(400, 3200);
+    const finishOffset = startOffset + duration;
+
+    scheduled.push({
+      offsetMs: startOffset,
+      event: `${task.name}.start`,
+      message: task.startMessage,
+      spanId,
+      parentSpanId: rootSpanId,
+    });
+
+    if (!willFail || finishOffset < failureOffset - 200) {
+      scheduled.push({
+        offsetMs: finishOffset,
+        event: `${task.name}.finish`,
+        message: task.finishMessage,
+        spanId,
+        parentSpanId: rootSpanId,
+        durationMs: duration,
+      });
+    }
+  }
+
+  if (willFail) {
+    const failureTask = pickOne(selectedTasks);
+    const failureSpanId = randomId("span");
+    const failureDetailOffset = Math.max(200, failureOffset - randomBetween(150, 400));
+
+    scheduled.push({
+      offsetMs: failureDetailOffset,
+      event: `${failureTask.name}.error`,
+      message: failureTask.errorMessage,
+      spanId: failureSpanId,
+      parentSpanId: rootSpanId,
+      level: "error",
+    });
+  }
+
+  scheduled.push({
+    offsetMs: finalOffset,
+    event: willFail ? "request.failed" : "request.complete",
+    message: willFail ? "Request failed" : "Request completed",
+    spanId: rootSpanId,
+    level: willFail ? "error" : "info",
+    durationMs: finalOffset,
+  });
+
+  scheduleEvents({ requestId, traceId, events: scheduled });
+}
+
+emitEvent(buildEvent({
+  requestId: "bootstrap",
+  traceId: randomId("trace"),
+  spanId: randomId("span"),
+  event: "sample.start",
+  message: "Sample event emitter started",
+  level: "info",
+}));
+
+function scheduleNextSequence(): void {
+  const delay = randomBetween(...REQUEST_INTERVAL_RANGE_MS);
+  setTimeout(() => {
+    emitRequestSequence();
+    scheduleNextSequence();
+  }, delay);
+}
+
+scheduleNextSequence();
+emitRequestSequence();

--- a/src/app.tui.tsx
+++ b/src/app.tui.tsx
@@ -317,6 +317,11 @@ function App({ relayConfig, onQuit }: AppProps) {
   const [pendingProcessEditWorkspaceId, setPendingProcessEditWorkspaceId] = useState<string | null>(null);
   const pendingProcessEditWorkspacesRef = useRef<unknown[] | null>(null);
   const [pendingProcessAttach, setPendingProcessAttach] = useState<PendingProcessAttachTarget | null>(null);
+  const pendingProcessAttachRef = useRef<PendingProcessAttachTarget | null>(null);
+
+  useEffect(() => {
+    pendingProcessAttachRef.current = pendingProcessAttach;
+  }, [pendingProcessAttach]);
 
   // Remote machines hook
   const remoteMachines = useRemoteMachines({
@@ -1316,23 +1321,24 @@ function App({ relayConfig, onQuit }: AppProps) {
       return;
     }
 
-    const timeout = setTimeout(() => {
-      setPendingProcessAttach((current) => {
-        if (
-          !current ||
-          current.workspaceId !== pendingProcessAttach.workspaceId ||
-          current.processName !== pendingProcessAttach.processName ||
-          current.instance !== pendingProcessAttach.instance
-        ) {
-          return current;
-        }
+    const target = pendingProcessAttach;
 
-        flow.showMessage({
-          title: 'Attach Timeout',
-          message: `Process started but no active session was found for ${current.processName}#${current.instance}.`,
-          variant: 'warning',
-        });
-        return null;
+    const timeout = setTimeout(() => {
+      const current = pendingProcessAttachRef.current;
+      if (
+        !current ||
+        current.workspaceId !== target.workspaceId ||
+        current.processName !== target.processName ||
+        current.instance !== target.instance
+      ) {
+        return;
+      }
+
+      setPendingProcessAttach(null);
+      flow.showMessage({
+        title: 'Attach Timeout',
+        message: `Process started but no active session was found for ${current.processName}#${current.instance}.`,
+        variant: 'warning',
       });
     }, 8000);
 

--- a/src/app.tui.tsx
+++ b/src/app.tui.tsx
@@ -1459,11 +1459,11 @@ function App({ relayConfig, onQuit }: AppProps) {
     const workspace = localWorkspaces.find(w => w.id === eventsWorkspaceId);
     if (!workspace) return;
 
-    const activeFilter = eventsProps.activeFilterName
-      ? localSavedEventFilters.find((filter) => filter.name === eventsProps.activeFilterName) ?? null
-      : null;
-
     const interval = setInterval(() => {
+      const activeFilter = eventsProps.activeFilterName
+        ? localSavedEventFilters.find((filter) => filter.name === eventsProps.activeFilterName) ?? null
+        : null;
+
       if (activeFilter) {
         const sinceMs = activeFilter.sinceMinutes
           ? Date.now() - activeFilter.sinceMinutes * 60 * 1000

--- a/src/app.tui.tsx
+++ b/src/app.tui.tsx
@@ -90,6 +90,7 @@ import { useLocalSession } from './hooks/useLocalSession.tui.js';
 import { useUserActivity } from './hooks/index.js';
 import { useBundleRefreshAttachFlow } from './session/index.js';
 import { useAttachController } from './app/session/useAttachController.js';
+import { useProcessActions } from './app/session/useProcessActions.js';
 import { useWorkspaceDeleteFlow } from './app/session/useWorkspaceDeleteFlow.js';
 import { buildEditProcessesCommand } from './lib/processes/editor.js';
 import { loadProcessesConfigWithDiagnostics } from './lib/processes/config.js';
@@ -222,12 +223,6 @@ type AppAction =
   | { type: 'SET_ERROR'; error: string | null }
   | { type: 'SWITCH_PANEL' };
 
-interface PendingProcessAttachTarget {
-  workspaceId: string;
-  processName: string;
-  instance: number;
-}
-
 function appReducer(state: AppState, action: AppAction): AppState {
   switch (action.type) {
     case 'SET_VIEW':
@@ -316,12 +311,6 @@ function App({ relayConfig, onQuit }: AppProps) {
   const [isViewOnlySession, setIsViewOnlySession] = useState(false);
   const [pendingProcessEditWorkspaceId, setPendingProcessEditWorkspaceId] = useState<string | null>(null);
   const pendingProcessEditWorkspacesRef = useRef<unknown[] | null>(null);
-  const [pendingProcessAttach, setPendingProcessAttach] = useState<PendingProcessAttachTarget | null>(null);
-  const pendingProcessAttachRef = useRef<PendingProcessAttachTarget | null>(null);
-
-  useEffect(() => {
-    pendingProcessAttachRef.current = pendingProcessAttach;
-  }, [pendingProcessAttach]);
 
   // Remote machines hook
   const remoteMachines = useRemoteMachines({
@@ -1246,108 +1235,54 @@ function App({ relayConfig, onQuit }: AppProps) {
     onRefresh: refreshProjects,
   });
 
-  // Process handlers
-  const handleStartProcess = useCallback((params: { workspaceId: string; processName: string }) => {
-    void startLocalProcess(params.workspaceId, params.processName);
-  }, [startLocalProcess]);
-
-  const handleStartProcessAttach = useCallback((params: { workspaceId: string; processName: string; instance: number }) => {
-    const target: PendingProcessAttachTarget = {
-      workspaceId: params.workspaceId,
-      processName: params.processName,
-      instance: params.instance,
-    };
-    setPendingProcessAttach(target);
-    void startLocalProcess(params.workspaceId, params.processName, params.instance)
-      .then(() => {
-        void refreshWorkspaces();
-      })
-      .catch((error) => {
-        setPendingProcessAttach((current) =>
-          current &&
-          current.workspaceId === target.workspaceId &&
-          current.processName === target.processName &&
-          current.instance === target.instance
-            ? null
-            : current
-        );
-        flow.showMessage({
-          title: 'Process Start Failed',
-          message: error instanceof Error ? error.message : String(error),
-          variant: 'error',
-        });
+  const processActions = useProcessActions({
+    sessions: sessionInfos,
+    startProcess: startLocalProcess,
+    stopProcess: stopLocalProcess,
+    attachSession: handleAttachSession,
+    onStartProcessError: (error) => {
+      flow.showMessage({
+        title: 'Process Start Failed',
+        message: error instanceof Error ? error.message : String(error),
+        variant: 'error',
       });
-  }, [flow, refreshWorkspaces, startLocalProcess]);
-
-  useEffect(() => {
-    if (!pendingProcessAttach) {
-      return;
-    }
-
-    const session = sessionInfos
-      .filter((item) =>
-        item.workspaceId === pendingProcessAttach.workspaceId &&
-        item.processName === pendingProcessAttach.processName &&
-        (item.processInstance ?? 1) === pendingProcessAttach.instance &&
-        item.exitCode === undefined
-      )
-      .sort((a, b) => b.createdAt - a.createdAt)[0];
-
-    if (!session) {
-      return;
-    }
-
-    const target = pendingProcessAttach;
-    setPendingProcessAttach((current) =>
-      current &&
-      current.workspaceId === target.workspaceId &&
-      current.processName === target.processName &&
-      current.instance === target.instance
-        ? null
-        : current
-    );
-
-    void handleAttachSession({ sessionId: session.id, viewOnly: true }).catch((error) => {
+    },
+    onStopProcessError: (error) => {
+      flow.showMessage({
+        title: 'Process Stop Failed',
+        message: error instanceof Error ? error.message : String(error),
+        variant: 'error',
+      });
+    },
+    onStartProcessAttachError: (error) => {
+      flow.showMessage({
+        title: 'Process Start Failed',
+        message: error instanceof Error ? error.message : String(error),
+        variant: 'error',
+      });
+    },
+    onAttachError: (error) => {
       flow.showMessage({
         title: 'Attach Failed',
         message: error instanceof Error ? error.message : String(error),
         variant: 'error',
       });
-    });
-  }, [flow, handleAttachSession, pendingProcessAttach, sessionInfos]);
-
-  useEffect(() => {
-    if (!pendingProcessAttach) {
-      return;
-    }
-
-    const target = pendingProcessAttach;
-
-    const timeout = setTimeout(() => {
-      const current = pendingProcessAttachRef.current;
-      if (
-        !current ||
-        current.workspaceId !== target.workspaceId ||
-        current.processName !== target.processName ||
-        current.instance !== target.instance
-      ) {
-        return;
-      }
-
-      setPendingProcessAttach(null);
+    },
+    onAttachTimeout: (target) => {
       flow.showMessage({
         title: 'Attach Timeout',
-        message: `Process started but no active session was found for ${current.processName}#${current.instance}.`,
+        message: `Process started but no active session was found for ${target.processName}#${target.instance}.`,
         variant: 'warning',
       });
-    }, 8000);
+    },
+    onStartProcessAttachFinally: () => {
+      void refreshWorkspaces();
+    },
+  });
 
-    return () => clearTimeout(timeout);
-  }, [flow, pendingProcessAttach]);
-
-  const handleStopProcess = useCallback((params: { workspaceId: string; processName: string }) => {
-    void stopLocalProcess(params.workspaceId, params.processName);
-  }, [stopLocalProcess]);
+  const handleStartProcess = processActions.handleStartProcess;
+  const handleStartProcessAttach = processActions.handleStartProcessAttach;
+  const handleStopProcess = processActions.handleStopProcess;
 
   const handleProcessDisabled = useCallback((params: { workspaceId: string; processName: string }) => {
     const workspace = localWorkspaces.find((item) => item.id === params.workspaceId);
@@ -1362,7 +1297,7 @@ function App({ relayConfig, onQuit }: AppProps) {
     if (workspace) {
       void requestLocalEvents(workspace.path);
     }
-    dispatch({ type: 'SET_VIEW', view: 'events' as AppView });
+    dispatch({ type: 'SET_VIEW', view: 'events' });
   }, [localWorkspaces, requestLocalEvents]);
 
   // Spaces browser hook

--- a/src/app.tui.tsx
+++ b/src/app.tui.tsx
@@ -1250,6 +1250,12 @@ function App({ relayConfig, onQuit }: AppProps) {
     void stopLocalProcess(params.workspaceId, params.processName);
   }, [stopLocalProcess]);
 
+  const handleProcessDisabled = useCallback((params: { workspaceId: string; processName: string }) => {
+    const workspace = localWorkspaces.find((item) => item.id === params.workspaceId);
+    const workspaceLabel = workspace?.name ?? params.workspaceId;
+    toast.error(`Process "${params.processName}" is disabled in ${workspaceLabel} (instances: 0).`);
+  }, [localWorkspaces]);
+
   const handleOpenEvents = useCallback((workspaceId: string) => {
     setEventsWorkspaceId(workspaceId);
     // Find workspace path for events request
@@ -1270,6 +1276,7 @@ function App({ relayConfig, onQuit }: AppProps) {
     onStartProcess: handleStartProcess,
     onStartProcessAttach: handleStartProcessAttach,
     onStopProcess: handleStopProcess,
+    onProcessDisabled: handleProcessDisabled,
     onOpenEvents: handleOpenEvents,
     onRefresh: refreshWorkspaces,
     onBack: () => dispatch({ type: 'SET_PANEL_FOCUS', focus: 'projects' }),
@@ -2807,6 +2814,9 @@ function getWorkspacesPanelHint(selectedItem: TreeItem | null | undefined): stri
   }
   if (selectedItem?.type === 'workspace') {
     return '[Tab] Switch  [Enter] Expand  [n] New Workspace  [d] Delete  [,] Settings  [?] Help  [q] Quit';
+  }
+  if (selectedItem?.type === 'process-disabled') {
+    return '[Tab] Switch  [Enter] Disabled  [,] Settings  [?] Help  [q] Quit';
   }
   if (selectedItem?.type === 'process-config-error') {
     return '[Tab] Switch  [Enter] Fix Process Config  [,] Settings  [?] Help  [q] Quit';

--- a/src/app.tui.tsx
+++ b/src/app.tui.tsx
@@ -1278,7 +1278,12 @@ function App({ relayConfig, onQuit }: AppProps) {
       const workspace = localWorkspaces.find(w => w.id === eventsWorkspaceId);
       if (!workspace) return;
       if (filter) {
-        void requestLocalEvents(workspace.path, filter.filter as WideEventFilter);
+        void requestLocalEvents(
+          workspace.path,
+          filter.filter as WideEventFilter,
+          undefined,
+          filter.sinceMinutes ? filter.sinceMinutes * 60 * 1000 : undefined
+        );
       } else {
         void requestLocalEvents(workspace.path);
       }
@@ -1295,12 +1300,32 @@ function App({ relayConfig, onQuit }: AppProps) {
     const workspace = localWorkspaces.find(w => w.id === eventsWorkspaceId);
     if (!workspace) return;
 
+    const activeFilter = eventsProps.activeFilterName
+      ? localSavedEventFilters.find((filter) => filter.name === eventsProps.activeFilterName) ?? null
+      : null;
+
     const interval = setInterval(() => {
-      void requestLocalEvents(workspace.path);
+      if (activeFilter) {
+        void requestLocalEvents(
+          workspace.path,
+          activeFilter.filter as WideEventFilter,
+          undefined,
+          activeFilter.sinceMinutes ? activeFilter.sinceMinutes * 60 * 1000 : undefined
+        );
+      } else {
+        void requestLocalEvents(workspace.path);
+      }
     }, 2000);
 
     return () => clearInterval(interval);
-  }, [state.view, eventsWorkspaceId, localWorkspaces, requestLocalEvents]);
+  }, [
+    state.view,
+    eventsWorkspaceId,
+    localWorkspaces,
+    eventsProps.activeFilterName,
+    localSavedEventFilters,
+    requestLocalEvents,
+  ]);
 
   // ========== Activity Tracking for Notifications ==========
 

--- a/src/app.tui.tsx
+++ b/src/app.tui.tsx
@@ -309,6 +309,7 @@ function App({ relayConfig, onQuit }: AppProps) {
   // View-only session state (true when attached to a running process session)
   const [isViewOnlySession, setIsViewOnlySession] = useState(false);
   const [pendingProcessEditWorkspaceId, setPendingProcessEditWorkspaceId] = useState<string | null>(null);
+  const pendingProcessEditWorkspacesRef = useRef<unknown[] | null>(null);
 
   // Remote machines hook
   const remoteMachines = useRemoteMachines({
@@ -630,14 +631,20 @@ function App({ relayConfig, onQuit }: AppProps) {
   // Open editor on .gitspace/processes.json in the workspace
   const handleEditProcesses = useCallback(({ workspaceId }: { workspaceId: string }) => {
     setIsViewOnlySession(false);
+    pendingProcessEditWorkspacesRef.current = localWorkspaces;
     setPendingProcessEditWorkspaceId(workspaceId);
     const commandSpec = buildEditProcessesCommand();
     void attachLocal({
       workspaceId,
       command: commandSpec.command,
       args: commandSpec.args,
+    }).then((attached) => {
+      if (!attached) {
+        pendingProcessEditWorkspacesRef.current = null;
+        setPendingProcessEditWorkspaceId(null);
+      }
     });
-  }, [attachLocal]);
+  }, [attachLocal, localWorkspaces]);
 
   useEffect(() => {
     if (!pendingProcessEditWorkspaceId) {
@@ -646,6 +653,14 @@ function App({ relayConfig, onQuit }: AppProps) {
     if (state.view !== 'projects' || localSessionMode !== 'browsing') {
       return;
     }
+
+    if (
+      pendingProcessEditWorkspacesRef.current &&
+      pendingProcessEditWorkspacesRef.current === localWorkspaces
+    ) {
+      return;
+    }
+    pendingProcessEditWorkspacesRef.current = null;
 
     const workspace = localWorkspaces.find((item) => item.id === pendingProcessEditWorkspaceId);
     if (!workspace) {

--- a/src/app.tui.tsx
+++ b/src/app.tui.tsx
@@ -41,8 +41,8 @@ import { ProjectListTUI } from './components/ProjectList.tui.js';
 import { InboxTUI } from './components/Inbox.tui.js';
 import { useInbox } from './components/Inbox.js';
 import { EventsTui } from './components/Events.tui.js';
-import { useEvents, type WideEventItem } from './components/Events.js';
-import type { WideEvent, SavedEventFilter, WideEventFilter } from './types/events.js';
+import { useEvents, toWideEventItem, type WideEventItem } from './components/Events.js';
+import type { SavedEventFilter, WideEventFilter } from './types/events.js';
 import { toast } from '@opentui-ui/toast';
 import {
   useNotifications,
@@ -1302,23 +1302,7 @@ function App({ relayConfig, onQuit }: AppProps) {
   });
 
   // Events hook
-  const eventsItems: WideEventItem[] = localEvents.map((event: WideEvent) => ({
-    eventId: event.eventId,
-    eventName: event.eventName,
-    level: event.level,
-    timestamp: event.timestamp,
-    timestampMs: event.timestampMs,
-    message: event.message,
-    processName: event.processName,
-    processInstance: event.processInstance,
-    sessionId: event.sessionId,
-    raw: event.raw,
-    kind: event.kind,
-    correlationId: event.correlationId,
-    timeline: event.timeline,
-    timelineMap: event.timelineMap,
-    timelineOrder: event.timelineOrder,
-  }));
+  const eventsItems: WideEventItem[] = localEvents.map(toWideEventItem);
 
   const eventsProps = useEvents({
     events: eventsItems,

--- a/src/app.tui.tsx
+++ b/src/app.tui.tsx
@@ -91,6 +91,8 @@ import { useUserActivity } from './hooks/index.js';
 import { useBundleRefreshAttachFlow } from './session/index.js';
 import { useAttachController } from './app/session/useAttachController.js';
 import { useWorkspaceDeleteFlow } from './app/session/useWorkspaceDeleteFlow.js';
+import { buildEditProcessesCommand } from './lib/processes/editor.js';
+import { loadProcessesConfigWithDiagnostics } from './lib/processes/config.js';
 import {
   consumeLegacyCleanupReminderForTui,
   initializeSecretRuntime,
@@ -306,6 +308,7 @@ function App({ relayConfig, onQuit }: AppProps) {
 
   // View-only session state (true when attached to a running process session)
   const [isViewOnlySession, setIsViewOnlySession] = useState(false);
+  const [pendingProcessEditWorkspaceId, setPendingProcessEditWorkspaceId] = useState<string | null>(null);
 
   // Remote machines hook
   const remoteMachines = useRemoteMachines({
@@ -627,12 +630,57 @@ function App({ relayConfig, onQuit }: AppProps) {
   // Open editor on .gitspace/processes.json in the workspace
   const handleEditProcesses = useCallback(({ workspaceId }: { workspaceId: string }) => {
     setIsViewOnlySession(false);
+    setPendingProcessEditWorkspaceId(workspaceId);
+    const commandSpec = buildEditProcessesCommand();
     void attachLocal({
       workspaceId,
-      command: 'sh',
-      args: ['-c', 'mkdir -p .gitspace && exec "${EDITOR:-vi}" .gitspace/processes.json'],
+      command: commandSpec.command,
+      args: commandSpec.args,
     });
   }, [attachLocal]);
+
+  useEffect(() => {
+    if (!pendingProcessEditWorkspaceId) {
+      return;
+    }
+    if (state.view !== 'projects' || localSessionMode !== 'browsing') {
+      return;
+    }
+
+    const workspace = localWorkspaces.find((item) => item.id === pendingProcessEditWorkspaceId);
+    if (!workspace) {
+      setPendingProcessEditWorkspaceId(null);
+      return;
+    }
+
+    const diagnostics = loadProcessesConfigWithDiagnostics(workspace.path);
+    if (diagnostics.error) {
+      flow.showMessage({
+        title: 'Invalid Processes Config',
+        message: diagnostics.error,
+        variant: 'error',
+      });
+    } else {
+      const processCount = diagnostics.config.processes.length;
+      flow.showMessage({
+        title: 'Processes Config Updated',
+        message: processCount === 0
+          ? 'Config is valid. No processes are defined yet.'
+          : `Config is valid. ${processCount} process${processCount === 1 ? '' : 'es'} defined.`,
+        variant: 'success',
+      });
+    }
+
+    setPendingProcessEditWorkspaceId(null);
+    void refreshWorkspaces();
+  }, [
+    flow,
+    localSessionMode,
+    localWorkspaces,
+    pendingProcessEditWorkspaceId,
+    refreshWorkspaces,
+    state.view,
+  ]);
 
   // Handle terminal detach
   const handleTerminalDetach = useCallback(async () => {
@@ -1146,6 +1194,9 @@ function App({ relayConfig, onQuit }: AppProps) {
       branch: workspace.branch,
       sessionCount: localSessions.filter((session) => session.workspaceId === workspace.id).length,
       isStale: workspace.isStale,
+      processes: workspace.processes,
+      processConfigError: workspace.processConfigError,
+      serveDomain: workspace.serveDomain,
     }));
 
   const sessionInfos = currentProject
@@ -1278,11 +1329,14 @@ function App({ relayConfig, onQuit }: AppProps) {
       const workspace = localWorkspaces.find(w => w.id === eventsWorkspaceId);
       if (!workspace) return;
       if (filter) {
+        const sinceMs = filter.sinceMinutes
+          ? Date.now() - filter.sinceMinutes * 60 * 1000
+          : undefined;
         void requestLocalEvents(
           workspace.path,
           filter.filter as WideEventFilter,
           undefined,
-          filter.sinceMinutes ? filter.sinceMinutes * 60 * 1000 : undefined
+          sinceMs
         );
       } else {
         void requestLocalEvents(workspace.path);
@@ -1306,11 +1360,14 @@ function App({ relayConfig, onQuit }: AppProps) {
 
     const interval = setInterval(() => {
       if (activeFilter) {
+        const sinceMs = activeFilter.sinceMinutes
+          ? Date.now() - activeFilter.sinceMinutes * 60 * 1000
+          : undefined;
         void requestLocalEvents(
           workspace.path,
           activeFilter.filter as WideEventFilter,
           undefined,
-          activeFilter.sinceMinutes ? activeFilter.sinceMinutes * 60 * 1000 : undefined
+          sinceMs
         );
       } else {
         void requestLocalEvents(workspace.path);
@@ -2740,6 +2797,9 @@ function getWorkspacesPanelHint(selectedItem: TreeItem | null | undefined): stri
   }
   if (selectedItem?.type === 'workspace') {
     return '[Tab] Switch  [Enter] Expand  [n] New Workspace  [d] Delete  [,] Settings  [?] Help  [q] Quit';
+  }
+  if (selectedItem?.type === 'process-config-error') {
+    return '[Tab] Switch  [Enter] Fix Process Config  [,] Settings  [?] Help  [q] Quit';
   }
   if (selectedItem?.type === 'edit-processes') {
     return '[Tab] Switch  [Enter] Edit Processes Config  [,] Settings  [?] Help  [q] Quit';

--- a/src/app.tui.tsx
+++ b/src/app.tui.tsx
@@ -222,6 +222,12 @@ type AppAction =
   | { type: 'SET_ERROR'; error: string | null }
   | { type: 'SWITCH_PANEL' };
 
+interface PendingProcessAttachTarget {
+  workspaceId: string;
+  processName: string;
+  instance: number;
+}
+
 function appReducer(state: AppState, action: AppAction): AppState {
   switch (action.type) {
     case 'SET_VIEW':
@@ -310,6 +316,7 @@ function App({ relayConfig, onQuit }: AppProps) {
   const [isViewOnlySession, setIsViewOnlySession] = useState(false);
   const [pendingProcessEditWorkspaceId, setPendingProcessEditWorkspaceId] = useState<string | null>(null);
   const pendingProcessEditWorkspacesRef = useRef<unknown[] | null>(null);
+  const [pendingProcessAttach, setPendingProcessAttach] = useState<PendingProcessAttachTarget | null>(null);
 
   // Remote machines hook
   const remoteMachines = useRemoteMachines({
@@ -1240,11 +1247,97 @@ function App({ relayConfig, onQuit }: AppProps) {
   }, [startLocalProcess]);
 
   const handleStartProcessAttach = useCallback((params: { workspaceId: string; processName: string; instance: number }) => {
-    void startLocalProcess(params.workspaceId, params.processName, params.instance).then(() => {
-      // After starting, find and attach to the session
-      void refreshWorkspaces();
+    const target: PendingProcessAttachTarget = {
+      workspaceId: params.workspaceId,
+      processName: params.processName,
+      instance: params.instance,
+    };
+    setPendingProcessAttach(target);
+    void startLocalProcess(params.workspaceId, params.processName, params.instance)
+      .then(() => {
+        void refreshWorkspaces();
+      })
+      .catch((error) => {
+        setPendingProcessAttach((current) =>
+          current &&
+          current.workspaceId === target.workspaceId &&
+          current.processName === target.processName &&
+          current.instance === target.instance
+            ? null
+            : current
+        );
+        flow.showMessage({
+          title: 'Process Start Failed',
+          message: error instanceof Error ? error.message : String(error),
+          variant: 'error',
+        });
+      });
+  }, [flow, refreshWorkspaces, startLocalProcess]);
+
+  useEffect(() => {
+    if (!pendingProcessAttach) {
+      return;
+    }
+
+    const session = sessionInfos
+      .filter((item) =>
+        item.workspaceId === pendingProcessAttach.workspaceId &&
+        item.processName === pendingProcessAttach.processName &&
+        (item.processInstance ?? 1) === pendingProcessAttach.instance &&
+        item.exitCode === undefined
+      )
+      .sort((a, b) => b.createdAt - a.createdAt)[0];
+
+    if (!session) {
+      return;
+    }
+
+    const target = pendingProcessAttach;
+    setPendingProcessAttach((current) =>
+      current &&
+      current.workspaceId === target.workspaceId &&
+      current.processName === target.processName &&
+      current.instance === target.instance
+        ? null
+        : current
+    );
+
+    void handleAttachSession({ sessionId: session.id, viewOnly: true }).catch((error) => {
+      flow.showMessage({
+        title: 'Attach Failed',
+        message: error instanceof Error ? error.message : String(error),
+        variant: 'error',
+      });
     });
-  }, [startLocalProcess, refreshWorkspaces]);
+  }, [flow, handleAttachSession, pendingProcessAttach, sessionInfos]);
+
+  useEffect(() => {
+    if (!pendingProcessAttach) {
+      return;
+    }
+
+    const timeout = setTimeout(() => {
+      setPendingProcessAttach((current) => {
+        if (
+          !current ||
+          current.workspaceId !== pendingProcessAttach.workspaceId ||
+          current.processName !== pendingProcessAttach.processName ||
+          current.instance !== pendingProcessAttach.instance
+        ) {
+          return current;
+        }
+
+        flow.showMessage({
+          title: 'Attach Timeout',
+          message: `Process started but no active session was found for ${current.processName}#${current.instance}.`,
+          variant: 'warning',
+        });
+        return null;
+      });
+    }, 8000);
+
+    return () => clearTimeout(timeout);
+  }, [flow, pendingProcessAttach]);
 
   const handleStopProcess = useCallback((params: { workspaceId: string; processName: string }) => {
     void stopLocalProcess(params.workspaceId, params.processName);

--- a/src/app.tui.tsx
+++ b/src/app.tui.tsx
@@ -1225,7 +1225,7 @@ function App({ relayConfig, onQuit }: AppProps) {
   }, [startLocalProcess]);
 
   const handleStartProcessAttach = useCallback((params: { workspaceId: string; processName: string; instance: number }) => {
-    void startLocalProcess(params.workspaceId, params.processName).then(() => {
+    void startLocalProcess(params.workspaceId, params.processName, params.instance).then(() => {
       // After starting, find and attach to the session
       void refreshWorkspaces();
     });

--- a/src/app.tui.tsx
+++ b/src/app.tui.tsx
@@ -36,6 +36,7 @@ import {
 import { FlowTUI } from './components/Flow.tui.js';
 import { MachineListTUI } from './components/MachineList.tui.js';
 import { SpacesBrowserTUI } from './components/SpacesBrowser.tui.js';
+import type { TreeItem } from './components/SpacesBrowser.js';
 import { ProjectListTUI } from './components/ProjectList.tui.js';
 import { InboxTUI } from './components/Inbox.tui.js';
 import { useInbox } from './components/Inbox.js';
@@ -303,6 +304,9 @@ function App({ relayConfig, onQuit }: AppProps) {
   // Events view state
   const [eventsWorkspaceId, setEventsWorkspaceId] = useState<string | null>(null);
 
+  // View-only session state (true when attached to a running process session)
+  const [isViewOnlySession, setIsViewOnlySession] = useState(false);
+
   // Remote machines hook
   const remoteMachines = useRemoteMachines({
     relayConfig,
@@ -428,7 +432,7 @@ function App({ relayConfig, onQuit }: AppProps) {
     onBeforeAttach: ({ target, params }) => {
       sessionSwitchingRef.current = true;
 
-      if (target === 'workspace' && params.workspaceId) {
+      if (target === 'workspace' && params.workspaceId && !params.command) {
         setScriptWorkspaceName(params.workspaceId.split(':').slice(-1)[0] ?? params.workspaceId);
         dispatch({ type: 'SET_VIEW', view: 'scripts' });
       }
@@ -615,15 +619,27 @@ function App({ relayConfig, onQuit }: AppProps) {
   }, [flow, refreshProjects]);
 
   // Attach to session using embedded terminal
-  const handleAttachSession = useCallback(async (params: { sessionId?: string; workspaceId?: string }) => {
+  const handleAttachSession = useCallback(async (params: { sessionId?: string; workspaceId?: string; viewOnly?: boolean }) => {
+    setIsViewOnlySession(params.viewOnly ?? false);
     await attachLocalFromSelection(params);
   }, [attachLocalFromSelection]);
+
+  // Open editor on .gitspace/processes.json in the workspace
+  const handleEditProcesses = useCallback(({ workspaceId }: { workspaceId: string }) => {
+    setIsViewOnlySession(false);
+    void attachLocal({
+      workspaceId,
+      command: 'sh',
+      args: ['-c', 'mkdir -p .gitspace && exec "${EDITOR:-vi}" .gitspace/processes.json'],
+    });
+  }, [attachLocal]);
 
   // Handle terminal detach
   const handleTerminalDetach = useCallback(async () => {
     // Don't navigate away if we're in the middle of switching sessions
     if (sessionSwitchingRef.current) return;
 
+    setIsViewOnlySession(false);
     await detachLocalSession();
     dispatch({ type: 'SET_VIEW', view: 'projects' });
     await refreshWorkspaces();
@@ -1184,6 +1200,7 @@ function App({ relayConfig, onQuit }: AppProps) {
     sessions: sessionInfos,
     onRequestSessions: () => {}, // Sessions already loaded
     onAttachSession: handleAttachSession,
+    onEditProcesses: handleEditProcesses,
     onStartProcess: handleStartProcess,
     onStartProcessAttach: handleStartProcessAttach,
     onStopProcess: handleStopProcess,
@@ -2013,10 +2030,12 @@ function App({ relayConfig, onQuit }: AppProps) {
             }
           }
         } else if (command === 'kill') {
-          // Kill session
+          // Kill session or stop running process
           const selected = spacesBrowserProps.selectedItem;
           if (selected?.type === 'session') {
             handleDeleteSession(selected.session.id, selected.session.name);
+          } else if (selected?.type === 'process' && selected.status === 'running') {
+            void handleStopProcess({ workspaceId: selected.workspaceId, processName: selected.processName });
           }
         } else if (command === 'refresh') {
           try {
@@ -2211,6 +2230,7 @@ function App({ relayConfig, onQuit }: AppProps) {
           interceptShiftTab={!!notifications.activeToast}
           modalOpen={flow.isOpen}
           onActivity={handleTerminalActivity}
+          readOnly={isViewOnlySession}
         />
         <FlowTUI flow={flow} />
       </Fragment>
@@ -2291,7 +2311,7 @@ function App({ relayConfig, onQuit }: AppProps) {
       <StatusBar
         hint={state.panelFocus === 'projects'
           ? '[Tab] Switch  [Enter] Select  [n] New Project  [d] Delete  [,] Settings  [?] Help  [q] Quit'
-          : '[Tab] Switch  [Enter] Open/Join  [n] New Workspace  [d] Delete  [x] Kill  [,] Settings  [?] Help  [q] Quit'
+          : getWorkspacesPanelHint(spacesBrowserProps.selectedItem)
         }
       />
 
@@ -2677,6 +2697,35 @@ function SettingsFlowModal({ flow }: { flow: SettingsFlowState }) {
       </box>
     </box>
   );
+}
+
+// ============================================================================
+// Status Bar Helpers
+// ============================================================================
+
+function getWorkspacesPanelHint(selectedItem: TreeItem | null | undefined): string {
+  if (selectedItem?.type === 'session') {
+    return '[Tab] Switch  [Enter] Attach  [x] Kill  [n] New Workspace  [d] Delete  [,] Settings  [?] Help  [q] Quit';
+  }
+  if (selectedItem?.type === 'process') {
+    if (selectedItem.status === 'running') {
+      return '[Tab] Switch  [Enter] View  [x] Stop  [,] Settings  [?] Help  [q] Quit';
+    }
+    return '[Tab] Switch  [Enter] Start  [,] Settings  [?] Help  [q] Quit';
+  }
+  if (selectedItem?.type === 'workspace') {
+    return '[Tab] Switch  [Enter] Expand  [n] New Workspace  [d] Delete  [,] Settings  [?] Help  [q] Quit';
+  }
+  if (selectedItem?.type === 'edit-processes') {
+    return '[Tab] Switch  [Enter] Edit Processes Config  [,] Settings  [?] Help  [q] Quit';
+  }
+  if (selectedItem?.type === 'events') {
+    return '[Tab] Switch  [Enter] Open Events  [,] Settings  [?] Help  [q] Quit';
+  }
+  if (selectedItem?.type === 'new-session') {
+    return '[Tab] Switch  [Enter] New Session  [,] Settings  [?] Help  [q] Quit';
+  }
+  return '[Tab] Switch  [Enter] Open  [n] New Workspace  [,] Settings  [?] Help  [q] Quit';
 }
 
 // ============================================================================

--- a/src/app.tui.tsx
+++ b/src/app.tui.tsx
@@ -2117,7 +2117,18 @@ function App({ relayConfig, onQuit }: AppProps) {
           if (selected?.type === 'session') {
             handleDeleteSession(selected.session.id, selected.session.name);
           } else if (selected?.type === 'process' && selected.status === 'running') {
-            void handleStopProcess({ workspaceId: selected.workspaceId, processName: selected.processName });
+            flow.showConfirm({
+              title: 'Stop Process',
+              message: `Stop process "${selected.processName}"?`,
+              variant: 'warning',
+              confirmLabel: 'Stop',
+              onConfirm: () => {
+                void handleStopProcess({
+                  workspaceId: selected.workspaceId,
+                  processName: selected.processName,
+                });
+              },
+            });
           }
         } else if (command === 'refresh') {
           try {

--- a/src/app.tui.tsx
+++ b/src/app.tui.tsx
@@ -39,6 +39,9 @@ import { SpacesBrowserTUI } from './components/SpacesBrowser.tui.js';
 import { ProjectListTUI } from './components/ProjectList.tui.js';
 import { InboxTUI } from './components/Inbox.tui.js';
 import { useInbox } from './components/Inbox.js';
+import { EventsTui } from './components/Events.tui.js';
+import { useEvents, type WideEventItem } from './components/Events.js';
+import type { WideEvent, SavedEventFilter, WideEventFilter } from './types/events.js';
 import { toast } from '@opentui-ui/toast';
 import {
   useNotifications,
@@ -297,6 +300,9 @@ function App({ relayConfig, onQuit }: AppProps) {
   const [settingsFlow, setSettingsFlow] = useState<SettingsFlowState>({ type: 'closed' });
   const [notificationConfig, setNotificationConfig] = useState<NotificationConfig>(DEFAULT_NOTIFICATION_CONFIG);
 
+  // Events view state
+  const [eventsWorkspaceId, setEventsWorkspaceId] = useState<string | null>(null);
+
   // Remote machines hook
   const remoteMachines = useRemoteMachines({
     relayConfig,
@@ -334,6 +340,12 @@ function App({ relayConfig, onQuit }: AppProps) {
     commandError: localCommandError,
     getBundleRefreshPlan: getLocalBundleRefreshPlan,
     applyBundleRefresh: applyLocalBundleRefresh,
+    startProcess: startLocalProcess,
+    stopProcess: stopLocalProcess,
+    requestEvents: requestLocalEvents,
+    events: localEvents,
+    liveEventIds: localLiveEventIds,
+    savedEventFilters: localSavedEventFilters,
   } = localSession;
 
   const currentProject =
@@ -1140,12 +1152,42 @@ function App({ relayConfig, onQuit }: AppProps) {
     onRefresh: refreshProjects,
   });
 
+  // Process handlers
+  const handleStartProcess = useCallback((params: { workspaceId: string; processName: string }) => {
+    void startLocalProcess(params.workspaceId, params.processName);
+  }, [startLocalProcess]);
+
+  const handleStartProcessAttach = useCallback((params: { workspaceId: string; processName: string; instance: number }) => {
+    void startLocalProcess(params.workspaceId, params.processName).then(() => {
+      // After starting, find and attach to the session
+      void refreshWorkspaces();
+    });
+  }, [startLocalProcess, refreshWorkspaces]);
+
+  const handleStopProcess = useCallback((params: { workspaceId: string; processName: string }) => {
+    void stopLocalProcess(params.workspaceId, params.processName);
+  }, [stopLocalProcess]);
+
+  const handleOpenEvents = useCallback((workspaceId: string) => {
+    setEventsWorkspaceId(workspaceId);
+    // Find workspace path for events request
+    const workspace = localWorkspaces.find(w => w.id === workspaceId);
+    if (workspace) {
+      void requestLocalEvents(workspace.path);
+    }
+    dispatch({ type: 'SET_VIEW', view: 'events' as AppView });
+  }, [localWorkspaces, requestLocalEvents]);
+
   // Spaces browser hook
   const spacesBrowserProps = useSpacesBrowser({
     workspaces: workspaceInfos,
     sessions: sessionInfos,
     onRequestSessions: () => {}, // Sessions already loaded
     onAttachSession: handleAttachSession,
+    onStartProcess: handleStartProcess,
+    onStartProcessAttach: handleStartProcessAttach,
+    onStopProcess: handleStopProcess,
+    onOpenEvents: handleOpenEvents,
     onRefresh: refreshWorkspaces,
     onBack: () => dispatch({ type: 'SET_PANEL_FOCUS', focus: 'projects' }),
     onCreateWorkspace: handleNewWorkspaceFlow,
@@ -1190,6 +1232,58 @@ function App({ relayConfig, onQuit }: AppProps) {
       dispatch({ type: 'SET_VIEW', view: 'projects' });
     },
   });
+
+  // Events hook
+  const eventsItems: WideEventItem[] = localEvents.map((event: WideEvent) => ({
+    eventId: event.eventId,
+    eventName: event.eventName,
+    level: event.level,
+    timestamp: event.timestamp,
+    timestampMs: event.timestampMs,
+    message: event.message,
+    processName: event.processName,
+    processInstance: event.processInstance,
+    sessionId: event.sessionId,
+    raw: event.raw,
+    kind: event.kind,
+    correlationId: event.correlationId,
+    timeline: event.timeline,
+    timelineMap: event.timelineMap,
+    timelineOrder: event.timelineOrder,
+  }));
+
+  const eventsProps = useEvents({
+    events: eventsItems,
+    liveEventIds: localLiveEventIds,
+    savedFilters: localSavedEventFilters,
+    onSelectFilter: (filter) => {
+      if (!eventsWorkspaceId) return;
+      const workspace = localWorkspaces.find(w => w.id === eventsWorkspaceId);
+      if (!workspace) return;
+      if (filter) {
+        void requestLocalEvents(workspace.path, filter.filter as WideEventFilter);
+      } else {
+        void requestLocalEvents(workspace.path);
+      }
+    },
+    onClose: () => {
+      setEventsWorkspaceId(null);
+      dispatch({ type: 'SET_VIEW', view: 'projects' });
+    },
+  });
+
+  // Events polling when events view is active
+  useEffect(() => {
+    if (state.view !== 'events' || !eventsWorkspaceId) return;
+    const workspace = localWorkspaces.find(w => w.id === eventsWorkspaceId);
+    if (!workspace) return;
+
+    const interval = setInterval(() => {
+      void requestLocalEvents(workspace.path);
+    }, 2000);
+
+    return () => clearInterval(interval);
+  }, [state.view, eventsWorkspaceId, localWorkspaces, requestLocalEvents]);
 
   // ========== Activity Tracking for Notifications ==========
 
@@ -1424,6 +1518,19 @@ function App({ relayConfig, onQuit }: AppProps) {
         )
       ) {
         dispatch({ type: 'SET_VIEW', view: 'projects' });
+      }
+      return;
+    }
+
+    // Events view keyboard handling
+    if (state.view === 'events') {
+      if (key.name === 'escape' || key.raw === 'q') {
+        setEventsWorkspaceId(null);
+        dispatch({ type: 'SET_VIEW', view: 'projects' });
+      } else if (key.name === 'up' || key.raw === 'k') {
+        eventsProps.selectIndex(eventsProps.selectedIndex - 1);
+      } else if (key.name === 'down' || key.raw === 'j') {
+        eventsProps.selectIndex(eventsProps.selectedIndex + 1);
       }
       return;
     }
@@ -2046,6 +2153,18 @@ function App({ relayConfig, onQuit }: AppProps) {
             dispatch({ type: 'SET_VIEW', view: 'machines' });
           }}
         />
+      </Fragment>
+    );
+  }
+
+  // Events view
+  if (state.view === 'events') {
+    return (
+      <Fragment>
+        <Toaster position="top-right" />
+        <EventsTui {...eventsProps} />
+        <FlowTUI flow={flow} />
+        <StatusBar hint="[Esc/q] Back  [j/k] Navigate" />
       </Fragment>
     );
   }

--- a/src/app.web.tsx
+++ b/src/app.web.tsx
@@ -86,6 +86,10 @@ export default function App() {
     useState<NotificationConfig | null>(null);
   const [isViewOnlySession, setIsViewOnlySession] = useState(false);
   const pendingProcessEditWorkspacesRef = useRef<unknown[] | null>(null);
+  const eventsKeyboardStateRef = useRef<{
+    selectedIndex: number;
+    selectIndex: (index: number) => void;
+  } | null>(null);
 
   // Terminal ref for external control (focus, sendData)
   const terminalRef = useRef<SessionTerminalHandle>(null);
@@ -610,6 +614,13 @@ export default function App() {
     },
   });
 
+  useEffect(() => {
+    eventsKeyboardStateRef.current = {
+      selectedIndex: eventsProps.selectedIndex,
+      selectIndex: eventsProps.selectIndex,
+    };
+  }, [eventsProps.selectedIndex, eventsProps.selectIndex]);
+
   // Events polling when events view is active
   useEffect(() => {
     if (!showEvents || !eventsWorkspacePath) return;
@@ -807,16 +818,20 @@ export default function App() {
         setEventsWorkspacePath(null);
       } else if (e.key === 'ArrowUp' || e.key === 'k') {
         e.preventDefault();
-        eventsProps.selectIndex(eventsProps.selectedIndex - 1);
+        const state = eventsKeyboardStateRef.current;
+        if (!state) return;
+        state.selectIndex(state.selectedIndex - 1);
       } else if (e.key === 'ArrowDown' || e.key === 'j') {
         e.preventDefault();
-        eventsProps.selectIndex(eventsProps.selectedIndex + 1);
+        const state = eventsKeyboardStateRef.current;
+        if (!state) return;
+        state.selectIndex(state.selectedIndex + 1);
       }
     };
 
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [showEvents, eventsProps]);
+  }, [showEvents]);
 
   // Spaces browser keyboard navigation
   useEffect(() => {

--- a/src/app.web.tsx
+++ b/src/app.web.tsx
@@ -558,17 +558,30 @@ export default function App() {
   }, [attachController, terminal.workspaces]);
 
   const handleStartProcessSelection = useCallback((params: { workspaceId: string; processName: string; instance?: number }) => {
-    terminal.startProcess(params.workspaceId, params.processName, params.instance);
+    void terminal.startProcess(params.workspaceId, params.processName, params.instance).catch((error) => {
+      toast.error(error instanceof Error ? error.message : String(error));
+    });
   }, [terminal]);
 
   const handleStartProcessAttachSelection = useCallback((params: { workspaceId: string; processName: string; instance?: number }) => {
     const instance = params.instance ?? 1;
-    setPendingProcessAttach({
+    const target: PendingProcessAttachTarget = {
       workspaceId: params.workspaceId,
       processName: params.processName,
       instance,
+    };
+    setPendingProcessAttach(target);
+    void terminal.startProcess(params.workspaceId, params.processName, instance).catch((error) => {
+      setPendingProcessAttach((current) =>
+        current &&
+        current.workspaceId === target.workspaceId &&
+        current.processName === target.processName &&
+        current.instance === target.instance
+          ? null
+          : current
+      );
+      toast.error(error instanceof Error ? error.message : String(error));
     });
-    terminal.startProcess(params.workspaceId, params.processName, instance);
   }, [terminal]);
 
   const handleProcessDisabled = useCallback((params: { workspaceId: string; processName: string }) => {
@@ -587,7 +600,9 @@ export default function App() {
     onStartProcess: (params) => handleStartProcessSelection(params),
     onStartProcessAttach: (params) => handleStartProcessAttachSelection(params),
     onStopProcess: (params) => {
-      terminal.stopProcess(params.workspaceId, params.processName);
+      void terminal.stopProcess(params.workspaceId, params.processName).catch((error) => {
+        toast.error(error instanceof Error ? error.message : String(error));
+      });
     },
     onProcessDisabled: handleProcessDisabled,
     onOpenEvents: (workspaceId) => {
@@ -724,11 +739,11 @@ export default function App() {
   useEffect(() => {
     if (!showEvents || !eventsWorkspacePath) return;
 
-    const activeFilter = eventsProps.activeFilterName
-      ? terminal.savedEventFilters.find((filter) => filter.name === eventsProps.activeFilterName) ?? null
-      : null;
-
     const interval = setInterval(() => {
+      const activeFilter = eventsProps.activeFilterName
+        ? terminal.savedEventFilters.find((filter) => filter.name === eventsProps.activeFilterName) ?? null
+        : null;
+
       if (activeFilter) {
         const sinceMs = activeFilter.sinceMinutes
           ? Date.now() - activeFilter.sinceMinutes * 60 * 1000
@@ -982,7 +997,9 @@ export default function App() {
             variant: 'warning',
             confirmLabel: 'Stop',
             onConfirm: () => {
-              terminal.stopProcess(selected.workspaceId, selected.processName);
+              void terminal.stopProcess(selected.workspaceId, selected.processName).catch((error) => {
+                toast.error(error instanceof Error ? error.message : String(error));
+              });
             },
           });
         }

--- a/src/app.web.tsx
+++ b/src/app.web.tsx
@@ -82,6 +82,7 @@ export default function App() {
   });
   const [localNotificationConfig, setLocalNotificationConfig] =
     useState<NotificationConfig | null>(null);
+  const [isViewOnlySession, setIsViewOnlySession] = useState(false);
 
   // Terminal ref for external control (focus, sendData)
   const terminalRef = useRef<SessionTerminalHandle>(null);
@@ -171,7 +172,7 @@ export default function App() {
         return;
       }
 
-      if (params.workspaceId) {
+      if (params.workspaceId && !params.command) {
         setShowInbox(false);
         setScriptWorkspaceName(params.workspaceId.split(':').slice(-1)[0] ?? params.workspaceId);
         setShowScriptTerminal(true);
@@ -442,7 +443,8 @@ export default function App() {
   });
 
   // Handle attach session - show modal for new sessions
-  const handleAttachSession = useCallback(async (params: { sessionId?: string; workspaceId?: string }) => {
+  const handleAttachSession = useCallback(async (params: { sessionId?: string; workspaceId?: string; viewOnly?: boolean }) => {
+    setIsViewOnlySession(params.viewOnly ?? false);
     await attachController.attachFromSelection(params);
   }, [attachController]);
 
@@ -456,12 +458,23 @@ export default function App() {
     setView('review');
   }, []);
 
+  // Open editor on .gitspace/processes.json in the workspace
+  const handleEditProcesses = useCallback(({ workspaceId }: { workspaceId: string }) => {
+    setIsViewOnlySession(false);
+    void attachController.attach({
+      workspaceId,
+      command: 'sh',
+      args: ['-c', 'mkdir -p .gitspace && exec "${EDITOR:-vi}" .gitspace/processes.json'],
+    });
+  }, [attachController]);
+
   // Spaces browser hook
   const spacesBrowserProps = useSpacesBrowser({
     workspaces: terminal.workspaces,
     sessions: terminal.sessions,
     onRequestSessions: () => terminal.requestSessions(),
     onAttachSession: handleAttachSession,
+    onEditProcesses: handleEditProcesses,
     onStartProcess: (params) => {
       terminal.startProcess(params.workspaceId, params.processName);
     },
@@ -616,6 +629,13 @@ export default function App() {
     terminal.requestNotificationConfig,
   ]);
 
+  // Reset view-only state when detached
+  useEffect(() => {
+    if (terminal.mode !== 'attached') {
+      setIsViewOnlySession(false);
+    }
+  }, [terminal.mode]);
+
   // ========== Keyboard Handlers ==========
 
   // Machine list keyboard navigation
@@ -767,6 +787,16 @@ export default function App() {
             confirmLabel: 'Kill',
             onConfirm: () => {
               terminal.killSession(selected.session.id);
+            },
+          });
+        } else if (selected?.type === 'process' && selected.status === 'running') {
+          flow.showConfirm({
+            title: 'Stop Process',
+            message: `Stop process "${selected.processName}"?`,
+            variant: 'warning',
+            confirmLabel: 'Stop',
+            onConfirm: () => {
+              terminal.stopProcess(selected.workspaceId, selected.processName);
             },
           });
         }
@@ -1141,6 +1171,7 @@ export default function App() {
               allowTapFocus={inputMode || !showMobileControls}
               allowTouchScroll={!inputMode}
               onActivity={handleTerminalActivity}
+              readOnly={isViewOnlySession}
             />
           </div>
           {/* Mobile controls toolbar - show in input mode */}

--- a/src/app.web.tsx
+++ b/src/app.web.tsx
@@ -309,6 +309,7 @@ export default function App() {
 
     const workspace = terminal.workspaces.find((item) => item.id === pendingProcessEditWorkspaceId);
     if (!workspace) {
+      setPendingProcessEditWorkspaceId(null);
       return;
     }
 

--- a/src/app.web.tsx
+++ b/src/app.web.tsx
@@ -18,6 +18,7 @@ import { applyDeviceClasses, isMobileLayout, isTouchDevice } from "./utils/devic
 import { useUserActivity } from "./hooks/index.js";
 import { useBundleRefreshAttachFlow } from './session/useBundleRefreshAttachFlow.js';
 import { useAttachController } from './app/session/useAttachController.js';
+import { useProcessActions } from './app/session/useProcessActions.js';
 import { useWorkspaceDeleteFlow } from './app/session/useWorkspaceDeleteFlow.js';
 import { ReviewPage } from './pages/ReviewPage.web.js';
 import { buildEditProcessesCommand } from './lib/processes/editor.js';
@@ -54,12 +55,6 @@ import {
 
 type View = "machines" | "terminal" | "review";
 
-interface PendingProcessAttachTarget {
-  workspaceId: string;
-  processName: string;
-  instance: number;
-}
-
 const PAGE_UP = '\x1b[5~';
 const PAGE_DOWN = '\x1b[6~';
 const DELETE_ERROR_CODES = new Set([
@@ -83,7 +78,6 @@ export default function App() {
   const [eventsWorkspacePath, setEventsWorkspacePath] = useState<string | null>(null);
   const [eventsWorkspaceLabel, setEventsWorkspaceLabel] = useState<string>('');
   const [pendingProcessEditWorkspaceId, setPendingProcessEditWorkspaceId] = useState<string | null>(null);
-  const [pendingProcessAttach, setPendingProcessAttach] = useState<PendingProcessAttachTarget | null>(null);
   const [modifiers, setModifiers] = useState<ModifierState>({
     ctrl: false,
     shift: false,
@@ -94,15 +88,10 @@ export default function App() {
   const [isViewOnlySession, setIsViewOnlySession] = useState(false);
   const pendingProcessEditWorkspacesRef = useRef<unknown[] | null>(null);
   const pendingProcessEditValidationArmedRef = useRef(false);
-  const pendingProcessAttachRef = useRef<PendingProcessAttachTarget | null>(null);
   const eventsKeyboardStateRef = useRef<{
     selectedIndex: number;
     selectIndex: (index: number) => void;
   } | null>(null);
-
-  useEffect(() => {
-    pendingProcessAttachRef.current = pendingProcessAttach;
-  }, [pendingProcessAttach]);
 
   // Terminal ref for external control (focus, sendData)
   const terminalRef = useRef<SessionTerminalHandle>(null);
@@ -524,6 +513,29 @@ export default function App() {
     await attachController.attachFromSelection(params);
   }, [attachController]);
 
+  const processActions = useProcessActions({
+    sessions: terminal.sessions,
+    startProcess: terminal.startProcess,
+    stopProcess: terminal.stopProcess,
+    attachSession: handleAttachSession,
+    onStartProcessError: (error) => {
+      toast.error(error instanceof Error ? error.message : String(error));
+    },
+    onStopProcessError: (error) => {
+      toast.error(error instanceof Error ? error.message : String(error));
+    },
+    onStartProcessAttachError: (error) => {
+      toast.error(error instanceof Error ? error.message : String(error));
+    },
+    onAttachError: (error) => {
+      toast.error(error instanceof Error ? error.message : String(error));
+    },
+    onAttachTimeout: (target) => {
+      toast.error(`Process started but no active session appeared for ${target.processName}#${target.instance}.`);
+    },
+    pendingAttachCancelSignal: terminal.commandError,
+  });
+
   // Handle opening review for a workspace
   const handleOpenReview = useCallback((workspace: WorkspaceInfo) => {
     setReviewWorkspace({
@@ -557,33 +569,6 @@ export default function App() {
     });
   }, [attachController, terminal.workspaces]);
 
-  const handleStartProcessSelection = useCallback((params: { workspaceId: string; processName: string; instance?: number }) => {
-    void terminal.startProcess(params.workspaceId, params.processName, params.instance).catch((error) => {
-      toast.error(error instanceof Error ? error.message : String(error));
-    });
-  }, [terminal]);
-
-  const handleStartProcessAttachSelection = useCallback((params: { workspaceId: string; processName: string; instance?: number }) => {
-    const instance = params.instance ?? 1;
-    const target: PendingProcessAttachTarget = {
-      workspaceId: params.workspaceId,
-      processName: params.processName,
-      instance,
-    };
-    setPendingProcessAttach(target);
-    void terminal.startProcess(params.workspaceId, params.processName, instance).catch((error) => {
-      setPendingProcessAttach((current) =>
-        current &&
-        current.workspaceId === target.workspaceId &&
-        current.processName === target.processName &&
-        current.instance === target.instance
-          ? null
-          : current
-      );
-      toast.error(error instanceof Error ? error.message : String(error));
-    });
-  }, [terminal]);
-
   const handleProcessDisabled = useCallback((params: { workspaceId: string; processName: string }) => {
     const workspace = terminal.workspaces.find((item) => item.id === params.workspaceId);
     const workspaceLabel = workspace?.name ?? params.workspaceId;
@@ -597,13 +582,9 @@ export default function App() {
     onRequestSessions: () => terminal.requestSessions(),
     onAttachSession: handleAttachSession,
     onEditProcesses: handleEditProcesses,
-    onStartProcess: (params) => handleStartProcessSelection(params),
-    onStartProcessAttach: (params) => handleStartProcessAttachSelection(params),
-    onStopProcess: (params) => {
-      void terminal.stopProcess(params.workspaceId, params.processName).catch((error) => {
-        toast.error(error instanceof Error ? error.message : String(error));
-      });
-    },
+    onStartProcess: (params) => processActions.handleStartProcess(params),
+    onStartProcessAttach: (params) => processActions.handleStartProcessAttach(params),
+    onStopProcess: (params) => processActions.handleStopProcess(params),
     onProcessDisabled: handleProcessDisabled,
     onOpenEvents: (workspaceId) => {
       const workspace = terminal.workspaces.find(w => w.id === workspaceId);
@@ -619,71 +600,6 @@ export default function App() {
     onBack: handleBackToMachines,
     machineName: selectedMachine?.label || selectedMachine?.machineId,
   });
-
-  useEffect(() => {
-    if (!pendingProcessAttach) {
-      return;
-    }
-
-    const session = terminal.sessions
-      .filter((item) =>
-        item.workspaceId === pendingProcessAttach.workspaceId &&
-        item.processName === pendingProcessAttach.processName &&
-        (item.processInstance ?? 1) === pendingProcessAttach.instance &&
-        item.exitCode === undefined
-      )
-      .sort((a, b) => b.createdAt - a.createdAt)[0];
-
-    if (!session) {
-      return;
-    }
-
-    const target = pendingProcessAttach;
-    setPendingProcessAttach((current) =>
-      current &&
-      current.workspaceId === target.workspaceId &&
-      current.processName === target.processName &&
-      current.instance === target.instance
-        ? null
-        : current
-    );
-
-    void handleAttachSession({ sessionId: session.id, viewOnly: true }).catch((error) => {
-      toast.error(error instanceof Error ? error.message : String(error));
-    });
-  }, [handleAttachSession, pendingProcessAttach, terminal.sessions]);
-
-  useEffect(() => {
-    if (!pendingProcessAttach) {
-      return;
-    }
-
-    const target = pendingProcessAttach;
-
-    const timeout = window.setTimeout(() => {
-      const current = pendingProcessAttachRef.current;
-      if (
-        !current ||
-        current.workspaceId !== target.workspaceId ||
-        current.processName !== target.processName ||
-        current.instance !== target.instance
-      ) {
-        return;
-      }
-
-      setPendingProcessAttach(null);
-      toast.error(`Process started but no active session appeared for ${current.processName}#${current.instance}.`);
-    }, 8000);
-
-    return () => window.clearTimeout(timeout);
-  }, [pendingProcessAttach]);
-
-  useEffect(() => {
-    if (!pendingProcessAttach || !terminal.commandError) {
-      return;
-    }
-    setPendingProcessAttach(null);
-  }, [pendingProcessAttach, terminal.commandError]);
 
   // Inbox hook
   const inboxProps = useInbox({
@@ -997,8 +913,9 @@ export default function App() {
             variant: 'warning',
             confirmLabel: 'Stop',
             onConfirm: () => {
-              void terminal.stopProcess(selected.workspaceId, selected.processName).catch((error) => {
-                toast.error(error instanceof Error ? error.message : String(error));
+              processActions.handleStopProcess({
+                workspaceId: selected.workspaceId,
+                processName: selected.processName,
               });
             },
           });

--- a/src/app.web.tsx
+++ b/src/app.web.tsx
@@ -20,6 +20,7 @@ import { useBundleRefreshAttachFlow } from './session/useBundleRefreshAttachFlow
 import { useAttachController } from './app/session/useAttachController.js';
 import { useWorkspaceDeleteFlow } from './app/session/useWorkspaceDeleteFlow.js';
 import { ReviewPage } from './pages/ReviewPage.web.js';
+import { buildEditProcessesCommand } from './lib/processes/editor.js';
 
 // Import shared components and hooks
 import {
@@ -75,6 +76,7 @@ export default function App() {
   const [showEvents, setShowEvents] = useState(false);
   const [eventsWorkspacePath, setEventsWorkspacePath] = useState<string | null>(null);
   const [eventsWorkspaceLabel, setEventsWorkspaceLabel] = useState<string>('');
+  const [pendingProcessEditWorkspaceId, setPendingProcessEditWorkspaceId] = useState<string | null>(null);
   const [modifiers, setModifiers] = useState<ModifierState>({
     ctrl: false,
     shift: false,
@@ -294,6 +296,43 @@ export default function App() {
   }, [terminal.mode, terminal.scriptState?.isRunning, terminal.status]);
 
   useEffect(() => {
+    if (!pendingProcessEditWorkspaceId || terminal.mode !== 'browsing') {
+      return;
+    }
+    terminal.requestWorkspaces();
+  }, [pendingProcessEditWorkspaceId, terminal.mode, terminal.requestWorkspaces]);
+
+  useEffect(() => {
+    if (!pendingProcessEditWorkspaceId || terminal.mode !== 'browsing') {
+      return;
+    }
+
+    const workspace = terminal.workspaces.find((item) => item.id === pendingProcessEditWorkspaceId);
+    if (!workspace) {
+      return;
+    }
+
+    if (workspace.processConfigError) {
+      flow.showMessage({
+        title: 'Invalid Processes Config',
+        message: workspace.processConfigError,
+        variant: 'error',
+      });
+    } else {
+      const processCount = workspace.processes?.length ?? 0;
+      flow.showMessage({
+        title: 'Processes Config Updated',
+        message: processCount === 0
+          ? 'Config is valid. No processes are defined yet.'
+          : `Config is valid. ${processCount} process${processCount === 1 ? '' : 'es'} defined.`,
+        variant: 'success',
+      });
+    }
+
+    setPendingProcessEditWorkspaceId(null);
+  }, [flow, pendingProcessEditWorkspaceId, terminal.mode, terminal.workspaces]);
+
+  useEffect(() => {
     const scriptError = terminal.scriptState?.error;
     if (!scriptError) {
       lastScriptErrorRef.current = null;
@@ -461,10 +500,12 @@ export default function App() {
   // Open editor on .gitspace/processes.json in the workspace
   const handleEditProcesses = useCallback(({ workspaceId }: { workspaceId: string }) => {
     setIsViewOnlySession(false);
+    setPendingProcessEditWorkspaceId(workspaceId);
+    const commandSpec = buildEditProcessesCommand();
     void attachController.attach({
       workspaceId,
-      command: 'sh',
-      args: ['-c', 'mkdir -p .gitspace && exec "${EDITOR:-vi}" .gitspace/processes.json'],
+      command: commandSpec.command,
+      args: commandSpec.args,
     });
   }, [attachController]);
 
@@ -539,11 +580,14 @@ export default function App() {
     onSelectFilter: (filter) => {
       if (!eventsWorkspacePath) return;
       if (filter) {
+        const sinceMs = filter.sinceMinutes
+          ? Date.now() - filter.sinceMinutes * 60 * 1000
+          : undefined;
         terminal.requestEvents(
           eventsWorkspacePath,
           filter.filter as WideEventFilter,
           undefined,
-          filter.sinceMinutes ? filter.sinceMinutes * 60 * 1000 : undefined
+          sinceMs
         );
       } else {
         terminal.requestEvents(eventsWorkspacePath);
@@ -565,11 +609,14 @@ export default function App() {
 
     const interval = setInterval(() => {
       if (activeFilter) {
+        const sinceMs = activeFilter.sinceMinutes
+          ? Date.now() - activeFilter.sinceMinutes * 60 * 1000
+          : undefined;
         terminal.requestEvents(
           eventsWorkspacePath,
           activeFilter.filter as WideEventFilter,
           undefined,
-          activeFilter.sinceMinutes ? activeFilter.sinceMinutes * 60 * 1000 : undefined
+          sinceMs
         );
       } else {
         terminal.requestEvents(eventsWorkspacePath);
@@ -846,6 +893,7 @@ export default function App() {
     terminal.mode,
     showInbox,
     showScriptTerminal,
+    showEvents,
     spacesBrowserProps,
     flow,
     deleteWorkspaceWithPrompt,

--- a/src/app.web.tsx
+++ b/src/app.web.tsx
@@ -54,6 +54,12 @@ import {
 
 type View = "machines" | "terminal" | "review";
 
+interface PendingProcessAttachTarget {
+  workspaceId: string;
+  processName: string;
+  instance: number;
+}
+
 const PAGE_UP = '\x1b[5~';
 const PAGE_DOWN = '\x1b[6~';
 const DELETE_ERROR_CODES = new Set([
@@ -77,6 +83,7 @@ export default function App() {
   const [eventsWorkspacePath, setEventsWorkspacePath] = useState<string | null>(null);
   const [eventsWorkspaceLabel, setEventsWorkspaceLabel] = useState<string>('');
   const [pendingProcessEditWorkspaceId, setPendingProcessEditWorkspaceId] = useState<string | null>(null);
+  const [pendingProcessAttach, setPendingProcessAttach] = useState<PendingProcessAttachTarget | null>(null);
   const [modifiers, setModifiers] = useState<ModifierState>({
     ctrl: false,
     shift: false,
@@ -530,6 +537,18 @@ export default function App() {
     terminal.requestSessions();
   }, [terminal]);
 
+  const handleStartProcessAttachSelection = useCallback((params: { workspaceId: string; processName: string; instance?: number }) => {
+    const instance = params.instance ?? 1;
+    setPendingProcessAttach({
+      workspaceId: params.workspaceId,
+      processName: params.processName,
+      instance,
+    });
+    terminal.startProcess(params.workspaceId, params.processName, instance);
+    terminal.requestWorkspaces();
+    terminal.requestSessions();
+  }, [terminal]);
+
   const handleProcessDisabled = useCallback((params: { workspaceId: string; processName: string }) => {
     const workspace = terminal.workspaces.find((item) => item.id === params.workspaceId);
     const workspaceLabel = workspace?.name ?? params.workspaceId;
@@ -544,7 +563,7 @@ export default function App() {
     onAttachSession: handleAttachSession,
     onEditProcesses: handleEditProcesses,
     onStartProcess: (params) => handleStartProcessSelection(params),
-    onStartProcessAttach: (params) => handleStartProcessSelection(params),
+    onStartProcessAttach: (params) => handleStartProcessAttachSelection(params),
     onStopProcess: (params) => {
       terminal.stopProcess(params.workspaceId, params.processName);
       terminal.requestWorkspaces();
@@ -565,6 +584,70 @@ export default function App() {
     onBack: handleBackToMachines,
     machineName: selectedMachine?.label || selectedMachine?.machineId,
   });
+
+  useEffect(() => {
+    if (!pendingProcessAttach) {
+      return;
+    }
+
+    const session = terminal.sessions
+      .filter((item) =>
+        item.workspaceId === pendingProcessAttach.workspaceId &&
+        item.processName === pendingProcessAttach.processName &&
+        (item.processInstance ?? 1) === pendingProcessAttach.instance &&
+        item.exitCode === undefined
+      )
+      .sort((a, b) => b.createdAt - a.createdAt)[0];
+
+    if (!session) {
+      return;
+    }
+
+    const target = pendingProcessAttach;
+    setPendingProcessAttach((current) =>
+      current &&
+      current.workspaceId === target.workspaceId &&
+      current.processName === target.processName &&
+      current.instance === target.instance
+        ? null
+        : current
+    );
+
+    void handleAttachSession({ sessionId: session.id, viewOnly: true }).catch((error) => {
+      toast.error(error instanceof Error ? error.message : String(error));
+    });
+  }, [handleAttachSession, pendingProcessAttach, terminal.sessions]);
+
+  useEffect(() => {
+    if (!pendingProcessAttach) {
+      return;
+    }
+
+    const timeout = window.setTimeout(() => {
+      setPendingProcessAttach((current) => {
+        if (
+          !current ||
+          current.workspaceId !== pendingProcessAttach.workspaceId ||
+          current.processName !== pendingProcessAttach.processName ||
+          current.instance !== pendingProcessAttach.instance
+        ) {
+          return current;
+        }
+
+        toast.error(`Process started but no active session appeared for ${current.processName}#${current.instance}.`);
+        return null;
+      });
+    }, 8000);
+
+    return () => window.clearTimeout(timeout);
+  }, [pendingProcessAttach]);
+
+  useEffect(() => {
+    if (!pendingProcessAttach || !terminal.commandError) {
+      return;
+    }
+    setPendingProcessAttach(null);
+  }, [pendingProcessAttach, terminal.commandError]);
 
   // Inbox hook
   const inboxProps = useInbox({

--- a/src/app.web.tsx
+++ b/src/app.web.tsx
@@ -93,6 +93,7 @@ export default function App() {
     useState<NotificationConfig | null>(null);
   const [isViewOnlySession, setIsViewOnlySession] = useState(false);
   const pendingProcessEditWorkspacesRef = useRef<unknown[] | null>(null);
+  const pendingProcessEditValidationArmedRef = useRef(false);
   const pendingProcessAttachRef = useRef<PendingProcessAttachTarget | null>(null);
   const eventsKeyboardStateRef = useRef<{
     selectedIndex: number;
@@ -313,14 +314,22 @@ export default function App() {
   }, [terminal.mode, terminal.scriptState?.isRunning, terminal.status]);
 
   useEffect(() => {
-    if (!pendingProcessEditWorkspaceId || terminal.mode !== 'browsing') {
+    if (
+      !pendingProcessEditWorkspaceId ||
+      !pendingProcessEditValidationArmedRef.current ||
+      terminal.mode !== 'browsing'
+    ) {
       return;
     }
     terminal.requestWorkspaces();
   }, [pendingProcessEditWorkspaceId, terminal.mode, terminal.requestWorkspaces]);
 
   useEffect(() => {
-    if (!pendingProcessEditWorkspaceId || terminal.mode !== 'browsing') {
+    if (
+      !pendingProcessEditWorkspaceId ||
+      !pendingProcessEditValidationArmedRef.current ||
+      terminal.mode !== 'browsing'
+    ) {
       return;
     }
 
@@ -334,6 +343,7 @@ export default function App() {
 
     const workspace = terminal.workspaces.find((item) => item.id === pendingProcessEditWorkspaceId);
     if (!workspace) {
+      pendingProcessEditValidationArmedRef.current = false;
       setPendingProcessEditWorkspaceId(null);
       return;
     }
@@ -355,6 +365,7 @@ export default function App() {
       });
     }
 
+    pendingProcessEditValidationArmedRef.current = false;
     setPendingProcessEditWorkspaceId(null);
   }, [flow, pendingProcessEditWorkspaceId, terminal.mode, terminal.workspaces]);
 
@@ -526,6 +537,7 @@ export default function App() {
   // Open editor on .gitspace/processes.json in the workspace
   const handleEditProcesses = useCallback(({ workspaceId }: { workspaceId: string }) => {
     setIsViewOnlySession(false);
+    pendingProcessEditValidationArmedRef.current = false;
     pendingProcessEditWorkspacesRef.current = terminal.workspaces;
     setPendingProcessEditWorkspaceId(workspaceId);
     const commandSpec = buildEditProcessesCommand();
@@ -535,16 +547,18 @@ export default function App() {
       args: commandSpec.args,
     }).then((attached) => {
       if (!attached) {
+        pendingProcessEditValidationArmedRef.current = false;
         pendingProcessEditWorkspacesRef.current = null;
         setPendingProcessEditWorkspaceId(null);
+        return;
       }
+
+      pendingProcessEditValidationArmedRef.current = true;
     });
   }, [attachController, terminal.workspaces]);
 
   const handleStartProcessSelection = useCallback((params: { workspaceId: string; processName: string; instance?: number }) => {
     terminal.startProcess(params.workspaceId, params.processName, params.instance);
-    terminal.requestWorkspaces();
-    terminal.requestSessions();
   }, [terminal]);
 
   const handleStartProcessAttachSelection = useCallback((params: { workspaceId: string; processName: string; instance?: number }) => {
@@ -555,8 +569,6 @@ export default function App() {
       instance,
     });
     terminal.startProcess(params.workspaceId, params.processName, instance);
-    terminal.requestWorkspaces();
-    terminal.requestSessions();
   }, [terminal]);
 
   const handleProcessDisabled = useCallback((params: { workspaceId: string; processName: string }) => {
@@ -576,8 +588,6 @@ export default function App() {
     onStartProcessAttach: (params) => handleStartProcessAttachSelection(params),
     onStopProcess: (params) => {
       terminal.stopProcess(params.workspaceId, params.processName);
-      terminal.requestWorkspaces();
-      terminal.requestSessions();
     },
     onProcessDisabled: handleProcessDisabled,
     onOpenEvents: (workspaceId) => {

--- a/src/app.web.tsx
+++ b/src/app.web.tsx
@@ -35,6 +35,9 @@ import { SpacesBrowserWeb } from "./components/SpacesBrowser.web.js";
 import { FlowWeb } from "./components/Flow.web.js";
 import { useInbox } from "./components/Inbox.js";
 import { InboxWeb } from "./components/Inbox.web.js";
+import { useEvents, type WideEventItem } from "./components/Events.js";
+import { EventsWeb } from "./components/Events.web.js";
+import type { WideEvent, WideEventFilter } from "./types/events.js";
 import {
   useNotifications,
   type ToastNotification,
@@ -69,6 +72,9 @@ export default function App() {
   const [copied, setCopied] = useState(false);
   const [showMobileControls, setShowMobileControls] = useState(false);
   const [inputMode, setInputMode] = useState(false);
+  const [showEvents, setShowEvents] = useState(false);
+  const [eventsWorkspacePath, setEventsWorkspacePath] = useState<string | null>(null);
+  const [eventsWorkspaceLabel, setEventsWorkspaceLabel] = useState<string>('');
   const [modifiers, setModifiers] = useState<ModifierState>({
     ctrl: false,
     shift: false,
@@ -406,6 +412,7 @@ export default function App() {
     terminal.disconnect();
     setSelectedMachine(null);
     setShowScriptTerminal(false);
+    setShowEvents(false);
     setInputMode(false); // Reset input mode when leaving terminal
     setView("machines");
   };
@@ -416,6 +423,7 @@ export default function App() {
     relay.disconnect();
     setSelectedMachine(null);
     setShowScriptTerminal(false);
+    setShowEvents(false);
     setView("machines");
     // Reconnect automatically
     relay.connect();
@@ -454,6 +462,24 @@ export default function App() {
     sessions: terminal.sessions,
     onRequestSessions: () => terminal.requestSessions(),
     onAttachSession: handleAttachSession,
+    onStartProcess: (params) => {
+      terminal.startProcess(params.workspaceId, params.processName);
+    },
+    onStartProcessAttach: (params) => {
+      terminal.startProcess(params.workspaceId, params.processName);
+    },
+    onStopProcess: (params) => {
+      terminal.stopProcess(params.workspaceId, params.processName);
+    },
+    onOpenEvents: (workspaceId) => {
+      const workspace = terminal.workspaces.find(w => w.id === workspaceId);
+      if (workspace) {
+        setEventsWorkspacePath(workspace.path);
+        setEventsWorkspaceLabel(workspace.name);
+        setShowEvents(true);
+        terminal.requestEvents(workspace.path, undefined, undefined, undefined);
+      }
+    },
     onRefresh: terminal.requestWorkspaces,
     onRefreshSessions: () => terminal.requestSessions(),
     onBack: handleBackToMachines,
@@ -473,6 +499,57 @@ export default function App() {
     },
     onClose: () => setShowInbox(false),
   });
+
+  // Events hook
+  const eventsItems: WideEventItem[] = terminal.events.map((event: WideEvent) => ({
+    eventId: event.eventId,
+    eventName: event.eventName,
+    level: event.level,
+    timestamp: event.timestamp,
+    timestampMs: event.timestampMs,
+    message: event.message,
+    processName: event.processName,
+    processInstance: event.processInstance,
+    sessionId: event.sessionId,
+    raw: event.raw,
+    kind: event.kind,
+    correlationId: event.correlationId,
+    timeline: event.timeline,
+    timelineMap: event.timelineMap,
+    timelineOrder: event.timelineOrder,
+  }));
+
+  const eventsProps = useEvents({
+    events: eventsItems,
+    liveEventIds: terminal.liveEventIds,
+    savedFilters: terminal.savedEventFilters,
+    onSelectFilter: (filter) => {
+      if (!eventsWorkspacePath) return;
+      if (filter) {
+        terminal.requestEvents(
+          eventsWorkspacePath,
+          filter.filter as WideEventFilter,
+          undefined,
+          filter.sinceMinutes ? filter.sinceMinutes * 60 * 1000 : undefined
+        );
+      } else {
+        terminal.requestEvents(eventsWorkspacePath);
+      }
+    },
+    onClose: () => {
+      setShowEvents(false);
+      setEventsWorkspacePath(null);
+    },
+  });
+
+  // Events polling when events view is active
+  useEffect(() => {
+    if (!showEvents || !eventsWorkspacePath) return;
+    const interval = setInterval(() => {
+      terminal.requestEvents(eventsWorkspacePath);
+    }, 2000);
+    return () => clearInterval(interval);
+  }, [showEvents, eventsWorkspacePath, terminal.requestEvents]);
 
   // ========== Activity Tracking for Notifications ==========
 
@@ -623,9 +700,35 @@ export default function App() {
     return () => window.removeEventListener("keydown", handleKeyDown);
   }, [showInbox, inboxProps.moveUp, inboxProps.moveDown, inboxProps.openThread, inboxProps.closeThread, inboxProps.deleteSelected, inboxProps.deleteThread, inboxProps.clearAll, inboxProps.attachToSession, inboxProps.isViewingThread]);
 
+  // Events keyboard navigation
+  useEffect(() => {
+    if (!showEvents) return;
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) {
+        return;
+      }
+
+      if (e.key === 'Escape' || e.key === 'q') {
+        e.preventDefault();
+        setShowEvents(false);
+        setEventsWorkspacePath(null);
+      } else if (e.key === 'ArrowUp' || e.key === 'k') {
+        e.preventDefault();
+        eventsProps.selectIndex(eventsProps.selectedIndex - 1);
+      } else if (e.key === 'ArrowDown' || e.key === 'j') {
+        e.preventDefault();
+        eventsProps.selectIndex(eventsProps.selectedIndex + 1);
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [showEvents, eventsProps]);
+
   // Spaces browser keyboard navigation
   useEffect(() => {
-    if (view !== "terminal" || terminal.status !== "established" || terminal.mode !== "browsing" || showInbox || showScriptTerminal) {
+    if (view !== "terminal" || terminal.status !== "established" || terminal.mode !== "browsing" || showInbox || showScriptTerminal || showEvents) {
       return;
     }
 
@@ -853,6 +956,17 @@ export default function App() {
       return (
         <>
           <InboxWeb {...inboxProps} />
+          <FlowWeb flow={flow} />
+          <Toaster theme="dark" position="top-right" richColors />
+        </>
+      );
+    }
+
+    // Show events if open
+    if (showEvents) {
+      return (
+        <>
+          <EventsWeb {...eventsProps} workspaceLabel={eventsWorkspaceLabel} />
           <FlowWeb flow={flow} />
           <Toaster theme="dark" position="top-right" richColors />
         </>

--- a/src/app.web.tsx
+++ b/src/app.web.tsx
@@ -558,11 +558,25 @@ export default function App() {
   // Events polling when events view is active
   useEffect(() => {
     if (!showEvents || !eventsWorkspacePath) return;
+
+    const activeFilter = eventsProps.activeFilterName
+      ? terminal.savedEventFilters.find((filter) => filter.name === eventsProps.activeFilterName) ?? null
+      : null;
+
     const interval = setInterval(() => {
-      terminal.requestEvents(eventsWorkspacePath);
+      if (activeFilter) {
+        terminal.requestEvents(
+          eventsWorkspacePath,
+          activeFilter.filter as WideEventFilter,
+          undefined,
+          activeFilter.sinceMinutes ? activeFilter.sinceMinutes * 60 * 1000 : undefined
+        );
+      } else {
+        terminal.requestEvents(eventsWorkspacePath);
+      }
     }, 2000);
     return () => clearInterval(interval);
-  }, [showEvents, eventsWorkspacePath, terminal.requestEvents]);
+  }, [showEvents, eventsWorkspacePath, eventsProps.activeFilterName, terminal.savedEventFilters, terminal.requestEvents]);
 
   // ========== Activity Tracking for Notifications ==========
 

--- a/src/app.web.tsx
+++ b/src/app.web.tsx
@@ -526,6 +526,8 @@ export default function App() {
 
   const handleStartProcessSelection = useCallback((params: { workspaceId: string; processName: string; instance?: number }) => {
     terminal.startProcess(params.workspaceId, params.processName, params.instance);
+    terminal.requestWorkspaces();
+    terminal.requestSessions();
   }, [terminal]);
 
   // Spaces browser hook

--- a/src/app.web.tsx
+++ b/src/app.web.tsx
@@ -85,6 +85,7 @@ export default function App() {
   const [localNotificationConfig, setLocalNotificationConfig] =
     useState<NotificationConfig | null>(null);
   const [isViewOnlySession, setIsViewOnlySession] = useState(false);
+  const pendingProcessEditWorkspacesRef = useRef<unknown[] | null>(null);
 
   // Terminal ref for external control (focus, sendData)
   const terminalRef = useRef<SessionTerminalHandle>(null);
@@ -307,6 +308,14 @@ export default function App() {
       return;
     }
 
+    if (
+      pendingProcessEditWorkspacesRef.current &&
+      pendingProcessEditWorkspacesRef.current === terminal.workspaces
+    ) {
+      return;
+    }
+    pendingProcessEditWorkspacesRef.current = null;
+
     const workspace = terminal.workspaces.find((item) => item.id === pendingProcessEditWorkspaceId);
     if (!workspace) {
       setPendingProcessEditWorkspaceId(null);
@@ -501,6 +510,7 @@ export default function App() {
   // Open editor on .gitspace/processes.json in the workspace
   const handleEditProcesses = useCallback(({ workspaceId }: { workspaceId: string }) => {
     setIsViewOnlySession(false);
+    pendingProcessEditWorkspacesRef.current = terminal.workspaces;
     setPendingProcessEditWorkspaceId(workspaceId);
     const commandSpec = buildEditProcessesCommand();
     void attachController.attach({
@@ -508,7 +518,11 @@ export default function App() {
       command: commandSpec.command,
       args: commandSpec.args,
     });
-  }, [attachController]);
+  }, [attachController, terminal.workspaces]);
+
+  const handleStartProcessSelection = useCallback((params: { workspaceId: string; processName: string; instance?: number }) => {
+    terminal.startProcess(params.workspaceId, params.processName, params.instance);
+  }, [terminal]);
 
   // Spaces browser hook
   const spacesBrowserProps = useSpacesBrowser({
@@ -517,12 +531,8 @@ export default function App() {
     onRequestSessions: () => terminal.requestSessions(),
     onAttachSession: handleAttachSession,
     onEditProcesses: handleEditProcesses,
-    onStartProcess: (params) => {
-      terminal.startProcess(params.workspaceId, params.processName);
-    },
-    onStartProcessAttach: (params) => {
-      terminal.startProcess(params.workspaceId, params.processName);
-    },
+    onStartProcess: (params) => handleStartProcessSelection(params),
+    onStartProcessAttach: (params) => handleStartProcessSelection(params),
     onStopProcess: (params) => {
       terminal.stopProcess(params.workspaceId, params.processName);
     },

--- a/src/app.web.tsx
+++ b/src/app.web.tsx
@@ -530,6 +530,12 @@ export default function App() {
     terminal.requestSessions();
   }, [terminal]);
 
+  const handleProcessDisabled = useCallback((params: { workspaceId: string; processName: string }) => {
+    const workspace = terminal.workspaces.find((item) => item.id === params.workspaceId);
+    const workspaceLabel = workspace?.name ?? params.workspaceId;
+    toast.error(`Process "${params.processName}" is disabled in ${workspaceLabel} (instances: 0).`);
+  }, [terminal.workspaces]);
+
   // Spaces browser hook
   const spacesBrowserProps = useSpacesBrowser({
     workspaces: terminal.workspaces,
@@ -544,6 +550,7 @@ export default function App() {
       terminal.requestWorkspaces();
       terminal.requestSessions();
     },
+    onProcessDisabled: handleProcessDisabled,
     onOpenEvents: (workspaceId) => {
       const workspace = terminal.workspaces.find(w => w.id === workspaceId);
       if (workspace) {

--- a/src/app.web.tsx
+++ b/src/app.web.tsx
@@ -528,6 +528,11 @@ export default function App() {
       workspaceId,
       command: commandSpec.command,
       args: commandSpec.args,
+    }).then((attached) => {
+      if (!attached) {
+        pendingProcessEditWorkspacesRef.current = null;
+        setPendingProcessEditWorkspaceId(null);
+      }
     });
   }, [attachController, terminal.workspaces]);
 

--- a/src/app.web.tsx
+++ b/src/app.web.tsx
@@ -36,9 +36,9 @@ import { SpacesBrowserWeb } from "./components/SpacesBrowser.web.js";
 import { FlowWeb } from "./components/Flow.web.js";
 import { useInbox } from "./components/Inbox.js";
 import { InboxWeb } from "./components/Inbox.web.js";
-import { useEvents, type WideEventItem } from "./components/Events.js";
+import { useEvents, toWideEventItem, type WideEventItem } from "./components/Events.js";
 import { EventsWeb } from "./components/Events.web.js";
-import type { WideEvent, WideEventFilter } from "./types/events.js";
+import type { WideEventFilter } from "./types/events.js";
 import {
   useNotifications,
   type ToastNotification,
@@ -541,6 +541,8 @@ export default function App() {
     onStartProcessAttach: (params) => handleStartProcessSelection(params),
     onStopProcess: (params) => {
       terminal.stopProcess(params.workspaceId, params.processName);
+      terminal.requestWorkspaces();
+      terminal.requestSessions();
     },
     onOpenEvents: (workspaceId) => {
       const workspace = terminal.workspaces.find(w => w.id === workspaceId);
@@ -572,23 +574,7 @@ export default function App() {
   });
 
   // Events hook
-  const eventsItems: WideEventItem[] = terminal.events.map((event: WideEvent) => ({
-    eventId: event.eventId,
-    eventName: event.eventName,
-    level: event.level,
-    timestamp: event.timestamp,
-    timestampMs: event.timestampMs,
-    message: event.message,
-    processName: event.processName,
-    processInstance: event.processInstance,
-    sessionId: event.sessionId,
-    raw: event.raw,
-    kind: event.kind,
-    correlationId: event.correlationId,
-    timeline: event.timeline,
-    timelineMap: event.timelineMap,
-    timelineOrder: event.timelineOrder,
-  }));
+  const eventsItems: WideEventItem[] = terminal.events.map(toWideEventItem);
 
   const eventsProps = useEvents({
     events: eventsItems,

--- a/src/app.web.tsx
+++ b/src/app.web.tsx
@@ -1142,11 +1142,19 @@ export default function App() {
         return;
       }
 
+      if (isViewOnlySession) {
+        return;
+      }
+
       terminal.send(new TextEncoder().encode(data));
     };
 
     // Handler for keyboard input - applies virtual modifiers then resets them
     const handleKeyboardData = (data: Uint8Array) => {
+      if (isViewOnlySession) {
+        return;
+      }
+
       const hasModifiers = modifiers.ctrl || modifiers.shift || modifiers.alt;
       if (hasModifiers) {
         // Apply modifiers and reset

--- a/src/app.web.tsx
+++ b/src/app.web.tsx
@@ -93,10 +93,15 @@ export default function App() {
     useState<NotificationConfig | null>(null);
   const [isViewOnlySession, setIsViewOnlySession] = useState(false);
   const pendingProcessEditWorkspacesRef = useRef<unknown[] | null>(null);
+  const pendingProcessAttachRef = useRef<PendingProcessAttachTarget | null>(null);
   const eventsKeyboardStateRef = useRef<{
     selectedIndex: number;
     selectIndex: (index: number) => void;
   } | null>(null);
+
+  useEffect(() => {
+    pendingProcessAttachRef.current = pendingProcessAttach;
+  }, [pendingProcessAttach]);
 
   // Terminal ref for external control (focus, sendData)
   const terminalRef = useRef<SessionTerminalHandle>(null);
@@ -628,20 +633,21 @@ export default function App() {
       return;
     }
 
-    const timeout = window.setTimeout(() => {
-      setPendingProcessAttach((current) => {
-        if (
-          !current ||
-          current.workspaceId !== pendingProcessAttach.workspaceId ||
-          current.processName !== pendingProcessAttach.processName ||
-          current.instance !== pendingProcessAttach.instance
-        ) {
-          return current;
-        }
+    const target = pendingProcessAttach;
 
-        toast.error(`Process started but no active session appeared for ${current.processName}#${current.instance}.`);
-        return null;
-      });
+    const timeout = window.setTimeout(() => {
+      const current = pendingProcessAttachRef.current;
+      if (
+        !current ||
+        current.workspaceId !== target.workspaceId ||
+        current.processName !== target.processName ||
+        current.instance !== target.instance
+      ) {
+        return;
+      }
+
+      setPendingProcessAttach(null);
+      toast.error(`Process started but no active session appeared for ${current.processName}#${current.instance}.`);
     }, 8000);
 
     return () => window.clearTimeout(timeout);

--- a/src/app/session/__tests__/useAttachController.test.ts
+++ b/src/app/session/__tests__/useAttachController.test.ts
@@ -124,6 +124,33 @@ describe('useAttachController', () => {
     )
   })
 
+  it('passes through viewOnly on existing session attaches', async () => {
+    const attachSessionWithBundleRefresh = mock(async () => true)
+
+    const { result } = renderHook(() =>
+      useAttachController({
+        flow: {
+          showInput: () => {},
+          showMessage: () => {},
+          close: () => {},
+        },
+        attachSessionWithBundleRefresh,
+      })
+    )
+
+    await result.current.attachFromSelection({ sessionId: 'session-view', viewOnly: true })
+
+    expect(attachSessionWithBundleRefresh).toHaveBeenCalledWith(
+      {
+        sessionId: 'session-view',
+        viewOnly: true,
+      },
+      {
+        projectName: null,
+      }
+    )
+  })
+
   it('runs lifecycle callbacks for cancelled and failed attach attempts', async () => {
     const onAttachCancelled = mock(() => {})
     const onAttachError = mock(() => {})

--- a/src/app/session/useAttachController.ts
+++ b/src/app/session/useAttachController.ts
@@ -8,6 +8,7 @@ import type {
 export interface AttachSelectionParams {
   sessionId?: string
   workspaceId?: string
+  viewOnly?: boolean
 }
 
 export type AttachTarget = 'session' | 'workspace'
@@ -182,7 +183,14 @@ export function useAttachController(options: UseAttachControllerOptions): UseAtt
         return
       }
 
-      await attach({ sessionId: selection.sessionId })
+      const attachParams: BundleRefreshAttachParams = {
+        sessionId: selection.sessionId,
+      }
+      if (selection.viewOnly !== undefined) {
+        attachParams.viewOnly = selection.viewOnly
+      }
+
+      await attach(attachParams)
       return
     }
 

--- a/src/app/session/useProcessActions.ts
+++ b/src/app/session/useProcessActions.ts
@@ -1,0 +1,201 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+export interface ProcessSessionInfo {
+  id: string
+  workspaceId: string
+  processName?: string
+  processInstance?: number
+  createdAt: number
+  exitCode?: number
+}
+
+export interface ProcessActionParams {
+  workspaceId: string
+  processName: string
+}
+
+export interface ProcessStartAttachParams extends ProcessActionParams {
+  instance?: number
+}
+
+export interface PendingProcessAttachTarget {
+  workspaceId: string
+  processName: string
+  instance: number
+}
+
+export interface UseProcessActionsOptions {
+  sessions: ProcessSessionInfo[]
+  startProcess: (workspaceId: string, processName: string, instance?: number) => Promise<void>
+  stopProcess: (workspaceId: string, processName: string) => Promise<void>
+  attachSession: (params: { sessionId?: string; workspaceId?: string; viewOnly?: boolean }) => Promise<void>
+  onStartProcessError?: (error: unknown) => void
+  onStopProcessError?: (error: unknown) => void
+  onStartProcessAttachError?: (error: unknown) => void
+  onAttachError?: (error: unknown) => void
+  onAttachTimeout?: (target: PendingProcessAttachTarget) => void
+  onStartProcessFinally?: () => void | Promise<void>
+  onStopProcessFinally?: () => void | Promise<void>
+  onStartProcessAttachFinally?: () => void | Promise<void>
+  pendingAttachCancelSignal?: unknown
+  attachTimeoutMs?: number
+}
+
+interface UseProcessActionsResult {
+  handleStartProcess: (params: ProcessActionParams) => void
+  handleStopProcess: (params: ProcessActionParams) => void
+  handleStartProcessAttach: (params: ProcessStartAttachParams) => void
+}
+
+function matchesTarget(
+  current: PendingProcessAttachTarget | null,
+  target: PendingProcessAttachTarget
+): boolean {
+  return Boolean(
+    current &&
+      current.workspaceId === target.workspaceId &&
+      current.processName === target.processName &&
+      current.instance === target.instance
+  )
+}
+
+export function useProcessActions(options: UseProcessActionsOptions): UseProcessActionsResult {
+  const {
+    sessions,
+    startProcess,
+    stopProcess,
+    attachSession,
+    onStartProcessError,
+    onStopProcessError,
+    onStartProcessAttachError,
+    onAttachError,
+    onAttachTimeout,
+    onStartProcessFinally,
+    onStopProcessFinally,
+    onStartProcessAttachFinally,
+    pendingAttachCancelSignal,
+    attachTimeoutMs = 8000,
+  } = options
+
+  const [pendingProcessAttach, setPendingProcessAttach] =
+    useState<PendingProcessAttachTarget | null>(null)
+  const pendingProcessAttachRef = useRef<PendingProcessAttachTarget | null>(null)
+
+  useEffect(() => {
+    pendingProcessAttachRef.current = pendingProcessAttach
+  }, [pendingProcessAttach])
+
+  const runFinally = useCallback((fn?: () => void | Promise<void>) => {
+    if (!fn) {
+      return
+    }
+    void Promise.resolve(fn()).catch(() => {})
+  }, [])
+
+  const handleStartProcess = useCallback((params: ProcessActionParams) => {
+    void Promise.resolve(startProcess(params.workspaceId, params.processName))
+      .catch((error) => {
+        onStartProcessError?.(error)
+      })
+      .finally(() => {
+        runFinally(onStartProcessFinally)
+      })
+  }, [onStartProcessError, onStartProcessFinally, runFinally, startProcess])
+
+  const handleStopProcess = useCallback((params: ProcessActionParams) => {
+    void Promise.resolve(stopProcess(params.workspaceId, params.processName))
+      .catch((error) => {
+        onStopProcessError?.(error)
+      })
+      .finally(() => {
+        runFinally(onStopProcessFinally)
+      })
+  }, [onStopProcessError, onStopProcessFinally, runFinally, stopProcess])
+
+  const handleStartProcessAttach = useCallback((params: ProcessStartAttachParams) => {
+    const target: PendingProcessAttachTarget = {
+      workspaceId: params.workspaceId,
+      processName: params.processName,
+      instance: params.instance ?? 1,
+    }
+
+    setPendingProcessAttach(target)
+    void Promise.resolve(startProcess(target.workspaceId, target.processName, target.instance))
+      .catch((error) => {
+        setPendingProcessAttach((current) =>
+          matchesTarget(current, target) ? null : current
+        )
+        const errorHandler = onStartProcessAttachError ?? onStartProcessError
+        errorHandler?.(error)
+      })
+      .finally(() => {
+        runFinally(onStartProcessAttachFinally)
+      })
+  }, [
+    onStartProcessAttachError,
+    onStartProcessAttachFinally,
+    onStartProcessError,
+    runFinally,
+    startProcess,
+  ])
+
+  useEffect(() => {
+    if (!pendingProcessAttach) {
+      return
+    }
+
+    const session = sessions
+      .filter((item) =>
+        item.workspaceId === pendingProcessAttach.workspaceId &&
+        item.processName === pendingProcessAttach.processName &&
+        (item.processInstance ?? 1) === pendingProcessAttach.instance &&
+        item.exitCode === undefined
+      )
+      .sort((a, b) => b.createdAt - a.createdAt)[0]
+
+    if (!session) {
+      return
+    }
+
+    const target = pendingProcessAttach
+    setPendingProcessAttach((current) =>
+      matchesTarget(current, target) ? null : current
+    )
+
+    void attachSession({ sessionId: session.id, viewOnly: true }).catch((error) => {
+      onAttachError?.(error)
+    })
+  }, [attachSession, onAttachError, pendingProcessAttach, sessions])
+
+  useEffect(() => {
+    if (!pendingProcessAttach) {
+      return
+    }
+
+    const target = pendingProcessAttach
+    const timeout = setTimeout(() => {
+      const current = pendingProcessAttachRef.current
+      if (!matchesTarget(current, target)) {
+        return
+      }
+
+      setPendingProcessAttach(null)
+      onAttachTimeout?.(target)
+    }, attachTimeoutMs)
+
+    return () => clearTimeout(timeout)
+  }, [attachTimeoutMs, onAttachTimeout, pendingProcessAttach])
+
+  useEffect(() => {
+    if (!pendingProcessAttach || !pendingAttachCancelSignal) {
+      return
+    }
+    setPendingProcessAttach(null)
+  }, [pendingAttachCancelSignal, pendingProcessAttach])
+
+  return {
+    handleStartProcess,
+    handleStopProcess,
+    handleStartProcessAttach,
+  }
+}

--- a/src/commands/__tests__/events.test.ts
+++ b/src/commands/__tests__/events.test.ts
@@ -2,7 +2,14 @@
  * Events command tests - validates error paths throw SpacesError with exit code 1
  */
 
-import { describe, expect, it, mock, beforeEach } from 'bun:test';
+import { describe, expect, it, mock, beforeEach, afterAll } from 'bun:test';
+import { mkdtempSync, mkdirSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import * as realConfig from '../../core/config.js';
+import * as realCli from '../../lib/tmux-lite/cli.js';
+import * as realEventPaths from '../../lib/events/paths.js';
+import * as realEventReader from '../../lib/events/reader.js';
 import { SpacesError } from '../../types/errors.js';
 
 // ============================================================================
@@ -10,46 +17,75 @@ import { SpacesError } from '../../types/errors.js';
 // ============================================================================
 
 // Mock config
-const mockGetCurrentProject = mock<() => string | null>(() => null);
+const mockGetCurrentProject = mock<() => string | null>(() => realConfig.getCurrentProject());
 mock.module('../../core/config.js', () => ({
+  ...realConfig,
   getCurrentProject: mockGetCurrentProject,
   getGitspaceDir: mock(() => '/tmp/gitspace'),
 }));
 
 // Mock tmux-lite CLI
 const mockListSessions = mock<() => Promise<Array<{ id: string; name: string; cwd: string }>>>(
-  () => Promise.resolve([])
+  () => realCli.listSessions()
 );
 mock.module('../../lib/tmux-lite/cli.js', () => ({
+  ...realCli,
   listSessions: mockListSessions,
 }));
 
 // Mock events paths
 const mockGetProcessEventsDir = mock<(workspacePath: string, processName: string) => string>(
-  () => '/tmp/events/processes/web-1'
+  (workspacePath: string, processName: string) =>
+    realEventPaths.getProcessEventsDir(workspacePath, processName)
 );
-const mockListProcessEventsDirs = mock<(workspacePath: string) => string[]>(() => []);
+const mockListProcessEventsDirs = mock<(workspacePath: string) => string[]>(
+  (workspacePath: string) => realEventPaths.listProcessEventsDirs(workspacePath)
+);
 mock.module('../../lib/events/paths.js', () => ({
+  ...realEventPaths,
   getProcessEventsDir: mockGetProcessEventsDir,
   listProcessEventsDirs: mockListProcessEventsDirs,
 }));
 
 // Mock events reader
-const mockReadWideEvents = mock<(...args: unknown[]) => unknown[]>(() => []);
+const mockReadWideEvents = mock<(...args: unknown[]) => unknown[]>((...args: unknown[]) =>
+  realEventReader.readWideEvents(...args as Parameters<typeof realEventReader.readWideEvents>)
+);
 mock.module('../../lib/events/reader.js', () => ({
+  ...realEventReader,
   readWideEvents: mockReadWideEvents,
 }));
 
-// Mock fs.existsSync
-const mockExistsSync = mock<(path: string) => boolean>(() => false);
-mock.module('fs', () => ({
-  existsSync: mockExistsSync,
-  // Re-export defaults that other modules may need
-  readFileSync: mock(() => ''),
-  writeFileSync: mock(() => {}),
-  mkdirSync: mock(() => {}),
-  readdirSync: mock(() => []),
-}));
+const tempDirs: string[] = [];
+
+function makeTempEventsDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'gssh-events-cmd-'));
+  tempDirs.push(dir);
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+afterAll(() => {
+  mock.module('../../core/config.js', () => ({
+    ...realConfig,
+  }));
+  mock.module('../../lib/tmux-lite/cli.js', () => ({
+    ...realCli,
+  }));
+  mock.module('../../lib/events/paths.js', () => ({
+    ...realEventPaths,
+  }));
+  mock.module('../../lib/events/reader.js', () => ({
+    ...realEventReader,
+  }));
+
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop();
+    if (dir) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }
+});
 
 // Import after mocking
 const { listEvents, showEvent, tailEvents } = await import('../events.js');
@@ -126,7 +162,6 @@ describe('events: no events directory', () => {
       Promise.resolve([{ id: 'sess-1', name: 'my-session', cwd: '/tmp/workspace' }])
     );
     mockListProcessEventsDirs.mockImplementation(() => []);
-    mockExistsSync.mockImplementation(() => false);
   });
 
   it('listEvents should throw SpacesError when no events dir found', async () => {
@@ -174,13 +209,15 @@ describe('showEvent', () => {
 // ============================================================================
 
 describe('events: happy path', () => {
+  let eventsDir = '';
+
   beforeEach(() => {
+    eventsDir = makeTempEventsDir();
     mockGetCurrentProject.mockImplementation(() => 'my-project');
     mockListSessions.mockImplementation(() =>
       Promise.resolve([{ id: 'sess-1', name: 'my-session', cwd: '/tmp/workspace' }])
     );
-    mockListProcessEventsDirs.mockImplementation(() => ['/tmp/workspace/.events/processes/web-1']);
-    mockExistsSync.mockImplementation(() => true);
+    mockListProcessEventsDirs.mockImplementation(() => [eventsDir]);
     mockReadWideEvents.mockReset();
   });
 

--- a/src/commands/__tests__/events.test.ts
+++ b/src/commands/__tests__/events.test.ts
@@ -1,0 +1,209 @@
+/**
+ * Events command tests - validates error paths throw SpacesError with exit code 1
+ */
+
+import { describe, expect, it, mock, beforeEach } from 'bun:test';
+import { SpacesError } from '../../types/errors.js';
+
+// ============================================================================
+// Mocks
+// ============================================================================
+
+// Mock config
+const mockGetCurrentProject = mock<() => string | null>(() => null);
+mock.module('../../core/config.js', () => ({
+  getCurrentProject: mockGetCurrentProject,
+  getGitspaceDir: mock(() => '/tmp/gitspace'),
+}));
+
+// Mock tmux-lite CLI
+const mockListSessions = mock<() => Promise<Array<{ id: string; name: string; cwd: string }>>>(
+  () => Promise.resolve([])
+);
+mock.module('../../lib/tmux-lite/cli.js', () => ({
+  listSessions: mockListSessions,
+}));
+
+// Mock events paths
+const mockGetProcessEventsDir = mock<(workspacePath: string, processName: string) => string>(
+  () => '/tmp/events/processes/web-1'
+);
+const mockListProcessEventsDirs = mock<(workspacePath: string) => string[]>(() => []);
+mock.module('../../lib/events/paths.js', () => ({
+  getProcessEventsDir: mockGetProcessEventsDir,
+  listProcessEventsDirs: mockListProcessEventsDirs,
+}));
+
+// Mock events reader
+const mockReadWideEvents = mock<(...args: unknown[]) => unknown[]>(() => []);
+mock.module('../../lib/events/reader.js', () => ({
+  readWideEvents: mockReadWideEvents,
+}));
+
+// Mock fs.existsSync
+const mockExistsSync = mock<(path: string) => boolean>(() => false);
+mock.module('fs', () => ({
+  existsSync: mockExistsSync,
+  // Re-export defaults that other modules may need
+  readFileSync: mock(() => ''),
+  writeFileSync: mock(() => {}),
+  mkdirSync: mock(() => {}),
+  readdirSync: mock(() => []),
+}));
+
+// Import after mocking
+const { listEvents, showEvent, tailEvents } = await import('../events.js');
+
+// ============================================================================
+// resolveEventsDir errors (shared by listEvents, showEvent, tailEvents)
+// ============================================================================
+
+describe('events: no current project', () => {
+  beforeEach(() => {
+    mockGetCurrentProject.mockImplementation(() => null);
+  });
+
+  it('listEvents should throw SpacesError when no current project', async () => {
+    try {
+      await listEvents({});
+      expect.unreachable('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(SpacesError);
+      expect((err as SpacesError).exitCode).toBe(1);
+      expect((err as SpacesError).code).toBe('USER_ERROR');
+      expect((err as SpacesError).message).toContain('No current project');
+    }
+  });
+
+  it('tailEvents should throw SpacesError when no current project', async () => {
+    try {
+      await tailEvents({});
+      expect.unreachable('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(SpacesError);
+      expect((err as SpacesError).exitCode).toBe(1);
+    }
+  });
+});
+
+describe('events: session not found', () => {
+  beforeEach(() => {
+    mockGetCurrentProject.mockImplementation(() => 'my-project');
+    mockListSessions.mockImplementation(() => Promise.resolve([]));
+  });
+
+  it('listEvents should throw SpacesError when no sessions exist', async () => {
+    try {
+      await listEvents({});
+      expect.unreachable('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(SpacesError);
+      expect((err as SpacesError).exitCode).toBe(1);
+      expect((err as SpacesError).message).toContain('Session not found');
+    }
+  });
+
+  it('listEvents should throw SpacesError when named session does not exist', async () => {
+    mockListSessions.mockImplementation(() =>
+      Promise.resolve([{ id: 'sess-1', name: 'other-session', cwd: '/tmp/ws' }])
+    );
+
+    try {
+      await listEvents({ session: 'nonexistent' });
+      expect.unreachable('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(SpacesError);
+      expect((err as SpacesError).exitCode).toBe(1);
+      expect((err as SpacesError).message).toContain('Session not found');
+    }
+  });
+});
+
+describe('events: no events directory', () => {
+  beforeEach(() => {
+    mockGetCurrentProject.mockImplementation(() => 'my-project');
+    mockListSessions.mockImplementation(() =>
+      Promise.resolve([{ id: 'sess-1', name: 'my-session', cwd: '/tmp/workspace' }])
+    );
+    mockListProcessEventsDirs.mockImplementation(() => []);
+    mockExistsSync.mockImplementation(() => false);
+  });
+
+  it('listEvents should throw SpacesError when no events dir found', async () => {
+    try {
+      await listEvents({});
+      expect.unreachable('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(SpacesError);
+      expect((err as SpacesError).exitCode).toBe(1);
+      expect((err as SpacesError).message).toContain('No process events directory');
+    }
+  });
+});
+
+// ============================================================================
+// showEvent specific validations
+// ============================================================================
+
+describe('showEvent', () => {
+  it('should throw SpacesError when no eventId filter provided', async () => {
+    try {
+      await showEvent({});
+      expect.unreachable('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(SpacesError);
+      expect((err as SpacesError).exitCode).toBe(1);
+      expect((err as SpacesError).message).toContain('eventId');
+    }
+  });
+
+  it('should throw SpacesError when filter is not eventId-prefixed', async () => {
+    try {
+      await showEvent({ filter: 'level=error' });
+      expect.unreachable('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(SpacesError);
+      expect((err as SpacesError).exitCode).toBe(1);
+      expect((err as SpacesError).message).toContain('eventId');
+    }
+  });
+});
+
+// ============================================================================
+// Happy path with mocked events dir
+// ============================================================================
+
+describe('events: happy path', () => {
+  beforeEach(() => {
+    mockGetCurrentProject.mockImplementation(() => 'my-project');
+    mockListSessions.mockImplementation(() =>
+      Promise.resolve([{ id: 'sess-1', name: 'my-session', cwd: '/tmp/workspace' }])
+    );
+    mockListProcessEventsDirs.mockImplementation(() => ['/tmp/workspace/.events/processes/web-1']);
+    mockExistsSync.mockImplementation(() => true);
+    mockReadWideEvents.mockReset();
+  });
+
+  it('listEvents should succeed when events dir exists', async () => {
+    mockReadWideEvents.mockImplementation(() => []);
+
+    // Should not throw
+    await listEvents({});
+  });
+
+  it('listEvents should output events as JSON', async () => {
+    const fakeEvent = { eventId: 'evt-1', eventName: 'test', timestamp: Date.now() };
+    mockReadWideEvents.mockImplementation(() => [fakeEvent]);
+
+    // Should not throw
+    await listEvents({});
+
+    expect(mockReadWideEvents).toHaveBeenCalledTimes(1);
+  });
+
+  it('tailEvents should succeed when events dir exists', async () => {
+    mockReadWideEvents.mockImplementation(() => []);
+
+    await tailEvents({});
+  });
+});

--- a/src/commands/__tests__/events.test.ts
+++ b/src/commands/__tests__/events.test.ts
@@ -1,5 +1,5 @@
 /**
- * Events command tests - validates error paths throw SpacesError with exit code 1
+ * Events command tests
  */
 
 import { describe, expect, it, mock, beforeEach, afterAll } from 'bun:test';
@@ -7,33 +7,29 @@ import { mkdtempSync, mkdirSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import * as realConfig from '../../core/config.js';
-import * as realCli from '../../lib/tmux-lite/cli.js';
 import * as realEventPaths from '../../lib/events/paths.js';
 import * as realEventReader from '../../lib/events/reader.js';
 import { SpacesError } from '../../types/errors.js';
 
-// ============================================================================
-// Mocks
-// ============================================================================
+const tempDirs: string[] = [];
 
-// Mock config
-const mockGetCurrentProject = mock<() => string | null>(() => realConfig.getCurrentProject());
+function makeTempDir(prefix: string): string {
+  const dir = mkdtempSync(join(tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}
+
+let baseDir = makeTempDir('gssh-events-base-');
+
+const mockGetProjectWorkspacesDir = mock<(projectName: string) => string>((projectName: string) =>
+  join(baseDir, projectName, 'workspaces')
+);
+
 mock.module('../../core/config.js', () => ({
   ...realConfig,
-  getCurrentProject: mockGetCurrentProject,
-  getGitspaceDir: mock(() => '/tmp/gitspace'),
+  getProjectWorkspacesDir: mockGetProjectWorkspacesDir,
 }));
 
-// Mock tmux-lite CLI
-const mockListSessions = mock<() => Promise<Array<{ id: string; name: string; cwd: string }>>>(
-  () => realCli.listSessions()
-);
-mock.module('../../lib/tmux-lite/cli.js', () => ({
-  ...realCli,
-  listSessions: mockListSessions,
-}));
-
-// Mock events paths
 const mockGetProcessEventsDir = mock<(workspacePath: string, processName: string) => string>(
   (workspacePath: string, processName: string) =>
     realEventPaths.getProcessEventsDir(workspacePath, processName)
@@ -41,44 +37,31 @@ const mockGetProcessEventsDir = mock<(workspacePath: string, processName: string
 const mockListProcessEventsDirs = mock<(workspacePath: string) => string[]>(
   (workspacePath: string) => realEventPaths.listProcessEventsDirs(workspacePath)
 );
+
 mock.module('../../lib/events/paths.js', () => ({
   ...realEventPaths,
   getProcessEventsDir: mockGetProcessEventsDir,
   listProcessEventsDirs: mockListProcessEventsDirs,
 }));
 
-// Mock events reader
 const mockReadWideEvents = mock<(...args: unknown[]) => unknown[]>((...args: unknown[]) =>
-  realEventReader.readWideEvents(...args as Parameters<typeof realEventReader.readWideEvents>)
+  realEventReader.readWideEvents(...(args as Parameters<typeof realEventReader.readWideEvents>))
 );
+
 mock.module('../../lib/events/reader.js', () => ({
   ...realEventReader,
   readWideEvents: mockReadWideEvents,
 }));
 
-const tempDirs: string[] = [];
+const { listEvents, showEvent, tailEvents } = await import('../events.js');
 
-function makeTempEventsDir(): string {
-  const dir = mkdtempSync(join(tmpdir(), 'gssh-events-cmd-'));
-  tempDirs.push(dir);
-  mkdirSync(dir, { recursive: true });
-  return dir;
+function makeWorkspace(projectName: string, workspaceName: string): string {
+  const workspacePath = join(mockGetProjectWorkspacesDir(projectName), workspaceName);
+  mkdirSync(workspacePath, { recursive: true });
+  return workspacePath;
 }
 
 afterAll(() => {
-  mock.module('../../core/config.js', () => ({
-    ...realConfig,
-  }));
-  mock.module('../../lib/tmux-lite/cli.js', () => ({
-    ...realCli,
-  }));
-  mock.module('../../lib/events/paths.js', () => ({
-    ...realEventPaths,
-  }));
-  mock.module('../../lib/events/reader.js', () => ({
-    ...realEventReader,
-  }));
-
   while (tempDirs.length > 0) {
     const dir = tempDirs.pop();
     if (dir) {
@@ -87,160 +70,119 @@ afterAll(() => {
   }
 });
 
-// Import after mocking
-const { listEvents, showEvent, tailEvents } = await import('../events.js');
+beforeEach(() => {
+  baseDir = makeTempDir('gssh-events-base-');
+  mockGetProcessEventsDir.mockReset();
+  mockListProcessEventsDirs.mockReset();
+  mockReadWideEvents.mockReset();
+  mockGetProjectWorkspacesDir.mockImplementation((projectName: string) =>
+    join(baseDir, projectName, 'workspaces')
+  );
+  mockListProcessEventsDirs.mockImplementation(() => []);
+  mockReadWideEvents.mockImplementation(() => []);
+});
 
-// ============================================================================
-// resolveEventsDir errors (shared by listEvents, showEvent, tailEvents)
-// ============================================================================
-
-describe('events: no current project', () => {
-  beforeEach(() => {
-    mockGetCurrentProject.mockImplementation(() => null);
-  });
-
-  it('listEvents should throw SpacesError when no current project', async () => {
+describe('events command requires explicit project/workspace', () => {
+  it('throws when --project is missing', async () => {
     try {
-      await listEvents({});
-      expect.unreachable('should have thrown');
+      await listEvents({ workspace: 'ws-1' });
+      expect.unreachable('should throw');
     } catch (err) {
       expect(err).toBeInstanceOf(SpacesError);
-      expect((err as SpacesError).exitCode).toBe(1);
-      expect((err as SpacesError).code).toBe('USER_ERROR');
-      expect((err as SpacesError).message).toContain('No current project');
+      expect((err as SpacesError).message).toContain('Provide project');
     }
   });
 
-  it('tailEvents should throw SpacesError when no current project', async () => {
+  it('throws when --workspace is missing', async () => {
     try {
-      await tailEvents({});
-      expect.unreachable('should have thrown');
+      await listEvents({ project: 'my-project' });
+      expect.unreachable('should throw');
     } catch (err) {
       expect(err).toBeInstanceOf(SpacesError);
-      expect((err as SpacesError).exitCode).toBe(1);
+      expect((err as SpacesError).message).toContain('Provide workspace');
+    }
+  });
+
+  it('throws when explicit workspace does not exist', async () => {
+    try {
+      await listEvents({ project: 'my-project', workspace: 'missing-ws' });
+      expect.unreachable('should throw');
+    } catch (err) {
+      expect(err).toBeInstanceOf(SpacesError);
+      expect((err as SpacesError).message).toContain('Workspace not found');
     }
   });
 });
 
-describe('events: session not found', () => {
-  beforeEach(() => {
-    mockGetCurrentProject.mockImplementation(() => 'my-project');
-    mockListSessions.mockImplementation(() => Promise.resolve([]));
-  });
-
-  it('listEvents should throw SpacesError when no sessions exist', async () => {
-    try {
-      await listEvents({});
-      expect.unreachable('should have thrown');
-    } catch (err) {
-      expect(err).toBeInstanceOf(SpacesError);
-      expect((err as SpacesError).exitCode).toBe(1);
-      expect((err as SpacesError).message).toContain('No active sessions found');
-    }
-  });
-
-  it('listEvents should throw SpacesError when named session does not exist', async () => {
-    mockListSessions.mockImplementation(() =>
-      Promise.resolve([{ id: 'sess-1', name: 'other-session', cwd: '/tmp/ws' }])
-    );
-
-    try {
-      await listEvents({ session: 'nonexistent' });
-      expect.unreachable('should have thrown');
-    } catch (err) {
-      expect(err).toBeInstanceOf(SpacesError);
-      expect((err as SpacesError).exitCode).toBe(1);
-      expect((err as SpacesError).message).toContain('Session not found');
-    }
-  });
-});
-
-describe('events: no events directory', () => {
-  beforeEach(() => {
-    mockGetCurrentProject.mockImplementation(() => 'my-project');
-    mockListSessions.mockImplementation(() =>
-      Promise.resolve([{ id: 'sess-1', name: 'my-session', cwd: '/tmp/workspace' }])
-    );
+describe('events command directory resolution', () => {
+  it('throws when no process events directory exists', async () => {
+    makeWorkspace('my-project', 'ws-1');
     mockListProcessEventsDirs.mockImplementation(() => []);
-  });
 
-  it('listEvents should throw SpacesError when no events dir found', async () => {
     try {
-      await listEvents({});
-      expect.unreachable('should have thrown');
+      await listEvents({ project: 'my-project', workspace: 'ws-1' });
+      expect.unreachable('should throw');
     } catch (err) {
       expect(err).toBeInstanceOf(SpacesError);
-      expect((err as SpacesError).exitCode).toBe(1);
       expect((err as SpacesError).message).toContain('No process events directory');
     }
   });
+
+  it('uses processName filter to resolve process-specific events dir', async () => {
+    const workspacePath = makeWorkspace('my-project', 'ws-1');
+    const eventsDir = makeTempDir('gssh-events-dir-');
+    mockGetProcessEventsDir.mockImplementation(() => eventsDir);
+
+    await listEvents({
+      project: 'my-project',
+      workspace: 'ws-1',
+      filter: 'processName=web',
+    });
+
+    expect(mockGetProcessEventsDir).toHaveBeenCalledWith(workspacePath, 'web');
+  });
 });
 
-// ============================================================================
-// showEvent specific validations
-// ============================================================================
-
-describe('showEvent', () => {
-  it('should throw SpacesError when no eventId filter provided', async () => {
+describe('showEvent validations', () => {
+  it('throws when eventId filter is missing', async () => {
     try {
-      await showEvent({});
-      expect.unreachable('should have thrown');
+      await showEvent({ project: 'my-project', workspace: 'ws-1' });
+      expect.unreachable('should throw');
     } catch (err) {
       expect(err).toBeInstanceOf(SpacesError);
-      expect((err as SpacesError).exitCode).toBe(1);
       expect((err as SpacesError).message).toContain('eventId');
     }
   });
 
-  it('should throw SpacesError when filter is not eventId-prefixed', async () => {
+  it('throws when filter is not eventId-prefixed', async () => {
     try {
-      await showEvent({ filter: 'level=error' });
-      expect.unreachable('should have thrown');
+      await showEvent({ project: 'my-project', workspace: 'ws-1', filter: 'level=error' });
+      expect.unreachable('should throw');
     } catch (err) {
       expect(err).toBeInstanceOf(SpacesError);
-      expect((err as SpacesError).exitCode).toBe(1);
       expect((err as SpacesError).message).toContain('eventId');
     }
   });
 });
 
-// ============================================================================
-// Happy path with mocked events dir
-// ============================================================================
-
-describe('events: happy path', () => {
-  let eventsDir = '';
-
-  beforeEach(() => {
-    eventsDir = makeTempEventsDir();
-    mockGetCurrentProject.mockImplementation(() => 'my-project');
-    mockListSessions.mockImplementation(() =>
-      Promise.resolve([{ id: 'sess-1', name: 'my-session', cwd: '/tmp/workspace' }])
-    );
+describe('events command happy path', () => {
+  it('listEvents succeeds when events dir exists', async () => {
+    makeWorkspace('my-project', 'ws-1');
+    const eventsDir = makeTempDir('gssh-events-dir-');
     mockListProcessEventsDirs.mockImplementation(() => [eventsDir]);
-    mockReadWideEvents.mockReset();
-  });
-
-  it('listEvents should succeed when events dir exists', async () => {
     mockReadWideEvents.mockImplementation(() => []);
 
-    // Should not throw
-    await listEvents({});
-  });
-
-  it('listEvents should output events as JSON', async () => {
-    const fakeEvent = { eventId: 'evt-1', eventName: 'test', timestamp: Date.now() };
-    mockReadWideEvents.mockImplementation(() => [fakeEvent]);
-
-    // Should not throw
-    await listEvents({});
-
+    await listEvents({ project: 'my-project', workspace: 'ws-1' });
     expect(mockReadWideEvents).toHaveBeenCalledTimes(1);
   });
 
-  it('tailEvents should succeed when events dir exists', async () => {
+  it('tailEvents succeeds when events dir exists', async () => {
+    makeWorkspace('my-project', 'ws-1');
+    const eventsDir = makeTempDir('gssh-events-dir-');
+    mockListProcessEventsDirs.mockImplementation(() => [eventsDir]);
     mockReadWideEvents.mockImplementation(() => []);
 
-    await tailEvents({});
+    await tailEvents({ project: 'my-project', workspace: 'ws-1' });
+    expect(mockReadWideEvents).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/commands/__tests__/events.test.ts
+++ b/src/commands/__tests__/events.test.ts
@@ -99,7 +99,7 @@ describe('events: session not found', () => {
     } catch (err) {
       expect(err).toBeInstanceOf(SpacesError);
       expect((err as SpacesError).exitCode).toBe(1);
-      expect((err as SpacesError).message).toContain('Session not found');
+      expect((err as SpacesError).message).toContain('No active sessions found');
     }
   });
 

--- a/src/commands/__tests__/events.test.ts
+++ b/src/commands/__tests__/events.test.ts
@@ -141,6 +141,19 @@ describe('events command directory resolution', () => {
 
     expect(mockGetProcessEventsDir).toHaveBeenCalledWith(workspacePath, 'web');
   });
+
+  it('aggregates events across all process dirs when processName is not provided', async () => {
+    makeWorkspace('my-project', 'ws-1');
+    const eventsDirA = makeTempDir('gssh-events-dir-a-');
+    const eventsDirB = makeTempDir('gssh-events-dir-b-');
+    mockListProcessEventsDirs.mockImplementation(() => [eventsDirA, eventsDirB]);
+
+    await listEvents({ project: 'my-project', workspace: 'ws-1' });
+
+    expect(mockReadWideEvents).toHaveBeenCalledTimes(2);
+    expect(mockReadWideEvents).toHaveBeenCalledWith({ eventsDir: eventsDirA, filter: {} });
+    expect(mockReadWideEvents).toHaveBeenCalledWith({ eventsDir: eventsDirB, filter: {} });
+  });
 });
 
 describe('showEvent validations', () => {

--- a/src/commands/__tests__/process.test.ts
+++ b/src/commands/__tests__/process.test.ts
@@ -1,0 +1,225 @@
+/**
+ * Process command tests - validates error paths throw SpacesError with exit code 1
+ */
+
+import { describe, expect, it, mock, beforeEach } from 'bun:test';
+import { SpacesError } from '../../types/errors.js';
+import type { ProcessInstanceSpec } from '../../types/processes.js';
+
+// ============================================================================
+// Mocks
+// ============================================================================
+
+// Mock tmux-lite CLI
+const mockListSessions = mock<() => Promise<Array<{ id: string; name: string; cwd: string }>>>(
+  () => Promise.resolve([])
+);
+mock.module('../../lib/tmux-lite/cli.js', () => ({
+  listSessions: mockListSessions,
+  createSession: mock(() => Promise.resolve({ id: 'sess-1', name: 'test' })),
+  killSession: mock(() => Promise.resolve()),
+}));
+
+// Mock process manager
+const mockGetProcessSpecs = mock<(workspacePath: string) => ProcessInstanceSpec[]>(() => []);
+const mockStartProcessInstance = mock(() => Promise.resolve({ sessionId: 'sess-1', created: true }));
+const mockStopProcessInstance = mock(() => Promise.resolve());
+const mockListProcessSessions = mock<
+  () => Promise<Array<{ sessionId: string; processName: string; instance: number; name: string; workspacePath: string }>>
+>(() => Promise.resolve([]));
+
+mock.module('../../lib/processes/manager.js', () => ({
+  getProcessSpecs: mockGetProcessSpecs,
+  startProcessInstance: mockStartProcessInstance,
+  stopProcessInstance: mockStopProcessInstance,
+  listProcessSessions: mockListProcessSessions,
+}));
+
+// Import after mocking
+const { listProcesses, startProcess, stopProcess, attachProcess } = await import('../process.js');
+
+// ============================================================================
+// startProcess
+// ============================================================================
+
+describe('startProcess', () => {
+  beforeEach(() => {
+    mockGetProcessSpecs.mockReset();
+    mockStartProcessInstance.mockReset();
+  });
+
+  it('should throw SpacesError with exit code 1 when --name is missing', async () => {
+    try {
+      await startProcess({});
+      expect.unreachable('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(SpacesError);
+      expect((err as SpacesError).exitCode).toBe(1);
+      expect((err as SpacesError).code).toBe('USER_ERROR');
+      expect((err as SpacesError).message).toContain('--name');
+    }
+  });
+
+  it('should throw SpacesError when process name is not found in specs', async () => {
+    mockGetProcessSpecs.mockImplementation(() => []);
+
+    try {
+      await startProcess({ name: 'nonexistent' });
+      expect.unreachable('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(SpacesError);
+      expect((err as SpacesError).exitCode).toBe(1);
+      expect((err as SpacesError).message).toContain('nonexistent');
+    }
+  });
+
+  it('should start process when spec exists', async () => {
+    const spec: ProcessInstanceSpec = {
+      name: 'web',
+      instance: 1,
+      definition: { name: 'web', command: 'npm start' },
+    };
+    mockGetProcessSpecs.mockImplementation(() => [spec]);
+    mockStartProcessInstance.mockResolvedValue({ sessionId: 'sess-1', created: true });
+
+    // Should not throw
+    await startProcess({ name: 'web' });
+
+    expect(mockStartProcessInstance).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ============================================================================
+// stopProcess
+// ============================================================================
+
+describe('stopProcess', () => {
+  beforeEach(() => {
+    mockGetProcessSpecs.mockReset();
+    mockStopProcessInstance.mockReset();
+  });
+
+  it('should throw SpacesError with exit code 1 when --name is missing', async () => {
+    try {
+      await stopProcess({});
+      expect.unreachable('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(SpacesError);
+      expect((err as SpacesError).exitCode).toBe(1);
+      expect((err as SpacesError).message).toContain('--name');
+    }
+  });
+
+  it('should throw SpacesError when process name is not found', async () => {
+    mockGetProcessSpecs.mockImplementation(() => []);
+
+    try {
+      await stopProcess({ name: 'nonexistent' });
+      expect.unreachable('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(SpacesError);
+      expect((err as SpacesError).exitCode).toBe(1);
+      expect((err as SpacesError).message).toContain('nonexistent');
+    }
+  });
+
+  it('should stop process when spec exists', async () => {
+    const spec: ProcessInstanceSpec = {
+      name: 'web',
+      instance: 1,
+      definition: { name: 'web', command: 'npm start' },
+    };
+    mockGetProcessSpecs.mockImplementation(() => [spec]);
+    mockStopProcessInstance.mockResolvedValue(undefined);
+
+    await stopProcess({ name: 'web' });
+
+    expect(mockStopProcessInstance).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ============================================================================
+// attachProcess
+// ============================================================================
+
+describe('attachProcess', () => {
+  beforeEach(() => {
+    mockListProcessSessions.mockReset();
+    mockListSessions.mockReset();
+  });
+
+  it('should throw SpacesError with exit code 1 when --name is missing', async () => {
+    try {
+      await attachProcess({});
+      expect.unreachable('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(SpacesError);
+      expect((err as SpacesError).exitCode).toBe(1);
+      expect((err as SpacesError).message).toContain('--name');
+    }
+  });
+
+  it('should throw SpacesError when process is not running', async () => {
+    mockListProcessSessions.mockImplementation(() => Promise.resolve([]));
+
+    try {
+      await attachProcess({ name: 'web' });
+      expect.unreachable('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(SpacesError);
+      expect((err as SpacesError).exitCode).toBe(1);
+      expect((err as SpacesError).message).toContain('not running');
+    }
+  });
+
+  it('should throw SYSTEM_ERROR when session is not found in tmux', async () => {
+    mockListProcessSessions.mockImplementation(() =>
+      Promise.resolve([
+        { sessionId: 'sess-99', processName: 'web', instance: 1, name: 'proc:ws:web:1', workspacePath: '/tmp' },
+      ])
+    );
+    mockListSessions.mockImplementation(() => Promise.resolve([]));
+
+    try {
+      await attachProcess({ name: 'web' });
+      expect.unreachable('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(SpacesError);
+      expect((err as SpacesError).exitCode).toBe(2);
+      expect((err as SpacesError).code).toBe('SYSTEM_ERROR');
+    }
+  });
+
+  it('should succeed when process is running and session exists', async () => {
+    mockListProcessSessions.mockImplementation(() =>
+      Promise.resolve([
+        { sessionId: 'sess-1', processName: 'web', instance: 1, name: 'proc:ws:web:1', workspacePath: '/tmp' },
+      ])
+    );
+    mockListSessions.mockImplementation(() =>
+      Promise.resolve([{ id: 'sess-1', name: 'proc:ws:web:1', cwd: '/tmp' }])
+    );
+
+    // Should not throw
+    await attachProcess({ name: 'web' });
+  });
+});
+
+// ============================================================================
+// listProcesses (no error paths, just smoke test)
+// ============================================================================
+
+describe('listProcesses', () => {
+  beforeEach(() => {
+    mockGetProcessSpecs.mockReset();
+    mockListProcessSessions.mockReset();
+  });
+
+  it('should not throw when no processes are configured', async () => {
+    mockGetProcessSpecs.mockImplementation(() => []);
+    mockListProcessSessions.mockImplementation(() => Promise.resolve([]));
+
+    // Should not throw
+    await listProcesses({});
+  });
+});

--- a/src/commands/__tests__/process.test.ts
+++ b/src/commands/__tests__/process.test.ts
@@ -5,6 +5,9 @@
 import { describe, expect, it, mock, beforeEach } from 'bun:test';
 import { SpacesError } from '../../types/errors.js';
 import type { ProcessInstanceSpec } from '../../types/processes.js';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
 
 // ============================================================================
 // Mocks
@@ -86,6 +89,29 @@ describe('startProcess', () => {
     await startProcess({ name: 'web' });
 
     expect(mockStartProcessInstance).toHaveBeenCalledTimes(1);
+  });
+
+  it('should throw disabled error when process exists with instances: 0', async () => {
+    mockGetProcessSpecs.mockImplementation(() => []);
+    const workspacePath = mkdtempSync(join(tmpdir(), 'gssh-process-test-'));
+    const gitspaceDir = join(workspacePath, '.gitspace');
+    mkdirSync(gitspaceDir, { recursive: true });
+    writeFileSync(
+      join(gitspaceDir, 'processes.json'),
+      JSON.stringify({ processes: [{ name: 'web', command: 'npm start', instances: 0 }] }),
+      'utf-8'
+    );
+
+    try {
+      await startProcess({ name: 'web', workspace: workspacePath });
+      expect.unreachable('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(SpacesError);
+      expect((err as SpacesError).exitCode).toBe(1);
+      expect((err as SpacesError).message).toContain('Process is disabled');
+    } finally {
+      rmSync(workspacePath, { recursive: true, force: true });
+    }
   });
 });
 

--- a/src/commands/__tests__/serve-process-hosting.test.ts
+++ b/src/commands/__tests__/serve-process-hosting.test.ts
@@ -4,11 +4,10 @@
 
 import { describe, expect, test } from "bun:test";
 import {
-  buildProcessHostname,
   buildServeIngressConfig,
-  normalizeHostLabel,
   type ProcessHostEntry,
 } from "../serve";
+import { buildProcessHostname, normalizeHostLabel } from "../../utils/hostnames";
 
 describe("process hosting helpers", () => {
   test("normalizeHostLabel cleans and lowercases", () => {

--- a/src/commands/__tests__/serve-process-hosting.test.ts
+++ b/src/commands/__tests__/serve-process-hosting.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Serve process hosting helpers tests
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+  buildProcessHostname,
+  buildServeIngressConfig,
+  normalizeHostLabel,
+  type ProcessHostEntry,
+} from "../serve";
+
+describe("process hosting helpers", () => {
+  test("normalizeHostLabel cleans and lowercases", () => {
+    expect(normalizeHostLabel("My App")).toBe("my-app");
+    expect(normalizeHostLabel("API__Server")).toBe("api-server");
+    expect(normalizeHostLabel("---")).toBe("x");
+  });
+
+  test("buildProcessHostname assembles expected segments", () => {
+    const hostname = buildProcessHostname(
+      "brad.serve.gitspace.sh",
+      "my-workspace",
+      "web-api",
+      2,
+      "web"
+    );
+
+    expect(hostname).toBe("web.web-api-2.my-workspace.brad.serve.gitspace.sh");
+  });
+
+  test("buildServeIngressConfig adds fallback", () => {
+    const entries: ProcessHostEntry[] = [
+      {
+        hostname: "web.api-1.alpha.brad.serve.gitspace.sh",
+        service: "http://127.0.0.1:3000",
+        protocol: "http",
+        workspaceId: "alpha",
+        processName: "api",
+        instance: 1,
+        port: 3000,
+        portName: "web",
+      },
+      {
+        hostname: "tcp.api-1.alpha.brad.serve.gitspace.sh",
+        service: "tcp://127.0.0.1:9000",
+        protocol: "tcp",
+        workspaceId: "alpha",
+        processName: "api",
+        instance: 1,
+        port: 9000,
+        portName: "tcp",
+      },
+    ];
+
+    const config = buildServeIngressConfig(entries);
+    expect(config).toContain("ingress:");
+    expect(config).toContain("hostname: web.api-1.alpha.brad.serve.gitspace.sh");
+    expect(config).toContain("service: http://127.0.0.1:3000");
+    expect(config).toContain("hostname: tcp.api-1.alpha.brad.serve.gitspace.sh");
+    expect(config).toContain("service: tcp://127.0.0.1:9000");
+    expect(config).toContain("service: http_status:404");
+  });
+});

--- a/src/commands/events.ts
+++ b/src/commands/events.ts
@@ -9,7 +9,7 @@ import { SpacesError } from '../types/errors.js';
 import { getProjectWorkspacesDir } from '../core/config.js';
 import { getProcessEventsDir, listProcessEventsDirs } from '../lib/events/paths.js';
 import { readWideEvents } from '../lib/events/reader.js';
-import type { WideEventFilter } from '../types/events.js';
+import type { WideEvent, WideEventFilter } from '../types/events.js';
 
 interface EventsCommandOptions {
   project?: string;
@@ -50,7 +50,7 @@ function parseFilter(filter?: string): WideEventFilter {
   }
 }
 
-async function resolveEventsDir(options: EventsCommandOptions): Promise<string> {
+async function resolveEventsDirs(options: EventsCommandOptions, filter: WideEventFilter): Promise<string[]> {
   if (!options.project) {
     throw new SpacesError('Provide project via --project <name>.', 'USER_ERROR');
   }
@@ -67,27 +67,53 @@ async function resolveEventsDir(options: EventsCommandOptions): Promise<string> 
     );
   }
 
-  const processName = parseFilter(options.filter).processName;
-  const eventsDir = processName
-    ? getProcessEventsDir(workspacePath, processName)
-    : listProcessEventsDirs(workspacePath)[0];
+  const processName = filter.processName;
+  const eventsDirs = processName
+    ? [getProcessEventsDir(workspacePath, processName)]
+    : listProcessEventsDirs(workspacePath);
 
-  if (!eventsDir || !existsSync(eventsDir)) {
+  const existingDirs = eventsDirs.filter((eventsDir) => existsSync(eventsDir));
+
+  if (existingDirs.length === 0) {
     throw new SpacesError('No process events directory found for this workspace.', 'USER_ERROR');
   }
 
-  return eventsDir;
+  return existingDirs;
+}
+
+function getEventTimestamp(event: WideEvent): number {
+  if (typeof event.timestampMs === 'number' && !Number.isNaN(event.timestampMs)) {
+    return event.timestampMs;
+  }
+  const parsed = Date.parse(event.timestamp);
+  return Number.isNaN(parsed) ? 0 : parsed;
+}
+
+function readWideEventsFromDirs(eventsDirs: string[], filter: WideEventFilter, limit?: number): WideEvent[] {
+  if (eventsDirs.length === 1) {
+    return readWideEvents({
+      eventsDir: eventsDirs[0],
+      filter,
+      limit,
+    });
+  }
+
+  const merged = eventsDirs.flatMap((eventsDir) =>
+    readWideEvents({
+      eventsDir,
+      filter,
+    })
+  );
+
+  const sortedNewestFirst = [...merged].sort((a, b) => getEventTimestamp(b) - getEventTimestamp(a));
+  const limited = typeof limit === 'number' ? sortedNewestFirst.slice(0, limit) : sortedNewestFirst;
+  return limited.reverse();
 }
 
 export async function listEvents(options: EventsCommandOptions): Promise<void> {
-  const eventsDir = await resolveEventsDir(options);
-
   const filter = parseFilter(options.filter);
-  const events = readWideEvents({
-    eventsDir,
-    filter,
-    limit: options.limit,
-  });
+  const eventsDirs = await resolveEventsDirs(options, filter);
+  const events = readWideEventsFromDirs(eventsDirs, filter, options.limit);
 
   if (events.length === 0) {
     logger.info('No events found.');
@@ -104,14 +130,9 @@ export async function showEvent(options: EventsCommandOptions): Promise<void> {
     throw new SpacesError('Provide eventId filter: --filter "eventId=<id>"', 'USER_ERROR');
   }
 
-  const eventsDir = await resolveEventsDir(options);
-
   const filter = parseFilter(options.filter);
-  const events = readWideEvents({
-    eventsDir,
-    filter,
-    limit: 1,
-  });
+  const eventsDirs = await resolveEventsDirs(options, filter);
+  const events = readWideEventsFromDirs(eventsDirs, filter, 1);
 
   if (events.length === 0) {
     logger.info('No event found.');
@@ -122,14 +143,9 @@ export async function showEvent(options: EventsCommandOptions): Promise<void> {
 }
 
 export async function tailEvents(options: EventsTailOptions): Promise<void> {
-  const eventsDir = await resolveEventsDir(options);
-
   const filter = parseFilter(options.filter);
-  const events = readWideEvents({
-    eventsDir,
-    filter,
-    limit: options.limit ?? 50,
-  });
+  const eventsDirs = await resolveEventsDirs(options, filter);
+  const events = readWideEventsFromDirs(eventsDirs, filter, options.limit ?? 50);
 
   for (const event of events) {
     logger.log(JSON.stringify(event));

--- a/src/commands/events.ts
+++ b/src/commands/events.ts
@@ -24,8 +24,10 @@ interface EventsTailOptions extends EventsCommandOptions {
 
 function parseFilter(filter?: string): WideEventFilter {
   if (!filter) return {};
-  const [key, value] = filter.split('=');
-  if (!key || value === undefined) return {};
+  const separator = filter.indexOf('=');
+  if (separator <= 0) return {};
+  const key = filter.slice(0, separator);
+  const value = filter.slice(separator + 1);
   const trimmed = key.trim();
   const val = value.trim();
   switch (trimmed) {
@@ -39,6 +41,10 @@ function parseFilter(filter?: string): WideEventFilter {
       return { message: val };
     case 'processName':
       return { processName: val };
+    case 'kind':
+      return val === 'source' || val === 'wide' ? { kind: val } : {};
+    case 'correlationId':
+      return { correlationId: val };
     default:
       return {};
   }
@@ -56,15 +62,16 @@ async function resolveEventsDir(options: EventsCommandOptions): Promise<{ events
     : sessions[0];
 
   if (!target) {
-    throw new SpacesError('Session not found.', 'USER_ERROR');
+    if (options.session) {
+      throw new SpacesError(`Session not found: ${options.session}`, 'USER_ERROR');
+    }
+    throw new SpacesError('No active sessions found.', 'USER_ERROR');
   }
 
   const workspacePath = target.cwd;
   const workspaceId = workspacePath.split('/').pop() || 'workspace';
 
-  const processName = options.filter?.startsWith('processName=')
-    ? options.filter.split('=')[1]
-    : undefined;
+  const processName = parseFilter(options.filter).processName;
   const eventsDir = processName
     ? getProcessEventsDir(workspacePath, processName)
     : listProcessEventsDirs(workspacePath)[0];

--- a/src/commands/events.ts
+++ b/src/commands/events.ts
@@ -50,7 +50,7 @@ function parseFilter(filter?: string): WideEventFilter {
   }
 }
 
-async function resolveEventsDir(options: EventsCommandOptions): Promise<{ eventsDir: string; sessionId: string }> {
+async function resolveEventsDir(options: EventsCommandOptions): Promise<string> {
   if (!options.project) {
     throw new SpacesError('Provide project via --project <name>.', 'USER_ERROR');
   }
@@ -76,15 +76,15 @@ async function resolveEventsDir(options: EventsCommandOptions): Promise<{ events
     throw new SpacesError('No process events directory found for this workspace.', 'USER_ERROR');
   }
 
-  return { eventsDir, sessionId: options.workspace };
+  return eventsDir;
 }
 
 export async function listEvents(options: EventsCommandOptions): Promise<void> {
-  const resolved = await resolveEventsDir(options);
+  const eventsDir = await resolveEventsDir(options);
 
   const filter = parseFilter(options.filter);
   const events = readWideEvents({
-    eventsDir: resolved.eventsDir,
+    eventsDir,
     filter,
     limit: options.limit,
   });
@@ -104,11 +104,11 @@ export async function showEvent(options: EventsCommandOptions): Promise<void> {
     throw new SpacesError('Provide eventId filter: --filter "eventId=<id>"', 'USER_ERROR');
   }
 
-  const resolved = await resolveEventsDir(options);
+  const eventsDir = await resolveEventsDir(options);
 
   const filter = parseFilter(options.filter);
   const events = readWideEvents({
-    eventsDir: resolved.eventsDir,
+    eventsDir,
     filter,
     limit: 1,
   });
@@ -122,11 +122,11 @@ export async function showEvent(options: EventsCommandOptions): Promise<void> {
 }
 
 export async function tailEvents(options: EventsTailOptions): Promise<void> {
-  const resolved = await resolveEventsDir(options);
+  const eventsDir = await resolveEventsDir(options);
 
   const filter = parseFilter(options.filter);
   const events = readWideEvents({
-    eventsDir: resolved.eventsDir,
+    eventsDir,
     filter,
     limit: options.limit ?? 50,
   });

--- a/src/commands/events.ts
+++ b/src/commands/events.ts
@@ -1,0 +1,144 @@
+/**
+ * Events command - query wide event logs
+ */
+
+import { existsSync } from 'fs';
+import { logger } from '../utils/logger.js';
+import { getCurrentProject } from '../core/config.js';
+import { listSessions } from '../lib/tmux-lite/cli.js';
+import { getProcessEventsDir, listProcessEventsDirs } from '../lib/events/paths.js';
+import { readWideEvents } from '../lib/events/reader.js';
+import type { WideEventFilter } from '../types/events.js';
+
+interface EventsCommandOptions {
+  session?: string;
+  workspace?: string;
+  filter?: string;
+  limit?: number;
+}
+
+interface EventsTailOptions extends EventsCommandOptions {
+  follow?: boolean;
+}
+
+function parseFilter(filter?: string): WideEventFilter {
+  if (!filter) return {};
+  const [key, value] = filter.split('=');
+  if (!key || value === undefined) return {};
+  const trimmed = key.trim();
+  const val = value.trim();
+  switch (trimmed) {
+    case 'eventName':
+      return { eventName: val };
+    case 'eventId':
+      return { eventId: val };
+    case 'level':
+      return { level: val };
+    case 'message':
+      return { message: val };
+    case 'processName':
+      return { processName: val };
+    default:
+      return {};
+  }
+}
+
+async function resolveEventsDir(options: EventsCommandOptions): Promise<{ eventsDir: string; sessionId: string } | null> {
+  const project = getCurrentProject();
+  if (!project) {
+    logger.error('No current project. Run `gssh switch project` first.');
+    return null;
+  }
+
+  const sessions = await listSessions();
+  const target = options.session
+    ? sessions.find((s) => s.id === options.session || s.name === options.session)
+    : sessions[0];
+
+  if (!target) {
+    logger.error('Session not found.');
+    return null;
+  }
+
+  const workspacePath = target.cwd;
+  const workspaceId = workspacePath.split('/').pop() || 'workspace';
+
+  const processName = options.filter?.startsWith('processName=')
+    ? options.filter.split('=')[1]
+    : undefined;
+  const eventsDir = processName
+    ? getProcessEventsDir(workspacePath, processName)
+    : listProcessEventsDirs(workspacePath)[0];
+
+  if (!eventsDir || !existsSync(eventsDir)) {
+    logger.error('No process events directory found for this workspace.');
+    return null;
+  }
+
+  return { eventsDir, sessionId: workspaceId };
+}
+
+export async function listEvents(options: EventsCommandOptions): Promise<void> {
+  const resolved = await resolveEventsDir(options);
+  if (!resolved) return;
+
+  const filter = parseFilter(options.filter);
+  const events = readWideEvents({
+    eventsDir: resolved.eventsDir,
+    filter,
+    limit: options.limit,
+  });
+
+  if (events.length === 0) {
+    logger.info('No events found.');
+    return;
+  }
+
+  for (const event of events) {
+    logger.log(JSON.stringify(event));
+  }
+}
+
+export async function showEvent(options: EventsCommandOptions): Promise<void> {
+  if (!options.filter || !options.filter.startsWith('eventId=')) {
+    logger.error('Provide eventId filter: --filter "eventId=<id>"');
+    return;
+  }
+
+  const resolved = await resolveEventsDir(options);
+  if (!resolved) return;
+
+  const filter = parseFilter(options.filter);
+  const events = readWideEvents({
+    eventsDir: resolved.eventsDir,
+    filter,
+    limit: 1,
+  });
+
+  if (events.length === 0) {
+    logger.info('No event found.');
+    return;
+  }
+
+  logger.log(JSON.stringify(events[0], null, 2));
+}
+
+export async function tailEvents(options: EventsTailOptions): Promise<void> {
+  const resolved = await resolveEventsDir(options);
+  if (!resolved) return;
+
+  const filter = parseFilter(options.filter);
+  const events = readWideEvents({
+    eventsDir: resolved.eventsDir,
+    filter,
+    limit: options.limit ?? 50,
+  });
+
+  for (const event of events) {
+    logger.log(JSON.stringify(event));
+  }
+
+  if (!options.follow) return;
+
+  logger.info('Follow mode not implemented yet.');
+}

--- a/src/commands/events.ts
+++ b/src/commands/events.ts
@@ -3,16 +3,16 @@
  */
 
 import { existsSync } from 'node:fs';
+import { join } from 'node:path';
 import { logger } from '../utils/logger.js';
 import { SpacesError } from '../types/errors.js';
-import { getCurrentProject } from '../core/config.js';
-import { listSessions } from '../lib/tmux-lite/cli.js';
+import { getProjectWorkspacesDir } from '../core/config.js';
 import { getProcessEventsDir, listProcessEventsDirs } from '../lib/events/paths.js';
 import { readWideEvents } from '../lib/events/reader.js';
 import type { WideEventFilter } from '../types/events.js';
 
 interface EventsCommandOptions {
-  session?: string;
+  project?: string;
   workspace?: string;
   filter?: string;
   limit?: number;
@@ -51,25 +51,21 @@ function parseFilter(filter?: string): WideEventFilter {
 }
 
 async function resolveEventsDir(options: EventsCommandOptions): Promise<{ eventsDir: string; sessionId: string }> {
-  const project = getCurrentProject();
-  if (!project) {
-    throw new SpacesError('No current project. Run `gssh switch project` first.', 'USER_ERROR');
+  if (!options.project) {
+    throw new SpacesError('Provide project via --project <name>.', 'USER_ERROR');
   }
 
-  const sessions = await listSessions();
-  const target = options.session
-    ? sessions.find((s) => s.id === options.session || s.name === options.session)
-    : sessions[0];
-
-  if (!target) {
-    if (options.session) {
-      throw new SpacesError(`Session not found: ${options.session}`, 'USER_ERROR');
-    }
-    throw new SpacesError('No active sessions found.', 'USER_ERROR');
+  if (!options.workspace) {
+    throw new SpacesError('Provide workspace via --workspace <name>.', 'USER_ERROR');
   }
 
-  const workspacePath = target.cwd;
-  const workspaceId = workspacePath.split('/').pop() || 'workspace';
+  const workspacePath = join(getProjectWorkspacesDir(options.project), options.workspace);
+  if (!existsSync(workspacePath)) {
+    throw new SpacesError(
+      `Workspace not found: ${options.project}/${options.workspace}`,
+      'USER_ERROR'
+    );
+  }
 
   const processName = parseFilter(options.filter).processName;
   const eventsDir = processName
@@ -80,7 +76,7 @@ async function resolveEventsDir(options: EventsCommandOptions): Promise<{ events
     throw new SpacesError('No process events directory found for this workspace.', 'USER_ERROR');
   }
 
-  return { eventsDir, sessionId: workspaceId };
+  return { eventsDir, sessionId: options.workspace };
 }
 
 export async function listEvents(options: EventsCommandOptions): Promise<void> {

--- a/src/commands/events.ts
+++ b/src/commands/events.ts
@@ -2,7 +2,7 @@
  * Events command - query wide event logs
  */
 
-import { existsSync } from 'fs';
+import { existsSync } from 'node:fs';
 import { logger } from '../utils/logger.js';
 import { SpacesError } from '../types/errors.js';
 import { getCurrentProject } from '../core/config.js';

--- a/src/commands/events.ts
+++ b/src/commands/events.ts
@@ -4,6 +4,7 @@
 
 import { existsSync } from 'fs';
 import { logger } from '../utils/logger.js';
+import { SpacesError } from '../types/errors.js';
 import { getCurrentProject } from '../core/config.js';
 import { listSessions } from '../lib/tmux-lite/cli.js';
 import { getProcessEventsDir, listProcessEventsDirs } from '../lib/events/paths.js';
@@ -43,11 +44,10 @@ function parseFilter(filter?: string): WideEventFilter {
   }
 }
 
-async function resolveEventsDir(options: EventsCommandOptions): Promise<{ eventsDir: string; sessionId: string } | null> {
+async function resolveEventsDir(options: EventsCommandOptions): Promise<{ eventsDir: string; sessionId: string }> {
   const project = getCurrentProject();
   if (!project) {
-    logger.error('No current project. Run `gssh switch project` first.');
-    return null;
+    throw new SpacesError('No current project. Run `gssh switch project` first.', 'USER_ERROR');
   }
 
   const sessions = await listSessions();
@@ -56,8 +56,7 @@ async function resolveEventsDir(options: EventsCommandOptions): Promise<{ events
     : sessions[0];
 
   if (!target) {
-    logger.error('Session not found.');
-    return null;
+    throw new SpacesError('Session not found.', 'USER_ERROR');
   }
 
   const workspacePath = target.cwd;
@@ -71,8 +70,7 @@ async function resolveEventsDir(options: EventsCommandOptions): Promise<{ events
     : listProcessEventsDirs(workspacePath)[0];
 
   if (!eventsDir || !existsSync(eventsDir)) {
-    logger.error('No process events directory found for this workspace.');
-    return null;
+    throw new SpacesError('No process events directory found for this workspace.', 'USER_ERROR');
   }
 
   return { eventsDir, sessionId: workspaceId };
@@ -80,7 +78,6 @@ async function resolveEventsDir(options: EventsCommandOptions): Promise<{ events
 
 export async function listEvents(options: EventsCommandOptions): Promise<void> {
   const resolved = await resolveEventsDir(options);
-  if (!resolved) return;
 
   const filter = parseFilter(options.filter);
   const events = readWideEvents({
@@ -101,12 +98,10 @@ export async function listEvents(options: EventsCommandOptions): Promise<void> {
 
 export async function showEvent(options: EventsCommandOptions): Promise<void> {
   if (!options.filter || !options.filter.startsWith('eventId=')) {
-    logger.error('Provide eventId filter: --filter "eventId=<id>"');
-    return;
+    throw new SpacesError('Provide eventId filter: --filter "eventId=<id>"', 'USER_ERROR');
   }
 
   const resolved = await resolveEventsDir(options);
-  if (!resolved) return;
 
   const filter = parseFilter(options.filter);
   const events = readWideEvents({
@@ -125,7 +120,6 @@ export async function showEvent(options: EventsCommandOptions): Promise<void> {
 
 export async function tailEvents(options: EventsTailOptions): Promise<void> {
   const resolved = await resolveEventsDir(options);
-  if (!resolved) return;
 
   const filter = parseFilter(options.filter);
   const events = readWideEvents({

--- a/src/commands/host.ts
+++ b/src/commands/host.ts
@@ -25,6 +25,7 @@ const API_BASE = process.env.GITSPACE_API_URL || 'https://api.gitspace.sh';
  */
 export interface HostConfig {
   subdomain: string;
+  serveSubdomain?: string;
   subdomains?: string[];
   createdAt: number;
 }
@@ -41,8 +42,15 @@ interface SubdomainInfo {
 interface SubdomainCreateResponse {
   id: string;
   subdomain: string;
+  tunnelToken?: string;
+  serveSubdomain?: string;
+  serveTunnelToken?: string;
   hosts: string[];
   isPrimary: boolean;
+}
+
+export function getServeTokenKey(subdomain: string): string {
+  return `TUNNEL_TOKEN_${subdomain}_serve`;
 }
 
 // ============================================================================
@@ -137,8 +145,13 @@ export async function syncHostConfig(interactive: boolean = false): Promise<void
     }
 
     if (primary) {
+      const serveSubdomain = activeSubdomains.find(
+        (s) => s.subdomain === `${primary.subdomain}.serve`
+      );
+      const resolvedServeSubdomain = serveSubdomain?.subdomain ?? `${primary.subdomain}.serve`;
       writeHostConfig({
         subdomain: primary.subdomain,
+        serveSubdomain: resolvedServeSubdomain,
         subdomains: activeSubdomains.map((s) => s.subdomain),
         createdAt: primary.created_at,
       });
@@ -156,6 +169,26 @@ export async function syncHostConfig(interactive: boolean = false): Promise<void
             await setSecret(`TUNNEL_TOKEN_${primary.subdomain}`, tunnelToken);
             if (interactive) {
               logger.success('Tunnel credentials saved');
+            }
+          }
+        } catch {
+          // Ignore token fetch errors
+        }
+      }
+
+      const serveTokenKey = getServeTokenKey(primary.subdomain);
+      const existingServeToken = await getSecret(serveTokenKey);
+      if (!existingServeToken) {
+        if (interactive) {
+          logger.dim(`Fetching tunnel credentials for ${resolvedServeSubdomain}.gitspace.sh...`);
+        }
+        try {
+          const tokenRes = await fetch(`${API_BASE}/subdomains/${resolvedServeSubdomain}/token`, { headers });
+          if (tokenRes.ok) {
+            const { tunnelToken } = await tokenRes.json();
+            await setSecret(serveTokenKey, tunnelToken);
+            if (interactive) {
+              logger.success('Serve tunnel credentials saved');
             }
           }
         } catch {
@@ -259,19 +292,51 @@ export async function hostReserve(subdomain: string): Promise<void> {
 
   // Fetch and store tunnel token in keychain
   logger.info('Saving credentials...');
-  const tokenRes = await fetch(
-    `${API_BASE}/subdomains/${subdomain}/token`,
-    {
-      headers,
-    }
-  );
+  let tunnelToken = data.tunnelToken;
+  if (!tunnelToken) {
+    const tokenRes = await fetch(
+      `${API_BASE}/subdomains/${subdomain}/token`,
+      {
+        headers,
+      }
+    );
 
-  if (!tokenRes.ok) {
+    if (!tokenRes.ok) {
+      throw new SpacesError('Failed to get tunnel token', 'SYSTEM_ERROR');
+    }
+
+    const tokenData = await tokenRes.json();
+    tunnelToken = tokenData.tunnelToken;
+  }
+
+  if (!tunnelToken) {
     throw new SpacesError('Failed to get tunnel token', 'SYSTEM_ERROR');
   }
 
-  const { tunnelToken } = await tokenRes.json();
+  const serveSubdomain = data.serveSubdomain ?? `${subdomain}.serve`;
+  let serveTunnelToken = data.serveTunnelToken;
+  if (!serveTunnelToken) {
+    const serveTokenRes = await fetch(
+      `${API_BASE}/subdomains/${serveSubdomain}/token`,
+      {
+        headers,
+      }
+    );
+
+    if (!serveTokenRes.ok) {
+      throw new SpacesError('Failed to get serve tunnel token', 'SYSTEM_ERROR');
+    }
+
+    const serveTokenData = await serveTokenRes.json();
+    serveTunnelToken = serveTokenData.tunnelToken;
+  }
+
+  if (!serveTunnelToken) {
+    throw new SpacesError('Failed to get serve tunnel token', 'SYSTEM_ERROR');
+  }
+
   await setSecret(`TUNNEL_TOKEN_${subdomain}`, tunnelToken);
+  await setSecret(getServeTokenKey(subdomain), serveTunnelToken);
 
   // Update local host config
   await syncHostConfig();
@@ -279,6 +344,8 @@ export async function hostReserve(subdomain: string): Promise<void> {
   logger.log('');
   logger.success(`Reserved: ${data.subdomain}.gitspace.sh`);
   logger.log(`  Wildcard: *.${data.subdomain}.gitspace.sh`);
+  logger.log(`Serve: ${serveSubdomain}.gitspace.sh`);
+  logger.log(`  Wildcard: *.${serveSubdomain}.gitspace.sh`);
   if (data.isPrimary) {
     logger.dim('  (set as primary)');
   }
@@ -321,6 +388,9 @@ export async function hostRelease(subdomain?: string): Promise<void> {
 
   // Clear local tunnel token
   await deleteSecret(`TUNNEL_TOKEN_${subdomain}`);
+  if (!subdomain.endsWith('.serve')) {
+    await deleteSecret(getServeTokenKey(subdomain));
+  }
 
   // Update local host config
   await syncHostConfig();
@@ -422,18 +492,24 @@ export async function hostStatus(): Promise<void> {
 
     const subdomains: SubdomainInfo[] = await res.json();
     const primary = subdomains.find((s) => s.is_primary && s.status === 'active');
-
     if (!primary) {
       logger.log('No primary subdomain set.');
       logger.dim('Run: gssh host reserve <name>');
       return;
     }
 
+    const primarySubdomain = primary.subdomain;
+    const serveSubdomain = subdomains.find(
+      (s) => s.subdomain === `${primarySubdomain}.serve` && s.status === 'active'
+    )?.subdomain ?? `${primarySubdomain}.serve`;
+
     logger.log(`Primary: ${primary.subdomain}.gitspace.sh`);
     logger.log(`Status: ${primary.status}`);
+    logger.log(`Serve: ${serveSubdomain}.gitspace.sh`);
 
     // Check if tunnel token exists locally
     let tunnelToken = await getSecret(`TUNNEL_TOKEN_${primary.subdomain}`);
+    let serveTunnelToken = await getSecret(getServeTokenKey(primary.subdomain));
 
     // Auto-fetch token if missing
     if (!tunnelToken) {
@@ -451,10 +527,29 @@ export async function hostStatus(): Promise<void> {
       }
     }
 
+    if (!serveTunnelToken) {
+      logger.dim('Serve tunnel credentials missing, fetching...');
+      try {
+        const tokenRes = await fetch(`${API_BASE}/subdomains/${serveSubdomain}/token`, { headers });
+        if (tokenRes.ok) {
+          const { tunnelToken: newToken } = await tokenRes.json();
+          await setSecret(getServeTokenKey(primary.subdomain), newToken);
+          serveTunnelToken = newToken;
+          logger.success('Serve tunnel credentials synced');
+        }
+      } catch {
+        // Ignore
+      }
+    }
+
     logger.log(`Tunnel token: ${tunnelToken ? 'configured' : 'missing'}`);
+    logger.log(`Serve tunnel token: ${serveTunnelToken ? 'configured' : 'missing'}`);
 
     if (!tunnelToken) {
       logger.warning('Could not fetch tunnel credentials');
+    }
+    if (!serveTunnelToken) {
+      logger.warning('Could not fetch serve tunnel credentials');
     }
   } catch {
     logger.log('Could not verify status (API unreachable)');
@@ -463,6 +558,9 @@ export async function hostStatus(): Promise<void> {
     const hostConfig = readHostConfig();
     if (hostConfig) {
       logger.log(`Local config: ${hostConfig.subdomain}.gitspace.sh`);
+      if (hostConfig.serveSubdomain) {
+        logger.log(`Local serve: ${hostConfig.serveSubdomain}.gitspace.sh`);
+      }
     }
   }
 }

--- a/src/commands/process.ts
+++ b/src/commands/process.ts
@@ -1,0 +1,103 @@
+/**
+ * Process commands
+ */
+
+import { logger } from '../utils/logger.js';
+import { listSessions } from '../lib/tmux-lite/cli.js';
+import {
+  getProcessSpecs,
+  startProcessInstance,
+  stopProcessInstance,
+  listProcessSessions,
+} from '../lib/processes/manager.js';
+
+interface ProcessCommandOptions {
+  workspace?: string;
+  name?: string;
+}
+
+function resolveWorkspacePath(): string {
+  return process.cwd();
+}
+
+export async function listProcesses(options: ProcessCommandOptions): Promise<void> {
+  const workspacePath = options.workspace || resolveWorkspacePath();
+  const specs = getProcessSpecs(workspacePath);
+  const sessions = await listProcessSessions(workspacePath);
+
+  if (specs.length === 0) {
+    logger.info('No processes configured in .gitspace/processes.json.');
+    return;
+  }
+
+  for (const spec of specs) {
+    const running = sessions.find(
+      (session) => session.processName === spec.name && session.instance === spec.instance
+    );
+    const status = running ? 'running' : 'stopped';
+    logger.log(`${spec.name}#${spec.instance} ${status}`);
+  }
+}
+
+export async function startProcess(options: ProcessCommandOptions): Promise<void> {
+  const workspacePath = options.workspace || resolveWorkspacePath();
+  if (!options.name) {
+    logger.error('Provide process name via --name');
+    return;
+  }
+
+  const specs = getProcessSpecs(workspacePath).filter((spec) => spec.name === options.name);
+  if (specs.length === 0) {
+    logger.error(`Process not found: ${options.name}`);
+    return;
+  }
+
+  for (const spec of specs) {
+    const result = await startProcessInstance(workspacePath, spec);
+    const note = result.created ? 'started' : 'already running';
+    logger.log(`${spec.name}#${spec.instance} ${note} (${result.sessionId})`);
+  }
+}
+
+export async function stopProcess(options: ProcessCommandOptions): Promise<void> {
+  const workspacePath = options.workspace || resolveWorkspacePath();
+  if (!options.name) {
+    logger.error('Provide process name via --name');
+    return;
+  }
+
+  const specs = getProcessSpecs(workspacePath).filter((spec) => spec.name === options.name);
+  if (specs.length === 0) {
+    logger.error(`Process not found: ${options.name}`);
+    return;
+  }
+
+  for (const spec of specs) {
+    await stopProcessInstance(workspacePath, spec);
+    logger.log(`${spec.name}#${spec.instance} stopped`);
+  }
+}
+
+export async function attachProcess(options: ProcessCommandOptions): Promise<void> {
+  const workspacePath = options.workspace || resolveWorkspacePath();
+  if (!options.name) {
+    logger.error('Provide process name via --name');
+    return;
+  }
+
+  const sessions = await listProcessSessions(workspacePath);
+  const target = sessions.find((session) => session.processName === options.name);
+  if (!target) {
+    logger.error(`Process not running: ${options.name}`);
+    return;
+  }
+
+  const sessionList = await listSessions();
+  const session = sessionList.find((item) => item.id === target.sessionId);
+  if (!session) {
+    logger.error(`Session not found for process ${options.name}`);
+    return;
+  }
+
+  logger.info(`Attach with: gssh tmux attach ${session.id}`);
+}

--- a/src/commands/process.ts
+++ b/src/commands/process.ts
@@ -3,6 +3,7 @@
  */
 
 import { logger } from '../utils/logger.js';
+import { SpacesError } from '../types/errors.js';
 import { listSessions } from '../lib/tmux-lite/cli.js';
 import {
   getProcessSpecs,
@@ -42,14 +43,12 @@ export async function listProcesses(options: ProcessCommandOptions): Promise<voi
 export async function startProcess(options: ProcessCommandOptions): Promise<void> {
   const workspacePath = options.workspace || resolveWorkspacePath();
   if (!options.name) {
-    logger.error('Provide process name via --name');
-    return;
+    throw new SpacesError('Provide process name via --name', 'USER_ERROR');
   }
 
   const specs = getProcessSpecs(workspacePath).filter((spec) => spec.name === options.name);
   if (specs.length === 0) {
-    logger.error(`Process not found: ${options.name}`);
-    return;
+    throw new SpacesError(`Process not found: ${options.name}`, 'USER_ERROR');
   }
 
   for (const spec of specs) {
@@ -62,14 +61,12 @@ export async function startProcess(options: ProcessCommandOptions): Promise<void
 export async function stopProcess(options: ProcessCommandOptions): Promise<void> {
   const workspacePath = options.workspace || resolveWorkspacePath();
   if (!options.name) {
-    logger.error('Provide process name via --name');
-    return;
+    throw new SpacesError('Provide process name via --name', 'USER_ERROR');
   }
 
   const specs = getProcessSpecs(workspacePath).filter((spec) => spec.name === options.name);
   if (specs.length === 0) {
-    logger.error(`Process not found: ${options.name}`);
-    return;
+    throw new SpacesError(`Process not found: ${options.name}`, 'USER_ERROR');
   }
 
   for (const spec of specs) {
@@ -81,22 +78,19 @@ export async function stopProcess(options: ProcessCommandOptions): Promise<void>
 export async function attachProcess(options: ProcessCommandOptions): Promise<void> {
   const workspacePath = options.workspace || resolveWorkspacePath();
   if (!options.name) {
-    logger.error('Provide process name via --name');
-    return;
+    throw new SpacesError('Provide process name via --name', 'USER_ERROR');
   }
 
   const sessions = await listProcessSessions(workspacePath);
   const target = sessions.find((session) => session.processName === options.name);
   if (!target) {
-    logger.error(`Process not running: ${options.name}`);
-    return;
+    throw new SpacesError(`Process not running: ${options.name}`, 'USER_ERROR');
   }
 
   const sessionList = await listSessions();
   const session = sessionList.find((item) => item.id === target.sessionId);
   if (!session) {
-    logger.error(`Session not found for process ${options.name}`);
-    return;
+    throw new SpacesError(`Session not found for process ${options.name}`, 'SYSTEM_ERROR');
   }
 
   logger.info(`Attach with: gssh tmux attach ${session.id}`);

--- a/src/commands/process.ts
+++ b/src/commands/process.ts
@@ -11,6 +11,8 @@ import {
   stopProcessInstance,
   listProcessSessions,
 } from '../lib/processes/manager.js';
+import { loadProcessesConfig, getProcessDefinition } from '../lib/processes/config.js';
+import { normalizeProcessInstanceCount } from '../lib/processes/instances.js';
 
 interface ProcessCommandOptions {
   workspace?: string;
@@ -48,6 +50,11 @@ export async function startProcess(options: ProcessCommandOptions): Promise<void
 
   const specs = getProcessSpecs(workspacePath).filter((spec) => spec.name === options.name);
   if (specs.length === 0) {
+    const processConfig = loadProcessesConfig(workspacePath);
+    const definition = getProcessDefinition(processConfig, options.name);
+    if (definition && normalizeProcessInstanceCount(definition.instances) === 0) {
+      throw new SpacesError(`Process is disabled (instances: 0): ${options.name}`, 'USER_ERROR');
+    }
     throw new SpacesError(`Process not found: ${options.name}`, 'USER_ERROR');
   }
 

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -626,6 +626,10 @@ class ServeProcessHostManager {
         }
       }
       if (!workspaceRef) continue;
+      seenWorkspaceIds.add(workspaceRef.workspaceId);
+      if (parsed?.workspaceId) {
+        seenWorkspaceIds.add(parsed.workspaceId);
+      }
 
       const config = configCache.get(workspaceRef.workspacePath) ?? loadProcessesConfig(workspaceRef.workspacePath);
       configCache.set(workspaceRef.workspacePath, config);
@@ -636,7 +640,8 @@ class ServeProcessHostManager {
         if (!Number.isInteger(port.port) || port.port <= 0) {
           continue;
         }
-        const portLabel = port.name?.trim().length ? port.name : String(port.port);
+        const trimmedPortName = port.name?.trim();
+        const portLabel = trimmedPortName && trimmedPortName.length > 0 ? trimmedPortName : String(port.port);
         const hostname = buildProcessHostname(
           this.serveDomain,
           workspaceRef.workspaceId,

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -670,7 +670,7 @@ class ServeProcessHostManager {
   }
 
   private spawnProcess(configPath: string): Subprocess {
-    const proc = spawn(['cloudflared', 'tunnel', 'run', '--config', configPath], {
+    const proc = spawn(['cloudflared', 'tunnel', '--config', configPath, 'run'], {
       env: { ...process.env, TUNNEL_TOKEN: this.tunnelToken },
       stdin: 'ignore',
       stdout: 'pipe',

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -9,7 +9,9 @@
  * Supports daemon mode with start/stop/status subcommands.
  */
 
-import { watch, appendFileSync, existsSync, writeFileSync } from 'fs';
+import { watch, appendFileSync, existsSync, writeFileSync, readdirSync } from 'fs';
+import { join } from 'path';
+import { createHash } from 'crypto';
 import { spawn, type Subprocess } from 'bun';
 import { logger } from '../utils/logger.js';
 import { promptPassword, promptConfirm } from '../utils/prompts.js';
@@ -39,7 +41,7 @@ import {
   NoIdentityError,
   SpacesError,
 } from '../types/errors.js';
-import { readHostConfig } from './host.js';
+import { getServeTokenKey, readHostConfig, type HostConfig } from './host.js';
 import { createRelayServer } from '../relay/server.js';
 import { generateRelayIdentity } from '../relay/identity.js';
 import { signMessage } from '../relay/signing.js';
@@ -59,9 +61,18 @@ import {
   getServeLogFile,
   setAccessCommandHandler,
   ensureServeDaemonDir,
+  getServeDaemonDir,
   type StatusResponse,
 } from '../serve/daemon.js';
 import { initializeSecretRuntime } from '../core/secret-runtime.js';
+import { listSessions } from '../lib/tmux-lite/cli.js';
+import { loadProcessesConfig } from '../lib/processes/config.js';
+import { parseProcessSessionName } from '../lib/processes/names.js';
+import { resolveWorkspaceRef } from '../lib/events/paths.js';
+import { getGitspaceDir } from '../core/config.js';
+import { buildProcessHostname, normalizeHostLabel } from '../utils/hostnames.js';
+export { buildProcessHostname, normalizeHostLabel };
+import type { ProcessPortConfig } from '../types/processes.js';
 
 /** Package version for daemon status */
 const PACKAGE_VERSION = '1.0.0';
@@ -453,6 +464,277 @@ function stopCloudflared(): void {
 }
 
 // ============================================================================
+// Process Hosting (Serve Tunnel)
+// ============================================================================
+
+export interface ProcessHostEntry {
+  hostname: string;
+  service: string;
+  protocol: 'http' | 'tcp';
+  workspaceId: string;
+  processName: string;
+  instance: number;
+  port: number;
+  portName?: string;
+}
+
+const SERVE_CONFIG_PATH = () => join(getServeDaemonDir(), 'serve-tunnel.yml');
+const SERVE_REFRESH_INTERVAL_MS = 5000;
+const SERVE_READY_TIMEOUT_MS = 5000;
+
+export function buildServeIngressConfig(entries: ProcessHostEntry[]): string {
+  const lines = ['ingress:'];
+  for (const entry of entries) {
+    lines.push(`  - hostname: ${entry.hostname}`);
+    lines.push(`    service: ${entry.service}`);
+  }
+  lines.push('  - service: http_status:404');
+  return `${lines.join('\n')}\n`;
+}
+
+function hashConfig(config: string): string {
+  return createHash('sha256').update(config).digest('hex');
+}
+
+function findWorkspacePathById(workspaceId: string): string | null {
+  const spacesDir = getGitspaceDir();
+  if (!existsSync(spacesDir)) {
+    return null;
+  }
+  const entries = readdirSync(spacesDir, { withFileTypes: true });
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    if (entry.name === 'app') continue;
+    const candidate = join(spacesDir, entry.name, 'workspaces', workspaceId);
+    if (existsSync(candidate)) {
+      return candidate;
+    }
+  }
+  return null;
+}
+
+async function waitForCloudflaredReady(proc: Subprocess): Promise<boolean> {
+  const result = await Promise.race([
+    proc.exited.then((code) => ({ code })),
+    Bun.sleep(SERVE_READY_TIMEOUT_MS).then(() => ({ code: null })),
+  ]);
+  return result.code === null;
+}
+
+class ServeProcessHostManager {
+  private serveDomain: string;
+  private tunnelToken: string;
+  private process: Subprocess | null = null;
+  private configHash: string | null = null;
+  private registry: ProcessHostEntry[] = [];
+  private refreshPromise: Promise<void> | null = null;
+  private restartAttempts = 0;
+  private workspacePathCache = new Map<string, string>();
+
+  constructor(options: { serveDomain: string; tunnelToken: string }) {
+    this.serveDomain = options.serveDomain;
+    this.tunnelToken = options.tunnelToken;
+  }
+
+  get domain(): string {
+    return this.serveDomain;
+  }
+
+  get entries(): ProcessHostEntry[] {
+    return [...this.registry];
+  }
+
+  async refresh(): Promise<void> {
+    if (this.refreshPromise) {
+      return this.refreshPromise;
+    }
+    this.refreshPromise = this.refreshInternal().finally(() => {
+      this.refreshPromise = null;
+    });
+    return this.refreshPromise;
+  }
+
+  stop(): void {
+    if (this.process) {
+      this.process.kill();
+      this.process = null;
+    }
+  }
+
+  private async refreshInternal(): Promise<void> {
+    const entries = await this.collectProcessHosts();
+    const sorted = entries.sort((a, b) => a.hostname.localeCompare(b.hostname));
+    const config = buildServeIngressConfig(sorted);
+    const nextHash = hashConfig(config);
+
+    if (this.configHash === nextHash && this.process) {
+      this.registry = sorted;
+      return;
+    }
+
+    ensureServeDaemonDir();
+    const configPath = SERVE_CONFIG_PATH();
+    writeFileSync(configPath, config, 'utf-8');
+
+    const swapped = await this.swapProcess(configPath);
+    if (swapped) {
+      this.registry = sorted;
+      this.configHash = nextHash;
+      logger.dim(`Serve tunnel updated (${sorted.length} routes)`);
+    }
+  }
+
+  private async collectProcessHosts(): Promise<ProcessHostEntry[]> {
+    let sessions: Awaited<ReturnType<typeof listSessions>> = [];
+    try {
+      sessions = await listSessions();
+    } catch {
+      return [];
+    }
+    const configCache = new Map<string, ReturnType<typeof loadProcessesConfig>>();
+    const entries: ProcessHostEntry[] = [];
+
+    for (const session of sessions) {
+      const parsed = parseProcessSessionName(session.name);
+      const processName = parsed?.processName;
+      if (!processName) continue;
+      const instance = parsed?.instance ?? 1;
+
+      let workspaceRef = resolveWorkspaceRef(session.cwd);
+      if (!workspaceRef && parsed?.workspaceId) {
+        const cached = this.workspacePathCache.get(parsed.workspaceId);
+        const workspacePath = cached ?? findWorkspacePathById(parsed.workspaceId);
+        if (workspacePath) {
+          this.workspacePathCache.set(parsed.workspaceId, workspacePath);
+          workspaceRef = resolveWorkspaceRef(workspacePath);
+        }
+      }
+      if (!workspaceRef) continue;
+
+      const config = configCache.get(workspaceRef.workspacePath) ?? loadProcessesConfig(workspaceRef.workspacePath);
+      configCache.set(workspaceRef.workspacePath, config);
+      const definition = config.processes.find((process) => process.name === processName);
+      const ports = (definition?.ports ?? []).filter((port): port is ProcessPortConfig => Boolean(port));
+
+      for (const port of ports) {
+        if (!Number.isInteger(port.port) || port.port <= 0) {
+          continue;
+        }
+        const portLabel = port.name?.trim().length ? port.name : String(port.port);
+        const hostname = buildProcessHostname(
+          this.serveDomain,
+          workspaceRef.workspaceId,
+          processName,
+          instance,
+          portLabel
+        );
+        const protocol = port.protocol === 'tcp' ? 'tcp' : 'http';
+        const service = `${protocol}://127.0.0.1:${port.port}`;
+        entries.push({
+          hostname,
+          service,
+          protocol,
+          workspaceId: workspaceRef.workspaceId,
+          processName,
+          instance,
+          port: port.port,
+          portName: port.name,
+        });
+      }
+    }
+
+    const deduped = new Map<string, ProcessHostEntry>();
+    for (const entry of entries) {
+      if (!deduped.has(entry.hostname)) {
+        deduped.set(entry.hostname, entry);
+      }
+    }
+    return Array.from(deduped.values());
+  }
+
+  private async swapProcess(configPath: string): Promise<boolean> {
+    const nextProcess = this.spawnProcess(configPath);
+    const ready = await waitForCloudflaredReady(nextProcess);
+    if (!ready) {
+      nextProcess.kill();
+      return false;
+    }
+
+    const previous = this.process;
+    this.process = nextProcess;
+    this.restartAttempts = 0;
+    if (previous) {
+      previous.kill();
+    }
+    return true;
+  }
+
+  private spawnProcess(configPath: string): Subprocess {
+    const proc = spawn(['cloudflared', 'tunnel', 'run', '--config', configPath], {
+      env: { ...process.env, TUNNEL_TOKEN: this.tunnelToken },
+      stdin: 'ignore',
+      stdout: 'pipe',
+      stderr: 'pipe',
+    });
+
+    handleCloudflaredOutput(proc);
+
+    proc.exited.then((exitCode) => {
+      if (exitCode !== 0 && this.process === proc) {
+        this.handleCrash();
+      }
+    });
+
+    return proc;
+  }
+
+  private handleCrash(): void {
+    this.restartAttempts += 1;
+    if (this.restartAttempts > MAX_CLOUDFLARED_RESTARTS) {
+      logger.error(`serve tunnel crashed ${MAX_CLOUDFLARED_RESTARTS} times, giving up`);
+      return;
+    }
+    logger.info(`Restarting serve tunnel (attempt ${this.restartAttempts}/${MAX_CLOUDFLARED_RESTARTS})...`);
+    setTimeout(() => {
+      void this.refresh();
+    }, CLOUDFLARED_RESTART_DELAY);
+  }
+}
+
+async function startServeProcessHosting(hostConfig: HostConfig): Promise<ServeProcessHostManager | null> {
+  const serveSubdomain = hostConfig.serveSubdomain ?? `${hostConfig.subdomain}.serve`;
+  const serveDomain = `${serveSubdomain}.gitspace.sh`;
+  const tunnelToken = await getSecret(getServeTokenKey(hostConfig.subdomain));
+
+  if (!tunnelToken) {
+    logger.warning(`No serve tunnel token found for ${serveDomain}`);
+    logger.dim(`Run: gssh host reserve ${hostConfig.subdomain} (to get token)`);
+    return null;
+  }
+
+  if (!await isCloudflaredInstalled()) {
+    logger.warning('cloudflared is not installed');
+    return null;
+  }
+
+  const manager = new ServeProcessHostManager({ serveDomain, tunnelToken });
+  await manager.refresh();
+  logger.success(`Serve tunnel active: https://${serveDomain}`);
+  logger.dim(`  Wildcard: https://*.${serveDomain}`);
+  return manager;
+}
+
+function stopServeProcessHosting(
+  manager: ServeProcessHostManager | null,
+  timer: ReturnType<typeof setInterval> | null
+): void {
+  if (timer) {
+    clearInterval(timer);
+  }
+  manager?.stop();
+}
+
+// ============================================================================
 // Serve Command
 // ============================================================================
 
@@ -541,6 +823,8 @@ export async function serve(options: {
   logger.log('');
   let localRelayServer: ReturnType<typeof createRelayServer> | null = null;
   let localRelayIdentity: ReturnType<typeof generateRelayIdentity> | null = null;
+  let processHostManager: ServeProcessHostManager | null = null;
+  let processHostRefreshTimer: ReturnType<typeof setInterval> | null = null;
 
   if (hostConfig?.subdomain) {
     logger.bold('gitspace.sh Hosting:');
@@ -575,7 +859,21 @@ export async function serve(options: {
       logger.dim('  Hosting not active (tunnel token missing)');
       logger.log('');
     }
+
+    processHostManager = await startServeProcessHosting(hostConfig);
+    if (processHostManager) {
+      processHostRefreshTimer = setInterval(() => {
+        void processHostManager?.refresh();
+      }, SERVE_REFRESH_INTERVAL_MS);
+    }
   }
+
+  const remoteSessionOptions = processHostManager
+    ? {
+        processHostDomain: processHostManager.domain,
+        onProcessesChanged: () => processHostManager?.refresh(),
+      }
+    : undefined;
 
   // If gitspace.sh hosting is active, connect to local relay instead of external
   if (localRelayServer && localRelayIdentity) {
@@ -588,6 +886,7 @@ export async function serve(options: {
       relay: localRelayUrl,
       identity,
       accessList,
+      remoteSessionOptions,
     });
 
     // Initialize session manager (starts tmux-lite server)
@@ -617,6 +916,7 @@ export async function serve(options: {
       logger.log('');
       logger.info('Shutting down...');
       stopCloudflared();
+      stopServeProcessHosting(processHostManager, processHostRefreshTimer);
       sessionManager.cleanup();
       localRelayServer?.stop();
       process.exit(0);
@@ -639,6 +939,7 @@ export async function serve(options: {
     relay: relayUrl,
     identity,
     accessList,
+    remoteSessionOptions,
   });
 
   // Initialize session manager (starts tmux-lite server)
@@ -674,7 +975,7 @@ export async function serve(options: {
   logger.log('');
 
   // Step 6: Handle shutdown
-  setupShutdownHandlers(sessionManager);
+  setupShutdownHandlers(sessionManager, false, () => stopServeProcessHosting(processHostManager, processHostRefreshTimer));
 
   // Keep process alive
   await new Promise(() => {
@@ -1115,13 +1416,18 @@ function updateSessionDisplay(sessionManager: ClientSessionManager): void {
 /**
  * Set up shutdown handlers
  */
-function setupShutdownHandlers(sessionManager: ClientSessionManager, isDaemon: boolean = false): void {
+function setupShutdownHandlers(
+  sessionManager: ClientSessionManager,
+  isDaemon: boolean = false,
+  cleanup?: () => void
+): void {
   const shutdown = () => {
     logger.log('');
     logger.info('Shutting down...');
 
     // Stop cloudflared if running
     stopCloudflared();
+    cleanup?.();
 
     clearRelayConfig();
     sessionManager.cleanup();
@@ -1339,6 +1645,8 @@ export async function serveStart(options: {
   let localRelayServer: ReturnType<typeof createRelayServer> | null = null;
   let localRelayIdentity: ReturnType<typeof generateRelayIdentity> | null = null;
   let effectiveRelayUrl = relayUrl || '';
+  let processHostManager: ServeProcessHostManager | null = null;
+  let processHostRefreshTimer: ReturnType<typeof setInterval> | null = null;
 
   // Initialize daemon state
   setDaemonState({
@@ -1384,15 +1692,30 @@ export async function serveStart(options: {
       });
     }
 
+    processHostManager = await startServeProcessHosting(hostConfig);
+    if (processHostManager) {
+      processHostRefreshTimer = setInterval(() => {
+        void processHostManager?.refresh();
+      }, SERVE_REFRESH_INTERVAL_MS);
+    }
+
     // Use local relay (machine will authenticate via challenge-response)
     effectiveRelayUrl = `ws://127.0.0.1:${LOCAL_RELAY_PORT}/ws`;
   }
+
+  const remoteSessionOptions = processHostManager
+    ? {
+        processHostDomain: processHostManager.domain,
+        onProcessesChanged: () => processHostManager?.refresh(),
+      }
+    : undefined;
 
   // Create session manager
   const sessionManager = new ClientSessionManager({
     relay: effectiveRelayUrl,
     identity,
     accessList,
+    remoteSessionOptions,
   });
 
   // Initialize session manager (starts tmux-lite server)
@@ -1442,7 +1765,7 @@ export async function serveStart(options: {
   });
 
   // Set up shutdown handlers with daemon cleanup
-  setupShutdownHandlers(sessionManager, true);
+  setupShutdownHandlers(sessionManager, true, () => stopServeProcessHosting(processHostManager, processHostRefreshTimer));
 
   // Keep process alive
   await new Promise(() => {});

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -71,7 +71,6 @@ import { parseProcessSessionName } from '../lib/processes/names.js';
 import { resolveWorkspaceRef } from '../lib/events/paths.js';
 import { getGitspaceDir } from '../core/config.js';
 import { buildProcessHostname, normalizeHostLabel } from '../utils/hostnames.js';
-export { buildProcessHostname, normalizeHostLabel };
 import type { ProcessPortConfig } from '../types/processes.js';
 
 /** Package version for daemon status */

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -689,6 +689,7 @@ class ServeProcessHostManager {
   }
 
   private handleCrash(): void {
+    this.process = null;
     this.restartAttempts += 1;
     if (this.restartAttempts > MAX_CLOUDFLARED_RESTARTS) {
       logger.error(`serve tunnel crashed ${MAX_CLOUDFLARED_RESTARTS} times, giving up`);

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -481,6 +481,7 @@ export interface ProcessHostEntry {
 const SERVE_CONFIG_PATH = () => join(getServeDaemonDir(), 'serve-tunnel.yml');
 const SERVE_REFRESH_INTERVAL_MS = 5000;
 const SERVE_READY_TIMEOUT_MS = 5000;
+const MAX_WORKSPACE_PATH_CACHE_SIZE = 256;
 
 export function buildServeIngressConfig(entries: ProcessHostEntry[]): string {
   const lines = ['ingress:'];
@@ -529,6 +530,7 @@ class ServeProcessHostManager {
   private registry: ProcessHostEntry[] = [];
   private refreshPromise: Promise<void> | null = null;
   private restartAttempts = 0;
+  private retryTimer: ReturnType<typeof setTimeout> | null = null;
   private workspacePathCache = new Map<string, string>();
 
   constructor(options: { serveDomain: string; tunnelToken: string }) {
@@ -544,6 +546,10 @@ class ServeProcessHostManager {
     return [...this.registry];
   }
 
+  get isActive(): boolean {
+    return this.process !== null;
+  }
+
   async refresh(): Promise<void> {
     if (this.refreshPromise) {
       return this.refreshPromise;
@@ -555,10 +561,15 @@ class ServeProcessHostManager {
   }
 
   stop(): void {
+    if (this.retryTimer) {
+      clearTimeout(this.retryTimer);
+      this.retryTimer = null;
+    }
     if (this.process) {
       this.process.kill();
       this.process = null;
     }
+    this.workspacePathCache.clear();
   }
 
   private async refreshInternal(): Promise<void> {
@@ -581,7 +592,10 @@ class ServeProcessHostManager {
       this.registry = sorted;
       this.configHash = nextHash;
       logger.dim(`Serve tunnel updated (${sorted.length} routes)`);
+      return;
     }
+
+    this.handleStartupFailure();
   }
 
   private async collectProcessHosts(): Promise<ProcessHostEntry[]> {
@@ -593,6 +607,7 @@ class ServeProcessHostManager {
     }
     const configCache = new Map<string, ReturnType<typeof loadProcessesConfig>>();
     const entries: ProcessHostEntry[] = [];
+    const seenWorkspaceIds = new Set<string>();
 
     for (const session of sessions) {
       const parsed = parseProcessSessionName(session.name);
@@ -605,8 +620,9 @@ class ServeProcessHostManager {
         const cached = this.workspacePathCache.get(parsed.workspaceId);
         const workspacePath = cached ?? findWorkspacePathById(parsed.workspaceId);
         if (workspacePath) {
-          this.workspacePathCache.set(parsed.workspaceId, workspacePath);
+          this.setCachedWorkspacePath(parsed.workspaceId, workspacePath);
           workspaceRef = resolveWorkspaceRef(workspacePath);
+          seenWorkspaceIds.add(parsed.workspaceId);
         }
       }
       if (!workspaceRef) continue;
@@ -649,6 +665,7 @@ class ServeProcessHostManager {
         deduped.set(entry.hostname, entry);
       }
     }
+    this.pruneWorkspacePathCache(seenWorkspaceIds);
     return Array.from(deduped.values());
   }
 
@@ -663,6 +680,10 @@ class ServeProcessHostManager {
     const previous = this.process;
     this.process = nextProcess;
     this.restartAttempts = 0;
+    if (this.retryTimer) {
+      clearTimeout(this.retryTimer);
+      this.retryTimer = null;
+    }
     if (previous) {
       previous.kill();
     }
@@ -690,15 +711,52 @@ class ServeProcessHostManager {
 
   private handleCrash(): void {
     this.process = null;
-    this.restartAttempts += 1;
-    if (this.restartAttempts > MAX_CLOUDFLARED_RESTARTS) {
-      logger.error(`serve tunnel crashed ${MAX_CLOUDFLARED_RESTARTS} times, giving up`);
+    this.scheduleRetry('crashed');
+  }
+
+  private handleStartupFailure(): void {
+    this.scheduleRetry('failed to start');
+  }
+
+  private scheduleRetry(reason: 'crashed' | 'failed to start'): void {
+    if (this.retryTimer) {
       return;
     }
-    logger.info(`Restarting serve tunnel (attempt ${this.restartAttempts}/${MAX_CLOUDFLARED_RESTARTS})...`);
-    setTimeout(() => {
+
+    this.restartAttempts += 1;
+    if (this.restartAttempts > MAX_CLOUDFLARED_RESTARTS) {
+      logger.error(`serve tunnel ${reason} ${MAX_CLOUDFLARED_RESTARTS} times, giving up`);
+      return;
+    }
+
+    logger.info(`Restarting serve tunnel (${reason}) (attempt ${this.restartAttempts}/${MAX_CLOUDFLARED_RESTARTS})...`);
+    this.retryTimer = setTimeout(() => {
+      this.retryTimer = null;
       void this.refresh();
     }, CLOUDFLARED_RESTART_DELAY);
+  }
+
+  private setCachedWorkspacePath(workspaceId: string, workspacePath: string): void {
+    if (this.workspacePathCache.has(workspaceId)) {
+      this.workspacePathCache.delete(workspaceId);
+    }
+    this.workspacePathCache.set(workspaceId, workspacePath);
+
+    while (this.workspacePathCache.size > MAX_WORKSPACE_PATH_CACHE_SIZE) {
+      const oldest = this.workspacePathCache.keys().next().value;
+      if (!oldest) {
+        break;
+      }
+      this.workspacePathCache.delete(oldest);
+    }
+  }
+
+  private pruneWorkspacePathCache(seenWorkspaceIds: Set<string>): void {
+    for (const key of this.workspacePathCache.keys()) {
+      if (!seenWorkspaceIds.has(key)) {
+        this.workspacePathCache.delete(key);
+      }
+    }
   }
 }
 
@@ -720,8 +778,12 @@ async function startServeProcessHosting(hostConfig: HostConfig): Promise<ServePr
 
   const manager = new ServeProcessHostManager({ serveDomain, tunnelToken });
   await manager.refresh();
-  logger.success(`Serve tunnel active: https://${serveDomain}`);
-  logger.dim(`  Wildcard: https://*.${serveDomain}`);
+  if (manager.isActive) {
+    logger.success(`Serve tunnel active: https://${serveDomain}`);
+    logger.dim(`  Wildcard: https://*.${serveDomain}`);
+  } else {
+    logger.warning(`Serve tunnel failed to start for https://${serveDomain}; retrying in background`);
+  }
   return manager;
 }
 

--- a/src/components/Events.tsx
+++ b/src/components/Events.tsx
@@ -1,0 +1,117 @@
+/**
+ * Events - Shared Hook
+ */
+
+import { useMemo, useState, useEffect } from 'react';
+
+export interface WideEventItem {
+  eventId: string;
+  eventName: string;
+  level: string;
+  timestamp: string;
+  timestampMs?: number;
+  message: string;
+  processName?: string;
+  processInstance?: number;
+  sessionId?: string;
+  raw?: Record<string, unknown>;
+  kind?: 'source' | 'wide';
+  correlationId?: string;
+  timeline?: import("../types/events.js").WideEventTimelineItem[];
+  timelineMap?: import("../types/events.js").WideSnapshotTimelineMap;
+  timelineOrder?: string[];
+}
+
+function getEventTimestamp(event: WideEventItem): number {
+  if (typeof event.timestampMs === 'number' && !Number.isNaN(event.timestampMs)) {
+    return event.timestampMs;
+  }
+  const parsed = Date.parse(event.timestamp);
+  return Number.isNaN(parsed) ? 0 : parsed;
+}
+
+function getEventKey(event: WideEventItem): string {
+  const processName = event.processName ?? 'unknown';
+  const instance = event.processInstance ?? 1;
+  const correlation = event.correlationId ?? event.eventId;
+  return `${processName}:${instance}:${correlation}`;
+}
+
+export interface UseEventsProps {
+  events: WideEventItem[];
+  liveEventIds: string[];
+  savedFilters: import("../types/events.js").SavedEventFilter[];
+  onSelectFilter: (filter: import("../types/events.js").SavedEventFilter | null) => void;
+  onClose: () => void;
+}
+
+export interface UseEventsReturn {
+  filtered: WideEventItem[];
+  selectedIndex: number;
+  selected: WideEventItem | null;
+  liveEventIds: string[];
+  savedFilters: import("../types/events.js").SavedEventFilter[];
+  activeFilterName: string | null;
+  selectIndex: (index: number) => void;
+  selectSavedFilter: (filter: import("../types/events.js").SavedEventFilter | null) => void;
+  close: () => void;
+}
+
+export function useEvents(props: UseEventsProps): UseEventsReturn {
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const [activeFilterName, setActiveFilterName] = useState<string | null>(null);
+  const [selectedKey, setSelectedKey] = useState<string | null>(null);
+
+  const filtered = useMemo(() => {
+    const wideEvents = props.events.filter((event) => event.kind === 'wide');
+    return [...wideEvents].sort((a, b) => getEventTimestamp(b) - getEventTimestamp(a));
+  }, [props.events]);
+
+  useEffect(() => {
+    if (!selectedKey && filtered.length > 0) {
+      setSelectedIndex(0);
+      setSelectedKey(getEventKey(filtered[0]));
+      return;
+    }
+
+    if (!selectedKey) return;
+    const nextIndex = filtered.findIndex((event) => getEventKey(event) === selectedKey);
+    if (nextIndex !== -1 && nextIndex !== selectedIndex) {
+      setSelectedIndex(nextIndex);
+      return;
+    }
+
+    if (nextIndex === -1 && filtered.length > 0) {
+      setSelectedIndex(0);
+      setSelectedKey(getEventKey(filtered[0]));
+    }
+  }, [filtered, selectedKey, selectedIndex]);
+
+  const selected = filtered[selectedIndex] ?? null;
+
+  const selectSavedFilter = (filter: import("../types/events.js").SavedEventFilter | null) => {
+    setSelectedIndex(0);
+    setSelectedKey(null);
+    setActiveFilterName(filter?.name ?? null);
+    props.onSelectFilter(filter);
+  };
+
+  const selectIndex = (index: number) => {
+    const clamped = Math.max(0, Math.min(index, filtered.length - 1));
+    setSelectedIndex(clamped);
+    const selectedEvent = filtered[clamped];
+    setSelectedKey(selectedEvent ? getEventKey(selectedEvent) : null);
+  };
+
+  return {
+    filtered,
+    selectedIndex,
+    selected,
+    liveEventIds: props.liveEventIds,
+    savedFilters: props.savedFilters,
+    activeFilterName,
+    selectIndex,
+    selectSavedFilter,
+    close: props.onClose,
+  };
+}

--- a/src/components/Events.tsx
+++ b/src/components/Events.tsx
@@ -2,7 +2,7 @@
  * Events - Shared Hook
  */
 
-import { useMemo, useState, useEffect } from 'react';
+import { useMemo, useState, useEffect, useCallback } from 'react';
 
 export interface WideEventItem {
   eventId: string;
@@ -109,19 +109,19 @@ export function useEvents(props: UseEventsProps): UseEventsReturn {
 
   const selected = filtered[selectedIndex] ?? null;
 
-  const selectSavedFilter = (filter: import("../types/events.js").SavedEventFilter | null) => {
+  const selectSavedFilter = useCallback((filter: import("../types/events.js").SavedEventFilter | null) => {
     setSelectedIndex(0);
     setSelectedKey(null);
     setActiveFilterName(filter?.name ?? null);
     props.onSelectFilter(filter);
-  };
+  }, [props.onSelectFilter]);
 
-  const selectIndex = (index: number) => {
+  const selectIndex = useCallback((index: number) => {
     const clamped = Math.max(0, Math.min(index, filtered.length - 1));
     setSelectedIndex(clamped);
     const selectedEvent = filtered[clamped];
     setSelectedKey(selectedEvent ? getEventKey(selectedEvent) : null);
-  };
+  }, [filtered]);
 
   return {
     filtered,

--- a/src/components/Events.tsx
+++ b/src/components/Events.tsx
@@ -89,23 +89,23 @@ export function useEvents(props: UseEventsProps): UseEventsReturn {
 
   useEffect(() => {
     if (!selectedKey && filtered.length > 0) {
-      setSelectedIndex(0);
+      setSelectedIndex((current) => (current === 0 ? current : 0));
       setSelectedKey(getEventKey(filtered[0]));
       return;
     }
 
     if (!selectedKey) return;
     const nextIndex = filtered.findIndex((event) => getEventKey(event) === selectedKey);
-    if (nextIndex !== -1 && nextIndex !== selectedIndex) {
-      setSelectedIndex(nextIndex);
+    if (nextIndex !== -1) {
+      setSelectedIndex((current) => (current === nextIndex ? current : nextIndex));
       return;
     }
 
     if (nextIndex === -1 && filtered.length > 0) {
-      setSelectedIndex(0);
+      setSelectedIndex((current) => (current === 0 ? current : 0));
       setSelectedKey(getEventKey(filtered[0]));
     }
-  }, [filtered, selectedKey, selectedIndex]);
+  }, [filtered, selectedKey]);
 
   const selected = filtered[selectedIndex] ?? null;
 

--- a/src/components/Events.tsx
+++ b/src/components/Events.tsx
@@ -22,6 +22,26 @@ export interface WideEventItem {
   timelineOrder?: string[];
 }
 
+export function toWideEventItem(event: import('../types/events.js').WideEvent): WideEventItem {
+  return {
+    eventId: event.eventId,
+    eventName: event.eventName,
+    level: event.level,
+    timestamp: event.timestamp,
+    timestampMs: event.timestampMs,
+    message: event.message,
+    processName: event.processName,
+    processInstance: event.processInstance,
+    sessionId: event.sessionId,
+    raw: event.raw,
+    kind: event.kind,
+    correlationId: event.correlationId,
+    timeline: event.timeline,
+    timelineMap: event.timelineMap,
+    timelineOrder: event.timelineOrder,
+  };
+}
+
 function getEventTimestamp(event: WideEventItem): number {
   if (typeof event.timestampMs === 'number' && !Number.isNaN(event.timestampMs)) {
     return event.timestampMs;

--- a/src/components/Events.tui.tsx
+++ b/src/components/Events.tui.tsx
@@ -1,0 +1,129 @@
+/**
+ * Events - TUI Display Component
+ */
+
+import type { UseEventsReturn } from './Events.js';
+
+const COLORS = {
+  border: '#555555',
+  title: '#00FF88',
+  text: '#FFFFFF',
+  textDim: '#888888',
+  selected: '#00AAFF',
+  info: '#3fb950',
+  warn: '#d29922',
+  error: '#f85149',
+};
+
+type TimelineEntry = {
+  eventName: string;
+  level: string;
+  timestamp: string;
+  message: string;
+};
+
+function formatEventTime(timestamp: string): string {
+  const parsed = Date.parse(timestamp);
+  if (Number.isNaN(parsed)) return timestamp;
+  const date = new Date(parsed);
+  const hours = date.getHours().toString().padStart(2, '0');
+  const minutes = date.getMinutes().toString().padStart(2, '0');
+  const seconds = date.getSeconds().toString().padStart(2, '0');
+  return `${hours}:${minutes}:${seconds}`;
+}
+
+function getLevelColor(level: string): string {
+  const normalized = level.toLowerCase();
+  if (normalized === 'error') return COLORS.error;
+  if (normalized === 'warn') return COLORS.warn;
+  return COLORS.info;
+}
+
+export function EventsTui(props: UseEventsReturn) {
+  const { filtered, selectedIndex, selected } = props;
+  const timeline = (selected?.timeline ?? []) as TimelineEntry[];
+
+  return (
+    <box flexDirection="column" flexGrow={1} width="100%" height="100%">
+      <box
+        flexDirection="row"
+        height={1}
+        width="100%"
+        backgroundColor="#222222"
+        paddingLeft={1}
+        paddingRight={1}
+      >
+        <text fg={COLORS.title}>Events</text>
+        <text fg={COLORS.textDim}> - Wide events</text>
+        <box flexGrow={1} />
+        <text fg={COLORS.textDim}>[Esc] Back</text>
+      </box>
+      <box flexDirection="row" flexGrow={1} width="100%">
+        <box
+          flexDirection="column"
+          width="45%"
+          border
+          borderStyle="single"
+          borderColor={COLORS.border}
+        >
+          <text fg={COLORS.title} paddingLeft={1} height={1}>
+            {' '}Wide events{' '}
+          </text>
+          <box flexDirection="column" paddingLeft={1} paddingTop={1} flexGrow={1} overflow="scroll">
+            {filtered.length === 0 ? (
+              <text fg={COLORS.textDim}>No wide events yet.</text>
+            ) : (
+              filtered.map((event, index) => {
+                const isSelected = index === selectedIndex;
+                const prefix = isSelected ? '>' : ' ';
+                const levelColor = getLevelColor(event.level);
+                return (
+                  <box key={event.eventId} flexDirection="row" height={1}>
+                    <text fg={isSelected ? COLORS.selected : COLORS.textDim}>{prefix}</text>
+                    <text fg={levelColor}> {event.level.toUpperCase()}</text>
+                    <text fg={COLORS.textDim}> {formatEventTime(event.timestamp)}</text>
+                    <text fg={isSelected ? COLORS.text : COLORS.textDim}> {event.correlationId ?? event.eventId}</text>
+                  </box>
+                );
+              })
+            )}
+          </box>
+        </box>
+        <box flexDirection="column" flexGrow={1} border borderStyle="single" borderColor={COLORS.border}>
+          <text fg={COLORS.title} paddingLeft={1} height={1}>
+            {' '}Timeline{' '}
+          </text>
+          <box flexDirection="column" paddingLeft={1} paddingTop={1} flexGrow={1} overflow="scroll">
+            {selected ? (
+              <box flexDirection="column">
+                <text fg={COLORS.text} height={1}>Correlation: {selected.correlationId ?? selected.eventId}</text>
+                <text fg={COLORS.textDim} height={1}>Latest: {selected.message}</text>
+                {selected.processName && (
+                  <text fg={COLORS.textDim} height={1}>Process: {selected.processName}</text>
+                )}
+                {selected.sessionId && (
+                  <text fg={COLORS.textDim} height={1}>Session: {selected.sessionId}</text>
+                )}
+                <box height={1} />
+                {timeline.length === 0 ? (
+                  <text fg={COLORS.textDim}>Collecting timeline...</text>
+                ) : (
+                  timeline.map((item, index) => (
+                    <box key={`${item.eventName}-${index}`} flexDirection="row" height={1}>
+                      <text fg={getLevelColor(item.level)}>{item.level.toUpperCase()}</text>
+                      <text fg={COLORS.textDim}> {formatEventTime(item.timestamp)}</text>
+                      <text fg={COLORS.text}> {item.eventName}</text>
+                      <text fg={COLORS.textDim}> - {item.message}</text>
+                    </box>
+                  ))
+                )}
+              </box>
+            ) : (
+              <text fg={COLORS.textDim}>Select a wide event to inspect.</text>
+            )}
+          </box>
+        </box>
+      </box>
+    </box>
+  );
+}

--- a/src/components/Events.web.tsx
+++ b/src/components/Events.web.tsx
@@ -1,0 +1,383 @@
+/** @jsxImportSource react */
+/**
+ * Events - Web Display Component
+ */
+
+import { useMemo, useState } from 'react';
+import type { UseEventsReturn } from './Events.js';
+
+const LEVEL_COLORS: Record<string, string> = {
+  error: '#f85149',
+  warn: '#d29922',
+  info: '#3fb950',
+};
+
+type TimelineBucket = {
+  label: string;
+  count: number;
+};
+
+type TimelinePoint = {
+  timestamp?: string;
+  timestampMs?: number;
+  processName?: string;
+  processInstance?: number;
+};
+
+function getTimelineTimestamp(event: TimelinePoint): number {
+  if (typeof event.timestampMs === 'number' && !Number.isNaN(event.timestampMs)) {
+    return event.timestampMs;
+  }
+  if (typeof event.timestamp === 'string') {
+    const parsed = Date.parse(event.timestamp);
+    if (!Number.isNaN(parsed)) {
+      return parsed;
+    }
+  }
+  return 0;
+}
+
+function buildTimelineBuckets(events: TimelinePoint[]): TimelineBucket[] {
+  if (events.length === 0) return [];
+  const timestamps = events.map((event) => getTimelineTimestamp(event));
+  const minTs = Math.min(...timestamps);
+  const maxTs = Math.max(...timestamps);
+  const rangeMs = Math.max(1, maxTs - minTs);
+
+  const bucketMs = rangeMs <= 15 * 60_000
+    ? 60_000
+    : rangeMs <= 2 * 60 * 60_000
+      ? 5 * 60_000
+      : rangeMs <= 12 * 60 * 60_000
+        ? 30 * 60_000
+        : 60 * 60_000;
+
+  const bucketCount = Math.max(6, Math.min(36, Math.ceil(rangeMs / bucketMs)));
+  const buckets: TimelineBucket[] = Array.from({ length: bucketCount }, (_, index) => ({
+    label: formatTimelineLabel(minTs + index * bucketMs),
+    count: 0,
+  }));
+
+  for (const timestamp of timestamps) {
+    const index = Math.min(bucketCount - 1, Math.floor((timestamp - minTs) / bucketMs));
+    buckets[index].count += 1;
+  }
+
+  return buckets;
+}
+
+function formatTimelineLabel(timestamp: number): string {
+  const date = new Date(timestamp);
+  const hours = date.getHours().toString().padStart(2, '0');
+  const minutes = date.getMinutes().toString().padStart(2, '0');
+  return `${hours}:${minutes}`;
+}
+
+function formatEventTime(timestamp: string): string {
+  const parsed = Date.parse(timestamp);
+  if (Number.isNaN(parsed)) return timestamp;
+  const date = new Date(parsed);
+  const hours = date.getHours().toString().padStart(2, '0');
+  const minutes = date.getMinutes().toString().padStart(2, '0');
+  const seconds = date.getSeconds().toString().padStart(2, '0');
+  return `${hours}:${minutes}:${seconds}`;
+}
+
+function formatLevel(level: string): string {
+  return level.toLowerCase();
+}
+
+export function EventsWeb(props: UseEventsReturn & { workspaceLabel?: string | null }) {
+  const { filtered, selectedIndex, selected, liveEventIds, savedFilters, activeFilterName, selectIndex, selectSavedFilter, close } = props;
+  const [search, setSearch] = useState('');
+
+  const filteredLogs = useMemo(() => {
+    const query = search.trim().toLowerCase();
+    const wideEvents = filtered.filter((event) => event.kind === 'wide');
+    if (!query) return wideEvents;
+    return wideEvents.filter((event) =>
+      event.message.toLowerCase().includes(query) ||
+      event.correlationId?.toLowerCase().includes(query)
+    );
+  }, [filtered, search]);
+
+  const timelineEvents = useMemo(() => {
+    if (!selected) return [] as Array<import('../types/events.js').WideSnapshotTimelineEntry>;
+    if (selected.timelineOrder && selected.timelineMap) {
+      return selected.timelineOrder
+        .map((key: string) => selected.timelineMap?.[key])
+        .filter((entry): entry is import('../types/events.js').WideSnapshotTimelineEntry => Boolean(entry));
+    }
+    if (selected.timeline && selected.timeline.length > 0) {
+      return selected.timeline.map((entry, index) => ({
+        ...entry,
+        key: `${entry.eventName}-${index + 1}`,
+        eventId: `${entry.eventName}-${index + 1}`,
+        processName: selected.processName,
+        processInstance: selected.processInstance,
+      }));
+    }
+    return [] as Array<import('../types/events.js').WideSnapshotTimelineEntry>;
+  }, [filtered, selected]);
+
+  const timelineBuckets = useMemo(() => buildTimelineBuckets(timelineEvents), [timelineEvents]);
+  const timelineMax = Math.max(1, ...timelineBuckets.map((bucket) => bucket.count));
+
+  const wideEvent = selected ?? null;
+
+  const processLabel = selected?.processName
+    ? `${selected.processName}${selected.processInstance ? `-${selected.processInstance}` : ''}`
+    : null;
+
+  return (
+    <div className="events-root h-visual-viewport w-full flex flex-col bg-[#0d1117] min-h-0">
+      <Header onBack={close} workspaceLabel={props.workspaceLabel} processLabel={processLabel} />
+      <div className="events-column flex-1 flex overflow-hidden min-h-0">
+        <div className="w-[38%] min-w-[320px] border-r border-[#30363d] flex flex-col min-h-0">
+          <div className="p-4 space-y-4 border-b border-[#30363d]">
+            <div>
+              <div className="text-xs text-[#6e7681] uppercase tracking-wide mb-2">Saved Filters</div>
+              <div className="space-y-2">
+                <button
+                  onClick={() => selectSavedFilter(null)}
+                  className={`w-full text-left text-xs truncate px-2 py-1 rounded ${activeFilterName === null ? 'bg-[#21262d] text-[#e6edf3]' : 'text-[#8b949e] hover:bg-[#161b22]'}`}
+                >
+                  All events
+                </button>
+                {savedFilters.length === 0 ? (
+                  <div className="text-xs text-[#8b949e]">No saved filters</div>
+                ) : (
+                  savedFilters.map((filter) => {
+                    const isActive = filter.name === activeFilterName;
+                    return (
+                      <button
+                        key={filter.name}
+                        onClick={() => selectSavedFilter(filter)}
+                        className={`w-full text-left text-xs truncate px-2 py-1 rounded ${isActive ? 'bg-[#21262d] text-[#e6edf3]' : 'text-[#8b949e] hover:bg-[#161b22]'}`}
+                      >
+                        {filter.name}
+                      </button>
+                    );
+                  })
+                )}
+              </div>
+            </div>
+            <div>
+              <div className="text-xs text-[#6e7681] uppercase tracking-wide mb-2">Search</div>
+              <input
+                value={search}
+                onChange={(event) => setSearch(event.target.value)}
+                placeholder="Search event name or message"
+                className="w-full rounded bg-[#0d1117] border border-[#30363d] px-2 py-1 text-sm text-[#e6edf3] placeholder:text-[#6e7681] focus:outline-none focus:border-[#58a6ff]"
+              />
+            </div>
+            <div className="grid grid-cols-2 gap-3 text-xs text-[#8b949e]">
+              <div>
+                <div className="text-[#6e7681]">Events</div>
+                <div className="text-[#e6edf3] text-sm">{filteredLogs.length}</div>
+              </div>
+              <div>
+                <div className="text-[#6e7681]">Live</div>
+                <div className="text-[#e6edf3] text-sm">{liveEventIds.length}</div>
+              </div>
+              <div>
+                <div className="text-[#6e7681]">Errors</div>
+                <div className="text-[#e6edf3] text-sm">
+                  {filteredLogs.filter((event) => formatLevel(event.level) === 'error').length}
+                </div>
+              </div>
+              <div>
+                <div className="text-[#6e7681]">Warnings</div>
+                <div className="text-[#e6edf3] text-sm">
+                  {filteredLogs.filter((event) => formatLevel(event.level) === 'warn').length}
+                </div>
+              </div>
+            </div>
+          </div>
+          <div className="events-scroll flex-1 overflow-y-auto min-h-0">
+              {filteredLogs.length === 0 ? (
+                <div className="text-[#8b949e] text-center py-8">No wide events</div>
+              ) : (
+                filteredLogs.map((event, index) => {
+                  const selectedEvent = filteredLogs[selectedIndex];
+                  const isSelected = selectedEvent?.eventId === event.eventId;
+                  const level = formatLevel(event.level);
+                  const levelColor = LEVEL_COLORS[level] ?? '#8b949e';
+                  return (
+                    <div
+                      key={`${event.eventId}-${index}`}
+                      onClick={() => selectIndex(index)}
+                      className={`px-4 py-3 border-b border-[#30363d] cursor-pointer ${isSelected ? 'bg-[#21262d] border-l-4 border-l-[#58a6ff]' : 'hover:bg-[#161b22]'}`}
+                    >
+                      <div className="flex items-center gap-2 text-xs text-[#6e7681]">
+                        <div className="uppercase" style={{ color: levelColor }}>{level}</div>
+                        <div>·</div>
+                        <div>{formatEventTime(event.timestamp)}</div>
+                        {event.processName && <div className="text-[#6e7681]">{event.processName}</div>}
+                      </div>
+                      <div className="text-[#e6edf3] text-sm font-medium truncate">
+                        Wide event {event.correlationId ? `· ${event.correlationId}` : ''}
+                      </div>
+                      <div className="text-[#8b949e] text-xs truncate">{event.message}</div>
+                    </div>
+                  );
+                })
+              )}
+
+          </div>
+        </div>
+        <div className="flex-1 flex flex-col min-h-0">
+            <div className="border-b border-[#30363d] p-4">
+              <div className="flex items-center justify-between mb-3">
+                <div className="text-xs text-[#6e7681] uppercase tracking-wide">
+                  {selected ? `${selected.eventName} timeline` : 'All events timeline'}
+                </div>
+                <div className="text-xs text-[#6e7681]">{timelineEvents.length} events</div>
+              </div>
+              {timelineBuckets.length === 0 ? (
+                <div className="text-[#8b949e] text-sm">No timeline data</div>
+              ) : (
+                <div className="flex items-end gap-1 h-24">
+                  {timelineBuckets.map((bucket, index) => (
+                    <div key={`${bucket.label}-${index}`} className="flex-1 flex flex-col items-center gap-2">
+                      <div
+                        className="w-full rounded bg-[#30363d]"
+                        style={{
+                          height: `${Math.max(6, (bucket.count / timelineMax) * 96)}px`,
+                          backgroundColor: selected ? '#58a6ff' : '#3fb950',
+                        }}
+                      />
+                      <div className="text-[10px] text-[#6e7681] truncate w-full text-center">
+                        {bucket.label}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+            <div className="events-scroll flex-1 overflow-y-auto p-4 min-h-0">
+            {selected ? (
+              <div className="space-y-4">
+                <div className="flex items-center justify-between">
+                  <div>
+                    <div className="text-[#e6edf3] text-lg font-semibold">Wide Event</div>
+                    <div className="text-xs text-[#6e7681]">{selected.correlationId ?? selected.eventId}</div>
+                  </div>
+                  {wideEvent && (
+                    <button
+                      onClick={() => navigator.clipboard.writeText(JSON.stringify(wideEvent.raw ?? wideEvent, null, 2))}
+                      className="text-xs px-2 py-1 rounded bg-[#21262d] hover:bg-[#30363d] text-[#e6edf3]"
+                    >
+                      Copy JSON
+                    </button>
+                  )}
+                </div>
+                <div className="grid grid-cols-2 gap-3 text-sm text-[#8b949e]">
+                  <div>
+                    <div className="text-xs text-[#6e7681]">Latest Level</div>
+                    <div className="text-[#e6edf3]">{formatLevel(selected.level)}</div>
+                  </div>
+                  <div>
+                    <div className="text-xs text-[#6e7681]">Latest Timestamp</div>
+                    <div className="text-[#e6edf3]">{selected.timestamp}</div>
+                  </div>
+                  <div>
+                    <div className="text-xs text-[#6e7681]">Process</div>
+                    <div className="text-[#e6edf3]">
+                      {selected.processName ? `${selected.processName}${selected.processInstance ? `#${selected.processInstance}` : ''}` : '—'}
+                    </div>
+                  </div>
+                  <div>
+                    <div className="text-xs text-[#6e7681]">Session</div>
+                    <div className="text-[#e6edf3]">{selected.sessionId ?? '—'}</div>
+                  </div>
+                </div>
+                <div>
+                  <div className="text-xs text-[#6e7681] uppercase tracking-wide mb-2">Latest Message</div>
+                  <div className="text-[#e6edf3] text-sm">{selected.message}</div>
+                </div>
+                <div>
+                  <div className="text-xs text-[#6e7681] uppercase tracking-wide mb-2">Source Timeline</div>
+                  {timelineEvents.length > 0 ? (
+                    <div className="space-y-2">
+                      {timelineEvents.map((item, index) => (
+                        <div key={`${item.eventName}-${index}`} className="border border-[#30363d] rounded px-3 py-2">
+                          <div className="flex items-center gap-2 text-xs text-[#6e7681]">
+                            <div className="uppercase" style={{ color: LEVEL_COLORS[formatLevel(item.level)] ?? '#8b949e' }}>
+                              {formatLevel(item.level)}
+                            </div>
+                            <div>·</div>
+                            <div>{formatEventTime(item.timestamp)}</div>
+                          </div>
+                          <div className="text-sm text-[#e6edf3]">{item.eventName}</div>
+                          <div className="text-xs text-[#8b949e]">{item.message}</div>
+                          {typeof item.processName === 'string' && (
+                            <div className="text-[11px] text-[#6e7681]">
+                              {item.processName}
+                              {typeof item.processInstance === 'number' ? `#${item.processInstance}` : ''}
+                            </div>
+                          )}
+                        </div>
+                      ))}
+                    </div>
+                  ) : (
+                    <div className="text-[#8b949e] text-sm">Collecting timeline...</div>
+                  )}
+                </div>
+                {wideEvent && (
+                  <div>
+                    <div className="text-xs text-[#6e7681] uppercase tracking-wide mb-2">Raw Wide Event</div>
+                    <pre className="text-xs bg-[#0d1117] border border-[#30363d] rounded p-3 text-[#e6edf3] overflow-x-auto">
+                      {JSON.stringify(wideEvent.raw ?? wideEvent, null, 2)}
+                    </pre>
+                  </div>
+                )}
+              </div>
+            ) : (
+              <div className="text-[#8b949e]">Select a wide event to inspect</div>
+            )}
+
+            </div>
+
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function Header({
+  onBack,
+  workspaceLabel,
+  processLabel,
+}: {
+  onBack: () => void;
+  workspaceLabel?: string | null;
+  processLabel?: string | null;
+}) {
+  return (
+    <div className="bg-[#161b22] px-4 py-3 flex items-center justify-between border-b border-[#30363d]">
+      <div className="flex items-center gap-3">
+        <button
+          onClick={onBack}
+          className="text-sm text-[#8b949e] hover:text-[#e6edf3] active:text-[#22c55e] py-2 pr-2 -ml-2 min-h-[44px] flex items-center"
+        >
+          ← <span className="hidden sm:inline ml-1">Back</span>
+        </button>
+        <div>
+          <div className="text-[#e6edf3] font-medium">Events</div>
+          {workspaceLabel && (
+            <div className="text-xs text-[#6e7681]">Workspace: {workspaceLabel}</div>
+          )}
+          {processLabel && (
+            <div className="text-xs text-[#6e7681]">Last update: {processLabel}</div>
+          )}
+        </div>
+      </div>
+      <div className="flex items-center gap-3 text-xs text-[#6e7681]">
+        <span>J/K: Navigate</span>
+        <span>Esc: Close</span>
+      </div>
+    </div>
+  );
+}
+

--- a/src/components/Events.web.tsx
+++ b/src/components/Events.web.tsx
@@ -95,6 +95,7 @@ export function EventsWeb(props: UseEventsReturn & { workspaceLabel?: string | n
     const query = search.trim().toLowerCase();
     if (!query) return filtered;
     return filtered.filter((event) =>
+      event.eventName.toLowerCase().includes(query) ||
       event.message.toLowerCase().includes(query) ||
       event.correlationId?.toLowerCase().includes(query)
     );
@@ -372,7 +373,7 @@ function Header({
             <div className="text-xs text-[#6e7681]">Workspace: {workspaceLabel}</div>
           )}
           {processLabel && (
-            <div className="text-xs text-[#6e7681]">Last update: {processLabel}</div>
+            <div className="text-xs text-[#6e7681]">Process: {processLabel}</div>
           )}
         </div>
       </div>

--- a/src/components/Events.web.tsx
+++ b/src/components/Events.web.tsx
@@ -88,14 +88,13 @@ function formatLevel(level: string): string {
 }
 
 export function EventsWeb(props: UseEventsReturn & { workspaceLabel?: string | null }) {
-  const { filtered, selectedIndex, selected, liveEventIds, savedFilters, activeFilterName, selectIndex, selectSavedFilter, close } = props;
+  const { filtered, selected, liveEventIds, savedFilters, activeFilterName, selectIndex, selectSavedFilter, close } = props;
   const [search, setSearch] = useState('');
 
   const filteredLogs = useMemo(() => {
     const query = search.trim().toLowerCase();
-    const wideEvents = filtered.filter((event) => event.kind === 'wide');
-    if (!query) return wideEvents;
-    return wideEvents.filter((event) =>
+    if (!query) return filtered;
+    return filtered.filter((event) =>
       event.message.toLowerCase().includes(query) ||
       event.correlationId?.toLowerCase().includes(query)
     );
@@ -118,7 +117,7 @@ export function EventsWeb(props: UseEventsReturn & { workspaceLabel?: string | n
       }));
     }
     return [] as Array<import('../types/events.js').WideSnapshotTimelineEntry>;
-  }, [filtered, selected]);
+  }, [selected]);
 
   const timelineBuckets = useMemo(() => buildTimelineBuckets(timelineEvents), [timelineEvents]);
   const timelineMax = Math.max(1, ...timelineBuckets.map((bucket) => bucket.count));

--- a/src/components/Events.web.tsx
+++ b/src/components/Events.web.tsx
@@ -199,14 +199,18 @@ export function EventsWeb(props: UseEventsReturn & { workspaceLabel?: string | n
                 <div className="text-[#8b949e] text-center py-8">No wide events</div>
               ) : (
                 filteredLogs.map((event, index) => {
-                  const selectedEvent = filteredLogs[selectedIndex];
-                  const isSelected = selectedEvent?.eventId === event.eventId;
+                  const isSelected = selected?.eventId === event.eventId;
                   const level = formatLevel(event.level);
                   const levelColor = LEVEL_COLORS[level] ?? '#8b949e';
                   return (
                     <div
                       key={`${event.eventId}-${index}`}
-                      onClick={() => selectIndex(index)}
+                      onClick={() => {
+                        const baseIndex = filtered.findIndex((item) => item.eventId === event.eventId);
+                        if (baseIndex >= 0) {
+                          selectIndex(baseIndex);
+                        }
+                      }}
                       className={`px-4 py-3 border-b border-[#30363d] cursor-pointer ${isSelected ? 'bg-[#21262d] border-l-4 border-l-[#58a6ff]' : 'hover:bg-[#161b22]'}`}
                     >
                       <div className="flex items-center gap-2 text-xs text-[#6e7681]">
@@ -380,4 +384,3 @@ function Header({
     </div>
   );
 }
-

--- a/src/components/RemoteMachineScreen.tui.tsx
+++ b/src/components/RemoteMachineScreen.tui.tsx
@@ -26,6 +26,7 @@ import { SessionTerminal } from './SessionTerminal.tui.js';
 import { ScriptTerminal, type ScriptTerminalHandle } from './ScriptTerminal.tui.js';
 import { getKeyboardInputChunk, normalizeInputText } from '../tui/input-text.js';
 import { useWorkspaceDeleteFlow } from '../app/session/useWorkspaceDeleteFlow.js';
+import { buildEditProcessesCommand } from '../lib/processes/editor.js';
 
 const COLORS = {
   statusBar: '#333333',
@@ -56,6 +57,7 @@ export function RemoteMachineScreen({ machine, relayUrl, identity, onBack }: Rem
   const [showInbox, setShowInbox] = useState(false);
   const [showScriptTerminal, setShowScriptTerminal] = useState(false);
   const [scriptWorkspaceName, setScriptWorkspaceName] = useState('workspace');
+  const [pendingProcessEditWorkspaceId, setPendingProcessEditWorkspaceId] = useState<string | null>(null);
   const scriptTerminalRef = useRef<ScriptTerminalHandle | null>(null);
   const flow = useFlow({
     onError: (error) => {
@@ -183,6 +185,43 @@ export function RemoteMachineScreen({ machine, relayUrl, identity, onBack }: Rem
     }
   }, [remote.mode]);
 
+  useEffect(() => {
+    if (!pendingProcessEditWorkspaceId || remote.mode !== 'browsing') {
+      return;
+    }
+    remote.requestWorkspaces();
+  }, [pendingProcessEditWorkspaceId, remote.mode, remote.requestWorkspaces]);
+
+  useEffect(() => {
+    if (!pendingProcessEditWorkspaceId || remote.mode !== 'browsing') {
+      return;
+    }
+
+    const workspace = remote.workspaces.find((item) => item.id === pendingProcessEditWorkspaceId);
+    if (!workspace) {
+      return;
+    }
+
+    if (workspace.processConfigError) {
+      flow.showMessage({
+        title: 'Invalid Processes Config',
+        message: workspace.processConfigError,
+        variant: 'error',
+      });
+    } else {
+      const processCount = workspace.processes?.length ?? 0;
+      flow.showMessage({
+        title: 'Processes Config Updated',
+        message: processCount === 0
+          ? 'Config is valid. No processes are defined yet.'
+          : `Config is valid. ${processCount} process${processCount === 1 ? '' : 'es'} defined.`,
+        variant: 'success',
+      });
+    }
+
+    setPendingProcessEditWorkspaceId(null);
+  }, [flow, pendingProcessEditWorkspaceId, remote.mode, remote.workspaces]);
+
   const handleStartProcessAttach = useCallback((params: { workspaceId: string; processName: string; instance: number }) => {
     void Promise.resolve(remote.startProcess(params.workspaceId, params.processName)).finally(() => {
       remote.requestWorkspaces();
@@ -199,10 +238,12 @@ export function RemoteMachineScreen({ machine, relayUrl, identity, onBack }: Rem
   }, [flow]);
 
   const handleEditProcesses = useCallback(({ workspaceId }: { workspaceId: string }) => {
+    setPendingProcessEditWorkspaceId(workspaceId);
+    const commandSpec = buildEditProcessesCommand();
     void attachController.attach({
       workspaceId,
-      command: 'sh',
-      args: ['-c', 'mkdir -p .gitspace && exec "${EDITOR:-vi}" .gitspace/processes.json'],
+      command: commandSpec.command,
+      args: commandSpec.args,
     });
   }, [attachController]);
 

--- a/src/components/RemoteMachineScreen.tui.tsx
+++ b/src/components/RemoteMachineScreen.tui.tsx
@@ -1,4 +1,4 @@
-import { Fragment, useEffect, useMemo, useRef, useState } from 'react';
+import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { PasteEvent } from '@opentui/core';
 import { useKeyboard, useRenderer } from '@opentui/react';
 import type { Identity } from '../types/identity.js';
@@ -90,7 +90,7 @@ export function RemoteMachineScreen({ machine, relayUrl, identity, onBack }: Rem
       return remote.selectedProjectName;
     },
     onBeforeAttach: ({ target, params }) => {
-      if (target === 'workspace' && params.workspaceId) {
+      if (target === 'workspace' && params.workspaceId && !params.command) {
         setShowInbox(false);
         setScriptWorkspaceName(params.workspaceId.split(':').slice(-1)[0] ?? params.workspaceId);
         setShowScriptTerminal(true);
@@ -183,13 +183,37 @@ export function RemoteMachineScreen({ machine, relayUrl, identity, onBack }: Rem
     }
   }, [remote.mode]);
 
+  const handleStartProcessAttach = useCallback((params: { workspaceId: string; processName: string; instance: number }) => {
+    void Promise.resolve(remote.startProcess(params.workspaceId, params.processName)).finally(() => {
+      remote.requestWorkspaces();
+      remote.requestSessions();
+    });
+  }, [remote]);
+
+  const handleOpenEvents = useCallback(() => {
+    flow.showMessage({
+      title: 'Events Unavailable',
+      message: 'Events view is not available in this remote TUI screen yet.',
+      variant: 'info',
+    });
+  }, [flow]);
+
+  const handleEditProcesses = useCallback(({ workspaceId }: { workspaceId: string }) => {
+    void attachController.attach({
+      workspaceId,
+      command: 'sh',
+      args: ['-c', 'mkdir -p .gitspace && exec "${EDITOR:-vi}" .gitspace/processes.json'],
+    });
+  }, [attachController]);
+
   const spacesBrowserProps = useSpacesBrowser({
     workspaces: remote.workspaces,
     sessions: remote.sessions,
     onRequestSessions: () => remote.requestSessions(),
     onAttachSession: attachController.attachFromSelection,
-    onStartProcessAttach: () => {},
-    onOpenEvents: () => {},
+    onEditProcesses: handleEditProcesses,
+    onStartProcessAttach: handleStartProcessAttach,
+    onOpenEvents: handleOpenEvents,
     onRefresh: remote.requestWorkspaces,
     onRefreshSessions: () => remote.requestSessions(),
     onBack,

--- a/src/components/RemoteMachineScreen.tui.tsx
+++ b/src/components/RemoteMachineScreen.tui.tsx
@@ -66,6 +66,7 @@ export function RemoteMachineScreen({ machine, relayUrl, identity, onBack }: Rem
   const [pendingProcessEditWorkspaceId, setPendingProcessEditWorkspaceId] = useState<string | null>(null);
   const [pendingProcessAttach, setPendingProcessAttach] = useState<PendingProcessAttachTarget | null>(null);
   const pendingProcessEditWorkspacesRef = useRef<unknown[] | null>(null);
+  const pendingProcessEditValidationArmedRef = useRef(false);
   const pendingProcessAttachRef = useRef<PendingProcessAttachTarget | null>(null);
   const scriptTerminalRef = useRef<ScriptTerminalHandle | null>(null);
   const flow = useFlow({
@@ -195,14 +196,22 @@ export function RemoteMachineScreen({ machine, relayUrl, identity, onBack }: Rem
   }, [remote.mode]);
 
   useEffect(() => {
-    if (!pendingProcessEditWorkspaceId || remote.mode !== 'browsing') {
+    if (
+      !pendingProcessEditWorkspaceId ||
+      !pendingProcessEditValidationArmedRef.current ||
+      remote.mode !== 'browsing'
+    ) {
       return;
     }
     remote.requestWorkspaces();
   }, [pendingProcessEditWorkspaceId, remote.mode, remote.requestWorkspaces]);
 
   useEffect(() => {
-    if (!pendingProcessEditWorkspaceId || remote.mode !== 'browsing') {
+    if (
+      !pendingProcessEditWorkspaceId ||
+      !pendingProcessEditValidationArmedRef.current ||
+      remote.mode !== 'browsing'
+    ) {
       return;
     }
 
@@ -216,6 +225,7 @@ export function RemoteMachineScreen({ machine, relayUrl, identity, onBack }: Rem
 
     const workspace = remote.workspaces.find((item) => item.id === pendingProcessEditWorkspaceId);
     if (!workspace) {
+      pendingProcessEditValidationArmedRef.current = false;
       setPendingProcessEditWorkspaceId(null);
       return;
     }
@@ -237,6 +247,7 @@ export function RemoteMachineScreen({ machine, relayUrl, identity, onBack }: Rem
       });
     }
 
+    pendingProcessEditValidationArmedRef.current = false;
     setPendingProcessEditWorkspaceId(null);
   }, [flow, pendingProcessEditWorkspaceId, remote.mode, remote.workspaces]);
 
@@ -362,6 +373,7 @@ export function RemoteMachineScreen({ machine, relayUrl, identity, onBack }: Rem
   }, [flow]);
 
   const handleEditProcesses = useCallback(({ workspaceId }: { workspaceId: string }) => {
+    pendingProcessEditValidationArmedRef.current = false;
     pendingProcessEditWorkspacesRef.current = remote.workspaces;
     setPendingProcessEditWorkspaceId(workspaceId);
     const commandSpec = buildEditProcessesCommand();
@@ -371,9 +383,13 @@ export function RemoteMachineScreen({ machine, relayUrl, identity, onBack }: Rem
       args: commandSpec.args,
     }).then((attached) => {
       if (!attached) {
+        pendingProcessEditValidationArmedRef.current = false;
         pendingProcessEditWorkspacesRef.current = null;
         setPendingProcessEditWorkspaceId(null);
+        return;
       }
+
+      pendingProcessEditValidationArmedRef.current = true;
     });
   }, [attachController, remote.workspaces]);
 

--- a/src/components/RemoteMachineScreen.tui.tsx
+++ b/src/components/RemoteMachineScreen.tui.tsx
@@ -239,6 +239,20 @@ export function RemoteMachineScreen({ machine, relayUrl, identity, onBack }: Rem
     });
   }, [remote]);
 
+  const handleStartProcess = useCallback((params: { workspaceId: string; processName: string }) => {
+    void Promise.resolve(remote.startProcess(params.workspaceId, params.processName)).finally(() => {
+      remote.requestWorkspaces();
+      remote.requestSessions();
+    });
+  }, [remote]);
+
+  const handleStopProcess = useCallback((params: { workspaceId: string; processName: string }) => {
+    void Promise.resolve(remote.stopProcess(params.workspaceId, params.processName)).finally(() => {
+      remote.requestWorkspaces();
+      remote.requestSessions();
+    });
+  }, [remote]);
+
   const handleOpenEvents = useCallback(() => {
     flow.showMessage({
       title: 'Events Unavailable',
@@ -264,7 +278,9 @@ export function RemoteMachineScreen({ machine, relayUrl, identity, onBack }: Rem
     onRequestSessions: () => remote.requestSessions(),
     onAttachSession: attachController.attachFromSelection,
     onEditProcesses: handleEditProcesses,
+    onStartProcess: handleStartProcess,
     onStartProcessAttach: handleStartProcessAttach,
+    onStopProcess: handleStopProcess,
     onOpenEvents: handleOpenEvents,
     onRefresh: remote.requestWorkspaces,
     onRefreshSessions: () => remote.requestSessions(),
@@ -471,6 +487,19 @@ export function RemoteMachineScreen({ machine, relayUrl, identity, onBack }: Rem
           confirmLabel: 'Kill',
           onConfirm: () => {
             remote.killSession(selected.session.id);
+          },
+        });
+      } else if (selected?.type === 'process' && selected.status === 'running') {
+        flow.showConfirm({
+          title: 'Stop Process',
+          message: `Stop process "${selected.processName}"?`,
+          variant: 'warning',
+          confirmLabel: 'Stop',
+          onConfirm: () => {
+            handleStopProcess({
+              workspaceId: selected.workspaceId,
+              processName: selected.processName,
+            });
           },
         });
       }

--- a/src/components/RemoteMachineScreen.tui.tsx
+++ b/src/components/RemoteMachineScreen.tui.tsx
@@ -363,6 +363,11 @@ export function RemoteMachineScreen({ machine, relayUrl, identity, onBack }: Rem
       workspaceId,
       command: commandSpec.command,
       args: commandSpec.args,
+    }).then((attached) => {
+      if (!attached) {
+        pendingProcessEditWorkspacesRef.current = null;
+        setPendingProcessEditWorkspaceId(null);
+      }
     });
   }, [attachController, remote.workspaces]);
 

--- a/src/components/RemoteMachineScreen.tui.tsx
+++ b/src/components/RemoteMachineScreen.tui.tsx
@@ -199,6 +199,7 @@ export function RemoteMachineScreen({ machine, relayUrl, identity, onBack }: Rem
 
     const workspace = remote.workspaces.find((item) => item.id === pendingProcessEditWorkspaceId);
     if (!workspace) {
+      setPendingProcessEditWorkspaceId(null);
       return;
     }
 

--- a/src/components/RemoteMachineScreen.tui.tsx
+++ b/src/components/RemoteMachineScreen.tui.tsx
@@ -66,6 +66,7 @@ export function RemoteMachineScreen({ machine, relayUrl, identity, onBack }: Rem
   const [pendingProcessEditWorkspaceId, setPendingProcessEditWorkspaceId] = useState<string | null>(null);
   const [pendingProcessAttach, setPendingProcessAttach] = useState<PendingProcessAttachTarget | null>(null);
   const pendingProcessEditWorkspacesRef = useRef<unknown[] | null>(null);
+  const pendingProcessAttachRef = useRef<PendingProcessAttachTarget | null>(null);
   const scriptTerminalRef = useRef<ScriptTerminalHandle | null>(null);
   const flow = useFlow({
     onError: (error) => {
@@ -239,6 +240,10 @@ export function RemoteMachineScreen({ machine, relayUrl, identity, onBack }: Rem
     setPendingProcessEditWorkspaceId(null);
   }, [flow, pendingProcessEditWorkspaceId, remote.mode, remote.workspaces]);
 
+  useEffect(() => {
+    pendingProcessAttachRef.current = pendingProcessAttach;
+  }, [pendingProcessAttach]);
+
   const handleStartProcessAttach = useCallback((params: { workspaceId: string; processName: string; instance: number }) => {
     setPendingProcessAttach({
       workspaceId: params.workspaceId,
@@ -293,23 +298,24 @@ export function RemoteMachineScreen({ machine, relayUrl, identity, onBack }: Rem
       return;
     }
 
-    const timeout = setTimeout(() => {
-      setPendingProcessAttach((current) => {
-        if (
-          !current ||
-          current.workspaceId !== pendingProcessAttach.workspaceId ||
-          current.processName !== pendingProcessAttach.processName ||
-          current.instance !== pendingProcessAttach.instance
-        ) {
-          return current;
-        }
+    const target = pendingProcessAttach;
 
-        flow.showMessage({
-          title: 'Attach Timeout',
-          message: `Process started but no active session was found for ${current.processName}#${current.instance}.`,
-          variant: 'warning',
-        });
-        return null;
+    const timeout = setTimeout(() => {
+      const current = pendingProcessAttachRef.current;
+      if (
+        !current ||
+        current.workspaceId !== target.workspaceId ||
+        current.processName !== target.processName ||
+        current.instance !== target.instance
+      ) {
+        return;
+      }
+
+      setPendingProcessAttach(null);
+      flow.showMessage({
+        title: 'Attach Timeout',
+        message: `Process started but no active session was found for ${current.processName}#${current.instance}.`,
+        variant: 'warning',
       });
     }, 8000);
 

--- a/src/components/RemoteMachineScreen.tui.tsx
+++ b/src/components/RemoteMachineScreen.tui.tsx
@@ -253,6 +253,16 @@ export function RemoteMachineScreen({ machine, relayUrl, identity, onBack }: Rem
     });
   }, [remote]);
 
+  const handleProcessDisabled = useCallback((params: { workspaceId: string; processName: string }) => {
+    const workspace = remote.workspaces.find((item) => item.id === params.workspaceId);
+    const workspaceLabel = workspace?.name ?? params.workspaceId;
+    flow.showMessage({
+      title: 'Process Disabled',
+      message: `Process "${params.processName}" is disabled in ${workspaceLabel} (instances: 0).`,
+      variant: 'error',
+    });
+  }, [flow, remote.workspaces]);
+
   const handleOpenEvents = useCallback(() => {
     flow.showMessage({
       title: 'Events Unavailable',
@@ -281,6 +291,7 @@ export function RemoteMachineScreen({ machine, relayUrl, identity, onBack }: Rem
     onStartProcess: handleStartProcess,
     onStartProcessAttach: handleStartProcessAttach,
     onStopProcess: handleStopProcess,
+    onProcessDisabled: handleProcessDisabled,
     onOpenEvents: handleOpenEvents,
     onRefresh: remote.requestWorkspaces,
     onRefreshSessions: () => remote.requestSessions(),

--- a/src/components/RemoteMachineScreen.tui.tsx
+++ b/src/components/RemoteMachineScreen.tui.tsx
@@ -62,6 +62,7 @@ export function RemoteMachineScreen({ machine, relayUrl, identity, onBack }: Rem
   const renderer = useRenderer();
   const [showInbox, setShowInbox] = useState(false);
   const [showScriptTerminal, setShowScriptTerminal] = useState(false);
+  const [isViewOnlySession, setIsViewOnlySession] = useState(false);
   const [scriptWorkspaceName, setScriptWorkspaceName] = useState('workspace');
   const [pendingProcessEditWorkspaceId, setPendingProcessEditWorkspaceId] = useState<string | null>(null);
   const [pendingProcessAttach, setPendingProcessAttach] = useState<PendingProcessAttachTarget | null>(null);
@@ -196,6 +197,17 @@ export function RemoteMachineScreen({ machine, relayUrl, identity, onBack }: Rem
   }, [remote.mode]);
 
   useEffect(() => {
+    if (remote.mode !== 'attached') {
+      setIsViewOnlySession(false);
+    }
+  }, [remote.mode]);
+
+  const handleAttachSession = useCallback(async (params: { sessionId?: string; workspaceId?: string; viewOnly?: boolean }) => {
+    setIsViewOnlySession(params.viewOnly ?? false);
+    await attachController.attachFromSelection(params);
+  }, [attachController]);
+
+  useEffect(() => {
     if (
       !pendingProcessEditWorkspaceId ||
       !pendingProcessEditValidationArmedRef.current ||
@@ -256,16 +268,33 @@ export function RemoteMachineScreen({ machine, relayUrl, identity, onBack }: Rem
   }, [pendingProcessAttach]);
 
   const handleStartProcessAttach = useCallback((params: { workspaceId: string; processName: string; instance: number }) => {
-    setPendingProcessAttach({
+    const target: PendingProcessAttachTarget = {
       workspaceId: params.workspaceId,
       processName: params.processName,
       instance: params.instance,
-    });
-    void Promise.resolve(remote.startProcess(params.workspaceId, params.processName, params.instance)).finally(() => {
-      remote.requestWorkspaces();
-      remote.requestSessions();
-    });
-  }, [remote]);
+    };
+    setPendingProcessAttach(target);
+    void Promise.resolve(remote.startProcess(params.workspaceId, params.processName, params.instance))
+      .catch((error) => {
+        setPendingProcessAttach((current) =>
+          current &&
+          current.workspaceId === target.workspaceId &&
+          current.processName === target.processName &&
+          current.instance === target.instance
+            ? null
+            : current
+        );
+        flow.showMessage({
+          title: 'Process Start Failed',
+          message: error instanceof Error ? error.message : String(error),
+          variant: 'error',
+        });
+      })
+      .finally(() => {
+        remote.requestWorkspaces();
+        remote.requestSessions();
+      });
+  }, [flow, remote]);
 
   useEffect(() => {
     if (!pendingProcessAttach) {
@@ -295,14 +324,14 @@ export function RemoteMachineScreen({ machine, relayUrl, identity, onBack }: Rem
         : current
     );
 
-    void attachController.attach({ sessionId: session.id, viewOnly: true }).catch((error) => {
+    void handleAttachSession({ sessionId: session.id, viewOnly: true }).catch((error) => {
       flow.showMessage({
         title: 'Attach Failed',
         message: error instanceof Error ? error.message : String(error),
         variant: 'error',
       });
     });
-  }, [attachController, flow, pendingProcessAttach, remote.sessions]);
+  }, [flow, handleAttachSession, pendingProcessAttach, remote.sessions]);
 
   useEffect(() => {
     if (!pendingProcessAttach) {
@@ -397,7 +426,7 @@ export function RemoteMachineScreen({ machine, relayUrl, identity, onBack }: Rem
     workspaces: remote.workspaces,
     sessions: remote.sessions,
     onRequestSessions: () => remote.requestSessions(),
-    onAttachSession: attachController.attachFromSelection,
+    onAttachSession: handleAttachSession,
     onEditProcesses: handleEditProcesses,
     onStartProcess: handleStartProcess,
     onStartProcessAttach: handleStartProcessAttach,
@@ -424,7 +453,7 @@ export function RemoteMachineScreen({ machine, relayUrl, identity, onBack }: Rem
     },
     onAttachSession: async (sessionId) => {
       setShowInbox(false);
-      await attachController.attach({ sessionId });
+      await handleAttachSession({ sessionId });
     },
     onClose: () => {
       setShowInbox(false);
@@ -671,6 +700,7 @@ export function RemoteMachineScreen({ machine, relayUrl, identity, onBack }: Rem
           onResize={remote.resize}
           onDetach={remote.detachSession}
           setWriteCallback={remote.setWriteCallback}
+          readOnly={isViewOnlySession}
         />
       </Fragment>
     );

--- a/src/components/RemoteMachineScreen.tui.tsx
+++ b/src/components/RemoteMachineScreen.tui.tsx
@@ -18,6 +18,7 @@ import { FlowTUI } from './Flow.tui.js';
 import { useRemoteTerminal } from '../hooks/useRemoteTerminal.tui.js';
 import { useBundleRefreshAttachFlow } from '../session/index.js';
 import { useAttachController } from '../app/session/useAttachController.js';
+import { useProcessActions } from '../app/session/useProcessActions.js';
 import {
   resolveInboxCommand,
   resolveSessionBrowserCommand,
@@ -35,12 +36,6 @@ const COLORS = {
   error: '#FF4444',
   title: '#00FF88',
 };
-
-interface PendingProcessAttachTarget {
-  workspaceId: string;
-  processName: string;
-  instance: number;
-}
 
 function StatusBar({ hint }: { hint: string }) {
   return (
@@ -65,10 +60,8 @@ export function RemoteMachineScreen({ machine, relayUrl, identity, onBack }: Rem
   const [isViewOnlySession, setIsViewOnlySession] = useState(false);
   const [scriptWorkspaceName, setScriptWorkspaceName] = useState('workspace');
   const [pendingProcessEditWorkspaceId, setPendingProcessEditWorkspaceId] = useState<string | null>(null);
-  const [pendingProcessAttach, setPendingProcessAttach] = useState<PendingProcessAttachTarget | null>(null);
   const pendingProcessEditWorkspacesRef = useRef<unknown[] | null>(null);
   const pendingProcessEditValidationArmedRef = useRef(false);
-  const pendingProcessAttachRef = useRef<PendingProcessAttachTarget | null>(null);
   const scriptTerminalRef = useRef<ScriptTerminalHandle | null>(null);
   const flow = useFlow({
     onError: (error) => {
@@ -263,125 +256,64 @@ export function RemoteMachineScreen({ machine, relayUrl, identity, onBack }: Rem
     setPendingProcessEditWorkspaceId(null);
   }, [flow, pendingProcessEditWorkspaceId, remote.mode, remote.workspaces]);
 
-  useEffect(() => {
-    pendingProcessAttachRef.current = pendingProcessAttach;
-  }, [pendingProcessAttach]);
-
-  const handleStartProcessAttach = useCallback((params: { workspaceId: string; processName: string; instance: number }) => {
-    const target: PendingProcessAttachTarget = {
-      workspaceId: params.workspaceId,
-      processName: params.processName,
-      instance: params.instance,
-    };
-    setPendingProcessAttach(target);
-    void Promise.resolve(remote.startProcess(params.workspaceId, params.processName, params.instance))
-      .catch((error) => {
-        setPendingProcessAttach((current) =>
-          current &&
-          current.workspaceId === target.workspaceId &&
-          current.processName === target.processName &&
-          current.instance === target.instance
-            ? null
-            : current
-        );
-        flow.showMessage({
-          title: 'Process Start Failed',
-          message: error instanceof Error ? error.message : String(error),
-          variant: 'error',
-        });
-      })
-      .finally(() => {
-        remote.requestWorkspaces();
-        remote.requestSessions();
+  const processActions = useProcessActions({
+    sessions: remote.sessions,
+    startProcess: remote.startProcess,
+    stopProcess: remote.stopProcess,
+    attachSession: handleAttachSession,
+    onStartProcessError: (error) => {
+      flow.showMessage({
+        title: 'Process Start Failed',
+        message: error instanceof Error ? error.message : String(error),
+        variant: 'error',
       });
-  }, [flow, remote]);
-
-  useEffect(() => {
-    if (!pendingProcessAttach) {
-      return;
-    }
-
-    const session = remote.sessions
-      .filter((item) =>
-        item.workspaceId === pendingProcessAttach.workspaceId &&
-        item.processName === pendingProcessAttach.processName &&
-        (item.processInstance ?? 1) === pendingProcessAttach.instance &&
-        item.exitCode === undefined
-      )
-      .sort((a, b) => b.createdAt - a.createdAt)[0];
-
-    if (!session) {
-      return;
-    }
-
-    const target = pendingProcessAttach;
-    setPendingProcessAttach((current) =>
-      current &&
-      current.workspaceId === target.workspaceId &&
-      current.processName === target.processName &&
-      current.instance === target.instance
-        ? null
-        : current
-    );
-
-    void handleAttachSession({ sessionId: session.id, viewOnly: true }).catch((error) => {
+    },
+    onStopProcessError: (error) => {
+      flow.showMessage({
+        title: 'Process Stop Failed',
+        message: error instanceof Error ? error.message : String(error),
+        variant: 'error',
+      });
+    },
+    onStartProcessAttachError: (error) => {
+      flow.showMessage({
+        title: 'Process Start Failed',
+        message: error instanceof Error ? error.message : String(error),
+        variant: 'error',
+      });
+    },
+    onAttachError: (error) => {
       flow.showMessage({
         title: 'Attach Failed',
         message: error instanceof Error ? error.message : String(error),
         variant: 'error',
       });
-    });
-  }, [flow, handleAttachSession, pendingProcessAttach, remote.sessions]);
-
-  useEffect(() => {
-    if (!pendingProcessAttach) {
-      return;
-    }
-
-    const target = pendingProcessAttach;
-
-    const timeout = setTimeout(() => {
-      const current = pendingProcessAttachRef.current;
-      if (
-        !current ||
-        current.workspaceId !== target.workspaceId ||
-        current.processName !== target.processName ||
-        current.instance !== target.instance
-      ) {
-        return;
-      }
-
-      setPendingProcessAttach(null);
+    },
+    onAttachTimeout: (target) => {
       flow.showMessage({
         title: 'Attach Timeout',
-        message: `Process started but no active session was found for ${current.processName}#${current.instance}.`,
+        message: `Process started but no active session was found for ${target.processName}#${target.instance}.`,
         variant: 'warning',
       });
-    }, 8000);
-
-    return () => clearTimeout(timeout);
-  }, [flow, pendingProcessAttach]);
-
-  useEffect(() => {
-    if (!pendingProcessAttach || !remote.commandError) {
-      return;
-    }
-    setPendingProcessAttach(null);
-  }, [pendingProcessAttach, remote.commandError]);
-
-  const handleStartProcess = useCallback((params: { workspaceId: string; processName: string }) => {
-    void Promise.resolve(remote.startProcess(params.workspaceId, params.processName)).finally(() => {
+    },
+    onStartProcessFinally: () => {
       remote.requestWorkspaces();
       remote.requestSessions();
-    });
-  }, [remote]);
-
-  const handleStopProcess = useCallback((params: { workspaceId: string; processName: string }) => {
-    void Promise.resolve(remote.stopProcess(params.workspaceId, params.processName)).finally(() => {
+    },
+    onStopProcessFinally: () => {
       remote.requestWorkspaces();
       remote.requestSessions();
-    });
-  }, [remote]);
+    },
+    onStartProcessAttachFinally: () => {
+      remote.requestWorkspaces();
+      remote.requestSessions();
+    },
+    pendingAttachCancelSignal: remote.commandError,
+  });
+
+  const handleStartProcess = processActions.handleStartProcess;
+  const handleStartProcessAttach = processActions.handleStartProcessAttach;
+  const handleStopProcess = processActions.handleStopProcess;
 
   const handleProcessDisabled = useCallback((params: { workspaceId: string; processName: string }) => {
     const workspace = remote.workspaces.find((item) => item.id === params.workspaceId);

--- a/src/components/RemoteMachineScreen.tui.tsx
+++ b/src/components/RemoteMachineScreen.tui.tsx
@@ -188,6 +188,8 @@ export function RemoteMachineScreen({ machine, relayUrl, identity, onBack }: Rem
     sessions: remote.sessions,
     onRequestSessions: () => remote.requestSessions(),
     onAttachSession: attachController.attachFromSelection,
+    onStartProcessAttach: () => {},
+    onOpenEvents: () => {},
     onRefresh: remote.requestWorkspaces,
     onRefreshSessions: () => remote.requestSessions(),
     onBack,

--- a/src/components/RemoteMachineScreen.tui.tsx
+++ b/src/components/RemoteMachineScreen.tui.tsx
@@ -58,6 +58,7 @@ export function RemoteMachineScreen({ machine, relayUrl, identity, onBack }: Rem
   const [showScriptTerminal, setShowScriptTerminal] = useState(false);
   const [scriptWorkspaceName, setScriptWorkspaceName] = useState('workspace');
   const [pendingProcessEditWorkspaceId, setPendingProcessEditWorkspaceId] = useState<string | null>(null);
+  const pendingProcessEditWorkspacesRef = useRef<unknown[] | null>(null);
   const scriptTerminalRef = useRef<ScriptTerminalHandle | null>(null);
   const flow = useFlow({
     onError: (error) => {
@@ -197,6 +198,14 @@ export function RemoteMachineScreen({ machine, relayUrl, identity, onBack }: Rem
       return;
     }
 
+    if (
+      pendingProcessEditWorkspacesRef.current &&
+      pendingProcessEditWorkspacesRef.current === remote.workspaces
+    ) {
+      return;
+    }
+    pendingProcessEditWorkspacesRef.current = null;
+
     const workspace = remote.workspaces.find((item) => item.id === pendingProcessEditWorkspaceId);
     if (!workspace) {
       setPendingProcessEditWorkspaceId(null);
@@ -224,7 +233,7 @@ export function RemoteMachineScreen({ machine, relayUrl, identity, onBack }: Rem
   }, [flow, pendingProcessEditWorkspaceId, remote.mode, remote.workspaces]);
 
   const handleStartProcessAttach = useCallback((params: { workspaceId: string; processName: string; instance: number }) => {
-    void Promise.resolve(remote.startProcess(params.workspaceId, params.processName)).finally(() => {
+    void Promise.resolve(remote.startProcess(params.workspaceId, params.processName, params.instance)).finally(() => {
       remote.requestWorkspaces();
       remote.requestSessions();
     });
@@ -239,6 +248,7 @@ export function RemoteMachineScreen({ machine, relayUrl, identity, onBack }: Rem
   }, [flow]);
 
   const handleEditProcesses = useCallback(({ workspaceId }: { workspaceId: string }) => {
+    pendingProcessEditWorkspacesRef.current = remote.workspaces;
     setPendingProcessEditWorkspaceId(workspaceId);
     const commandSpec = buildEditProcessesCommand();
     void attachController.attach({
@@ -246,7 +256,7 @@ export function RemoteMachineScreen({ machine, relayUrl, identity, onBack }: Rem
       command: commandSpec.command,
       args: commandSpec.args,
     });
-  }, [attachController]);
+  }, [attachController, remote.workspaces]);
 
   const spacesBrowserProps = useSpacesBrowser({
     workspaces: remote.workspaces,

--- a/src/components/RemoteMachineScreen.tui.tsx
+++ b/src/components/RemoteMachineScreen.tui.tsx
@@ -36,6 +36,12 @@ const COLORS = {
   title: '#00FF88',
 };
 
+interface PendingProcessAttachTarget {
+  workspaceId: string;
+  processName: string;
+  instance: number;
+}
+
 function StatusBar({ hint }: { hint: string }) {
   return (
     <box height={1} width="100%" backgroundColor={COLORS.statusBar} paddingLeft={1}>
@@ -58,6 +64,7 @@ export function RemoteMachineScreen({ machine, relayUrl, identity, onBack }: Rem
   const [showScriptTerminal, setShowScriptTerminal] = useState(false);
   const [scriptWorkspaceName, setScriptWorkspaceName] = useState('workspace');
   const [pendingProcessEditWorkspaceId, setPendingProcessEditWorkspaceId] = useState<string | null>(null);
+  const [pendingProcessAttach, setPendingProcessAttach] = useState<PendingProcessAttachTarget | null>(null);
   const pendingProcessEditWorkspacesRef = useRef<unknown[] | null>(null);
   const scriptTerminalRef = useRef<ScriptTerminalHandle | null>(null);
   const flow = useFlow({
@@ -233,11 +240,88 @@ export function RemoteMachineScreen({ machine, relayUrl, identity, onBack }: Rem
   }, [flow, pendingProcessEditWorkspaceId, remote.mode, remote.workspaces]);
 
   const handleStartProcessAttach = useCallback((params: { workspaceId: string; processName: string; instance: number }) => {
+    setPendingProcessAttach({
+      workspaceId: params.workspaceId,
+      processName: params.processName,
+      instance: params.instance,
+    });
     void Promise.resolve(remote.startProcess(params.workspaceId, params.processName, params.instance)).finally(() => {
       remote.requestWorkspaces();
       remote.requestSessions();
     });
   }, [remote]);
+
+  useEffect(() => {
+    if (!pendingProcessAttach) {
+      return;
+    }
+
+    const session = remote.sessions
+      .filter((item) =>
+        item.workspaceId === pendingProcessAttach.workspaceId &&
+        item.processName === pendingProcessAttach.processName &&
+        (item.processInstance ?? 1) === pendingProcessAttach.instance &&
+        item.exitCode === undefined
+      )
+      .sort((a, b) => b.createdAt - a.createdAt)[0];
+
+    if (!session) {
+      return;
+    }
+
+    const target = pendingProcessAttach;
+    setPendingProcessAttach((current) =>
+      current &&
+      current.workspaceId === target.workspaceId &&
+      current.processName === target.processName &&
+      current.instance === target.instance
+        ? null
+        : current
+    );
+
+    void attachController.attach({ sessionId: session.id, viewOnly: true }).catch((error) => {
+      flow.showMessage({
+        title: 'Attach Failed',
+        message: error instanceof Error ? error.message : String(error),
+        variant: 'error',
+      });
+    });
+  }, [attachController, flow, pendingProcessAttach, remote.sessions]);
+
+  useEffect(() => {
+    if (!pendingProcessAttach) {
+      return;
+    }
+
+    const timeout = setTimeout(() => {
+      setPendingProcessAttach((current) => {
+        if (
+          !current ||
+          current.workspaceId !== pendingProcessAttach.workspaceId ||
+          current.processName !== pendingProcessAttach.processName ||
+          current.instance !== pendingProcessAttach.instance
+        ) {
+          return current;
+        }
+
+        flow.showMessage({
+          title: 'Attach Timeout',
+          message: `Process started but no active session was found for ${current.processName}#${current.instance}.`,
+          variant: 'warning',
+        });
+        return null;
+      });
+    }, 8000);
+
+    return () => clearTimeout(timeout);
+  }, [flow, pendingProcessAttach]);
+
+  useEffect(() => {
+    if (!pendingProcessAttach || !remote.commandError) {
+      return;
+    }
+    setPendingProcessAttach(null);
+  }, [pendingProcessAttach, remote.commandError]);
 
   const handleStartProcess = useCallback((params: { workspaceId: string; processName: string }) => {
     void Promise.resolve(remote.startProcess(params.workspaceId, params.processName)).finally(() => {

--- a/src/components/SessionTerminal.tui.tsx
+++ b/src/components/SessionTerminal.tui.tsx
@@ -54,6 +54,8 @@ export interface SessionTerminalProps {
   interceptShiftTab?: boolean;
   modalOpen?: boolean;
   onActivity?: () => void;
+  /** When true, keyboard input and paste are disabled (view-only mode) */
+  readOnly?: boolean;
 }
 
 export function SessionTerminal({
@@ -66,6 +68,7 @@ export function SessionTerminal({
   interceptShiftTab,
   modalOpen,
   onActivity,
+  readOnly = false,
 }: SessionTerminalProps) {
   const renderer = useRenderer();
   const [termSize, setTermSize] = useState(getTerminalSize);
@@ -234,7 +237,7 @@ export function SessionTerminal({
 
   useEffect(() => {
     const handlePaste = (event: PasteEvent) => {
-      if (modalOpen) {
+      if (modalOpen || readOnly) {
         return;
       }
       const text = event.text ?? '';
@@ -256,6 +259,15 @@ export function SessionTerminal({
 
   useKeyboard((key) => {
     if (modalOpen) {
+      return;
+    }
+
+    if (key.name === 'escape' && key.ctrl) {
+      onDetach();
+      return;
+    }
+
+    if (readOnly) {
       return;
     }
 
@@ -289,11 +301,6 @@ export function SessionTerminal({
         scrollBox.scrollBy(1, 'viewport');
         return;
       }
-    }
-
-    if (key.name === 'escape' && key.ctrl) {
-      onDetach();
-      return;
     }
 
     let data: string | undefined;
@@ -355,8 +362,9 @@ export function SessionTerminal({
         <box flexGrow={1} flexDirection="row">
           <text fg={COLORS.session}>{sessionName}</text>
           <text fg={COLORS.textDim}> ({endpointLabel})</text>
+          {readOnly && <text fg={COLORS.textDim}> [view only]</text>}
         </box>
-        <text fg={COLORS.detachHint}>[Ctrl+Esc] Detach</text>
+        <text fg={COLORS.detachHint}>[Ctrl+Esc] {readOnly ? 'Back' : 'Detach'}</text>
       </box>
 
       <scrollbox

--- a/src/components/SessionTerminal.tui.tsx
+++ b/src/components/SessionTerminal.tui.tsx
@@ -255,7 +255,7 @@ export function SessionTerminal({
     return () => {
       renderer.keyInput.off('paste', handlePaste);
     };
-  }, [modalOpen, onActivity, onData, renderer]);
+  }, [modalOpen, onActivity, onData, readOnly, renderer]);
 
   useKeyboard((key) => {
     if (modalOpen) {

--- a/src/components/SessionTerminal.tui.tsx
+++ b/src/components/SessionTerminal.tui.tsx
@@ -267,10 +267,6 @@ export function SessionTerminal({
       return;
     }
 
-    if (readOnly) {
-      return;
-    }
-
     if (key.name === 'pageup') {
       const scrollBox = scrollBoxRef.current;
       if (
@@ -283,6 +279,10 @@ export function SessionTerminal({
         })
       ) {
         scrollBox.scrollBy(-1, 'viewport');
+        return;
+      }
+
+      if (readOnly) {
         return;
       }
     }
@@ -301,6 +301,14 @@ export function SessionTerminal({
         scrollBox.scrollBy(1, 'viewport');
         return;
       }
+
+      if (readOnly) {
+        return;
+      }
+    }
+
+    if (readOnly) {
+      return;
     }
 
     let data: string | undefined;

--- a/src/components/SessionTerminal.tui.tsx
+++ b/src/components/SessionTerminal.tui.tsx
@@ -363,7 +363,7 @@ export function SessionTerminal({
         ref={(el: ScrollBoxRenderable | null) => {
           scrollBoxRef.current = el;
         }}
-        focusable={false}
+        {...{ focusable: false } as any}
         flexGrow={1}
         viewportCulling={true}
         stickyScroll={true}

--- a/src/components/SessionTerminal.tui.tsx
+++ b/src/components/SessionTerminal.tui.tsx
@@ -371,7 +371,6 @@ export function SessionTerminal({
         ref={(el: ScrollBoxRenderable | null) => {
           scrollBoxRef.current = el;
         }}
-        {...{ focusable: false } as any}
         flexGrow={1}
         viewportCulling={true}
         stickyScroll={true}

--- a/src/components/SessionTerminal.web.tsx
+++ b/src/components/SessionTerminal.web.tsx
@@ -16,6 +16,8 @@ interface Props {
   allowTapFocus?: boolean;
   /** Whether touch scrolling is enabled. Default: true. Disable when using floating controls. */
   allowTouchScroll?: boolean;
+  /** When true, keyboard input is disabled (view-only mode) */
+  readOnly?: boolean;
 }
 
 /** Methods exposed via ref for external control */
@@ -64,7 +66,7 @@ function shouldHandleIosWordInput(event: InputEvent): boolean {
 }
 
 export const SessionTerminal = forwardRef<SessionTerminalHandle, Props>(function SessionTerminal(
-  { onData, setWriteCallback, onResize, onActivity, allowTapFocus = true, allowTouchScroll = true },
+  { onData, setWriteCallback, onResize, onActivity, allowTapFocus = true, allowTouchScroll = true, readOnly = false },
   ref
 ) {
   const containerRef = useRef<HTMLDivElement>(null);
@@ -74,6 +76,7 @@ export const SessionTerminal = forwardRef<SessionTerminalHandle, Props>(function
   const onActivityRef = useRef(onActivity);
   const onResizeRef = useRef(onResize);
   const allowTapFocusRef = useRef(allowTapFocus);
+  const readOnlyRef = useRef(readOnly);
 
   // Touch state with accumulated delta pattern
   const touchStateRef = useRef<{
@@ -108,6 +111,11 @@ export const SessionTerminal = forwardRef<SessionTerminalHandle, Props>(function
   useEffect(() => {
     allowTouchScrollRef.current = allowTouchScroll;
   }, [allowTouchScroll]);
+
+  // Keep readOnly ref in sync
+  useEffect(() => {
+    readOnlyRef.current = readOnly;
+  }, [readOnly]);
 
   const tryConsumePageNavigation = useCallback((direction: PageDirection): boolean => {
     const terminal = terminalRef.current as unknown as TerminalViewportLike | null;
@@ -217,6 +225,9 @@ export const SessionTerminal = forwardRef<SessionTerminalHandle, Props>(function
         term.loadAddon(fitAddon);
 
         term.onData((data: string) => {
+          if (readOnlyRef.current) {
+            return;
+          }
           onActivityRef.current?.();
           onDataRef.current(new TextEncoder().encode(data));
         });

--- a/src/components/SessionTerminal.web.tsx
+++ b/src/components/SessionTerminal.web.tsx
@@ -236,6 +236,9 @@ export const SessionTerminal = forwardRef<SessionTerminalHandle, Props>(function
           if (event.key === 'Tab' && event.shiftKey) {
             event.preventDefault();
             event.stopPropagation();
+            if (readOnlyRef.current) {
+              return;
+            }
             onDataRef.current(new TextEncoder().encode('\x1b[Z'));
             return;
           }
@@ -283,7 +286,7 @@ export const SessionTerminal = forwardRef<SessionTerminalHandle, Props>(function
         };
 
         const handleInputFallback = (event: Event) => {
-          if (!isIOS || !helperTextarea || isComposing) {
+          if (!isIOS || !helperTextarea || isComposing || readOnlyRef.current) {
             return;
           }
 

--- a/src/components/SpacesBrowser.tsx
+++ b/src/components/SpacesBrowser.tsx
@@ -56,6 +56,7 @@ export type TreeItem =
   | { type: 'workspace'; workspace: WorkspaceInfo; expanded: boolean }
   | { type: 'session'; session: SessionInfo; workspaceId: string }
   | { type: 'process'; processName: string; instance: number; workspaceId: string; status: 'running' | 'stopped' | 'failed'; ports?: WorkspaceProcessPort[]; serveDomain?: string }
+  | { type: 'edit-processes'; workspaceId: string }
   | { type: 'events'; workspaceId: string }
   | { type: 'new-session'; workspaceId: string };
 
@@ -70,11 +71,12 @@ export interface UseSpacesBrowserProps {
   workspaces: WorkspaceInfo[];
   sessions: SessionInfo[];
   onRequestSessions: (workspaceId?: string) => void;
-  onAttachSession: (params: { sessionId?: string; workspaceId?: string }) => void | Promise<void>;
+  onAttachSession: (params: { sessionId?: string; workspaceId?: string; viewOnly?: boolean }) => void | Promise<void>;
   onStartProcess?: (params: { workspaceId: string; processName: string }) => void;
   onStartProcessAttach: (params: { workspaceId: string; processName: string; instance: number }) => void;
   onStopProcess?: (params: { workspaceId: string; processName: string }) => void;
   onOpenEvents: (workspaceId: string) => void;
+  onEditProcesses?: (params: { workspaceId: string }) => void;
   onRefresh: () => void | Promise<void>;
   /** Called to refresh sessions after workspace refresh (full refresh by default). */
   onRefreshSessions?: () => void | Promise<void>;
@@ -113,6 +115,7 @@ export interface UseSpacesBrowserReturn {
   createWorkspace: () => void;
   refresh: () => Promise<void>;
   openEvents: (workspaceId: string) => void;
+  editProcesses: (params: { workspaceId: string }) => void;
   back: () => void;
 }
 
@@ -240,6 +243,12 @@ function buildTree(
           });
         }
 
+        // Edit processes config action
+        items.push({
+          type: 'edit-processes',
+          workspaceId: ws.id,
+        });
+
         // Events action
         items.push({
           type: 'events',
@@ -280,6 +289,7 @@ export function useSpacesBrowser(props: UseSpacesBrowserProps): UseSpacesBrowser
     onStartProcessAttach,
     onStopProcess,
     onOpenEvents,
+    onEditProcesses,
     onRefresh,
     onRefreshSessions,
     onBack,
@@ -370,7 +380,7 @@ export function useSpacesBrowser(props: UseSpacesBrowserProps): UseSpacesBrowser
           selectedItem.instance
         );
         if (session) {
-          await onAttachSession({ sessionId: session.id });
+          await onAttachSession({ sessionId: session.id, viewOnly: true });
         }
       } else {
         onStartProcessAttach({
@@ -379,12 +389,14 @@ export function useSpacesBrowser(props: UseSpacesBrowserProps): UseSpacesBrowser
           instance: selectedItem.instance,
         });
       }
+    } else if (selectedItem.type === 'edit-processes') {
+      onEditProcesses?.({ workspaceId: selectedItem.workspaceId });
     } else if (selectedItem.type === 'events') {
       onOpenEvents(selectedItem.workspaceId);
     } else if (selectedItem.type === 'new-session') {
       await onAttachSession({ workspaceId: selectedItem.workspaceId });
     }
-  }, [selectedItem, toggleWorkspace, onAttachSession, onStartProcessAttach, findSessionForProcess, onOpenEvents]);
+  }, [selectedItem, toggleWorkspace, onAttachSession, onStartProcessAttach, findSessionForProcess, onEditProcesses, onOpenEvents]);
 
   const createNewSession = useCallback(async () => {
     if (!selectedItem) return;
@@ -444,6 +456,7 @@ export function useSpacesBrowser(props: UseSpacesBrowserProps): UseSpacesBrowser
     createWorkspace,
     refresh,
     openEvents: (workspaceId) => onOpenEvents(workspaceId),
+    editProcesses: (params) => onEditProcesses?.(params),
     back,
   };
 }

--- a/src/components/SpacesBrowser.tsx
+++ b/src/components/SpacesBrowser.tsx
@@ -422,6 +422,12 @@ export function useSpacesBrowser(props: UseSpacesBrowserProps): UseSpacesBrowser
         );
         if (session) {
           await onAttachSession({ sessionId: session.id, viewOnly: true });
+        } else {
+          onStartProcessAttach({
+            workspaceId: item.workspaceId,
+            processName: item.processName,
+            instance: item.instance,
+          });
         }
       } else {
         onStartProcessAttach({

--- a/src/components/SpacesBrowser.tsx
+++ b/src/components/SpacesBrowser.tsx
@@ -354,12 +354,15 @@ export function useSpacesBrowser(props: UseSpacesBrowserProps): UseSpacesBrowser
 
   const findSessionForProcess = useCallback(
     (workspaceId: string, processName: string, instance: number) =>
-      sessions.find(
-        (session) =>
-          session.workspaceId === workspaceId &&
-          session.processName === processName &&
-          (session.processInstance ?? 1) === instance
-      ),
+      sessions
+        .filter(
+          (session) =>
+            session.workspaceId === workspaceId &&
+            session.processName === processName &&
+            (session.processInstance ?? 1) === instance &&
+            session.exitCode === undefined
+        )
+        .sort((a, b) => b.createdAt - a.createdAt)[0],
     [sessions]
   );
 

--- a/src/components/SpacesBrowser.tsx
+++ b/src/components/SpacesBrowser.tsx
@@ -110,7 +110,7 @@ export interface UseSpacesBrowserReturn {
   activateSelected: () => Promise<void>;
   activateIndex: (index: number) => Promise<void>;
   /** Direct attach - bypasses state timing issues on mobile */
-  attachSession: (params: { sessionId?: string; workspaceId?: string }) => Promise<void>;
+  attachSession: (params: { sessionId?: string; workspaceId?: string; viewOnly?: boolean }) => Promise<void>;
   startProcessAttach: (params: { workspaceId: string; processName: string; instance: number }) => void;
   startProcess: (params: { workspaceId: string; processName: string }) => void;
   stopProcess: (params: { workspaceId: string; processName: string }) => void;

--- a/src/components/SpacesBrowser.tsx
+++ b/src/components/SpacesBrowser.tsx
@@ -388,7 +388,10 @@ export function useSpacesBrowser(props: UseSpacesBrowserProps): UseSpacesBrowser
     if (item.type === 'workspace') {
       toggleWorkspace(item.workspace.id);
     } else if (item.type === 'session') {
-      await onAttachSession({ sessionId: item.session.id });
+      await onAttachSession({
+        sessionId: item.session.id,
+        viewOnly: item.session.processName ? true : undefined,
+      });
     } else if (item.type === 'process') {
       if (item.status === 'running') {
         const session = findSessionForProcess(
@@ -433,11 +436,7 @@ export function useSpacesBrowser(props: UseSpacesBrowserProps): UseSpacesBrowser
     let workspaceId: string | null = null;
     if (selectedItem.type === 'workspace') {
       workspaceId = selectedItem.workspace.id;
-    } else if (
-      selectedItem.type === 'session' ||
-      selectedItem.type === 'new-session' ||
-      selectedItem.type === 'process-config-error'
-    ) {
+    } else if ('workspaceId' in selectedItem) {
       workspaceId = selectedItem.workspaceId;
     }
 

--- a/src/components/SpacesBrowser.tsx
+++ b/src/components/SpacesBrowser.tsx
@@ -108,6 +108,7 @@ export interface UseSpacesBrowserReturn {
   selectIndex: (index: number) => void;
   toggleWorkspace: (workspaceId: string) => void;
   activateSelected: () => Promise<void>;
+  activateIndex: (index: number) => Promise<void>;
   /** Direct attach - bypasses state timing issues on mobile */
   attachSession: (params: { sessionId?: string; workspaceId?: string }) => Promise<void>;
   startProcessAttach: (params: { workspaceId: string; processName: string; instance: number }) => void;
@@ -381,40 +382,50 @@ export function useSpacesBrowser(props: UseSpacesBrowserProps): UseSpacesBrowser
     });
   }, [onRequestSessions]);
 
-  const activateSelected = useCallback(async () => {
-    if (!selectedItem) return;
+  const activateItem = useCallback(async (item: TreeItem | null) => {
+    if (!item) return;
 
-    if (selectedItem.type === 'workspace') {
-      toggleWorkspace(selectedItem.workspace.id);
-    } else if (selectedItem.type === 'session') {
-      await onAttachSession({ sessionId: selectedItem.session.id });
-    } else if (selectedItem.type === 'process') {
-      if (selectedItem.status === 'running') {
+    if (item.type === 'workspace') {
+      toggleWorkspace(item.workspace.id);
+    } else if (item.type === 'session') {
+      await onAttachSession({ sessionId: item.session.id });
+    } else if (item.type === 'process') {
+      if (item.status === 'running') {
         const session = findSessionForProcess(
-          selectedItem.workspaceId,
-          selectedItem.processName,
-          selectedItem.instance
+          item.workspaceId,
+          item.processName,
+          item.instance
         );
         if (session) {
           await onAttachSession({ sessionId: session.id, viewOnly: true });
         }
       } else {
         onStartProcessAttach({
-          workspaceId: selectedItem.workspaceId,
-          processName: selectedItem.processName,
-          instance: selectedItem.instance,
+          workspaceId: item.workspaceId,
+          processName: item.processName,
+          instance: item.instance,
         });
       }
-    } else if (selectedItem.type === 'process-config-error') {
-      onEditProcesses?.({ workspaceId: selectedItem.workspaceId });
-    } else if (selectedItem.type === 'edit-processes') {
-      onEditProcesses?.({ workspaceId: selectedItem.workspaceId });
-    } else if (selectedItem.type === 'events') {
-      onOpenEvents(selectedItem.workspaceId);
-    } else if (selectedItem.type === 'new-session') {
-      await onAttachSession({ workspaceId: selectedItem.workspaceId });
+    } else if (item.type === 'process-config-error') {
+      onEditProcesses?.({ workspaceId: item.workspaceId });
+    } else if (item.type === 'edit-processes') {
+      onEditProcesses?.({ workspaceId: item.workspaceId });
+    } else if (item.type === 'events') {
+      onOpenEvents(item.workspaceId);
+    } else if (item.type === 'new-session') {
+      await onAttachSession({ workspaceId: item.workspaceId });
     }
-  }, [selectedItem, toggleWorkspace, onAttachSession, onStartProcessAttach, findSessionForProcess, onEditProcesses, onOpenEvents]);
+  }, [toggleWorkspace, onAttachSession, onStartProcessAttach, findSessionForProcess, onEditProcesses, onOpenEvents]);
+
+  const activateSelected = useCallback(async () => {
+    await activateItem(selectedItem);
+  }, [activateItem, selectedItem]);
+
+  const activateIndex = useCallback(async (index: number) => {
+    const clamped = Math.max(0, Math.min(index, tree.length - 1));
+    setSelectedIndex(clamped);
+    await activateItem(tree[clamped] ?? null);
+  }, [activateItem, tree]);
 
   const createNewSession = useCallback(async () => {
     if (!selectedItem) return;
@@ -468,6 +479,7 @@ export function useSpacesBrowser(props: UseSpacesBrowserProps): UseSpacesBrowser
     selectIndex,
     toggleWorkspace,
     activateSelected,
+    activateIndex,
     attachSession: async (params) => {
       await onAttachSession(params);
     },

--- a/src/components/SpacesBrowser.tsx
+++ b/src/components/SpacesBrowser.tsx
@@ -11,6 +11,19 @@ import { useState, useCallback, useMemo, useEffect } from 'react';
 // Types
 // ============================================================================
 
+/** Process summary for workspace */
+export interface WorkspaceProcessInfo {
+  name: string;
+  instances?: number;
+  ports?: WorkspaceProcessPort[];
+}
+
+export interface WorkspaceProcessPort {
+  port: number;
+  name?: string;
+  protocol?: 'http' | 'tcp';
+}
+
 /** Workspace info from machine */
 export interface WorkspaceInfo {
   id: string;
@@ -20,6 +33,8 @@ export interface WorkspaceInfo {
   branch?: string;
   sessionCount: number;
   isStale?: boolean;
+  processes?: WorkspaceProcessInfo[];
+  serveDomain?: string;
 }
 
 /** Session info from machine */
@@ -30,6 +45,9 @@ export interface SessionInfo {
   attached: boolean;
   createdAt: number;
   processTitle?: string;
+  processName?: string;
+  processInstance?: number;
+  exitCode?: number;
 }
 
 /** Tree item types for flattened list */
@@ -37,6 +55,8 @@ export type TreeItem =
   | { type: 'project'; name: string; workspaceCount: number }
   | { type: 'workspace'; workspace: WorkspaceInfo; expanded: boolean }
   | { type: 'session'; session: SessionInfo; workspaceId: string }
+  | { type: 'process'; processName: string; instance: number; workspaceId: string; status: 'running' | 'stopped' | 'failed'; ports?: WorkspaceProcessPort[]; serveDomain?: string }
+  | { type: 'events'; workspaceId: string }
   | { type: 'new-session'; workspaceId: string };
 
 /** Tree item with selection state */
@@ -51,6 +71,10 @@ export interface UseSpacesBrowserProps {
   sessions: SessionInfo[];
   onRequestSessions: (workspaceId?: string) => void;
   onAttachSession: (params: { sessionId?: string; workspaceId?: string }) => void | Promise<void>;
+  onStartProcess?: (params: { workspaceId: string; processName: string }) => void;
+  onStartProcessAttach: (params: { workspaceId: string; processName: string; instance: number }) => void;
+  onStopProcess?: (params: { workspaceId: string; processName: string }) => void;
+  onOpenEvents: (workspaceId: string) => void;
   onRefresh: () => void | Promise<void>;
   /** Called to refresh sessions after workspace refresh (full refresh by default). */
   onRefreshSessions?: () => void | Promise<void>;
@@ -82,9 +106,13 @@ export interface UseSpacesBrowserReturn {
   activateSelected: () => Promise<void>;
   /** Direct attach - bypasses state timing issues on mobile */
   attachSession: (params: { sessionId?: string; workspaceId?: string }) => Promise<void>;
+  startProcessAttach: (params: { workspaceId: string; processName: string; instance: number }) => void;
+  startProcess: (params: { workspaceId: string; processName: string }) => void;
+  stopProcess: (params: { workspaceId: string; processName: string }) => void;
   createNewSession: () => Promise<void>;
   createWorkspace: () => void;
   refresh: () => Promise<void>;
+  openEvents: (workspaceId: string) => void;
   back: () => void;
 }
 
@@ -142,16 +170,82 @@ function buildTree(
         expanded: isExpanded,
       });
 
-      // If expanded, show sessions and new session action
+      // If expanded, show processes, sessions, events, and new session action
       if (isExpanded) {
-        const workspaceSessions = sessions.filter(s => s.workspaceId === ws.id);
-        for (const session of workspaceSessions) {
+        const workspaceSessions = sessions
+          .filter(s => s.workspaceId === ws.id)
+          .sort((a, b) => {
+            const aProcess = a.processName ? 0 : 1;
+            const bProcess = b.processName ? 0 : 1;
+            if (aProcess !== bProcess) return aProcess - bProcess;
+            return a.name.localeCompare(b.name);
+          });
+        const processSessions = workspaceSessions.filter(s => s.processName);
+        const adHocSessions = workspaceSessions.filter(s => !s.processName);
+
+        // Build process entries from workspace config
+        const processEntries = ws.processes ?? [];
+        const processInstances = new Map<string, Set<number>>();
+        for (const session of processSessions) {
+          const instance = session.processInstance ?? 1;
+          const set = processInstances.get(session.processName ?? '') || new Set<number>();
+          set.add(instance);
+          processInstances.set(session.processName ?? '', set);
+        }
+
+        for (const process of processEntries) {
+          const knownInstances = processInstances.get(process.name) ?? new Set<number>();
+          const configuredCount = process.instances ?? 1;
+          const configuredInstances = Array.from({ length: configuredCount }, (_, idx) => idx + 1);
+          const instanceList = configuredInstances.length > 0 ? configuredInstances : [1];
+          for (const instance of instanceList) {
+            const sessionMatch = processSessions.find(
+              (session) => session.processName === process.name && (session.processInstance ?? 1) === instance
+            );
+            const exitCode = sessionMatch?.exitCode;
+            const status = exitCode !== undefined
+              ? exitCode === 0
+                ? 'stopped'
+                : 'failed'
+              : knownInstances.has(instance)
+                ? 'running'
+                : 'stopped';
+            items.push({
+              type: 'process',
+              processName: process.name,
+              instance,
+              workspaceId: ws.id,
+              status,
+              ports: process.ports,
+              serveDomain: ws.serveDomain,
+            });
+          }
+        }
+
+        // Process sessions
+        for (const session of processSessions) {
           items.push({
             type: 'session',
             session,
             workspaceId: ws.id,
           });
         }
+
+        // Ad-hoc sessions
+        for (const session of adHocSessions) {
+          items.push({
+            type: 'session',
+            session,
+            workspaceId: ws.id,
+          });
+        }
+
+        // Events action
+        items.push({
+          type: 'events',
+          workspaceId: ws.id,
+        });
+
         // New session action
         items.push({
           type: 'new-session',
@@ -182,6 +276,10 @@ export function useSpacesBrowser(props: UseSpacesBrowserProps): UseSpacesBrowser
     sessions,
     onRequestSessions,
     onAttachSession,
+    onStartProcess,
+    onStartProcessAttach,
+    onStopProcess,
+    onOpenEvents,
     onRefresh,
     onRefreshSessions,
     onBack,
@@ -208,6 +306,17 @@ export function useSpacesBrowser(props: UseSpacesBrowserProps): UseSpacesBrowser
 
   // Selected item
   const selectedItem = tree[selectedIndex] ?? null;
+
+  const findSessionForProcess = useCallback(
+    (workspaceId: string, processName: string, instance: number) =>
+      sessions.find(
+        (session) =>
+          session.workspaceId === workspaceId &&
+          session.processName === processName &&
+          (session.processInstance ?? 1) === instance
+      ),
+    [sessions]
+  );
 
   // Computed
   const isEmpty = workspaces.length === 0;
@@ -253,10 +362,29 @@ export function useSpacesBrowser(props: UseSpacesBrowserProps): UseSpacesBrowser
       toggleWorkspace(selectedItem.workspace.id);
     } else if (selectedItem.type === 'session') {
       await onAttachSession({ sessionId: selectedItem.session.id });
+    } else if (selectedItem.type === 'process') {
+      if (selectedItem.status === 'running') {
+        const session = findSessionForProcess(
+          selectedItem.workspaceId,
+          selectedItem.processName,
+          selectedItem.instance
+        );
+        if (session) {
+          await onAttachSession({ sessionId: session.id });
+        }
+      } else {
+        onStartProcessAttach({
+          workspaceId: selectedItem.workspaceId,
+          processName: selectedItem.processName,
+          instance: selectedItem.instance,
+        });
+      }
+    } else if (selectedItem.type === 'events') {
+      onOpenEvents(selectedItem.workspaceId);
     } else if (selectedItem.type === 'new-session') {
       await onAttachSession({ workspaceId: selectedItem.workspaceId });
     }
-  }, [selectedItem, toggleWorkspace, onAttachSession]);
+  }, [selectedItem, toggleWorkspace, onAttachSession, onStartProcessAttach, findSessionForProcess, onOpenEvents]);
 
   const createNewSession = useCallback(async () => {
     if (!selectedItem) return;
@@ -309,9 +437,13 @@ export function useSpacesBrowser(props: UseSpacesBrowserProps): UseSpacesBrowser
     attachSession: async (params) => {
       await onAttachSession(params);
     },
+    startProcessAttach: (params) => onStartProcessAttach(params),
+    startProcess: (params) => onStartProcess?.(params),
+    stopProcess: (params) => onStopProcess?.(params),
     createNewSession,
     createWorkspace,
     refresh,
+    openEvents: (workspaceId) => onOpenEvents(workspaceId),
     back,
   };
 }

--- a/src/components/SpacesBrowser.tsx
+++ b/src/components/SpacesBrowser.tsx
@@ -6,6 +6,7 @@
  */
 
 import { useState, useCallback, useMemo, useEffect } from 'react';
+import { normalizeProcessInstanceCount } from '../lib/processes/instances.js';
 
 // ============================================================================
 // Types
@@ -57,6 +58,7 @@ export type TreeItem =
   | { type: 'workspace'; workspace: WorkspaceInfo; expanded: boolean }
   | { type: 'session'; session: SessionInfo; workspaceId: string }
   | { type: 'process'; processName: string; instance: number; workspaceId: string; status: 'running' | 'stopped' | 'failed'; ports?: WorkspaceProcessPort[]; serveDomain?: string }
+  | { type: 'process-disabled'; processName: string; workspaceId: string; ports?: WorkspaceProcessPort[] }
   | { type: 'process-config-error'; workspaceId: string; error: string }
   | { type: 'edit-processes'; workspaceId: string }
   | { type: 'events'; workspaceId: string }
@@ -77,6 +79,7 @@ export interface UseSpacesBrowserProps {
   onStartProcess?: (params: { workspaceId: string; processName: string }) => void;
   onStartProcessAttach: (params: { workspaceId: string; processName: string; instance: number }) => void;
   onStopProcess?: (params: { workspaceId: string; processName: string }) => void;
+  onProcessDisabled?: (params: { workspaceId: string; processName: string }) => void;
   onOpenEvents: (workspaceId: string) => void;
   onEditProcesses?: (params: { workspaceId: string }) => void;
   onRefresh: () => void | Promise<void>;
@@ -206,10 +209,19 @@ function buildTree(
         };
 
         for (const process of processEntries) {
-          const configuredCount = process.instances ?? 1;
+          const configuredCount = normalizeProcessInstanceCount(process.instances);
+          if (configuredCount === 0) {
+            items.push({
+              type: 'process-disabled',
+              processName: process.name,
+              workspaceId: ws.id,
+              ports: process.ports,
+            });
+            continue;
+          }
+
           const configuredInstances = Array.from({ length: configuredCount }, (_, idx) => idx + 1);
-          const instanceList = configuredInstances.length > 0 ? configuredInstances : [1];
-          for (const instance of instanceList) {
+          for (const instance of configuredInstances) {
             const sessionKey = `${process.name}:${instance}`;
             const matchingSessions = processSessionGroups.get(sessionKey) ?? [];
             const runningSession = getLatestSession(matchingSessions.filter((session) => session.exitCode === undefined));
@@ -310,6 +322,7 @@ export function useSpacesBrowser(props: UseSpacesBrowserProps): UseSpacesBrowser
     onStartProcess,
     onStartProcessAttach,
     onStopProcess,
+    onProcessDisabled,
     onOpenEvents,
     onEditProcesses,
     onRefresh,
@@ -414,6 +427,11 @@ export function useSpacesBrowser(props: UseSpacesBrowserProps): UseSpacesBrowser
           instance: item.instance,
         });
       }
+    } else if (item.type === 'process-disabled') {
+      onProcessDisabled?.({
+        workspaceId: item.workspaceId,
+        processName: item.processName,
+      });
     } else if (item.type === 'process-config-error') {
       onEditProcesses?.({ workspaceId: item.workspaceId });
     } else if (item.type === 'edit-processes') {
@@ -423,7 +441,7 @@ export function useSpacesBrowser(props: UseSpacesBrowserProps): UseSpacesBrowser
     } else if (item.type === 'new-session') {
       await onAttachSession({ workspaceId: item.workspaceId });
     }
-  }, [toggleWorkspace, onAttachSession, onStartProcessAttach, findSessionForProcess, onEditProcesses, onOpenEvents]);
+  }, [toggleWorkspace, onAttachSession, onStartProcessAttach, findSessionForProcess, onProcessDisabled, onEditProcesses, onOpenEvents]);
 
   const activateSelected = useCallback(async () => {
     await activateItem(selectedItem);

--- a/src/components/SpacesBrowser.tsx
+++ b/src/components/SpacesBrowser.tsx
@@ -190,6 +190,7 @@ function buildTree(
 
         // Build process entries from workspace config
         const processEntries = ws.processes ?? [];
+        const renderedProcessKeys = new Set<string>();
         const processInstances = new Map<string, Set<number>>();
         for (const session of processSessions) {
           const instance = session.processInstance ?? 1;
@@ -224,11 +225,16 @@ function buildTree(
               ports: process.ports,
               serveDomain: ws.serveDomain,
             });
+            renderedProcessKeys.add(`${process.name}:${instance}`);
           }
         }
 
-        // Process sessions
+        // Process sessions not represented by process rows (orphaned/unconfigured)
         for (const session of processSessions) {
+          const processKey = `${session.processName}:${session.processInstance ?? 1}`;
+          if (renderedProcessKeys.has(processKey)) {
+            continue;
+          }
           items.push({
             type: 'session',
             session,

--- a/src/components/SpacesBrowser.tsx
+++ b/src/components/SpacesBrowser.tsx
@@ -35,6 +35,7 @@ export interface WorkspaceInfo {
   isStale?: boolean;
   processes?: WorkspaceProcessInfo[];
   serveDomain?: string;
+  processConfigError?: string;
 }
 
 /** Session info from machine */
@@ -56,6 +57,7 @@ export type TreeItem =
   | { type: 'workspace'; workspace: WorkspaceInfo; expanded: boolean }
   | { type: 'session'; session: SessionInfo; workspaceId: string }
   | { type: 'process'; processName: string; instance: number; workspaceId: string; status: 'running' | 'stopped' | 'failed'; ports?: WorkspaceProcessPort[]; serveDomain?: string }
+  | { type: 'process-config-error'; workspaceId: string; error: string }
   | { type: 'edit-processes'; workspaceId: string }
   | { type: 'events'; workspaceId: string }
   | { type: 'new-session'; workspaceId: string };
@@ -243,6 +245,14 @@ function buildTree(
           });
         }
 
+        if (ws.processConfigError) {
+          items.push({
+            type: 'process-config-error',
+            workspaceId: ws.id,
+            error: ws.processConfigError,
+          });
+        }
+
         // Edit processes config action
         items.push({
           type: 'edit-processes',
@@ -389,6 +399,8 @@ export function useSpacesBrowser(props: UseSpacesBrowserProps): UseSpacesBrowser
           instance: selectedItem.instance,
         });
       }
+    } else if (selectedItem.type === 'process-config-error') {
+      onEditProcesses?.({ workspaceId: selectedItem.workspaceId });
     } else if (selectedItem.type === 'edit-processes') {
       onEditProcesses?.({ workspaceId: selectedItem.workspaceId });
     } else if (selectedItem.type === 'events') {
@@ -404,7 +416,11 @@ export function useSpacesBrowser(props: UseSpacesBrowserProps): UseSpacesBrowser
     let workspaceId: string | null = null;
     if (selectedItem.type === 'workspace') {
       workspaceId = selectedItem.workspace.id;
-    } else if (selectedItem.type === 'session' || selectedItem.type === 'new-session') {
+    } else if (
+      selectedItem.type === 'session' ||
+      selectedItem.type === 'new-session' ||
+      selectedItem.type === 'process-config-error'
+    ) {
       workspaceId = selectedItem.workspaceId;
     }
 

--- a/src/components/SpacesBrowser.tsx
+++ b/src/components/SpacesBrowser.tsx
@@ -192,31 +192,36 @@ function buildTree(
         // Build process entries from workspace config
         const processEntries = ws.processes ?? [];
         const renderedProcessKeys = new Set<string>();
-        const processInstances = new Map<string, Set<number>>();
+        const processSessionGroups = new Map<string, SessionInfo[]>();
         for (const session of processSessions) {
-          const instance = session.processInstance ?? 1;
-          const set = processInstances.get(session.processName ?? '') || new Set<number>();
-          set.add(instance);
-          processInstances.set(session.processName ?? '', set);
+          const key = `${session.processName ?? ''}:${session.processInstance ?? 1}`;
+          const existing = processSessionGroups.get(key) ?? [];
+          existing.push(session);
+          processSessionGroups.set(key, existing);
         }
 
+        const getLatestSession = (items: SessionInfo[]): SessionInfo | null => {
+          if (items.length === 0) return null;
+          return [...items].sort((a, b) => b.createdAt - a.createdAt)[0] ?? null;
+        };
+
         for (const process of processEntries) {
-          const knownInstances = processInstances.get(process.name) ?? new Set<number>();
           const configuredCount = process.instances ?? 1;
           const configuredInstances = Array.from({ length: configuredCount }, (_, idx) => idx + 1);
           const instanceList = configuredInstances.length > 0 ? configuredInstances : [1];
           for (const instance of instanceList) {
-            const sessionMatch = processSessions.find(
-              (session) => session.processName === process.name && (session.processInstance ?? 1) === instance
-            );
-            const exitCode = sessionMatch?.exitCode;
-            const status = exitCode !== undefined
-              ? exitCode === 0
-                ? 'stopped'
-                : 'failed'
-              : knownInstances.has(instance)
-                ? 'running'
-                : 'stopped';
+            const sessionKey = `${process.name}:${instance}`;
+            const matchingSessions = processSessionGroups.get(sessionKey) ?? [];
+            const runningSession = getLatestSession(matchingSessions.filter((session) => session.exitCode === undefined));
+            const latestSession = getLatestSession(matchingSessions);
+
+            let status: 'running' | 'stopped' | 'failed' = 'stopped';
+            if (runningSession) {
+              status = 'running';
+            } else if (latestSession?.exitCode !== undefined) {
+              status = latestSession.exitCode === 0 ? 'stopped' : 'failed';
+            }
+
             items.push({
               type: 'process',
               processName: process.name,

--- a/src/components/SpacesBrowser.tui.tsx
+++ b/src/components/SpacesBrowser.tui.tsx
@@ -50,6 +50,9 @@ function getSpacesBrowserHint(selectedItem: TreeItem | null | undefined): string
       ? '[↑↓] Navigate  [Enter] View  [x] Stop  [r] Refresh  [q] Back'
       : '[↑↓] Navigate  [Enter] Start  [r] Refresh  [q] Back';
   }
+  if (selectedItem?.type === 'process-disabled') {
+    return '[↑↓] Navigate  [Enter] Disabled  [r] Refresh  [q] Back';
+  }
   if (selectedItem?.type === 'process-config-error') {
     return '[↑↓] Navigate  [Enter] Fix Config  [r] Refresh  [q] Back';
   }
@@ -187,6 +190,18 @@ export function SpacesBrowserTUI(props: SpacesBrowserTUIProps) {
                 <text fg={textColor}> {item.processName}#{item.instance}</text>
                 {portInfo && <text fg={COLORS.textDim}>{portInfo}</text>}
                 <text fg={statusColor}> ({item.status})</text>
+              </box>
+            );
+          }
+
+          if (item.type === 'process-disabled') {
+            const textColor = isSelected ? COLORS.selected : '#D29922';
+            const prefix = isSelected ? '>' : ' ';
+            return (
+              <box key={`process-disabled-${item.workspaceId}-${item.processName}`} flexDirection="row" height={1}>
+                <text fg={textColor}>{prefix}   </text>
+                <text fg="#D29922">⏸</text>
+                <text fg={textColor}> {item.processName} (disabled)</text>
               </box>
             );
           }

--- a/src/components/SpacesBrowser.tui.tsx
+++ b/src/components/SpacesBrowser.tui.tsx
@@ -50,6 +50,9 @@ function getSpacesBrowserHint(selectedItem: TreeItem | null | undefined): string
       ? '[↑↓] Navigate  [Enter] View  [x] Stop  [r] Refresh  [q] Back'
       : '[↑↓] Navigate  [Enter] Start  [r] Refresh  [q] Back';
   }
+  if (selectedItem?.type === 'process-config-error') {
+    return '[↑↓] Navigate  [Enter] Fix Config  [r] Refresh  [q] Back';
+  }
   if (selectedItem?.type === 'workspace') {
     return '[↑↓] Navigate  [Enter] Expand  [n] New  [d] Delete  [r] Refresh  [q] Back';
   }
@@ -194,6 +197,16 @@ export function SpacesBrowserTUI(props: SpacesBrowserTUIProps) {
             return (
               <text key={`edit-processes-${item.workspaceId}`} fg={textColor} height={1}>
                 {prefix}   ⚙ Edit Processes Config
+              </text>
+            );
+          }
+
+          if (item.type === 'process-config-error') {
+            const textColor = isSelected ? COLORS.selected : '#FF6666';
+            const prefix = isSelected ? '>' : ' ';
+            return (
+              <text key={`process-config-error-${item.workspaceId}`} fg={textColor} height={1}>
+                {prefix}   ⚠ Invalid processes config
               </text>
             );
           }

--- a/src/components/SpacesBrowser.tui.tsx
+++ b/src/components/SpacesBrowser.tui.tsx
@@ -5,7 +5,7 @@
  * Receives all state and actions from useSpacesBrowser hook.
  */
 
-import type { UseSpacesBrowserReturn } from './SpacesBrowser.js';
+import type { UseSpacesBrowserReturn, TreeItem } from './SpacesBrowser.js';
 import { formatTime } from './SpacesBrowser.js';
 
 // ============================================================================
@@ -38,6 +38,34 @@ interface SpacesBrowserTUIProps extends UseSpacesBrowserReturn {
 }
 
 // ============================================================================
+// Hint Helper
+// ============================================================================
+
+function getSpacesBrowserHint(selectedItem: TreeItem | null | undefined): string {
+  if (selectedItem?.type === 'session') {
+    return '[↑↓] Navigate  [Enter] Attach  [x] Kill  [r] Refresh  [q] Back';
+  }
+  if (selectedItem?.type === 'process') {
+    return selectedItem.status === 'running'
+      ? '[↑↓] Navigate  [Enter] View  [x] Stop  [r] Refresh  [q] Back'
+      : '[↑↓] Navigate  [Enter] Start  [r] Refresh  [q] Back';
+  }
+  if (selectedItem?.type === 'workspace') {
+    return '[↑↓] Navigate  [Enter] Expand  [n] New  [d] Delete  [r] Refresh  [q] Back';
+  }
+  if (selectedItem?.type === 'edit-processes') {
+    return '[↑↓] Navigate  [Enter] Edit Processes Config  [r] Refresh  [q] Back';
+  }
+  if (selectedItem?.type === 'events') {
+    return '[↑↓] Navigate  [Enter] Open Events  [r] Refresh  [q] Back';
+  }
+  if (selectedItem?.type === 'new-session') {
+    return '[↑↓] Navigate  [Enter] New Session  [r] Refresh  [q] Back';
+  }
+  return '[↑↓] Navigate  [Enter] Select  [n] New  [r] Refresh  [q] Back';
+}
+
+// ============================================================================
 // Component
 // ============================================================================
 
@@ -47,6 +75,7 @@ export function SpacesBrowserTUI(props: SpacesBrowserTUIProps) {
     machineName,
     isEmpty,
     focused = true,
+    selectedItem,
   } = props;
 
   // Empty state
@@ -141,6 +170,44 @@ export function SpacesBrowserTUI(props: SpacesBrowserTUIProps) {
             );
           }
 
+          if (item.type === 'process') {
+            const statusIcon = item.status === 'running' ? '▶' : item.status === 'failed' ? '✗' : '■';
+            const statusColor = item.status === 'running' ? '#00FF00' : item.status === 'failed' ? '#FF4444' : COLORS.textDim;
+            const textColor = isSelected ? COLORS.selected : COLORS.text;
+            const prefix = isSelected ? '>' : ' ';
+            const portInfo = item.ports?.length ? ` :${item.ports.map(p => p.port).join(',')}` : '';
+
+            return (
+              <box key={`process-${item.workspaceId}-${item.processName}-${item.instance}`} flexDirection="row" height={1}>
+                <text fg={textColor}>{prefix}   </text>
+                <text fg={statusColor}>{statusIcon}</text>
+                <text fg={textColor}> {item.processName}#{item.instance}</text>
+                {portInfo && <text fg={COLORS.textDim}>{portInfo}</text>}
+                <text fg={statusColor}> ({item.status})</text>
+              </box>
+            );
+          }
+
+          if (item.type === 'edit-processes') {
+            const textColor = isSelected ? COLORS.selected : '#FFAA55';
+            const prefix = isSelected ? '>' : ' ';
+            return (
+              <text key={`edit-processes-${item.workspaceId}`} fg={textColor} height={1}>
+                {prefix}   ⚙ Edit Processes Config
+              </text>
+            );
+          }
+
+          if (item.type === 'events') {
+            const textColor = isSelected ? COLORS.selected : '#AA88FF';
+            const prefix = isSelected ? '>' : ' ';
+            return (
+              <text key={`events-${item.workspaceId}`} fg={textColor} height={1}>
+                {prefix}   ◆ Events
+              </text>
+            );
+          }
+
           if (item.type === 'new-session') {
             const textColor = isSelected ? COLORS.selected : COLORS.newSession;
             return (
@@ -156,7 +223,7 @@ export function SpacesBrowserTUI(props: SpacesBrowserTUIProps) {
 
       {/* Footer hint */}
       <text fg={COLORS.textDim} height={1} paddingLeft={1}>
-        [↑↓] Navigate  [Enter] Select  [n] New  [r] Refresh  [q] Back
+        {getSpacesBrowserHint(selectedItem)}
       </text>
     </box>
   );

--- a/src/components/SpacesBrowser.web.tsx
+++ b/src/components/SpacesBrowser.web.tsx
@@ -23,9 +23,7 @@ export function SpacesBrowserWeb(props: SpacesBrowserWebProps) {
     items,
     machineName,
     isEmpty,
-    selectIndex,
-    toggleWorkspace,
-    attachSession,
+    activateIndex,
     refresh,
     back,
     onReview,
@@ -74,9 +72,7 @@ export function SpacesBrowserWeb(props: SpacesBrowserWebProps) {
                 key={`ws-${ws.id}`}
                 onClick={(e) => {
                   e.stopPropagation();
-                  console.log('[SpacesBrowser] Workspace clicked:', ws.id, ws.name);
-                  selectIndex(index);
-                  toggleWorkspace(ws.id);
+                  void activateIndex(index);
                 }}
                 className={`
                   px-4 py-4 cursor-pointer border-b border-[#30363d] flex items-center justify-between min-h-[56px]
@@ -126,9 +122,7 @@ export function SpacesBrowserWeb(props: SpacesBrowserWebProps) {
                 key={`session-${session.id}`}
                 onClick={(e) => {
                   e.stopPropagation();
-                  console.log('[SpacesBrowser] Session clicked:', session.id, session.name);
-                  selectIndex(index);
-                  attachSession({ sessionId: session.id });
+                  void activateIndex(index);
                 }}
                 className={`
                   pl-10 sm:pl-12 pr-4 py-3 cursor-pointer border-b border-[#30363d] flex items-center justify-between min-h-[52px]
@@ -161,7 +155,7 @@ export function SpacesBrowserWeb(props: SpacesBrowserWebProps) {
                 key={`process-${item.workspaceId}-${item.processName}-${item.instance}`}
                 onClick={(e) => {
                   e.stopPropagation();
-                  selectIndex(index);
+                  void activateIndex(index);
                 }}
                 className={`
                   pl-10 sm:pl-12 pr-4 py-3 cursor-pointer border-b border-[#30363d] flex items-center justify-between min-h-[52px]
@@ -186,8 +180,7 @@ export function SpacesBrowserWeb(props: SpacesBrowserWebProps) {
                 key={`process-config-error-${item.workspaceId}`}
                 onClick={(e) => {
                   e.stopPropagation();
-                  selectIndex(index);
-                  props.editProcesses({ workspaceId: item.workspaceId });
+                  void activateIndex(index);
                 }}
                 className={`
                   pl-10 sm:pl-12 pr-4 py-3 cursor-pointer border-b border-[#30363d] min-h-[48px] flex items-center
@@ -206,8 +199,7 @@ export function SpacesBrowserWeb(props: SpacesBrowserWebProps) {
                 key={`edit-processes-${item.workspaceId}`}
                 onClick={(e) => {
                   e.stopPropagation();
-                  selectIndex(index);
-                  props.editProcesses({ workspaceId: item.workspaceId });
+                  void activateIndex(index);
                 }}
                 className={`
                   pl-10 sm:pl-12 pr-4 py-3 cursor-pointer border-b border-[#30363d] min-h-[48px] flex items-center
@@ -225,8 +217,7 @@ export function SpacesBrowserWeb(props: SpacesBrowserWebProps) {
                 key={`events-${item.workspaceId}`}
                 onClick={(e) => {
                   e.stopPropagation();
-                  selectIndex(index);
-                  props.openEvents(item.workspaceId);
+                  void activateIndex(index);
                 }}
                 className={`
                   pl-10 sm:pl-12 pr-4 py-3 cursor-pointer border-b border-[#30363d] min-h-[48px] flex items-center
@@ -244,9 +235,7 @@ export function SpacesBrowserWeb(props: SpacesBrowserWebProps) {
                 key={`new-${item.workspaceId}`}
                 onClick={(e) => {
                   e.stopPropagation();
-                  console.log('[SpacesBrowser] New session clicked for workspace:', item.workspaceId);
-                  selectIndex(index);
-                  attachSession({ workspaceId: item.workspaceId });
+                  void activateIndex(index);
                 }}
                 className={`
                   pl-10 sm:pl-12 pr-4 py-3 cursor-pointer border-b border-[#30363d] min-h-[48px] flex items-center

--- a/src/components/SpacesBrowser.web.tsx
+++ b/src/components/SpacesBrowser.web.tsx
@@ -174,6 +174,24 @@ export function SpacesBrowserWeb(props: SpacesBrowserWebProps) {
             );
           }
 
+          if (item.type === 'process-disabled') {
+            return (
+              <div
+                key={`process-disabled-${item.workspaceId}-${item.processName}`}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  void activateIndex(index);
+                }}
+                className={`
+                  pl-10 sm:pl-12 pr-4 py-3 cursor-pointer border-b border-[#30363d] min-h-[52px] flex items-center
+                  ${isSelected ? 'bg-[#21262d] border-l-4 border-l-[#58a6ff]' : 'hover:bg-[#161b22] active:bg-[#21262d]'}
+                `}
+              >
+                <span className="text-[#d29922]">⏸ {item.processName} (disabled)</span>
+              </div>
+            );
+          }
+
           if (item.type === 'process-config-error') {
             return (
               <div

--- a/src/components/SpacesBrowser.web.tsx
+++ b/src/components/SpacesBrowser.web.tsx
@@ -180,6 +180,26 @@ export function SpacesBrowserWeb(props: SpacesBrowserWebProps) {
             );
           }
 
+          if (item.type === 'process-config-error') {
+            return (
+              <div
+                key={`process-config-error-${item.workspaceId}`}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  selectIndex(index);
+                  props.editProcesses({ workspaceId: item.workspaceId });
+                }}
+                className={`
+                  pl-10 sm:pl-12 pr-4 py-3 cursor-pointer border-b border-[#30363d] min-h-[48px] flex items-center
+                  ${isSelected ? 'bg-[#21262d] border-l-4 border-l-[#58a6ff]' : 'hover:bg-[#161b22] active:bg-[#21262d]'}
+                `}
+                title={item.error}
+              >
+                <span className="text-[#f85149]">⚠ Invalid processes config</span>
+              </div>
+            );
+          }
+
           if (item.type === 'edit-processes') {
             return (
               <div

--- a/src/components/SpacesBrowser.web.tsx
+++ b/src/components/SpacesBrowser.web.tsx
@@ -151,6 +151,73 @@ export function SpacesBrowserWeb(props: SpacesBrowserWebProps) {
             );
           }
 
+          if (item.type === 'process') {
+            const statusIcon = item.status === 'running' ? '▶' : item.status === 'failed' ? '✗' : '■';
+            const statusColor = item.status === 'running' ? 'text-[#3fb950]' : item.status === 'failed' ? 'text-[#f85149]' : 'text-[#8b949e]';
+            const portInfo = item.ports?.length ? ` :${item.ports.map(p => p.port).join(',')}` : '';
+
+            return (
+              <div
+                key={`process-${item.workspaceId}-${item.processName}-${item.instance}`}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  selectIndex(index);
+                }}
+                className={`
+                  pl-10 sm:pl-12 pr-4 py-3 cursor-pointer border-b border-[#30363d] flex items-center justify-between min-h-[52px]
+                  ${isSelected ? 'bg-[#21262d] border-l-4 border-l-[#58a6ff]' : 'hover:bg-[#161b22] active:bg-[#21262d]'}
+                `}
+              >
+                <div className="flex items-center gap-3 min-w-0 flex-1">
+                  <span className={`w-2.5 h-2.5 flex-shrink-0 ${statusColor}`}>{statusIcon}</span>
+                  <div className="min-w-0 flex-1">
+                    <span className="text-[#e6edf3] truncate block">{item.processName}#{item.instance}</span>
+                    {portInfo && <span className="text-xs text-[#8b949e] truncate block">{portInfo}</span>}
+                  </div>
+                </div>
+                <span className={`text-xs ${statusColor} flex-shrink-0 ml-2`}>{item.status}</span>
+              </div>
+            );
+          }
+
+          if (item.type === 'edit-processes') {
+            return (
+              <div
+                key={`edit-processes-${item.workspaceId}`}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  selectIndex(index);
+                  props.editProcesses({ workspaceId: item.workspaceId });
+                }}
+                className={`
+                  pl-10 sm:pl-12 pr-4 py-3 cursor-pointer border-b border-[#30363d] min-h-[48px] flex items-center
+                  ${isSelected ? 'bg-[#21262d] border-l-4 border-l-[#58a6ff]' : 'hover:bg-[#161b22] active:bg-[#21262d]'}
+                `}
+              >
+                <span className="text-[#ffaa55]">⚙ Edit Processes Config</span>
+              </div>
+            );
+          }
+
+          if (item.type === 'events') {
+            return (
+              <div
+                key={`events-${item.workspaceId}`}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  selectIndex(index);
+                  props.openEvents(item.workspaceId);
+                }}
+                className={`
+                  pl-10 sm:pl-12 pr-4 py-3 cursor-pointer border-b border-[#30363d] min-h-[48px] flex items-center
+                  ${isSelected ? 'bg-[#21262d] border-l-4 border-l-[#58a6ff]' : 'hover:bg-[#161b22] active:bg-[#21262d]'}
+                `}
+              >
+                <span className="text-[#d2a8ff]">◆ Events</span>
+              </div>
+            );
+          }
+
           if (item.type === 'new-session') {
             return (
               <div

--- a/src/components/__tests__/SpacesBrowser.test.ts
+++ b/src/components/__tests__/SpacesBrowser.test.ts
@@ -411,6 +411,42 @@ describe('useSpacesBrowser activateSelected', () => {
     expect(onAttachSession).toHaveBeenCalledWith({ sessionId: 'proc-sess-1', viewOnly: true });
   });
 
+  it('ignores exited process sessions when attaching from running process item', async () => {
+    const ws = makeWorkspace({
+      sessionCount: 2,
+      processes: [{ name: 'web-server' }],
+    });
+    const exitedSession = makeSession({
+      id: 'proc-sess-exited',
+      processName: 'web-server',
+      processInstance: 1,
+      createdAt: Date.now(),
+      exitCode: 1,
+    });
+    const runningSession = makeSession({
+      id: 'proc-sess-running',
+      processName: 'web-server',
+      processInstance: 1,
+      createdAt: Date.now() - 30_000,
+    });
+    const onAttachSession = mock(async () => {});
+    const props = makeProps({
+      workspaces: [ws],
+      sessions: [exitedSession, runningSession],
+      onAttachSession,
+    });
+    const { result } = renderHook(() => useSpacesBrowser(props));
+
+    act(() => { result.current.toggleWorkspace('ws-1'); });
+
+    const processIndex = result.current.items.findIndex((item) => item.type === 'process');
+    act(() => { result.current.selectIndex(processIndex); });
+
+    await act(async () => { await result.current.activateSelected(); });
+
+    expect(onAttachSession).toHaveBeenCalledWith({ sessionId: 'proc-sess-running', viewOnly: true });
+  });
+
   it('calls onProcessDisabled when disabled process row is activated', async () => {
     const ws = makeWorkspace({
       processes: [{ name: 'worker', instances: 0 }],

--- a/src/components/__tests__/SpacesBrowser.test.ts
+++ b/src/components/__tests__/SpacesBrowser.test.ts
@@ -295,6 +295,23 @@ describe('useSpacesBrowser activateSelected', () => {
     expect(editIdx).toBeLessThan(eventsIdx);
   });
 
+  it('shows process-config-error item and routes activation to edit config', async () => {
+    const ws = makeWorkspace({ processConfigError: 'Invalid config' });
+    const onEditProcesses = mock(() => {});
+    const props = makeProps({ workspaces: [ws], onEditProcesses });
+    const { result } = renderHook(() => useSpacesBrowser(props));
+
+    act(() => { result.current.toggleWorkspace('ws-1'); });
+
+    const errorIndex = result.current.items.findIndex((item) => item.type === 'process-config-error');
+    expect(errorIndex).toBeGreaterThanOrEqual(0);
+
+    act(() => { result.current.selectIndex(errorIndex); });
+    await act(async () => { await result.current.activateSelected(); });
+
+    expect(onEditProcesses).toHaveBeenCalledWith({ workspaceId: 'ws-1' });
+  });
+
   it('calls onStartProcessAttach when stopped process is activated', async () => {
     const ws = makeWorkspace({
       processes: [{ name: 'web-server' }],

--- a/src/components/__tests__/SpacesBrowser.test.ts
+++ b/src/components/__tests__/SpacesBrowser.test.ts
@@ -190,6 +190,38 @@ describe('useSpacesBrowser tree building', () => {
     expect(processItem!.type === 'process' && processItem!.status).toBe('failed');
   });
 
+  it('prefers running session status over older exited sessions for same process instance', () => {
+    const ws = makeWorkspace({
+      sessionCount: 2,
+      processes: [{ name: 'web-server', instances: 1 }],
+    });
+    const olderExited = makeSession({
+      id: 'proc-old',
+      name: 'a-old-exited',
+      processName: 'web-server',
+      processInstance: 1,
+      exitCode: 1,
+      createdAt: Date.now() - 120_000,
+    });
+    const newerRunning = makeSession({
+      id: 'proc-new',
+      name: 'z-new-running',
+      processName: 'web-server',
+      processInstance: 1,
+      createdAt: Date.now() - 5_000,
+    });
+    const props = makeProps({ workspaces: [ws], sessions: [olderExited, newerRunning] });
+    const { result } = renderHook(() => useSpacesBrowser(props));
+
+    act(() => { result.current.toggleWorkspace('ws-1'); });
+
+    const processItem = result.current.items.find(
+      (item) => item.type === 'process' && item.processName === 'web-server'
+    );
+    expect(processItem).toBeDefined();
+    expect(processItem!.type === 'process' && processItem!.status).toBe('running');
+  });
+
   it('always includes events item under expanded workspace', () => {
     const ws = makeWorkspace();
     const props = makeProps({ workspaces: [ws] });

--- a/src/components/__tests__/SpacesBrowser.test.ts
+++ b/src/components/__tests__/SpacesBrowser.test.ts
@@ -1,0 +1,392 @@
+/**
+ * SpacesBrowser hook tests
+ *
+ * Validates tree building, process/events item generation,
+ * and activateSelected behavior for all item types.
+ */
+
+import { afterAll, beforeAll, describe, expect, it, mock } from 'bun:test';
+import { act, renderHook } from '@testing-library/react';
+import { Window } from 'happy-dom';
+import {
+  useSpacesBrowser,
+  type WorkspaceInfo,
+  type SessionInfo,
+  type UseSpacesBrowserProps,
+} from '../SpacesBrowser.js';
+
+// ============================================================================
+// happy-dom setup (required for renderHook)
+// ============================================================================
+
+const domWindow = new Window();
+const originalWindow = globalThis.window;
+const originalDocument = globalThis.document;
+
+beforeAll(() => {
+  // @ts-expect-error test DOM setup
+  globalThis.window = domWindow;
+  // @ts-expect-error test DOM setup
+  globalThis.document = domWindow.document;
+});
+
+afterAll(() => {
+  globalThis.window = originalWindow;
+  globalThis.document = originalDocument;
+});
+
+// ============================================================================
+// Fixtures
+// ============================================================================
+
+function makeWorkspace(overrides: Partial<WorkspaceInfo> = {}): WorkspaceInfo {
+  return {
+    id: 'ws-1',
+    name: 'my-workspace',
+    path: '/home/user/gitspace/proj/workspaces/my-workspace',
+    projectName: 'proj',
+    branch: 'main',
+    sessionCount: 0,
+    ...overrides,
+  };
+}
+
+function makeSession(overrides: Partial<SessionInfo> = {}): SessionInfo {
+  return {
+    id: 'sess-1',
+    name: 'proj:my-workspace:default',
+    workspaceId: 'ws-1',
+    attached: false,
+    createdAt: Date.now() - 60000,
+    ...overrides,
+  };
+}
+
+function makeProps(overrides: Partial<UseSpacesBrowserProps> = {}): UseSpacesBrowserProps {
+  return {
+    workspaces: [],
+    sessions: [],
+    onRequestSessions: mock(() => {}),
+    onAttachSession: mock(async () => {}),
+    onStartProcess: mock(() => {}),
+    onStartProcessAttach: mock(() => {}),
+    onStopProcess: mock(() => {}),
+    onOpenEvents: mock(() => {}),
+    onRefresh: mock(async () => {}),
+    onBack: mock(() => {}),
+    showProjectHeaders: false,
+    ...overrides,
+  };
+}
+
+// ============================================================================
+// Tree building
+// ============================================================================
+
+describe('useSpacesBrowser tree building', () => {
+  it('builds empty tree for no workspaces', () => {
+    const props = makeProps();
+    const { result } = renderHook(() => useSpacesBrowser(props));
+
+    expect(result.current.isEmpty).toBe(true);
+    expect(result.current.items).toHaveLength(0);
+  });
+
+  it('builds workspace items (collapsed)', () => {
+    const ws = makeWorkspace();
+    const props = makeProps({ workspaces: [ws] });
+    const { result } = renderHook(() => useSpacesBrowser(props));
+
+    expect(result.current.items).toHaveLength(1);
+    expect(result.current.items[0].type).toBe('workspace');
+  });
+
+  it('shows sessions, events, and new-session when expanded', () => {
+    const ws = makeWorkspace({ sessionCount: 1 });
+    const session = makeSession();
+    const props = makeProps({ workspaces: [ws], sessions: [session] });
+    const { result } = renderHook(() => useSpacesBrowser(props));
+
+    // Expand the workspace
+    act(() => { result.current.toggleWorkspace('ws-1'); });
+
+    const types = result.current.items.map((item) => item.type);
+    expect(types).toContain('workspace');
+    expect(types).toContain('session');
+    expect(types).toContain('events');
+    expect(types).toContain('new-session');
+  });
+
+  it('includes process items when workspace has processes configured', () => {
+    const ws = makeWorkspace({
+      sessionCount: 0,
+      processes: [
+        { name: 'web-server', instances: 1, ports: [{ port: 3000, name: 'http', protocol: 'http' }] },
+        { name: 'worker', instances: 2 },
+      ],
+    });
+    const props = makeProps({ workspaces: [ws] });
+    const { result } = renderHook(() => useSpacesBrowser(props));
+
+    // Expand
+    act(() => { result.current.toggleWorkspace('ws-1'); });
+
+    const processItems = result.current.items.filter((item) => item.type === 'process');
+    // web-server has 1 instance, worker has 2 instances = 3 process items
+    expect(processItems).toHaveLength(3);
+
+    const names = processItems.map((item) =>
+      item.type === 'process' ? `${item.processName}#${item.instance}` : ''
+    );
+    expect(names).toContain('web-server#1');
+    expect(names).toContain('worker#1');
+    expect(names).toContain('worker#2');
+  });
+
+  it('derives process status from sessions', () => {
+    const ws = makeWorkspace({
+      sessionCount: 1,
+      processes: [{ name: 'web-server', instances: 1 }],
+    });
+    const session = makeSession({
+      id: 'proc-sess-1',
+      name: 'proc:ws-1:web-server:1',
+      processName: 'web-server',
+      processInstance: 1,
+    });
+    const props = makeProps({ workspaces: [ws], sessions: [session] });
+    const { result } = renderHook(() => useSpacesBrowser(props));
+
+    act(() => { result.current.toggleWorkspace('ws-1'); });
+
+    const processItem = result.current.items.find(
+      (item) => item.type === 'process' && item.processName === 'web-server'
+    );
+    expect(processItem).toBeDefined();
+    expect(processItem!.type === 'process' && processItem!.status).toBe('running');
+  });
+
+  it('marks process as failed when session has non-zero exitCode', () => {
+    const ws = makeWorkspace({
+      sessionCount: 1,
+      processes: [{ name: 'crasher' }],
+    });
+    const session = makeSession({
+      id: 'proc-sess-crash',
+      name: 'proc:ws-1:crasher:1',
+      processName: 'crasher',
+      processInstance: 1,
+      exitCode: 1,
+    });
+    const props = makeProps({ workspaces: [ws], sessions: [session] });
+    const { result } = renderHook(() => useSpacesBrowser(props));
+
+    act(() => { result.current.toggleWorkspace('ws-1'); });
+
+    const processItem = result.current.items.find(
+      (item) => item.type === 'process' && item.processName === 'crasher'
+    );
+    expect(processItem).toBeDefined();
+    expect(processItem!.type === 'process' && processItem!.status).toBe('failed');
+  });
+
+  it('always includes events item under expanded workspace', () => {
+    const ws = makeWorkspace();
+    const props = makeProps({ workspaces: [ws] });
+    const { result } = renderHook(() => useSpacesBrowser(props));
+
+    act(() => { result.current.toggleWorkspace('ws-1'); });
+
+    const eventsItem = result.current.items.find((item) => item.type === 'events');
+    expect(eventsItem).toBeDefined();
+    if (eventsItem && eventsItem.type === 'events') {
+      expect(eventsItem.workspaceId).toBe('ws-1');
+    }
+  });
+});
+
+// ============================================================================
+// activateSelected behavior
+// ============================================================================
+
+describe('useSpacesBrowser activateSelected', () => {
+  it('toggles workspace on activate', async () => {
+    const ws = makeWorkspace();
+    const props = makeProps({ workspaces: [ws] });
+    const { result } = renderHook(() => useSpacesBrowser(props));
+
+    // Workspace is at index 0, selected by default
+    expect(result.current.selectedItem?.type).toBe('workspace');
+
+    await act(async () => { await result.current.activateSelected(); });
+
+    // Should have expanded (now shows children)
+    expect(result.current.items.length).toBeGreaterThan(1);
+  });
+
+  it('attaches session on activate', async () => {
+    const ws = makeWorkspace({ sessionCount: 1 });
+    const session = makeSession();
+    const onAttachSession = mock(async () => {});
+    const props = makeProps({ workspaces: [ws], sessions: [session], onAttachSession });
+    const { result } = renderHook(() => useSpacesBrowser(props));
+
+    // Expand workspace
+    act(() => { result.current.toggleWorkspace('ws-1'); });
+
+    // Navigate to session item
+    const sessionIndex = result.current.items.findIndex((item) => item.type === 'session');
+    act(() => { result.current.selectIndex(sessionIndex); });
+
+    await act(async () => { await result.current.activateSelected(); });
+
+    expect(onAttachSession).toHaveBeenCalledWith({ sessionId: 'sess-1' });
+  });
+
+  it('calls onOpenEvents when events item is activated', async () => {
+    const ws = makeWorkspace();
+    const onOpenEvents = mock(() => {});
+    const props = makeProps({ workspaces: [ws], onOpenEvents });
+    const { result } = renderHook(() => useSpacesBrowser(props));
+
+    // Expand workspace
+    act(() => { result.current.toggleWorkspace('ws-1'); });
+
+    // Navigate to events item
+    const eventsIndex = result.current.items.findIndex((item) => item.type === 'events');
+    act(() => { result.current.selectIndex(eventsIndex); });
+
+    await act(async () => { await result.current.activateSelected(); });
+
+    expect(onOpenEvents).toHaveBeenCalledWith('ws-1');
+  });
+
+  it('calls onEditProcesses when edit-processes item is activated', async () => {
+    const ws = makeWorkspace();
+    const onEditProcesses = mock(() => {});
+    const props = makeProps({ workspaces: [ws], onEditProcesses });
+    const { result } = renderHook(() => useSpacesBrowser(props));
+
+    // Expand workspace
+    act(() => { result.current.toggleWorkspace('ws-1'); });
+
+    // Navigate to edit-processes item
+    const editIndex = result.current.items.findIndex((item) => item.type === 'edit-processes');
+    expect(editIndex).toBeGreaterThanOrEqual(0);
+    act(() => { result.current.selectIndex(editIndex); });
+
+    await act(async () => { await result.current.activateSelected(); });
+
+    expect(onEditProcesses).toHaveBeenCalledWith({ workspaceId: 'ws-1' });
+  });
+
+  it('edit-processes item appears before events item in expanded workspace', () => {
+    const ws = makeWorkspace();
+    const props = makeProps({ workspaces: [ws] });
+    const { result } = renderHook(() => useSpacesBrowser(props));
+
+    act(() => { result.current.toggleWorkspace('ws-1'); });
+
+    const types = result.current.items.map((item) => item.type);
+    const editIdx = types.indexOf('edit-processes');
+    const eventsIdx = types.indexOf('events');
+    expect(editIdx).toBeGreaterThanOrEqual(0);
+    expect(eventsIdx).toBeGreaterThanOrEqual(0);
+    expect(editIdx).toBeLessThan(eventsIdx);
+  });
+
+  it('calls onStartProcessAttach when stopped process is activated', async () => {
+    const ws = makeWorkspace({
+      processes: [{ name: 'web-server' }],
+    });
+    const onStartProcessAttach = mock(() => {});
+    const props = makeProps({ workspaces: [ws], onStartProcessAttach });
+    const { result } = renderHook(() => useSpacesBrowser(props));
+
+    // Expand workspace
+    act(() => { result.current.toggleWorkspace('ws-1'); });
+
+    // Navigate to process item (should be stopped since no matching session)
+    const processIndex = result.current.items.findIndex((item) => item.type === 'process');
+    act(() => { result.current.selectIndex(processIndex); });
+
+    await act(async () => { await result.current.activateSelected(); });
+
+    expect(onStartProcessAttach).toHaveBeenCalledWith({
+      workspaceId: 'ws-1',
+      processName: 'web-server',
+      instance: 1,
+    });
+  });
+
+  it('attaches to session when running process is activated', async () => {
+    const ws = makeWorkspace({
+      sessionCount: 1,
+      processes: [{ name: 'web-server' }],
+    });
+    const session = makeSession({
+      id: 'proc-sess-1',
+      processName: 'web-server',
+      processInstance: 1,
+    });
+    const onAttachSession = mock(async () => {});
+    const props = makeProps({ workspaces: [ws], sessions: [session], onAttachSession });
+    const { result } = renderHook(() => useSpacesBrowser(props));
+
+    // Expand workspace
+    act(() => { result.current.toggleWorkspace('ws-1'); });
+
+    // Navigate to process item (should be running)
+    const processIndex = result.current.items.findIndex((item) => item.type === 'process');
+    act(() => { result.current.selectIndex(processIndex); });
+
+    await act(async () => { await result.current.activateSelected(); });
+
+    expect(onAttachSession).toHaveBeenCalledWith({ sessionId: 'proc-sess-1', viewOnly: true });
+  });
+});
+
+// ============================================================================
+// Navigation
+// ============================================================================
+
+describe('useSpacesBrowser navigation', () => {
+  it('clamps selection when tree shrinks', () => {
+    const ws1 = makeWorkspace({ id: 'ws-1', name: 'alpha' });
+    const ws2 = makeWorkspace({ id: 'ws-2', name: 'beta' });
+    const props = makeProps({ workspaces: [ws1, ws2] });
+    const { result, rerender } = renderHook(
+      ({ p }) => useSpacesBrowser(p),
+      { initialProps: { p: props } }
+    );
+
+    // Select last item
+    act(() => { result.current.selectIndex(1); });
+    expect(result.current.selectedIndex).toBe(1);
+
+    // Remove a workspace - tree shrinks
+    const newProps = makeProps({ workspaces: [ws1] });
+    rerender({ p: newProps });
+
+    expect(result.current.selectedIndex).toBeLessThanOrEqual(result.current.items.length - 1);
+  });
+
+  it('moveUp/moveDown respects bounds', () => {
+    const ws1 = makeWorkspace({ id: 'ws-1', name: 'alpha' });
+    const ws2 = makeWorkspace({ id: 'ws-2', name: 'beta' });
+    const props = makeProps({ workspaces: [ws1, ws2] });
+    const { result } = renderHook(() => useSpacesBrowser(props));
+
+    // At 0, moveUp stays at 0
+    act(() => { result.current.moveUp(); });
+    expect(result.current.selectedIndex).toBe(0);
+
+    // Move to end
+    act(() => { result.current.moveDown(); });
+    expect(result.current.selectedIndex).toBe(1);
+
+    // At end, moveDown stays
+    act(() => { result.current.moveDown(); });
+    expect(result.current.selectedIndex).toBe(1);
+  });
+});

--- a/src/components/__tests__/SpacesBrowser.test.ts
+++ b/src/components/__tests__/SpacesBrowser.test.ts
@@ -411,6 +411,31 @@ describe('useSpacesBrowser activateSelected', () => {
     expect(onAttachSession).toHaveBeenCalledWith({ sessionId: 'proc-sess-1', viewOnly: true });
   });
 
+  it('falls back to start-and-attach when running process has no active session', async () => {
+    const ws = makeWorkspace({
+      sessionCount: 1,
+      processes: [{ name: 'web-server' }],
+    });
+    const onStartProcessAttach = mock(() => {});
+    const onAttachSession = mock(async () => {});
+    const props = makeProps({ workspaces: [ws], sessions: [], onStartProcessAttach, onAttachSession });
+    const { result } = renderHook(() => useSpacesBrowser(props));
+
+    act(() => { result.current.toggleWorkspace('ws-1'); });
+
+    const processIndex = result.current.items.findIndex((item) => item.type === 'process');
+    act(() => { result.current.selectIndex(processIndex); });
+
+    await act(async () => { await result.current.activateSelected(); });
+
+    expect(onAttachSession).not.toHaveBeenCalled();
+    expect(onStartProcessAttach).toHaveBeenCalledWith({
+      workspaceId: 'ws-1',
+      processName: 'web-server',
+      instance: 1,
+    });
+  });
+
   it('ignores exited process sessions when attaching from running process item', async () => {
     const ws = makeWorkspace({
       sessionCount: 2,

--- a/src/components/__tests__/SpacesBrowser.test.ts
+++ b/src/components/__tests__/SpacesBrowser.test.ts
@@ -143,6 +143,23 @@ describe('useSpacesBrowser tree building', () => {
     expect(names).toContain('worker#2');
   });
 
+  it('shows disabled process rows when instances is 0', () => {
+    const ws = makeWorkspace({
+      sessionCount: 0,
+      processes: [
+        { name: 'web', instances: 0 },
+      ],
+    });
+    const props = makeProps({ workspaces: [ws] });
+    const { result } = renderHook(() => useSpacesBrowser(props));
+
+    act(() => { result.current.toggleWorkspace('ws-1'); });
+
+    const disabledRows = result.current.items.filter((item) => item.type === 'process-disabled');
+    expect(disabledRows).toHaveLength(1);
+    expect(disabledRows[0]?.type === 'process-disabled' && disabledRows[0].processName).toBe('web');
+  });
+
   it('derives process status from sessions', () => {
     const ws = makeWorkspace({
       sessionCount: 1,
@@ -392,6 +409,28 @@ describe('useSpacesBrowser activateSelected', () => {
     await act(async () => { await result.current.activateSelected(); });
 
     expect(onAttachSession).toHaveBeenCalledWith({ sessionId: 'proc-sess-1', viewOnly: true });
+  });
+
+  it('calls onProcessDisabled when disabled process row is activated', async () => {
+    const ws = makeWorkspace({
+      processes: [{ name: 'worker', instances: 0 }],
+    });
+    const onProcessDisabled = mock(() => {});
+    const props = makeProps({ workspaces: [ws], onProcessDisabled });
+    const { result } = renderHook(() => useSpacesBrowser(props));
+
+    act(() => { result.current.toggleWorkspace('ws-1'); });
+
+    const disabledIndex = result.current.items.findIndex((item) => item.type === 'process-disabled');
+    expect(disabledIndex).toBeGreaterThanOrEqual(0);
+    act(() => { result.current.selectIndex(disabledIndex); });
+
+    await act(async () => { await result.current.activateSelected(); });
+
+    expect(onProcessDisabled).toHaveBeenCalledWith({
+      workspaceId: 'ws-1',
+      processName: 'worker',
+    });
   });
 });
 

--- a/src/components/__tests__/SpacesBrowser.tui.test.tsx
+++ b/src/components/__tests__/SpacesBrowser.tui.test.tsx
@@ -28,6 +28,7 @@ function makeTuiProps(overrides: Partial<UseSpacesBrowserReturn> = {}): UseSpace
     selectIndex: mock(() => {}),
     toggleWorkspace: mock(() => {}),
     activateSelected: mock(async () => {}),
+    activateIndex: mock(async () => {}),
     attachSession: mock(async () => {}),
     startProcessAttach: mock(() => {}),
     startProcess: mock(() => {}),

--- a/src/components/__tests__/SpacesBrowser.tui.test.tsx
+++ b/src/components/__tests__/SpacesBrowser.tui.test.tsx
@@ -1,0 +1,248 @@
+/**
+ * SpacesBrowser TUI renderer test
+ *
+ * POC: Uses OpenTUI testRender to verify that SpacesBrowserTUI
+ * renders process and events items in the terminal frame output.
+ */
+
+import { describe, expect, it, mock, afterEach } from 'bun:test';
+import { testRender } from '@opentui/react/test-utils';
+import { SpacesBrowserTUI } from '../SpacesBrowser.tui.js';
+import type { UseSpacesBrowserReturn, TreeItemWithState } from '../SpacesBrowser.js';
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/** Build minimal props for SpacesBrowserTUI */
+function makeTuiProps(overrides: Partial<UseSpacesBrowserReturn> = {}): UseSpacesBrowserReturn {
+  return {
+    items: [],
+    selectedIndex: 0,
+    selectedItem: null,
+    expandedWorkspaces: new Set(),
+    machineName: 'test-machine',
+    isEmpty: false,
+    moveUp: mock(() => {}),
+    moveDown: mock(() => {}),
+    selectIndex: mock(() => {}),
+    toggleWorkspace: mock(() => {}),
+    activateSelected: mock(async () => {}),
+    attachSession: mock(async () => {}),
+    startProcessAttach: mock(() => {}),
+    startProcess: mock(() => {}),
+    stopProcess: mock(() => {}),
+    createNewSession: mock(async () => {}),
+    createWorkspace: mock(() => {}),
+    refresh: mock(async () => {}),
+    openEvents: mock(() => {}),
+    editProcesses: mock(() => {}),
+    back: mock(() => {}),
+    ...overrides,
+  };
+}
+
+function makeWorkspaceItem(overrides: Partial<Extract<TreeItemWithState, { type: 'workspace' }>> = {}): TreeItemWithState {
+  return {
+    type: 'workspace',
+    workspace: {
+      id: 'ws-1',
+      name: 'my-workspace',
+      path: '/workspaces/my-workspace',
+      projectName: 'proj',
+      branch: 'main',
+      sessionCount: 2,
+    },
+    expanded: true,
+    isSelected: false,
+    index: 0,
+    ...overrides,
+  };
+}
+
+function makeSessionItem(overrides: Partial<Extract<TreeItemWithState, { type: 'session' }>> = {}): TreeItemWithState {
+  return {
+    type: 'session',
+    session: {
+      id: 'sess-1',
+      name: 'proj:my-workspace:default',
+      workspaceId: 'ws-1',
+      attached: false,
+      createdAt: Date.now() - 60000,
+    },
+    workspaceId: 'ws-1',
+    isSelected: false,
+    index: 1,
+    ...overrides,
+  };
+}
+
+function makeNewSessionItem(): TreeItemWithState {
+  return {
+    type: 'new-session',
+    workspaceId: 'ws-1',
+    isSelected: false,
+    index: 2,
+  };
+}
+
+// ============================================================================
+// Cleanup
+// ============================================================================
+
+let destroyRenderer: (() => void) | null = null;
+
+afterEach(() => {
+  if (destroyRenderer) {
+    destroyRenderer();
+    destroyRenderer = null;
+  }
+});
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('SpacesBrowserTUI renderer', () => {
+  it('renders workspace and session items in terminal frame', async () => {
+    const items: TreeItemWithState[] = [
+      makeWorkspaceItem(),
+      makeSessionItem(),
+      makeNewSessionItem(),
+    ];
+
+    const props = makeTuiProps({ items });
+
+    const { renderer, renderOnce, captureCharFrame } = await testRender(
+      <SpacesBrowserTUI {...props} />,
+      { width: 80, height: 24 }
+    );
+    destroyRenderer = () => renderer.destroy();
+
+    await renderOnce();
+    const frame = captureCharFrame();
+
+    // Should contain machine name header
+    expect(frame).toContain('test-machine');
+    // Should contain workspace name
+    expect(frame).toContain('my-workspace');
+    // Should contain new session action
+    expect(frame).toContain('New Session');
+  });
+
+  it('renders empty state when isEmpty is true', async () => {
+    const props = makeTuiProps({ isEmpty: true, items: [] });
+
+    const { renderer, renderOnce, captureCharFrame } = await testRender(
+      <SpacesBrowserTUI {...props} />,
+      { width: 80, height: 24 }
+    );
+    destroyRenderer = () => renderer.destroy();
+
+    await renderOnce();
+    const frame = captureCharFrame();
+
+    expect(frame).toContain('No workspaces found');
+  });
+
+  it('shows selection indicator on selected item', async () => {
+    const items: TreeItemWithState[] = [
+      makeWorkspaceItem({ isSelected: true, index: 0 }),
+      makeSessionItem({ index: 1 }),
+      makeNewSessionItem(),
+    ];
+
+    const props = makeTuiProps({ items, selectedIndex: 0 });
+
+    const { renderer, renderOnce, captureCharFrame } = await testRender(
+      <SpacesBrowserTUI {...props} />,
+      { width: 80, height: 24 }
+    );
+    destroyRenderer = () => renderer.destroy();
+
+    await renderOnce();
+    const frame = captureCharFrame();
+
+    // Selected workspace should show '>' prefix
+    expect(frame).toContain('>');
+    expect(frame).toContain('my-workspace');
+  });
+
+  it('renders process items with status indicators', async () => {
+    const items: TreeItemWithState[] = [
+      makeWorkspaceItem(),
+      {
+        type: 'process',
+        processName: 'web-server',
+        instance: 1,
+        workspaceId: 'ws-1',
+        status: 'running',
+        ports: [{ port: 3000, name: 'http', protocol: 'http' as const }],
+        isSelected: false,
+        index: 1,
+      },
+      {
+        type: 'process',
+        processName: 'worker',
+        instance: 1,
+        workspaceId: 'ws-1',
+        status: 'stopped',
+        isSelected: false,
+        index: 2,
+      },
+      {
+        type: 'process',
+        processName: 'crasher',
+        instance: 1,
+        workspaceId: 'ws-1',
+        status: 'failed',
+        isSelected: false,
+        index: 3,
+      },
+      makeNewSessionItem(),
+    ];
+
+    const props = makeTuiProps({ items });
+
+    const { renderer, renderOnce, captureCharFrame } = await testRender(
+      <SpacesBrowserTUI {...props} />,
+      { width: 80, height: 24 }
+    );
+    destroyRenderer = () => renderer.destroy();
+
+    await renderOnce();
+    const frame = captureCharFrame();
+
+    // Process names should be visible in the frame
+    expect(frame).toContain('web-server');
+    expect(frame).toContain('worker');
+    expect(frame).toContain('crasher');
+  });
+
+  it('renders events item', async () => {
+    const items: TreeItemWithState[] = [
+      makeWorkspaceItem(),
+      {
+        type: 'events',
+        workspaceId: 'ws-1',
+        isSelected: false,
+        index: 1,
+      },
+      makeNewSessionItem(),
+    ];
+
+    const props = makeTuiProps({ items });
+
+    const { renderer, renderOnce, captureCharFrame } = await testRender(
+      <SpacesBrowserTUI {...props} />,
+      { width: 80, height: 24 }
+    );
+    destroyRenderer = () => renderer.destroy();
+
+    await renderOnce();
+    const frame = captureCharFrame();
+
+    // Events row should show something identifiable
+    expect(frame).toContain('Events');
+  });
+});

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -27,6 +27,8 @@ export {
 
 // SpacesBrowser
 export type {
+  WorkspaceProcessInfo,
+  WorkspaceProcessPort,
   WorkspaceInfo,
   SessionInfo,
   TreeItem,

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -13,10 +13,11 @@ import {
 } from 'fs'
 import { join, dirname } from 'path'
 import { homedir } from 'os'
-import type { GlobalConfig, ProjectConfig, NotificationConfig } from '../types/config.js'
+import type { GlobalConfig, ProjectConfig, NotificationConfig, EventsConfig } from '../types/config.js'
 import {
 	DEFAULT_GLOBAL_CONFIG,
 	DEFAULT_NOTIFICATION_CONFIG,
+	DEFAULT_EVENTS_CONFIG,
 	createDefaultProjectConfig,
 } from '../types/config.js'
 import { SpacesError } from '../types/errors.js'
@@ -389,4 +390,16 @@ export function updateNotificationConfig(
 	}
 	updateGlobalConfig({ notifications: updated })
 	return updated
+}
+
+/**
+ * Get events config for a project, falling back to defaults
+ */
+export function getProjectEventsConfig(projectName: string): EventsConfig {
+	try {
+		const config = readProjectConfig(projectName)
+		return config.events ?? { ...DEFAULT_EVENTS_CONFIG }
+	} catch {
+		return { ...DEFAULT_EVENTS_CONFIG }
+	}
 }

--- a/src/hooks/useLocalSession.tui.ts
+++ b/src/hooks/useLocalSession.tui.ts
@@ -9,6 +9,7 @@ import {
   type SessionBackend,
 } from '../session/index.js';
 import type { NotificationConfig } from '../notifications/types.js';
+import type { WideEventFilter } from '../types/events.js';
 import { createBunLocalSessionBackend } from '../app/session/createSessionBackend.bun.js';
 import { logger } from '../utils/logger.js';
 import { SpacesError } from '../types/errors.js';
@@ -322,6 +323,33 @@ export function useLocalSession(options: UseLocalSessionOptions = {}) {
     });
   }, [enabled]);
 
+  const startProcess = useCallback(async (workspaceId: string, processName: string) => {
+    await runWithBackend(async (sessionEngine) => {
+      await sessionEngine.startProcess(backendKey, workspaceId, processName);
+      await sessionEngine.listWorkspaces(backendKey);
+      await sessionEngine.listSessions(backendKey);
+    });
+  }, [backendKey, runWithBackend]);
+
+  const stopProcess = useCallback(async (workspaceId: string, processName: string) => {
+    await runWithBackend(async (sessionEngine) => {
+      await sessionEngine.stopProcess(backendKey, workspaceId, processName);
+      await sessionEngine.listWorkspaces(backendKey);
+      await sessionEngine.listSessions(backendKey);
+    });
+  }, [backendKey, runWithBackend]);
+
+  const requestEvents = useCallback(async (
+    workspacePath: string,
+    filter?: WideEventFilter,
+    limit?: number,
+    sinceMs?: number,
+  ) => {
+    await runWithBackend(async (sessionEngine) => {
+      await sessionEngine.requestEvents(backendKey, workspacePath, filter, limit, sinceMs);
+    });
+  }, [backendKey, runWithBackend]);
+
   const setWriteCallback = useCallback((fn: ((data: Uint8Array) => void) | null) => {
     writeCallbackRef.current = fn;
     backendRef.current?.setPtyOutputHandler(fn);
@@ -340,6 +368,9 @@ export function useLocalSession(options: UseLocalSessionOptions = {}) {
     attachedSessionName: localState?.attachedSessionName ?? null,
     scriptState: localState?.scriptState ?? null,
     commandError: localState?.commandError ?? null,
+    events: localState?.events ?? [],
+    liveEventIds: localState?.liveEventIds ?? [],
+    savedEventFilters: localState?.savedEventFilters ?? [],
     requestProjects,
     requestWorkspaces,
     requestSessions,
@@ -354,6 +385,9 @@ export function useLocalSession(options: UseLocalSessionOptions = {}) {
     deleteWorkspace,
     getBundleRefreshPlan,
     applyBundleRefresh,
+    startProcess,
+    stopProcess,
+    requestEvents,
     send,
     resize,
     setWriteCallback,

--- a/src/hooks/useLocalSession.tui.ts
+++ b/src/hooks/useLocalSession.tui.ts
@@ -323,9 +323,9 @@ export function useLocalSession(options: UseLocalSessionOptions = {}) {
     });
   }, [enabled]);
 
-  const startProcess = useCallback(async (workspaceId: string, processName: string) => {
+  const startProcess = useCallback(async (workspaceId: string, processName: string, instance?: number) => {
     await runWithBackend(async (sessionEngine) => {
-      await sessionEngine.startProcess(backendKey, workspaceId, processName);
+      await sessionEngine.startProcess(backendKey, workspaceId, processName, instance);
       await sessionEngine.listWorkspaces(backendKey);
       await sessionEngine.listSessions(backendKey);
     });

--- a/src/index.ts
+++ b/src/index.ts
@@ -756,7 +756,8 @@ const eventsFilterOption = '--filter <expr>'
 eventsCommand
 	.command('list')
 	.description('List events (NDJSON)')
-	.option('--session <id>', 'Session ID or name')
+	.requiredOption('--project <name>', 'Project name')
+	.requiredOption('--workspace <name>', 'Workspace name')
 	.option(eventsFilterOption, 'Filter in key=value format')
 	.option('--limit <n>', 'Limit results', (value: string) => Number(value), 100)
 	.action(async (options: Record<string, unknown>) => {
@@ -771,7 +772,8 @@ eventsCommand
 eventsCommand
 	.command('show')
 	.description('Show a single event by eventId')
-	.option('--session <id>', 'Session ID or name')
+	.requiredOption('--project <name>', 'Project name')
+	.requiredOption('--workspace <name>', 'Workspace name')
 	.option(eventsFilterOption, 'Filter in key=value format')
 	.action(async (options: Record<string, unknown>) => {
 		await checkFirstTimeSetup()
@@ -785,7 +787,8 @@ eventsCommand
 eventsCommand
 	.command('tail')
 	.description('Tail recent events (no follow yet)')
-	.option('--session <id>', 'Session ID or name')
+	.requiredOption('--project <name>', 'Project name')
+	.requiredOption('--workspace <name>', 'Workspace name')
 	.option(eventsFilterOption, 'Filter in key=value format')
 	.option('--limit <n>', 'Limit results', (value: string) => Number(value), 50)
 	.action(async (options: Record<string, unknown>) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,12 @@ if (process.argv.includes('--internal-tmux-server')) {
 	await new Promise(() => {}); // Block forever
 }
 
+// Internal command: run process runner directly
+if (process.argv.includes('--internal-process-runner')) {
+	await import('./lib/processes/runner.js');
+	await new Promise(() => {}); // Runner will exit the process
+}
+
 import { Command } from 'commander'
 import { readFileSync } from 'fs'
 import { join } from 'path'
@@ -70,6 +76,8 @@ import {
 	addLineReview,
 	showSpaceContext,
 } from './commands/review.js'
+import { listEvents, showEvent, tailEvents } from './commands/events.js'
+import { listProcesses, startProcess, stopProcess, attachProcess } from './commands/process.js'
 
 const program = new Command()
 
@@ -730,6 +738,123 @@ configLinearCommand
 		await checkFirstTimeSetup()
 		try {
 			await linearClear(options)
+		} catch (error) {
+			handleError(error)
+		}
+	})
+
+// ============================================================================
+// Events Commands
+// ============================================================================
+
+const eventsCommand = program
+	.command('events')
+	.description('Query wide event logs')
+
+const eventsFilterOption = '--filter <expr>'
+
+eventsCommand
+	.command('list')
+	.description('List events (NDJSON)')
+	.option('--session <id>', 'Session ID or name')
+	.option(eventsFilterOption, 'Filter in key=value format')
+	.option('--limit <n>', 'Limit results', (value: string) => Number(value), 100)
+	.action(async (options: Record<string, unknown>) => {
+		await checkFirstTimeSetup()
+		try {
+			await listEvents(options)
+		} catch (error) {
+			handleError(error)
+		}
+	})
+
+eventsCommand
+	.command('show')
+	.description('Show a single event by eventId')
+	.option('--session <id>', 'Session ID or name')
+	.option(eventsFilterOption, 'Filter in key=value format')
+	.action(async (options: Record<string, unknown>) => {
+		await checkFirstTimeSetup()
+		try {
+			await showEvent(options)
+		} catch (error) {
+			handleError(error)
+		}
+	})
+
+eventsCommand
+	.command('tail')
+	.description('Tail recent events (no follow yet)')
+	.option('--session <id>', 'Session ID or name')
+	.option(eventsFilterOption, 'Filter in key=value format')
+	.option('--limit <n>', 'Limit results', (value: string) => Number(value), 50)
+	.action(async (options: Record<string, unknown>) => {
+		await checkFirstTimeSetup()
+		try {
+			await tailEvents(options)
+		} catch (error) {
+			handleError(error)
+		}
+	})
+
+// ============================================================================
+// Process Commands
+// ============================================================================
+
+const processCommand = program
+	.command('process')
+	.description('Manage workspace processes')
+
+processCommand
+	.command('list')
+	.description('List configured processes')
+	.option('--workspace <path>', 'Workspace path (defaults to cwd)')
+	.action(async (options: Record<string, unknown>) => {
+		await checkFirstTimeSetup()
+		try {
+			await listProcesses(options)
+		} catch (error) {
+			handleError(error)
+		}
+	})
+
+processCommand
+	.command('start')
+	.description('Start a process by name')
+	.option('--workspace <path>', 'Workspace path (defaults to cwd)')
+	.option('--name <name>', 'Process name')
+	.action(async (options: Record<string, unknown>) => {
+		await checkFirstTimeSetup()
+		try {
+			await startProcess(options)
+		} catch (error) {
+			handleError(error)
+		}
+	})
+
+processCommand
+	.command('stop')
+	.description('Stop a process by name')
+	.option('--workspace <path>', 'Workspace path (defaults to cwd)')
+	.option('--name <name>', 'Process name')
+	.action(async (options: Record<string, unknown>) => {
+		await checkFirstTimeSetup()
+		try {
+			await stopProcess(options)
+		} catch (error) {
+			handleError(error)
+		}
+	})
+
+processCommand
+	.command('attach')
+	.description('Show attach hint for process')
+	.option('--workspace <path>', 'Workspace path (defaults to cwd)')
+	.option('--name <name>', 'Process name')
+	.action(async (options: Record<string, unknown>) => {
+		await checkFirstTimeSetup()
+		try {
+			await attachProcess(options)
 		} catch (error) {
 			handleError(error)
 		}

--- a/src/lib/events/__tests__/collector-filter.test.ts
+++ b/src/lib/events/__tests__/collector-filter.test.ts
@@ -1,0 +1,75 @@
+/**
+ * matchFilter tests - pure event filter matching from collector
+ */
+
+import { describe, expect, it } from 'bun:test';
+import { matchFilter } from '../collector.js';
+import type { WideEvent, WideEventFilter } from '../../../types/events.js';
+
+function makeEvent(overrides: Partial<WideEvent> = {}): WideEvent {
+  return {
+    eventId: 'evt-1',
+    eventName: 'http_request',
+    level: 'info',
+    timestamp: '2025-01-01T00:00:00.000Z',
+    timestampMs: 1735689600000,
+    message: 'GET /api/users 200',
+    sessionId: 'sess-1',
+    workspaceId: 'ws-1',
+    projectName: 'proj-1',
+    raw: {},
+    ...overrides,
+  };
+}
+
+// ============================================================================
+// matchFilter
+// ============================================================================
+
+describe('matchFilter', () => {
+  it('should match when filter is empty', () => {
+    expect(matchFilter(makeEvent(), {})).toBe(true);
+  });
+
+  it('should match on eventName', () => {
+    expect(matchFilter(makeEvent(), { eventName: 'http_request' })).toBe(true);
+  });
+
+  it('should reject on eventName mismatch', () => {
+    expect(matchFilter(makeEvent(), { eventName: 'db_query' })).toBe(false);
+  });
+
+  it('should match on eventId', () => {
+    expect(matchFilter(makeEvent(), { eventId: 'evt-1' })).toBe(true);
+  });
+
+  it('should reject on eventId mismatch', () => {
+    expect(matchFilter(makeEvent(), { eventId: 'evt-2' })).toBe(false);
+  });
+
+  it('should match on level', () => {
+    expect(matchFilter(makeEvent({ level: 'error' }), { level: 'error' })).toBe(true);
+  });
+
+  it('should reject on level mismatch', () => {
+    expect(matchFilter(makeEvent({ level: 'info' }), { level: 'error' })).toBe(false);
+  });
+
+  it('should match on message substring', () => {
+    expect(matchFilter(makeEvent(), { message: '/api/users' })).toBe(true);
+  });
+
+  it('should reject on message substring mismatch', () => {
+    expect(matchFilter(makeEvent(), { message: '/api/posts' })).toBe(false);
+  });
+
+  it('should match with multiple filter fields (AND logic)', () => {
+    const event = makeEvent({ eventName: 'http_request', level: 'error' });
+    expect(matchFilter(event, { eventName: 'http_request', level: 'error' })).toBe(true);
+  });
+
+  it('should reject when any filter field mismatches', () => {
+    const event = makeEvent({ eventName: 'http_request', level: 'info' });
+    expect(matchFilter(event, { eventName: 'http_request', level: 'error' })).toBe(false);
+  });
+});

--- a/src/lib/events/__tests__/collector-filter.test.ts
+++ b/src/lib/events/__tests__/collector-filter.test.ts
@@ -63,6 +63,36 @@ describe('matchFilter', () => {
     expect(matchFilter(makeEvent(), { message: '/api/posts' })).toBe(false);
   });
 
+  it('should match on processName', () => {
+    const event = makeEvent({ processName: 'web' });
+    expect(matchFilter(event, { processName: 'web' })).toBe(true);
+  });
+
+  it('should reject on processName mismatch', () => {
+    const event = makeEvent({ processName: 'worker' });
+    expect(matchFilter(event, { processName: 'web' })).toBe(false);
+  });
+
+  it('should match on kind', () => {
+    const event = makeEvent({ kind: 'wide' });
+    expect(matchFilter(event, { kind: 'wide' })).toBe(true);
+  });
+
+  it('should reject on kind mismatch', () => {
+    const event = makeEvent({ kind: 'source' });
+    expect(matchFilter(event, { kind: 'wide' })).toBe(false);
+  });
+
+  it('should match on correlationId', () => {
+    const event = makeEvent({ correlationId: 'corr-1' });
+    expect(matchFilter(event, { correlationId: 'corr-1' })).toBe(true);
+  });
+
+  it('should reject on correlationId mismatch', () => {
+    const event = makeEvent({ correlationId: 'corr-2' });
+    expect(matchFilter(event, { correlationId: 'corr-1' })).toBe(false);
+  });
+
   it('should match with multiple filter fields (AND logic)', () => {
     const event = makeEvent({ eventName: 'http_request', level: 'error' });
     expect(matchFilter(event, { eventName: 'http_request', level: 'error' })).toBe(true);

--- a/src/lib/events/__tests__/store-query.test.ts
+++ b/src/lib/events/__tests__/store-query.test.ts
@@ -1,0 +1,103 @@
+/**
+ * selectFilesForQuery tests - pure index pruning logic
+ */
+
+import { describe, expect, it } from 'bun:test';
+import { selectFilesForQuery } from '../store.js';
+import type { WideEventIndex } from '../../../types/events.js';
+
+function makeIndex(overrides: Partial<WideEventIndex> = {}): WideEventIndex {
+  return {
+    file: 'events-2025-01-01T00-00.ndjson',
+    minTs: 1000,
+    maxTs: 2000,
+    levels: ['info', 'error'],
+    eventNames: ['http_request', 'db_query'],
+    count: 10,
+    ...overrides,
+  };
+}
+
+// ============================================================================
+// selectFilesForQuery
+// ============================================================================
+
+describe('selectFilesForQuery', () => {
+  it('should return all indexes when no filter or time range', () => {
+    const indexes = [makeIndex(), makeIndex({ file: 'events-2.ndjson' })];
+    const result = selectFilesForQuery(indexes, { filter: {} });
+    expect(result.length).toBe(2);
+  });
+
+  it('should exclude indexes before sinceMs', () => {
+    const indexes = [
+      makeIndex({ minTs: 1000, maxTs: 2000 }),
+      makeIndex({ file: 'events-2.ndjson', minTs: 3000, maxTs: 4000 }),
+    ];
+    const result = selectFilesForQuery(indexes, { filter: {}, sinceMs: 2500 });
+    expect(result.length).toBe(1);
+    expect(result[0].file).toBe('events-2.ndjson');
+  });
+
+  it('should include index that overlaps sinceMs', () => {
+    const indexes = [makeIndex({ minTs: 1000, maxTs: 3000 })];
+    const result = selectFilesForQuery(indexes, { filter: {}, sinceMs: 2000 });
+    expect(result.length).toBe(1);
+  });
+
+  it('should exclude indexes after untilMs', () => {
+    const indexes = [
+      makeIndex({ minTs: 1000, maxTs: 2000 }),
+      makeIndex({ file: 'events-2.ndjson', minTs: 5000, maxTs: 6000 }),
+    ];
+    const result = selectFilesForQuery(indexes, { filter: {}, untilMs: 3000 });
+    expect(result.length).toBe(1);
+    expect(result[0].minTs).toBe(1000);
+  });
+
+  it('should filter by level', () => {
+    const indexes = [
+      makeIndex({ levels: ['info'] }),
+      makeIndex({ file: 'events-2.ndjson', levels: ['error', 'warn'] }),
+    ];
+    const result = selectFilesForQuery(indexes, { filter: { level: 'error' } });
+    expect(result.length).toBe(1);
+    expect(result[0].file).toBe('events-2.ndjson');
+  });
+
+  it('should filter by eventName', () => {
+    const indexes = [
+      makeIndex({ eventNames: ['http_request'] }),
+      makeIndex({ file: 'events-2.ndjson', eventNames: ['db_query'] }),
+    ];
+    const result = selectFilesForQuery(indexes, { filter: { eventName: 'db_query' } });
+    expect(result.length).toBe(1);
+    expect(result[0].file).toBe('events-2.ndjson');
+  });
+
+  it('should combine time range and filter', () => {
+    const indexes = [
+      makeIndex({ minTs: 1000, maxTs: 2000, levels: ['info'] }),
+      makeIndex({ file: 'events-2.ndjson', minTs: 3000, maxTs: 4000, levels: ['error'] }),
+      makeIndex({ file: 'events-3.ndjson', minTs: 5000, maxTs: 6000, levels: ['error'] }),
+    ];
+    const result = selectFilesForQuery(indexes, {
+      filter: { level: 'error' },
+      sinceMs: 2500,
+      untilMs: 4500,
+    });
+    expect(result.length).toBe(1);
+    expect(result[0].file).toBe('events-2.ndjson');
+  });
+
+  it('should return empty when no indexes match', () => {
+    const indexes = [makeIndex({ levels: ['info'] })];
+    const result = selectFilesForQuery(indexes, { filter: { level: 'fatal' } });
+    expect(result.length).toBe(0);
+  });
+
+  it('should return empty for empty input', () => {
+    const result = selectFilesForQuery([], { filter: {} });
+    expect(result.length).toBe(0);
+  });
+});

--- a/src/lib/events/collector.ts
+++ b/src/lib/events/collector.ts
@@ -1,0 +1,491 @@
+/**
+ * Wide event collector for tmux-lite output
+ */
+
+import { appendFileSync, existsSync, mkdirSync, readdirSync, statSync, unlinkSync, readFileSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import type { EventsConfig } from '../../types/config.js';
+import type { WideEvent, WideEventFilter, WideEventIndex, WideEventTimelineItem, WideSnapshot, WideSnapshotTimelineEntry, WideSnapshotTimelineMap } from '../../types/events.js';
+import { getProcessEventsDir, getProcessSnapshotsPath } from './paths.js';
+import { writeIndexFile } from './indexer.js';
+
+const LINE_BUFFER_LIMIT = 1_000_000; // 1MB safety cap
+
+interface EventFileState {
+  filePath: string;
+  indexPath: string;
+  createdAt: number;
+  bytesWritten: number;
+  index: WideEventIndex;
+}
+
+export interface WideEventCollectorOptions {
+  config: EventsConfig;
+  sessionId: string;
+  workspacePath: string;
+  workspaceId: string;
+  projectName: string;
+  processName?: string;
+  processInstance?: number;
+}
+
+export class WideEventCollector {
+  private config: EventsConfig;
+  private sessionId: string;
+  private workspacePath: string;
+  private workspaceId: string;
+  private projectName: string;
+  private processName?: string;
+  private processInstance?: number;
+  private buffer = '';
+  private fileState: EventFileState | null = null;
+  private liveEvents = new Map<string, number>();
+  private correlationTimeline = new Map<string, WideEventTimelineItem[]>();
+  private lastWideEmitAt = new Map<string, number>();
+  private snapshotCache = new Map<string, WideSnapshot>();
+  private snapshotCacheBytes = 0;
+  private snapshotsLoaded = false;
+
+  constructor(options: WideEventCollectorOptions) {
+    this.config = options.config;
+    this.sessionId = options.sessionId;
+    this.workspacePath = options.workspacePath;
+    this.workspaceId = options.workspaceId;
+    this.projectName = options.projectName;
+    this.processName = options.processName;
+    this.processInstance = options.processInstance;
+  }
+
+  handleChunk(data: Buffer): WideEvent[] {
+    if (!this.config.enabled) {
+      return [];
+    }
+    const chunk = data.toString('utf-8');
+    if (!chunk) {
+      return [];
+    }
+
+    this.buffer += chunk;
+    if (this.buffer.length > LINE_BUFFER_LIMIT) {
+      this.buffer = this.buffer.slice(-LINE_BUFFER_LIMIT);
+    }
+
+    const events: WideEvent[] = [];
+    let newlineIndex = this.buffer.indexOf('\n');
+    while (newlineIndex !== -1) {
+      const line = this.buffer.slice(0, newlineIndex).trim();
+      this.buffer = this.buffer.slice(newlineIndex + 1);
+      if (line.length > 0) {
+        const event = this.tryParseEvent(line);
+        if (event) {
+          const emitted = this.appendEvent(event);
+          events.push(...emitted);
+        }
+      }
+      newlineIndex = this.buffer.indexOf('\n');
+    }
+
+    return events;
+  }
+
+  finalize(): void {
+    if (this.fileState) {
+      this.flushIndex(this.fileState);
+    }
+  }
+
+  getLiveEventIds(ttlMs: number): string[] {
+    const now = Date.now();
+    const live: string[] = [];
+    for (const [eventId, lastSeen] of this.liveEvents.entries()) {
+      if (now - lastSeen <= ttlMs) {
+        live.push(eventId);
+      }
+    }
+    return live;
+  }
+
+  private tryParseEvent(line: string): WideEvent | null {
+    const { mode, prefix } = this.config;
+    let payload = line;
+
+    if (mode === 'prefix') {
+      if (!payload.startsWith(prefix)) {
+        return null;
+      }
+      payload = payload.slice(prefix.length).trim();
+    }
+
+    let parsed: Record<string, unknown> | null = null;
+    try {
+      parsed = JSON.parse(payload) as Record<string, unknown>;
+    } catch {
+      return null;
+    }
+
+    if (!parsed || typeof parsed !== 'object') {
+      return null;
+    }
+
+    const fields = this.config.fields;
+    const eventName = parsed[fields.name];
+    const eventId = parsed[fields.id];
+    const level = parsed[fields.level];
+    const timestamp = parsed[fields.timestamp];
+    const message = parsed[fields.message];
+
+    if (
+      typeof eventName !== 'string' ||
+      typeof eventId !== 'string' ||
+      typeof level !== 'string' ||
+      typeof timestamp !== 'string' ||
+      typeof message !== 'string'
+    ) {
+      return null;
+    }
+
+    const timestampMs = Date.parse(timestamp);
+    const normalizedTimestampMs = Number.isNaN(timestampMs) ? Date.now() : timestampMs;
+
+    if (this.config.aggregateMode === 'stream' && this.config.correlationField) {
+      const rawCorrelation = parsed[this.config.correlationField];
+      if (typeof rawCorrelation === 'string') {
+        parsed[this.config.correlationField] = rawCorrelation.trim();
+      }
+    }
+
+    return {
+      eventId,
+      eventName,
+      level,
+      timestamp,
+      timestampMs: normalizedTimestampMs,
+      message,
+      sessionId: '',
+      workspaceId: this.workspaceId,
+      projectName: this.projectName,
+      processName: this.processName,
+      processInstance: this.processInstance,
+      raw: parsed,
+      kind: 'source',
+    };
+  }
+
+  private appendEvent(event: WideEvent): WideEvent[] {
+    const emitted: WideEvent[] = [];
+    const sourceEvent = { ...event, kind: 'source' as const };
+    this.writeEvent(sourceEvent);
+    emitted.push(sourceEvent);
+
+    if (this.config.aggregateMode === 'stream') {
+      const correlationField = this.config.correlationField;
+      const correlationId = correlationField ? (event.raw[correlationField] as string | undefined) : undefined;
+      if (correlationId && correlationId.trim().length > 0) {
+        const timeline = this.correlationTimeline.get(correlationId) ?? [];
+        const timelineItem: WideEventTimelineItem = {
+          eventName: event.eventName,
+          level: event.level,
+          timestamp: event.timestamp,
+          timestampMs: event.timestampMs,
+          message: event.message,
+          raw: event.raw,
+        };
+        timeline.push(timelineItem);
+        const maxTimeline = this.config.maxTimeline ?? 200;
+        if (timeline.length > maxTimeline) {
+          timeline.splice(0, timeline.length - maxTimeline);
+        }
+        this.correlationTimeline.set(correlationId, timeline);
+
+        const now = Date.now();
+        const lastEmit = this.lastWideEmitAt.get(correlationId) ?? 0;
+        const interval = this.config.updateIntervalMs ?? 250;
+        if (now - lastEmit >= interval) {
+          const wideEvent: WideEvent = {
+            ...event,
+            kind: 'wide',
+            correlationId,
+            timeline: [...timeline],
+          };
+          this.writeEvent(wideEvent);
+          emitted.push(wideEvent);
+          this.lastWideEmitAt.set(correlationId, now);
+        }
+
+        const snapshot = this.updateSnapshot(correlationId, event);
+        if (snapshot) {
+          this.writeSnapshot(snapshot);
+        }
+      }
+    }
+
+    return emitted;
+  }
+
+  private writeEvent(event: WideEvent): void {
+    const state = this.ensureFileState();
+    const line = JSON.stringify(event) + '\n';
+    appendFileSync(state.filePath, line, 'utf-8');
+    state.bytesWritten += Buffer.byteLength(line);
+
+    state.index.count += 1;
+    state.index.minTs = Math.min(state.index.minTs, event.timestampMs);
+    state.index.maxTs = Math.max(state.index.maxTs, event.timestampMs);
+    if (!state.index.levels.includes(event.level)) {
+      state.index.levels.push(event.level);
+    }
+    if (!state.index.eventNames.includes(event.eventName)) {
+      state.index.eventNames.push(event.eventName);
+    }
+
+    this.liveEvents.set(event.eventId, Date.now());
+    this.flushIndex(state);
+
+    if (this.shouldRotate(state)) {
+      this.rotate(state);
+    }
+  }
+
+  private ensureFileState(): EventFileState {
+    if (this.fileState) {
+      return this.fileState;
+    }
+
+    const dir = getProcessEventsDir(
+      this.workspacePath,
+      this.processName ?? 'unknown',
+      this.processInstance
+    );
+    if (!existsSync(dir)) {
+      mkdirSync(dir, { recursive: true });
+    }
+
+    const now = new Date();
+    const stamp = now.toISOString().slice(0, 16).replace(/:/g, '-');
+    const fileName = `events-${stamp}.ndjson`;
+    const filePath = join(dir, fileName);
+    const indexPath = join(dir, `events-${stamp}.index.json`);
+
+    const state: EventFileState = {
+      filePath,
+      indexPath,
+      createdAt: Date.now(),
+      bytesWritten: 0,
+      index: {
+        file: fileName,
+        minTs: Number.POSITIVE_INFINITY,
+        maxTs: 0,
+        levels: [],
+        eventNames: [],
+        count: 0,
+      },
+    };
+
+    this.fileState = state;
+    return state;
+  }
+
+  private shouldRotate(state: EventFileState): boolean {
+    if (state.bytesWritten >= this.config.rotation.maxBytes) {
+      return true;
+    }
+    const ageMinutes = (Date.now() - state.createdAt) / (1000 * 60);
+    return ageMinutes >= this.config.rotation.maxMinutes;
+  }
+
+  private rotate(state: EventFileState): void {
+    this.flushIndex(state);
+    this.fileState = null;
+    this.pruneOldFiles();
+  }
+
+  private flushIndex(state: EventFileState): void {
+    if (state.index.count === 0) {
+      return;
+    }
+    writeIndexFile(state.indexPath, state.index);
+  }
+
+  private pruneOldFiles(): void {
+    const dir = getProcessEventsDir(
+      this.workspacePath,
+      this.processName ?? 'unknown',
+      this.processInstance
+    );
+    if (!existsSync(dir)) {
+      return;
+    }
+
+    const files = readdirSync(dir)
+      .filter((file) => file.endsWith('.ndjson') && !file.endsWith('wide-snapshots.ndjson'))
+      .map((file) => ({
+        file,
+        path: join(dir, file),
+        mtime: statSync(join(dir, file)).mtimeMs,
+      }))
+      .sort((a, b) => b.mtime - a.mtime);
+
+    if (files.length <= this.config.rotation.keepFiles) {
+      return;
+    }
+
+    const toRemove = files.slice(this.config.rotation.keepFiles);
+    for (const entry of toRemove) {
+      try {
+        unlinkSync(entry.path);
+        const indexPath = entry.path.replace('.ndjson', '.index.json');
+        if (existsSync(indexPath)) {
+          unlinkSync(indexPath);
+        }
+      } catch {
+        // Ignore rotation errors
+      }
+    }
+  }
+
+  private updateSnapshot(correlationId: string, event: WideEvent): WideSnapshot | null {
+    if (!correlationId) return null;
+    this.ensureSnapshotsLoaded();
+    const existing = this.snapshotCache.get(correlationId);
+    const timelineMap: WideSnapshotTimelineMap = existing?.timelineMap ? { ...existing.timelineMap } : {};
+    const timelineOrder = existing?.timelineOrder ? [...existing.timelineOrder] : [];
+    const maxTimeline = Math.max(1, this.config.maxTimeline ?? 200);
+    if (timelineOrder.length >= maxTimeline) {
+      const overflow = Math.max(0, timelineOrder.length - (maxTimeline - 1));
+      if (overflow > 0) {
+        const removed = timelineOrder.splice(0, overflow);
+        for (const key of removed) {
+          delete timelineMap[key];
+        }
+      }
+    }
+    const counts = new Map<string, number>();
+    for (const entry of Object.values(timelineMap)) {
+      if (!entry) continue;
+      const baseName = entry.eventName;
+      counts.set(baseName, (counts.get(baseName) ?? 0) + 1);
+    }
+
+    const baseName = event.eventName;
+    const currentCount = counts.get(baseName) ?? 0;
+    const nextCount = currentCount + 1;
+    counts.set(baseName, nextCount);
+    const key = nextCount === 1 ? baseName : `${baseName}#${nextCount}`;
+
+    const entry: WideSnapshotTimelineEntry = {
+      key,
+      eventId: event.eventId,
+      eventName: event.eventName,
+      level: event.level,
+      timestamp: event.timestamp,
+      timestampMs: event.timestampMs,
+      message: event.message,
+      raw: event.raw,
+      processName: event.processName,
+      processInstance: event.processInstance,
+    };
+
+    timelineMap[key] = entry;
+    timelineOrder.push(key);
+
+    const snapshot: WideSnapshot = {
+      correlationId,
+      updatedAt: Date.now(),
+      processName: this.processName,
+      processInstance: this.processInstance,
+      level: event.level,
+      message: event.message,
+      eventName: event.eventName,
+      lastEventId: event.eventId,
+      timelineMap,
+      timelineOrder,
+      raw: event.raw,
+    };
+
+    this.setSnapshotCache(snapshot);
+    this.evictSnapshots();
+    return snapshot;
+  }
+
+  private setSnapshotCache(snapshot: WideSnapshot): void {
+    const existing = this.snapshotCache.get(snapshot.correlationId);
+    const existingSize = existing ? Buffer.byteLength(JSON.stringify(existing)) : 0;
+    const snapshotSize = Buffer.byteLength(JSON.stringify(snapshot));
+    this.snapshotCache.set(snapshot.correlationId, snapshot);
+    this.snapshotCacheBytes = Math.max(0, this.snapshotCacheBytes - existingSize) + snapshotSize;
+  }
+
+  private ensureSnapshotsLoaded(): void {
+    if (this.snapshotsLoaded) return;
+    this.snapshotsLoaded = true;
+    const path = getProcessSnapshotsPath(
+      this.workspacePath,
+      this.processName ?? 'unknown',
+      this.processInstance
+    );
+    if (!existsSync(path)) {
+      return;
+    }
+    try {
+      const content = readFileSync(path, 'utf-8');
+      for (const line of content.split('\n')) {
+        if (line.trim().length === 0) continue;
+        try {
+          const parsed = JSON.parse(line) as WideSnapshot;
+          if (!parsed || typeof parsed !== 'object') continue;
+          if (typeof parsed.correlationId !== 'string') continue;
+          const existing = this.snapshotCache.get(parsed.correlationId);
+          if (existing && existing.updatedAt > parsed.updatedAt) {
+            continue;
+          }
+          this.setSnapshotCache(parsed);
+        } catch {
+          // Ignore malformed snapshot lines
+        }
+      }
+      this.evictSnapshots();
+    } catch {
+      // Ignore snapshot load errors
+    }
+  }
+
+  private evictSnapshots(): void {
+    const maxBytes = this.config.snapshotCacheMaxBytes ?? 64 * 1024 * 1024;
+    if (this.snapshotCacheBytes <= maxBytes) return;
+    const entries = Array.from(this.snapshotCache.values()).sort((a, b) => a.updatedAt - b.updatedAt);
+    for (const entry of entries) {
+      if (this.snapshotCacheBytes <= maxBytes) break;
+      const size = Buffer.byteLength(JSON.stringify(entry));
+      this.snapshotCache.delete(entry.correlationId);
+      this.snapshotCacheBytes = Math.max(0, this.snapshotCacheBytes - size);
+    }
+  }
+
+  private writeSnapshot(snapshot: WideSnapshot): void {
+    const dir = getProcessEventsDir(
+      this.workspacePath,
+      this.processName ?? 'unknown',
+      this.processInstance
+    );
+    if (!existsSync(dir)) {
+      mkdirSync(dir, { recursive: true });
+    }
+    const path = getProcessSnapshotsPath(
+      this.workspacePath,
+      this.processName ?? 'unknown',
+      this.processInstance
+    );
+    this.ensureSnapshotsLoaded();
+    const ordered = Array.from(this.snapshotCache.values()).sort((a, b) => a.updatedAt - b.updatedAt);
+    const content = ordered.map((entry) => JSON.stringify(entry)).join('\n');
+    writeFileSync(path, content.length > 0 ? `${content}\n` : '', 'utf-8');
+  }
+}
+
+export function matchFilter(event: WideEvent, filter: WideEventFilter): boolean {
+  if (filter.eventName && event.eventName !== filter.eventName) return false;
+  if (filter.eventId && event.eventId !== filter.eventId) return false;
+  if (filter.level && event.level !== filter.level) return false;
+  if (filter.message && !event.message.includes(filter.message)) return false;
+  return true;
+}

--- a/src/lib/events/collector.ts
+++ b/src/lib/events/collector.ts
@@ -487,5 +487,8 @@ export function matchFilter(event: WideEvent, filter: WideEventFilter): boolean 
   if (filter.eventId && event.eventId !== filter.eventId) return false;
   if (filter.level && event.level !== filter.level) return false;
   if (filter.message && !event.message.includes(filter.message)) return false;
+  if (filter.processName && event.processName !== filter.processName) return false;
+  if (filter.kind && event.kind !== filter.kind) return false;
+  if (filter.correlationId && event.correlationId !== filter.correlationId) return false;
   return true;
 }

--- a/src/lib/events/filters.ts
+++ b/src/lib/events/filters.ts
@@ -1,0 +1,26 @@
+/**
+ * Saved events filter helpers
+ */
+
+import { existsSync, readFileSync } from 'fs';
+import { join } from 'path';
+import type { EventsConfigFile, SavedEventFilter } from '../../types/events.js';
+
+export function getEventsConfigPath(workspacePath: string): string {
+  return join(workspacePath, '.gitspace', 'events.json');
+}
+
+export function loadSavedEventFilters(workspacePath: string): SavedEventFilter[] {
+  const path = getEventsConfigPath(workspacePath);
+  if (!existsSync(path)) {
+    return [];
+  }
+
+  try {
+    const raw = readFileSync(path, 'utf-8');
+    const parsed = JSON.parse(raw) as EventsConfigFile;
+    return Array.isArray(parsed.savedFilters) ? parsed.savedFilters : [];
+  } catch {
+    return [];
+  }
+}

--- a/src/lib/events/index.ts
+++ b/src/lib/events/index.ts
@@ -1,0 +1,11 @@
+/**
+ * Wide event module exports
+ */
+
+export * from './collector.js';
+export * from './paths.js';
+
+export * from './reader.js';
+export * from './store.js';
+export * from './indexer.js';
+export * from './filters.js';

--- a/src/lib/events/indexer.ts
+++ b/src/lib/events/indexer.ts
@@ -1,0 +1,14 @@
+/**
+ * Wide event index maintenance helpers
+ */
+
+import { writeFileSync } from 'fs';
+import type { WideEventIndex } from '../../types/events.js';
+
+export function writeIndexFile(path: string, index: WideEventIndex): void {
+  const data = {
+    ...index,
+    minTs: index.minTs === Number.POSITIVE_INFINITY ? index.maxTs : index.minTs,
+  };
+  writeFileSync(path, JSON.stringify(data, null, 2), 'utf-8');
+}

--- a/src/lib/events/paths.ts
+++ b/src/lib/events/paths.ts
@@ -5,6 +5,7 @@
 import { existsSync, readdirSync } from 'fs';
 import { join, relative, sep } from 'path';
 import { getGitspaceDir } from '../../core/config.js';
+import { encodeProcessNameForPath } from '../processes/names.js';
 
 const DEFAULT_INSTANCE = 1;
 
@@ -45,7 +46,7 @@ export function getProcessEventsDir(
   processInstance?: number
 ): string {
   const instance = processInstance ?? DEFAULT_INSTANCE;
-  return join(workspacePath, '.events', 'processes', `${processName}-${instance}`);
+  return join(workspacePath, '.events', 'processes', `${encodeProcessNameForPath(processName)}-${instance}`);
 }
 
 export function getProcessSnapshotsPath(

--- a/src/lib/events/paths.ts
+++ b/src/lib/events/paths.ts
@@ -1,0 +1,68 @@
+/**
+ * Wide event path helpers
+ */
+
+import { existsSync, readdirSync } from 'fs';
+import { join, relative, sep } from 'path';
+import { getGitspaceDir } from '../../core/config.js';
+
+const DEFAULT_INSTANCE = 1;
+
+export interface WorkspaceRef {
+  projectName: string;
+  workspaceId: string;
+  workspacePath: string;
+}
+
+/**
+ * Resolve workspace/project info from a cwd path
+ */
+export function resolveWorkspaceRef(cwd: string): WorkspaceRef | null {
+  const spacesDir = getGitspaceDir();
+  const rel = relative(spacesDir, cwd);
+  if (!rel || rel.startsWith('..')) {
+    return null;
+  }
+  const parts = rel.split(sep).filter(Boolean);
+  if (parts.length < 3) {
+    return null;
+  }
+  if (parts[1] !== 'workspaces') {
+    return null;
+  }
+  const projectName = parts[0];
+  const workspaceId = parts[2];
+  const workspacePath = join(spacesDir, projectName, 'workspaces', workspaceId);
+  return { projectName, workspaceId, workspacePath };
+}
+
+/**
+ * Get events directory for a process
+ */
+export function getProcessEventsDir(
+  workspacePath: string,
+  processName: string,
+  processInstance?: number
+): string {
+  const instance = processInstance ?? DEFAULT_INSTANCE;
+  return join(workspacePath, '.events', 'processes', `${processName}-${instance}`);
+}
+
+export function getProcessSnapshotsPath(
+  workspacePath: string,
+  processName: string,
+  processInstance?: number
+): string {
+  return join(getProcessEventsDir(workspacePath, processName, processInstance), 'wide-snapshots.ndjson');
+}
+
+/**
+ * Get all process events directories for a workspace
+ */
+export function listProcessEventsDirs(workspacePath: string): string[] {
+  const base = join(workspacePath, '.events', 'processes');
+  if (!existsSync(base)) return [];
+  return readdirSync(base)
+    .filter((entry: string) => !entry.startsWith('.'))
+    .map((entry: string) => join(base, entry));
+}

--- a/src/lib/events/reader.ts
+++ b/src/lib/events/reader.ts
@@ -1,0 +1,204 @@
+/**
+ * Wide event reader for CLI queries
+ */
+
+import { join } from 'path';
+import { readFileSync } from 'fs';
+import type { WideEvent, WideEventFilter, WideSnapshot, WideSnapshotTimelineEntry } from '../../types/events.js';
+import { listEventIndexes, selectFilesForQuery, queryEvents } from './store.js';
+import { listProcessEventsDirs } from './paths.js';
+
+export interface WideEventQueryParams {
+  eventsDir: string;
+  filter: WideEventFilter;
+  limit?: number;
+  sinceMs?: number;
+  untilMs?: number;
+}
+
+export function readWideEvents(params: WideEventQueryParams): WideEvent[] {
+  const indexes = listEventIndexes(params.eventsDir);
+  const selected = selectFilesForQuery(indexes, {
+    filter: params.filter,
+    limit: params.limit,
+    sinceMs: params.sinceMs,
+    untilMs: params.untilMs,
+  });
+  const sorted = [...selected].sort((a, b) => b.maxTs - a.maxTs);
+  const results = queryEvents(
+    params.eventsDir,
+    sorted,
+    {
+      filter: params.filter,
+      limit: params.limit,
+      sinceMs: params.sinceMs,
+      untilMs: params.untilMs,
+    }
+  );
+  return results.reverse();
+
+}
+
+export function getEventsFilePath(eventsDir: string, indexFile: string): string {
+  return join(eventsDir, indexFile);
+}
+
+type SnapshotCacheEntry = {
+  snapshots: Map<string, WideSnapshot>;
+  bytes: number;
+  updatedAt: number;
+};
+
+const workspaceSnapshotCache = new Map<string, SnapshotCacheEntry>();
+const DEFAULT_CACHE_BYTES = 64 * 1024 * 1024;
+const DEFAULT_CACHE_TTL_MS = 1000;
+const DEFAULT_MAX_TIMELINE = 200;
+
+function estimateSnapshotSize(snapshot: WideSnapshot): number {
+  return Buffer.byteLength(JSON.stringify(snapshot));
+}
+
+function readSnapshotFile(filePath: string): WideSnapshot[] {
+  try {
+    const content = readFileSync(filePath, 'utf-8');
+    const snapshots: WideSnapshot[] = [];
+    for (const line of content.split('\n')) {
+      if (line.trim().length === 0) continue;
+      try {
+        const parsed = JSON.parse(line) as WideSnapshot;
+        if (!parsed || typeof parsed !== 'object') continue;
+        if (typeof parsed.correlationId !== 'string') continue;
+        snapshots.push(parsed);
+      } catch {
+        // Skip malformed snapshot entries
+      }
+    }
+    return snapshots;
+  } catch {
+    return [];
+  }
+}
+
+function mergeSnapshot(
+  existing: WideSnapshot | undefined,
+  incoming: WideSnapshot,
+  maxTimeline: number
+): WideSnapshot {
+  if (!existing) {
+    return incoming;
+  }
+
+  const orderedEntries: Array<{ entry: WideSnapshotTimelineEntry; seq: number }> = [];
+  existing.timelineOrder.forEach((key, index) => {
+    const entry = existing.timelineMap[key];
+    if (entry) {
+      orderedEntries.push({ entry, seq: index });
+    }
+  });
+  const incomingOffset = orderedEntries.length;
+  incoming.timelineOrder.forEach((key, index) => {
+    const entry = incoming.timelineMap[key];
+    if (entry) {
+      orderedEntries.push({ entry, seq: incomingOffset + index });
+    }
+  });
+
+  orderedEntries.sort((a, b) => {
+    if (a.entry.timestampMs !== b.entry.timestampMs) {
+      return a.entry.timestampMs - b.entry.timestampMs;
+    }
+    return a.seq - b.seq;
+  });
+
+  const maxEntries = Math.max(1, maxTimeline);
+  const trimmedEntries =
+    orderedEntries.length > maxEntries
+      ? orderedEntries.slice(orderedEntries.length - maxEntries)
+      : orderedEntries;
+
+  const timelineMap: Record<string, WideSnapshotTimelineEntry> = {};
+  const timelineOrder: string[] = [];
+  const keyCounts = new Map<string, number>();
+  for (const { entry } of trimmedEntries) {
+    const baseName = entry.eventName;
+    const count = keyCounts.get(baseName) ?? 0;
+    const next = count + 1;
+    keyCounts.set(baseName, next);
+    const key = next === 1 ? baseName : `${baseName}#${next}`;
+    timelineMap[key] = { ...entry, key };
+    timelineOrder.push(key);
+  }
+
+  const isIncomingLatest = incoming.updatedAt >= existing.updatedAt;
+
+  return {
+    correlationId: incoming.correlationId,
+    updatedAt: Math.max(existing.updatedAt, incoming.updatedAt),
+    processName: isIncomingLatest ? incoming.processName : existing.processName,
+    processInstance: isIncomingLatest ? incoming.processInstance : existing.processInstance,
+    level: isIncomingLatest ? incoming.level : existing.level,
+    message: isIncomingLatest ? incoming.message : existing.message,
+    eventName: isIncomingLatest ? incoming.eventName : existing.eventName,
+    lastEventId: isIncomingLatest ? incoming.lastEventId : existing.lastEventId,
+    timelineMap,
+    timelineOrder,
+    raw: isIncomingLatest ? incoming.raw : existing.raw,
+  };
+}
+
+function applyCacheLimit(entry: SnapshotCacheEntry, maxBytes: number): void {
+  if (entry.bytes <= maxBytes) return;
+  const sorted = Array.from(entry.snapshots.values()).sort((a, b) => a.updatedAt - b.updatedAt);
+  for (const snapshot of sorted) {
+    if (entry.bytes <= maxBytes) break;
+    entry.snapshots.delete(snapshot.correlationId);
+    entry.bytes = Math.max(0, entry.bytes - estimateSnapshotSize(snapshot));
+  }
+}
+
+export interface ReadWorkspaceSnapshotsOptions {
+  maxBytes?: number;
+  maxTimeline?: number;
+  refresh?: boolean;
+}
+
+export function readWorkspaceSnapshots(
+  workspacePath: string,
+  options: ReadWorkspaceSnapshotsOptions = {}
+): WideSnapshot[] {
+  const cached = workspaceSnapshotCache.get(workspacePath);
+  const isFresh = cached ? Date.now() - cached.updatedAt <= DEFAULT_CACHE_TTL_MS : false;
+  if (cached && !options.refresh && isFresh) {
+    return Array.from(cached.snapshots.values()).sort((a, b) => b.updatedAt - a.updatedAt);
+  }
+
+  const maxBytes = options.maxBytes ?? DEFAULT_CACHE_BYTES;
+  const maxTimeline = options.maxTimeline ?? DEFAULT_MAX_TIMELINE;
+
+  const entry: SnapshotCacheEntry = {
+    snapshots: new Map<string, WideSnapshot>(),
+    bytes: 0,
+    updatedAt: Date.now(),
+  };
+
+  const processDirs = listProcessEventsDirs(workspacePath);
+  for (const dir of processDirs) {
+    const filePath = join(dir, 'wide-snapshots.ndjson');
+    const snapshots = readSnapshotFile(filePath);
+    for (const snapshot of snapshots) {
+      const existing = entry.snapshots.get(snapshot.correlationId);
+      const merged = mergeSnapshot(existing, snapshot, maxTimeline);
+      if (!existing) {
+        entry.bytes += estimateSnapshotSize(merged);
+      } else {
+        entry.bytes = Math.max(0, entry.bytes - estimateSnapshotSize(existing));
+        entry.bytes += estimateSnapshotSize(merged);
+      }
+      entry.snapshots.set(merged.correlationId, merged);
+    }
+  }
+
+  applyCacheLimit(entry, maxBytes);
+  workspaceSnapshotCache.set(workspacePath, entry);
+  return Array.from(entry.snapshots.values()).sort((a, b) => b.updatedAt - a.updatedAt);
+}

--- a/src/lib/events/reader.ts
+++ b/src/lib/events/reader.ts
@@ -68,6 +68,14 @@ function readSnapshotFile(filePath: string): WideSnapshot[] {
         const parsed = JSON.parse(line) as WideSnapshot;
         if (!parsed || typeof parsed !== 'object') continue;
         if (typeof parsed.correlationId !== 'string') continue;
+        if (typeof parsed.updatedAt !== 'number' || Number.isNaN(parsed.updatedAt)) continue;
+        if (typeof parsed.eventName !== 'string') continue;
+        if (typeof parsed.level !== 'string') continue;
+        if (typeof parsed.message !== 'string') continue;
+        if (typeof parsed.lastEventId !== 'string') continue;
+        if (!parsed.timelineMap || typeof parsed.timelineMap !== 'object') continue;
+        if (!Array.isArray(parsed.timelineOrder)) continue;
+        if (!parsed.timelineOrder.every((entry) => typeof entry === 'string')) continue;
         snapshots.push(parsed);
       } catch {
         // Skip malformed snapshot entries

--- a/src/lib/events/store.ts
+++ b/src/lib/events/store.ts
@@ -1,0 +1,141 @@
+/**
+ * Wide event storage and query helpers
+ */
+
+import { existsSync, readFileSync, readdirSync } from 'fs';
+import { join } from 'path';
+import type { WideEvent, WideEventFilter, WideEventIndex } from '../../types/events.js';
+
+export interface WideEventQueryOptions {
+  filter: WideEventFilter;
+  limit?: number;
+  sinceMs?: number;
+  untilMs?: number;
+}
+
+export function listEventIndexes(eventsDir: string): WideEventIndex[] {
+  if (!existsSync(eventsDir)) {
+    return [];
+  }
+  return readdirSync(eventsDir)
+    .filter((file) => file.endsWith('.index.json'))
+    .map((file) => {
+      const path = join(eventsDir, file);
+      try {
+        const data = JSON.parse(readFileSync(path, 'utf-8')) as WideEventIndex;
+        return data;
+      } catch {
+        return null;
+      }
+    })
+    .filter((item): item is WideEventIndex => Boolean(item));
+}
+
+export function selectFilesForQuery(indexes: WideEventIndex[], options: WideEventQueryOptions): WideEventIndex[] {
+  return indexes.filter((index) => {
+    if (options.sinceMs !== undefined && index.maxTs < options.sinceMs) {
+      return false;
+    }
+    if (options.untilMs !== undefined && index.minTs > options.untilMs) {
+      return false;
+    }
+    if (options.filter.level && !index.levels.includes(options.filter.level)) {
+      return false;
+    }
+    if (options.filter.eventName && !index.eventNames.includes(options.filter.eventName)) {
+      return false;
+    }
+    return true;
+  });
+}
+
+export function queryEvents(
+  eventsDir: string,
+  indexes: WideEventIndex[],
+  options: WideEventQueryOptions
+): WideEvent[] {
+  const results: WideEvent[] = [];
+  const limit = options.limit ?? 100;
+
+  for (const index of indexes) {
+    const path = join(eventsDir, index.file);
+    if (!existsSync(path)) continue;
+
+    const lines = readFileSync(path, 'utf-8').split('\n');
+    for (let i = lines.length - 1; i >= 0; i -= 1) {
+      const line = lines[i];
+      if (!line || !line.trim()) continue;
+      try {
+        const raw = JSON.parse(line) as Record<string, unknown>;
+        const event = normalizeStoredEvent(raw);
+        if (!event) continue;
+        if (!matchesQuery(event, options)) continue;
+        results.push(event);
+        if (results.length >= limit) {
+          return results;
+        }
+      } catch {
+        // Ignore malformed lines
+      }
+    }
+  }
+
+  return results;
+}
+
+function normalizeStoredEvent(raw: Record<string, unknown>): WideEvent | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const eventId = typeof raw.eventId === 'string' ? raw.eventId : null;
+  const eventName = typeof raw.eventName === 'string' ? raw.eventName : null;
+  const level = typeof raw.level === 'string' ? raw.level : null;
+  const timestamp = typeof raw.timestamp === 'string' ? raw.timestamp : null;
+  const message = typeof raw.message === 'string' ? raw.message : null;
+  const timestampMs = typeof raw.timestampMs === 'number' ? raw.timestampMs : Date.parse(timestamp ?? '');
+  const sessionId = typeof raw.sessionId === 'string' ? raw.sessionId : '';
+  const workspaceId = typeof raw.workspaceId === 'string' ? raw.workspaceId : '';
+  const projectName = typeof raw.projectName === 'string' ? raw.projectName : '';
+  const processName = typeof raw.processName === 'string' ? raw.processName : undefined;
+  const processInstance = typeof raw.processInstance === 'number' ? raw.processInstance : undefined;
+  const kind = raw.kind === 'wide' || raw.kind === 'source' ? raw.kind : undefined;
+  const correlationId = typeof raw.correlationId === 'string' ? raw.correlationId : undefined;
+  const timeline = Array.isArray(raw.timeline)
+    ? (raw.timeline as WideEvent['timeline'])
+    : undefined;
+
+  if (!eventId || !eventName || !level || !timestamp || !message || Number.isNaN(timestampMs)) {
+    return null;
+  }
+
+  return {
+    eventId,
+    eventName,
+    level,
+    timestamp,
+    timestampMs,
+    message,
+    sessionId,
+    workspaceId,
+    projectName,
+    processName,
+    processInstance,
+    raw,
+    kind,
+    correlationId,
+    timeline,
+  };
+
+}
+
+function matchesQuery(event: WideEvent, options: WideEventQueryOptions): boolean {
+  const { filter, sinceMs, untilMs } = options;
+  if (filter.eventName && event.eventName !== filter.eventName) return false;
+  if (filter.eventId && event.eventId !== filter.eventId) return false;
+  if (filter.level && event.level !== filter.level) return false;
+  if (filter.message && !event.message.includes(filter.message)) return false;
+  if (filter.processName && event.processName !== filter.processName) return false;
+  if (filter.kind && event.kind !== filter.kind) return false;
+  if (filter.correlationId && event.correlationId !== filter.correlationId) return false;
+  if (sinceMs !== undefined && event.timestampMs < sinceMs) return false;
+  if (untilMs !== undefined && event.timestampMs > untilMs) return false;
+  return true;
+}

--- a/src/lib/processes/__tests__/config.test.ts
+++ b/src/lib/processes/__tests__/config.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from 'bun:test';
+import { describe, expect, it } from 'bun:test';
 import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
@@ -8,75 +8,76 @@ import {
   loadProcessesConfigWithDiagnostics,
 } from '../config.js';
 
-const tempDirs: string[] = [];
-
 function makeWorkspace(): string {
   const dir = mkdtempSync(join(tmpdir(), 'gssh-process-config-'));
-  tempDirs.push(dir);
   mkdirSync(join(dir, '.gitspace'), { recursive: true });
   return dir;
 }
 
-afterEach(() => {
-  while (tempDirs.length > 0) {
-    const dir = tempDirs.pop();
-    if (dir) {
-      rmSync(dir, { recursive: true, force: true });
-    }
+function withWorkspace<T>(run: (workspace: string) => T): T {
+  const workspace = makeWorkspace();
+  try {
+    return run(workspace);
+  } finally {
+    rmSync(workspace, { recursive: true, force: true });
   }
-});
+}
 
 describe('loadProcessesConfigWithDiagnostics', () => {
   it('parses JSONC comments and trailing commas', () => {
-    const workspace = makeWorkspace();
-    const path = getProcessesConfigPath(workspace);
-    writeFileSync(path, [
-      '{',
-      '  // One process',
-      '  "processes": [',
-      '    {',
-      '      "name": "web",',
-      '      "command": "bun",',
-      '      "args": ["run", "dev",],',
-      '    },',
-      '  ],',
-      '}',
-      '',
-    ].join('\n'));
+    withWorkspace((workspace) => {
+      const path = getProcessesConfigPath(workspace);
+      writeFileSync(path, [
+        '{',
+        '  // One process',
+        '  "processes": [',
+        '    {',
+        '      "name": "web",',
+        '      "command": "bun",',
+        '      "args": ["run", "dev",],',
+        '    },',
+        '  ],',
+        '}',
+        '',
+      ].join('\n'));
 
-    const result = loadProcessesConfigWithDiagnostics(workspace);
-    expect(result.error).toBeNull();
-    expect(result.config.processes).toHaveLength(1);
-    expect(result.config.processes[0]?.name).toBe('web');
+      const result = loadProcessesConfigWithDiagnostics(workspace);
+      expect(result.error).toBeNull();
+      expect(result.config.processes).toHaveLength(1);
+      expect(result.config.processes[0]?.name).toBe('web');
+    });
   });
 
   it('returns parse diagnostics for malformed JSONC', () => {
-    const workspace = makeWorkspace();
-    const path = getProcessesConfigPath(workspace);
-    writeFileSync(path, '{\n  "processes": [\n    {\n');
+    withWorkspace((workspace) => {
+      const path = getProcessesConfigPath(workspace);
+      writeFileSync(path, '{\n  "processes": [\n    {\n');
 
-    const result = loadProcessesConfigWithDiagnostics(workspace);
-    expect(result.config.processes).toEqual([]);
-    expect(result.error).toContain('Failed to parse .gitspace/processes.json');
+      const result = loadProcessesConfigWithDiagnostics(workspace);
+      expect(result.config.processes).toEqual([]);
+      expect(result.error).toContain('Failed to parse .gitspace/processes.json');
+    });
   });
 
   it('returns validation diagnostics for invalid config', () => {
-    const workspace = makeWorkspace();
-    const path = getProcessesConfigPath(workspace);
-    writeFileSync(path, '{"processes":[{"name":"web"}]}');
+    withWorkspace((workspace) => {
+      const path = getProcessesConfigPath(workspace);
+      writeFileSync(path, '{"processes":[{"name":"web"}]}');
 
-    const result = loadProcessesConfigWithDiagnostics(workspace);
-    expect(result.error).toContain('Invalid .gitspace/processes.json');
-    expect(result.error).toContain('missing command');
+      const result = loadProcessesConfigWithDiagnostics(workspace);
+      expect(result.error).toContain('Invalid .gitspace/processes.json');
+      expect(result.error).toContain('missing command');
+    });
   });
 
   it('loadProcessesConfig stays backward-compatible', () => {
-    const workspace = makeWorkspace();
-    const path = getProcessesConfigPath(workspace);
-    writeFileSync(path, '{"processes":[{"name":"api","command":"bun"}]}');
+    withWorkspace((workspace) => {
+      const path = getProcessesConfigPath(workspace);
+      writeFileSync(path, '{"processes":[{"name":"api","command":"bun"}]}');
 
-    const config = loadProcessesConfig(workspace);
-    expect(config.processes).toHaveLength(1);
-    expect(config.processes[0]?.name).toBe('api');
+      const config = loadProcessesConfig(workspace);
+      expect(config.processes).toHaveLength(1);
+      expect(config.processes[0]?.name).toBe('api');
+    });
   });
 });

--- a/src/lib/processes/__tests__/config.test.ts
+++ b/src/lib/processes/__tests__/config.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, describe, expect, it } from 'bun:test';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import {
+  getProcessesConfigPath,
+  loadProcessesConfig,
+  loadProcessesConfigWithDiagnostics,
+} from '../config.js';
+
+const tempDirs: string[] = [];
+
+function makeWorkspace(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'gssh-process-config-'));
+  tempDirs.push(dir);
+  mkdirSync(join(dir, '.gitspace'), { recursive: true });
+  return dir;
+}
+
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop();
+    if (dir) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }
+});
+
+describe('loadProcessesConfigWithDiagnostics', () => {
+  it('parses JSONC comments and trailing commas', () => {
+    const workspace = makeWorkspace();
+    const path = getProcessesConfigPath(workspace);
+    writeFileSync(path, [
+      '{',
+      '  // One process',
+      '  "processes": [',
+      '    {',
+      '      "name": "web",',
+      '      "command": "bun",',
+      '      "args": ["run", "dev",],',
+      '    },',
+      '  ],',
+      '}',
+      '',
+    ].join('\n'));
+
+    const result = loadProcessesConfigWithDiagnostics(workspace);
+    expect(result.error).toBeNull();
+    expect(result.config.processes).toHaveLength(1);
+    expect(result.config.processes[0]?.name).toBe('web');
+  });
+
+  it('returns parse diagnostics for malformed JSONC', () => {
+    const workspace = makeWorkspace();
+    const path = getProcessesConfigPath(workspace);
+    writeFileSync(path, '{\n  "processes": [\n    {\n');
+
+    const result = loadProcessesConfigWithDiagnostics(workspace);
+    expect(result.config.processes).toEqual([]);
+    expect(result.error).toContain('Failed to parse .gitspace/processes.json');
+  });
+
+  it('returns validation diagnostics for invalid config', () => {
+    const workspace = makeWorkspace();
+    const path = getProcessesConfigPath(workspace);
+    writeFileSync(path, '{"processes":[{"name":"web"}]}');
+
+    const result = loadProcessesConfigWithDiagnostics(workspace);
+    expect(result.error).toContain('Invalid .gitspace/processes.json');
+    expect(result.error).toContain('missing command');
+  });
+
+  it('loadProcessesConfig stays backward-compatible', () => {
+    const workspace = makeWorkspace();
+    const path = getProcessesConfigPath(workspace);
+    writeFileSync(path, '{"processes":[{"name":"api","command":"bun"}]}');
+
+    const config = loadProcessesConfig(workspace);
+    expect(config.processes).toHaveLength(1);
+    expect(config.processes[0]?.name).toBe('api');
+  });
+});

--- a/src/lib/processes/__tests__/names.test.ts
+++ b/src/lib/processes/__tests__/names.test.ts
@@ -30,6 +30,7 @@ describe('buildProcessSessionName', () => {
     const longWorkspace = 'a'.repeat(80);
     const name = buildProcessSessionName(longWorkspace, 'web', 1);
     expect(name.length).toBeLessThanOrEqual(PROCESS_SESSION_MAX_NAME);
+    expect(parseProcessSessionName(name)).not.toBeNull();
   });
 
   it('should not truncate short names', () => {

--- a/src/lib/processes/__tests__/names.test.ts
+++ b/src/lib/processes/__tests__/names.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Process session naming tests
+ */
+
+import { describe, expect, it } from 'bun:test';
+import {
+  buildProcessSessionName,
+  parseProcessSessionName,
+  PROCESS_SESSION_PREFIX,
+  PROCESS_SESSION_MAX_NAME,
+} from '../names.js';
+
+// ============================================================================
+// buildProcessSessionName
+// ============================================================================
+
+describe('buildProcessSessionName', () => {
+  it('should build name with correct format', () => {
+    const name = buildProcessSessionName('my-workspace', 'web', 1);
+    expect(name).toBe('proc:my-workspace:web:1');
+  });
+
+  it('should use the PROCESS_SESSION_PREFIX', () => {
+    const name = buildProcessSessionName('ws', 'api', 2);
+    expect(name.startsWith(`${PROCESS_SESSION_PREFIX}:`)).toBe(true);
+  });
+
+  it('should truncate names exceeding max length', () => {
+    const longWorkspace = 'a'.repeat(80);
+    const name = buildProcessSessionName(longWorkspace, 'web', 1);
+    expect(name.length).toBeLessThanOrEqual(PROCESS_SESSION_MAX_NAME);
+  });
+
+  it('should not truncate short names', () => {
+    const name = buildProcessSessionName('ws', 'api', 1);
+    expect(name).toBe('proc:ws:api:1');
+    expect(name.length).toBeLessThan(PROCESS_SESSION_MAX_NAME);
+  });
+
+  it('should handle instance numbers > 1', () => {
+    const name = buildProcessSessionName('ws', 'worker', 5);
+    expect(name).toBe('proc:ws:worker:5');
+  });
+});
+
+// ============================================================================
+// parseProcessSessionName
+// ============================================================================
+
+describe('parseProcessSessionName', () => {
+  it('should parse a valid process session name', () => {
+    const result = parseProcessSessionName('proc:my-workspace:web:1');
+    expect(result).toEqual({
+      workspaceId: 'my-workspace',
+      processName: 'web',
+      instance: 1,
+    });
+  });
+
+  it('should return null for non-process names', () => {
+    expect(parseProcessSessionName('alpha:ws:1')).toBeNull();
+  });
+
+  it('should return null for empty string', () => {
+    expect(parseProcessSessionName('')).toBeNull();
+  });
+
+  it('should return null for wrong prefix', () => {
+    expect(parseProcessSessionName('session:ws:web:1')).toBeNull();
+  });
+
+  it('should return null for too few parts', () => {
+    expect(parseProcessSessionName('proc:ws')).toBeNull();
+    expect(parseProcessSessionName('proc:ws:web')).toBeNull();
+  });
+
+  it('should return null for non-numeric instance', () => {
+    expect(parseProcessSessionName('proc:ws:web:abc')).toBeNull();
+  });
+
+  it('should handle instance 0', () => {
+    const result = parseProcessSessionName('proc:ws:web:0');
+    expect(result).toEqual({
+      workspaceId: 'ws',
+      processName: 'web',
+      instance: 0,
+    });
+  });
+});
+
+// ============================================================================
+// Round-trip
+// ============================================================================
+
+describe('buildProcessSessionName / parseProcessSessionName round-trip', () => {
+  it('should round-trip standard names', () => {
+    const name = buildProcessSessionName('workspace', 'dev-server', 1);
+    const parsed = parseProcessSessionName(name);
+    expect(parsed).toEqual({
+      workspaceId: 'workspace',
+      processName: 'dev-server',
+      instance: 1,
+    });
+  });
+
+  it('should round-trip multi-instance', () => {
+    for (let i = 1; i <= 5; i++) {
+      const name = buildProcessSessionName('ws', 'worker', i);
+      const parsed = parseProcessSessionName(name);
+      expect(parsed?.instance).toBe(i);
+    }
+  });
+});

--- a/src/lib/processes/__tests__/names.test.ts
+++ b/src/lib/processes/__tests__/names.test.ts
@@ -5,6 +5,7 @@
 import { describe, expect, it } from 'bun:test';
 import {
   buildProcessSessionName,
+  encodeProcessNameForPath,
   parseProcessSessionName,
   PROCESS_SESSION_PREFIX,
   PROCESS_SESSION_MAX_NAME,
@@ -109,5 +110,15 @@ describe('buildProcessSessionName / parseProcessSessionName round-trip', () => {
       const parsed = parseProcessSessionName(name);
       expect(parsed?.instance).toBe(i);
     }
+  });
+});
+
+describe('encodeProcessNameForPath', () => {
+  it('encodes path separators and dot segments safely', () => {
+    expect(encodeProcessNameForPath('../api/server')).toBe('..%2Fapi%2Fserver');
+  });
+
+  it('keeps simple names readable', () => {
+    expect(encodeProcessNameForPath('web-server')).toBe('web-server');
   });
 });

--- a/src/lib/processes/__tests__/schema.test.ts
+++ b/src/lib/processes/__tests__/schema.test.ts
@@ -74,6 +74,32 @@ describe('validateProcessesConfig', () => {
     expect(result.errors).toContain('process web missing command');
   });
 
+  it('should allow instances set to 0 (disabled process)', () => {
+    const config: ProcessesConfig = {
+      processes: [{ name: 'worker', command: 'npm run worker', instances: 0 }],
+    };
+    const result = validateProcessesConfig(config);
+    expect(result.valid).toBe(true);
+  });
+
+  it('should fail when instances is negative', () => {
+    const config = {
+      processes: [{ name: 'worker', command: 'npm run worker', instances: -1 }],
+    } as unknown as ProcessesConfig;
+    const result = validateProcessesConfig(config);
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain('process worker instances must be a non-negative integer');
+  });
+
+  it('should fail when instances is not an integer', () => {
+    const config = {
+      processes: [{ name: 'worker', command: 'npm run worker', instances: 1.5 }],
+    } as unknown as ProcessesConfig;
+    const result = validateProcessesConfig(config);
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain('process worker instances must be a non-negative integer');
+  });
+
   it('should fail when keepRawOutput is not boolean', () => {
     const config = {
       processes: [

--- a/src/lib/processes/__tests__/schema.test.ts
+++ b/src/lib/processes/__tests__/schema.test.ts
@@ -1,0 +1,182 @@
+/**
+ * Process schema validation tests
+ */
+
+import { describe, expect, it } from 'bun:test';
+import { validateProcessesConfig, describeProcess } from '../schema.js';
+import type { ProcessesConfig, ProcessDefinition } from '../../../types/processes.js';
+
+// ============================================================================
+// validateProcessesConfig
+// ============================================================================
+
+describe('validateProcessesConfig', () => {
+  it('should pass for valid config with one process', () => {
+    const config: ProcessesConfig = {
+      processes: [{ name: 'web', command: 'npm start' }],
+    };
+    const result = validateProcessesConfig(config);
+    expect(result.valid).toBe(true);
+    expect(result.errors).toEqual([]);
+  });
+
+  it('should pass for valid config with multiple processes', () => {
+    const config: ProcessesConfig = {
+      processes: [
+        { name: 'web', command: 'npm start' },
+        { name: 'worker', command: 'npm run worker' },
+      ],
+    };
+    const result = validateProcessesConfig(config);
+    expect(result.valid).toBe(true);
+  });
+
+  it('should pass for empty processes array', () => {
+    const config: ProcessesConfig = { processes: [] };
+    const result = validateProcessesConfig(config);
+    expect(result.valid).toBe(true);
+  });
+
+  it('should fail when processes is not an array', () => {
+    const config = { processes: 'not-an-array' } as unknown as ProcessesConfig;
+    const result = validateProcessesConfig(config);
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain('processes must be an array');
+  });
+
+  it('should fail when process has no name', () => {
+    const config = {
+      processes: [{ command: 'npm start' }],
+    } as unknown as ProcessesConfig;
+    const result = validateProcessesConfig(config);
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain('process is missing name');
+  });
+
+  it('should fail for duplicate process names', () => {
+    const config: ProcessesConfig = {
+      processes: [
+        { name: 'web', command: 'npm start' },
+        { name: 'web', command: 'npm run dev' },
+      ],
+    };
+    const result = validateProcessesConfig(config);
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain('duplicate process name: web');
+  });
+
+  it('should fail when process has no command', () => {
+    const config = {
+      processes: [{ name: 'web' }],
+    } as unknown as ProcessesConfig;
+    const result = validateProcessesConfig(config);
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain('process web missing command');
+  });
+
+  it('should fail when keepRawOutput is not boolean', () => {
+    const config = {
+      processes: [
+        { name: 'web', command: 'npm start', events: { keepRawOutput: 'yes' } },
+      ],
+    } as unknown as ProcessesConfig;
+    const result = validateProcessesConfig(config);
+    expect(result.valid).toBe(false);
+    expect(result.errors[0]).toContain('keepRawOutput must be a boolean');
+  });
+
+  it('should pass when keepRawOutput is boolean', () => {
+    const config: ProcessesConfig = {
+      processes: [
+        { name: 'web', command: 'npm start', events: { keepRawOutput: true } },
+      ],
+    };
+    const result = validateProcessesConfig(config);
+    expect(result.valid).toBe(true);
+  });
+
+  it('should fail when ports is not an array', () => {
+    const config = {
+      processes: [{ name: 'web', command: 'npm start', ports: 'not-array' }],
+    } as unknown as ProcessesConfig;
+    const result = validateProcessesConfig(config);
+    expect(result.valid).toBe(false);
+    expect(result.errors[0]).toContain('ports must be an array');
+  });
+
+  it('should fail for port out of range', () => {
+    const config: ProcessesConfig = {
+      processes: [
+        { name: 'web', command: 'npm start', ports: [{ port: 0 }] },
+      ],
+    };
+    const result = validateProcessesConfig(config);
+    expect(result.valid).toBe(false);
+    expect(result.errors[0]).toContain('port must be a number between 1 and 65535');
+  });
+
+  it('should fail for port over 65535', () => {
+    const config: ProcessesConfig = {
+      processes: [
+        { name: 'web', command: 'npm start', ports: [{ port: 70000 }] },
+      ],
+    };
+    const result = validateProcessesConfig(config);
+    expect(result.valid).toBe(false);
+  });
+
+  it('should pass for valid port config', () => {
+    const config: ProcessesConfig = {
+      processes: [
+        { name: 'web', command: 'npm start', ports: [{ port: 3000, name: 'http', protocol: 'http' }] },
+      ],
+    };
+    const result = validateProcessesConfig(config);
+    expect(result.valid).toBe(true);
+  });
+
+  it('should fail for invalid port protocol', () => {
+    const config = {
+      processes: [
+        { name: 'web', command: 'npm start', ports: [{ port: 3000, protocol: 'udp' }] },
+      ],
+    } as unknown as ProcessesConfig;
+    const result = validateProcessesConfig(config);
+    expect(result.valid).toBe(false);
+    expect(result.errors[0]).toContain('protocol must be http or tcp');
+  });
+
+  it('should accumulate multiple errors', () => {
+    const config = {
+      processes: [
+        { name: 'web', command: 'npm start' },
+        { name: 'web', command: 'npm run dev' },  // duplicate
+        { command: 'npm test' },                    // missing name
+      ],
+    } as unknown as ProcessesConfig;
+    const result = validateProcessesConfig(config);
+    expect(result.valid).toBe(false);
+    expect(result.errors.length).toBeGreaterThanOrEqual(2);
+  });
+});
+
+// ============================================================================
+// describeProcess
+// ============================================================================
+
+describe('describeProcess', () => {
+  it('should describe process with command only', () => {
+    const process: ProcessDefinition = { name: 'web', command: 'npm start' };
+    expect(describeProcess(process)).toBe('web: npm start');
+  });
+
+  it('should describe process with args', () => {
+    const process: ProcessDefinition = { name: 'api', command: 'node', args: ['server.js', '--port', '3000'] };
+    expect(describeProcess(process)).toBe('api: node server.js --port 3000');
+  });
+
+  it('should describe process with empty args', () => {
+    const process: ProcessDefinition = { name: 'worker', command: 'python', args: [] };
+    expect(describeProcess(process)).toBe('worker: python');
+  });
+});

--- a/src/lib/processes/__tests__/watchdog.test.ts
+++ b/src/lib/processes/__tests__/watchdog.test.ts
@@ -1,0 +1,188 @@
+/**
+ * Process watchdog tests - restart policy enforcement with injected deps
+ *
+ * NOTE: The watchdog uses a module-level restartState map keyed by "name:instance".
+ * Each test uses a unique process name to avoid state leaking between tests.
+ */
+
+import { describe, expect, it, mock } from 'bun:test';
+import { reconcileProcessRestarts, type ProcessWatchdogDeps } from '../watchdog.js';
+import type { ProcessInstanceSpec } from '../../../types/processes.js';
+
+let testCounter = 0;
+function uniqueName(): string {
+  return `test-proc-${++testCounter}`;
+}
+
+function makeSpec(overrides: {
+  name?: string;
+  instance?: number;
+  policy?: 'always' | 'on-failure' | 'never';
+  maxAttempts?: number;
+  backoffMs?: number;
+  maxBackoffMs?: number;
+} = {}): ProcessInstanceSpec {
+  const name = overrides.name ?? uniqueName();
+  return {
+    name,
+    instance: overrides.instance ?? 1,
+    definition: {
+      name,
+      command: 'npm start',
+      restart: {
+        policy: overrides.policy ?? 'always',
+        maxAttempts: overrides.maxAttempts ?? 5,
+        backoffMs: overrides.backoffMs ?? 1000,
+        maxBackoffMs: overrides.maxBackoffMs ?? 30000,
+      },
+    },
+  };
+}
+
+function makeDeps(overrides: Partial<ProcessWatchdogDeps> = {}): ProcessWatchdogDeps {
+  return {
+    listSessions: mock(() => Promise.resolve([])),
+    startProcessInstance: mock(() => Promise.resolve({ sessionId: 'sess-1', created: true })),
+    isProcessRestartDisabled: mock(() => false),
+    disableProcessRestart: mock(() => {}),
+    hasProcessStarted: mock(() => true),
+    readProcessExit: mock(() => null),
+    now: mock(() => Date.now()),
+    ...overrides,
+  };
+}
+
+// ============================================================================
+// reconcileProcessRestarts
+// ============================================================================
+
+describe('reconcileProcessRestarts', () => {
+  it('should skip processes with restart policy "never"', async () => {
+    const deps = makeDeps();
+    const specs = [makeSpec({ policy: 'never' })];
+
+    await reconcileProcessRestarts('/tmp/ws', specs, deps);
+
+    expect(deps.startProcessInstance).not.toHaveBeenCalled();
+  });
+
+  it('should skip processes that are currently running', async () => {
+    const spec = makeSpec();
+    const deps = makeDeps({
+      listSessions: mock(() =>
+        Promise.resolve([
+          { id: 's1', name: `proc:ws:${spec.name}:1`, socketPath: '/tmp/s', pid: 1, attached: false, cwd: '/tmp/ws', createdAt: 0 },
+        ])
+      ),
+    });
+
+    await reconcileProcessRestarts('/tmp/ws', [spec], deps);
+
+    expect(deps.startProcessInstance).not.toHaveBeenCalled();
+  });
+
+  it('should skip processes where restart is externally disabled', async () => {
+    const deps = makeDeps({
+      isProcessRestartDisabled: mock(() => true),
+    });
+    const specs = [makeSpec()];
+
+    await reconcileProcessRestarts('/tmp/ws', specs, deps);
+
+    expect(deps.startProcessInstance).not.toHaveBeenCalled();
+  });
+
+  it('should skip processes that have never been started', async () => {
+    const deps = makeDeps({
+      hasProcessStarted: mock(() => false),
+    });
+    const specs = [makeSpec()];
+
+    await reconcileProcessRestarts('/tmp/ws', specs, deps);
+
+    expect(deps.startProcessInstance).not.toHaveBeenCalled();
+  });
+
+  it('should restart a crashed process with "always" policy', async () => {
+    const deps = makeDeps();
+    const specs = [makeSpec({ policy: 'always' })];
+
+    await reconcileProcessRestarts('/tmp/ws', specs, deps);
+
+    expect(deps.startProcessInstance).toHaveBeenCalledTimes(1);
+  });
+
+  it('should restart a process with "on-failure" policy when exit code is non-zero', async () => {
+    const deps = makeDeps({
+      readProcessExit: mock(() => ({ exitCode: 1, exitedAt: Date.now() })),
+    });
+    const specs = [makeSpec({ policy: 'on-failure' })];
+
+    await reconcileProcessRestarts('/tmp/ws', specs, deps);
+
+    expect(deps.startProcessInstance).toHaveBeenCalledTimes(1);
+  });
+
+  it('should NOT restart a process with "on-failure" policy when exit code is 0', async () => {
+    const deps = makeDeps({
+      readProcessExit: mock(() => ({ exitCode: 0, exitedAt: Date.now() })),
+    });
+    const specs = [makeSpec({ policy: 'on-failure' })];
+
+    await reconcileProcessRestarts('/tmp/ws', specs, deps);
+
+    expect(deps.startProcessInstance).not.toHaveBeenCalled();
+  });
+
+  it('should disable restart after maxAttempts exceeded', async () => {
+    const startMock = mock(() => Promise.resolve({ sessionId: 's', created: true }));
+    let currentTime = 1000;
+
+    const deps = makeDeps({
+      startProcessInstance: startMock,
+      now: mock(() => {
+        currentTime += 100000; // jump forward enough to skip backoff
+        return currentTime;
+      }),
+    });
+
+    const spec = makeSpec({ maxAttempts: 2, backoffMs: 1 });
+    const specs = [spec];
+
+    // First call: attempt 1
+    await reconcileProcessRestarts('/tmp/ws', specs, deps);
+    expect(startMock).toHaveBeenCalledTimes(1);
+
+    // Second call: attempt 2
+    await reconcileProcessRestarts('/tmp/ws', specs, deps);
+    expect(startMock).toHaveBeenCalledTimes(2);
+
+    // Third call: maxAttempts exceeded, should disable
+    await reconcileProcessRestarts('/tmp/ws', specs, deps);
+    expect(deps.disableProcessRestart).toHaveBeenCalled();
+    expect(startMock).toHaveBeenCalledTimes(2); // no additional start
+  });
+
+  it('should respect backoff delay', async () => {
+    let currentTime = 1000;
+    const deps = makeDeps({
+      now: mock(() => currentTime),
+    });
+
+    const specs = [makeSpec({ backoffMs: 5000 })];
+
+    // First call starts the process
+    await reconcileProcessRestarts('/tmp/ws', specs, deps);
+    expect(deps.startProcessInstance).toHaveBeenCalledTimes(1);
+
+    // Second call too soon - should skip due to backoff
+    currentTime += 1000; // only 1 second later, but backoff doubled to 10000
+    await reconcileProcessRestarts('/tmp/ws', specs, deps);
+    expect(deps.startProcessInstance).toHaveBeenCalledTimes(1); // still 1
+
+    // Third call after backoff - should restart
+    currentTime += 20000; // well past doubled backoff
+    await reconcileProcessRestarts('/tmp/ws', specs, deps);
+    expect(deps.startProcessInstance).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/lib/processes/__tests__/watchdog.test.ts
+++ b/src/lib/processes/__tests__/watchdog.test.ts
@@ -1,7 +1,7 @@
 /**
  * Process watchdog tests - restart policy enforcement with injected deps
  *
- * NOTE: The watchdog uses a module-level restartState map keyed by "name:instance".
+ * NOTE: The watchdog uses a module-level restartState map keyed by "workspacePath:name:instance".
  * Each test uses a unique process name to avoid state leaking between tests.
  */
 
@@ -184,5 +184,27 @@ describe('reconcileProcessRestarts', () => {
     currentTime += 20000; // well past doubled backoff
     await reconcileProcessRestarts('/tmp/ws', specs, deps);
     expect(deps.startProcessInstance).toHaveBeenCalledTimes(2);
+  });
+
+  it('keeps restart backoff isolated per workspace for same process name', async () => {
+    const name = uniqueName();
+    const spec = makeSpec({ name, backoffMs: 60_000 });
+    const startA = mock(() => Promise.resolve({ sessionId: 'a', created: true }));
+    const startB = mock(() => Promise.resolve({ sessionId: 'b', created: true }));
+
+    const depsA = makeDeps({
+      startProcessInstance: startA,
+      now: mock(() => 1000),
+    });
+    const depsB = makeDeps({
+      startProcessInstance: startB,
+      now: mock(() => 1000),
+    });
+
+    await reconcileProcessRestarts('/tmp/ws-a', [spec], depsA);
+    await reconcileProcessRestarts('/tmp/ws-b', [spec], depsB);
+
+    expect(startA).toHaveBeenCalledTimes(1);
+    expect(startB).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/lib/processes/autostart.ts
+++ b/src/lib/processes/autostart.ts
@@ -1,0 +1,16 @@
+/**
+ * Process autostart helpers
+ */
+
+import type { ProcessInstanceSpec } from '../../types/processes.js';
+import { startProcessInstance } from './manager.js';
+
+export async function autostartProcesses(
+  workspacePath: string,
+  specs: ProcessInstanceSpec[]
+): Promise<void> {
+  const autostart = specs.filter((spec) => spec.definition.autostart);
+  for (const spec of autostart) {
+    await startProcessInstance(workspacePath, spec);
+  }
+}

--- a/src/lib/processes/config.ts
+++ b/src/lib/processes/config.ts
@@ -7,27 +7,147 @@ import { join } from 'path';
 import type { ProcessesConfig, ProcessDefinition, ProcessInstanceSpec } from '../../types/processes.js';
 import { validateProcessesConfig } from './schema.js';
 
+export interface ProcessesConfigLoadResult {
+  config: ProcessesConfig;
+  error: string | null;
+}
+
+function stripJsoncComments(input: string): string {
+  let result = '';
+  let inString = false;
+  let escaped = false;
+  let inLineComment = false;
+  let inBlockComment = false;
+
+  for (let i = 0; i < input.length; i += 1) {
+    const ch = input[i];
+    const next = input[i + 1];
+
+    if (inLineComment) {
+      if (ch === '\n') {
+        inLineComment = false;
+        result += ch;
+      }
+      continue;
+    }
+
+    if (inBlockComment) {
+      if (ch === '*' && next === '/') {
+        inBlockComment = false;
+        i += 1;
+      }
+      continue;
+    }
+
+    if (inString) {
+      result += ch;
+      if (escaped) {
+        escaped = false;
+      } else if (ch === '\\') {
+        escaped = true;
+      } else if (ch === '"') {
+        inString = false;
+      }
+      continue;
+    }
+
+    if (ch === '"') {
+      inString = true;
+      result += ch;
+      continue;
+    }
+
+    if (ch === '/' && next === '/') {
+      inLineComment = true;
+      i += 1;
+      continue;
+    }
+
+    if (ch === '/' && next === '*') {
+      inBlockComment = true;
+      i += 1;
+      continue;
+    }
+
+    result += ch;
+  }
+
+  return result;
+}
+
+function stripJsonTrailingCommas(input: string): string {
+  let result = '';
+  let inString = false;
+  let escaped = false;
+
+  for (let i = 0; i < input.length; i += 1) {
+    const ch = input[i];
+
+    if (inString) {
+      result += ch;
+      if (escaped) {
+        escaped = false;
+      } else if (ch === '\\') {
+        escaped = true;
+      } else if (ch === '"') {
+        inString = false;
+      }
+      continue;
+    }
+
+    if (ch === '"') {
+      inString = true;
+      result += ch;
+      continue;
+    }
+
+    if (ch === ',') {
+      let j = i + 1;
+      while (j < input.length && /\s/.test(input[j])) {
+        j += 1;
+      }
+      const nextNonWhitespace = input[j];
+      if (nextNonWhitespace === '}' || nextNonWhitespace === ']') {
+        continue;
+      }
+    }
+
+    result += ch;
+  }
+
+  return result;
+}
+
+function parseJsonc(raw: string): unknown {
+  const withoutComments = stripJsoncComments(raw);
+  const withoutTrailingCommas = stripJsonTrailingCommas(withoutComments);
+  return JSON.parse(withoutTrailingCommas);
+}
+
 export function getProcessesConfigPath(workspacePath: string): string {
   return join(workspacePath, '.gitspace', 'processes.json');
 }
 
-export function loadProcessesConfig(workspacePath: string): ProcessesConfig {
+export function loadProcessesConfigWithDiagnostics(workspacePath: string): ProcessesConfigLoadResult {
   const path = getProcessesConfigPath(workspacePath);
   if (!existsSync(path)) {
-    return { processes: [] };
+    return { config: { processes: [] }, error: null };
   }
 
   const raw = readFileSync(path, 'utf-8').trim();
   if (!raw) {
-    return { processes: [] };
+    return { config: { processes: [] }, error: null };
   }
 
   let parsed: ProcessesConfig;
   try {
-    parsed = JSON.parse(raw) as ProcessesConfig;
-  } catch {
-    console.warn(`[processes] Failed to parse ${path}`);
-    return { processes: [] };
+    parsed = parseJsonc(raw) as ProcessesConfig;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'invalid JSONC';
+    return {
+      config: { processes: [] },
+      error: `Failed to parse .gitspace/processes.json: ${message}`,
+    };
   }
 
   const normalized: ProcessesConfig = {
@@ -35,9 +155,16 @@ export function loadProcessesConfig(workspacePath: string): ProcessesConfig {
   };
   const validation = validateProcessesConfig(normalized);
   if (!validation.valid) {
-    console.warn(`[processes] Invalid config at ${path}: ${validation.errors.join(', ')}`);
+    return {
+      config: normalized,
+      error: `Invalid .gitspace/processes.json: ${validation.errors.join(', ')}`,
+    };
   }
-  return normalized;
+  return { config: normalized, error: null };
+}
+
+export function loadProcessesConfig(workspacePath: string): ProcessesConfig {
+  return loadProcessesConfigWithDiagnostics(workspacePath).config;
 }
 
 export function getProcessInstances(config: ProcessesConfig): ProcessInstanceSpec[] {

--- a/src/lib/processes/config.ts
+++ b/src/lib/processes/config.ts
@@ -1,0 +1,48 @@
+/**
+ * Process config loader (repo workspace only)
+ */
+
+import { existsSync, readFileSync } from 'fs';
+import { join } from 'path';
+import type { ProcessesConfig, ProcessDefinition, ProcessInstanceSpec } from '../../types/processes.js';
+import { validateProcessesConfig } from './schema.js';
+
+export function getProcessesConfigPath(workspacePath: string): string {
+  return join(workspacePath, '.gitspace', 'processes.json');
+}
+
+export function loadProcessesConfig(workspacePath: string): ProcessesConfig {
+  const path = getProcessesConfigPath(workspacePath);
+  if (!existsSync(path)) {
+    return { processes: [] };
+  }
+
+  const raw = readFileSync(path, 'utf-8');
+  const parsed = JSON.parse(raw) as ProcessesConfig;
+  const normalized: ProcessesConfig = {
+    processes: Array.isArray(parsed.processes) ? parsed.processes : [],
+  };
+  const validation = validateProcessesConfig(normalized);
+  if (!validation.valid) {
+    console.warn(`[processes] Invalid config at ${path}: ${validation.errors.join(', ')}`);
+  }
+  return normalized;
+}
+
+export function getProcessInstances(config: ProcessesConfig): ProcessInstanceSpec[] {
+  const instances: ProcessInstanceSpec[] = [];
+  for (const process of config.processes) {
+    const count = Math.max(1, process.instances ?? 1);
+    for (let idx = 1; idx <= count; idx++) {
+      instances.push({ name: process.name, instance: idx, definition: process });
+    }
+  }
+  return instances;
+}
+
+export function getProcessDefinition(
+  config: ProcessesConfig,
+  name: string
+): ProcessDefinition | null {
+  return config.processes.find((process) => process.name === name) ?? null;
+}

--- a/src/lib/processes/config.ts
+++ b/src/lib/processes/config.ts
@@ -6,6 +6,7 @@ import { existsSync, readFileSync } from 'fs';
 import { join } from 'path';
 import type { ProcessesConfig, ProcessDefinition, ProcessInstanceSpec } from '../../types/processes.js';
 import { validateProcessesConfig } from './schema.js';
+import { normalizeProcessInstanceCount } from './instances.js';
 
 export interface ProcessesConfigLoadResult {
   config: ProcessesConfig;
@@ -170,7 +171,7 @@ export function loadProcessesConfig(workspacePath: string): ProcessesConfig {
 export function getProcessInstances(config: ProcessesConfig): ProcessInstanceSpec[] {
   const instances: ProcessInstanceSpec[] = [];
   for (const process of config.processes) {
-    const count = Math.max(1, process.instances ?? 1);
+    const count = normalizeProcessInstanceCount(process.instances);
     for (let idx = 1; idx <= count; idx++) {
       instances.push({ name: process.name, instance: idx, definition: process });
     }

--- a/src/lib/processes/config.ts
+++ b/src/lib/processes/config.ts
@@ -17,8 +17,19 @@ export function loadProcessesConfig(workspacePath: string): ProcessesConfig {
     return { processes: [] };
   }
 
-  const raw = readFileSync(path, 'utf-8');
-  const parsed = JSON.parse(raw) as ProcessesConfig;
+  const raw = readFileSync(path, 'utf-8').trim();
+  if (!raw) {
+    return { processes: [] };
+  }
+
+  let parsed: ProcessesConfig;
+  try {
+    parsed = JSON.parse(raw) as ProcessesConfig;
+  } catch {
+    console.warn(`[processes] Failed to parse ${path}`);
+    return { processes: [] };
+  }
+
   const normalized: ProcessesConfig = {
     processes: Array.isArray(parsed.processes) ? parsed.processes : [],
   };

--- a/src/lib/processes/control.ts
+++ b/src/lib/processes/control.ts
@@ -4,6 +4,7 @@
 
 import { existsSync, mkdirSync, rmSync, writeFileSync } from 'fs';
 import { join } from 'path';
+import { encodeProcessNameForPath } from './names.js';
 
 export function getProcessControlDir(workspacePath: string): string {
   return join(workspacePath, '.gitspace', '.processes');
@@ -18,7 +19,7 @@ export function getProcessDisablePath(
   name: string,
   instance: number
 ): string {
-  return join(getProcessDisableDir(workspacePath), `${name}-${instance}`);
+  return join(getProcessDisableDir(workspacePath), `${encodeProcessNameForPath(name)}-${instance}`);
 }
 
 export function disableProcessRestart(

--- a/src/lib/processes/control.ts
+++ b/src/lib/processes/control.ts
@@ -1,0 +1,52 @@
+/**
+ * Process control helpers (disable/enable restarts)
+ */
+
+import { existsSync, mkdirSync, rmSync, writeFileSync } from 'fs';
+import { join } from 'path';
+
+export function getProcessControlDir(workspacePath: string): string {
+  return join(workspacePath, '.gitspace', '.processes');
+}
+
+export function getProcessDisableDir(workspacePath: string): string {
+  return join(getProcessControlDir(workspacePath), 'disabled');
+}
+
+export function getProcessDisablePath(
+  workspacePath: string,
+  name: string,
+  instance: number
+): string {
+  return join(getProcessDisableDir(workspacePath), `${name}-${instance}`);
+}
+
+export function disableProcessRestart(
+  workspacePath: string,
+  name: string,
+  instance: number
+): void {
+  const dir = getProcessDisableDir(workspacePath);
+  mkdirSync(dir, { recursive: true });
+  const file = getProcessDisablePath(workspacePath, name, instance);
+  writeFileSync(file, new Date().toISOString(), 'utf-8');
+}
+
+export function enableProcessRestart(
+  workspacePath: string,
+  name: string,
+  instance: number
+): void {
+  const file = getProcessDisablePath(workspacePath, name, instance);
+  if (existsSync(file)) {
+    rmSync(file, { force: true });
+  }
+}
+
+export function isProcessRestartDisabled(
+  workspacePath: string,
+  name: string,
+  instance: number
+): boolean {
+  return existsSync(getProcessDisablePath(workspacePath, name, instance));
+}

--- a/src/lib/processes/editor.ts
+++ b/src/lib/processes/editor.ts
@@ -1,0 +1,32 @@
+export const PROCESSES_CONFIG_TEMPLATE = [
+  '{',
+  '  // Managed process definitions for this workspace.',
+  '  // Uncomment and edit the example below, then save and exit.',
+  '  "processes": [',
+  '    // {',
+  '    //   "name": "web",',
+  '    //   "command": "bun",',
+  '    //   "args": ["run", "dev"],',
+  '    //   "autostart": false',
+  '    // }',
+  '  ]',
+  '}',
+  '',
+].join('\n');
+
+export function buildEditProcessesCommand(): { command: string; args: string[] } {
+  const shellScript = [
+    'mkdir -p .gitspace',
+    'if [ ! -f .gitspace/processes.json ]; then',
+    "  cat > .gitspace/processes.json <<'JSONC'",
+    PROCESSES_CONFIG_TEMPLATE,
+    'JSONC',
+    'fi',
+    'exec "${EDITOR:-vi}" .gitspace/processes.json',
+  ].join('\n');
+
+  return {
+    command: 'sh',
+    args: ['-c', shellScript],
+  };
+}

--- a/src/lib/processes/events-config.ts
+++ b/src/lib/processes/events-config.ts
@@ -1,0 +1,37 @@
+/**
+ * Process-level events config overrides
+ */
+
+import type { EventsConfig } from '../../types/config.js';
+import type { ProcessDefinition } from '../../types/processes.js';
+import { getProjectEventsConfig } from '../../core/config.js';
+
+export function buildProcessEventsConfig(
+  projectName: string,
+  definition?: ProcessDefinition
+): EventsConfig {
+  const baseConfig = getProjectEventsConfig(projectName);
+
+  if (!definition?.events) {
+    return baseConfig;
+  }
+
+  let merged: EventsConfig = {
+    ...baseConfig,
+    ...definition.events,
+    fields: {
+      ...baseConfig.fields,
+      ...(definition.events?.fields || {}),
+    },
+    rotation: {
+      ...baseConfig.rotation,
+      ...(definition.events?.rotation || {}),
+    },
+  };
+
+  if (definition.events.enabled === false) {
+    merged = { ...merged, enabled: false };
+  }
+
+  return merged;
+}

--- a/src/lib/processes/index.ts
+++ b/src/lib/processes/index.ts
@@ -1,0 +1,14 @@
+/**
+ * Process manager exports
+ */
+
+export * from './config.js';
+export * from './manager.js';
+export * from './watchdog.js';
+export * from './scheduler.js';
+export * from './autostart.js';
+export * from './registry.js';
+export * from './names.js';
+export * from './events-config.js';
+export * from './schema.js';
+export * from './control.js';

--- a/src/lib/processes/instances.ts
+++ b/src/lib/processes/instances.ts
@@ -1,0 +1,20 @@
+/**
+ * Normalize configured process instance count.
+ *
+ * Semantics:
+ * - undefined/null => 1
+ * - 0 => disabled process definition
+ * - positive integers => exact instance count
+ * - invalid/non-integer values => 1 (defensive fallback)
+ */
+export function normalizeProcessInstanceCount(instances?: number): number {
+  if (instances === undefined || instances === null) {
+    return 1;
+  }
+
+  if (!Number.isInteger(instances)) {
+    return 1;
+  }
+
+  return Math.max(0, instances);
+}

--- a/src/lib/processes/manager.ts
+++ b/src/lib/processes/manager.ts
@@ -25,7 +25,7 @@ export interface ProcessRunResult {
 
 export async function listProcessSessions(workspacePath: string): Promise<ProcessSessionInfo[]> {
   const sessions = await listSessions();
-  const workspaceId = workspacePath.split('/').pop() ?? workspacePath;
+  const isWorkspaceMatch = (cwd: string) => cwd === workspacePath || cwd.startsWith(`${workspacePath}/`);
   return sessions
     .filter((session) => session.name.startsWith('proc:'))
     .map((session) => {
@@ -40,10 +40,7 @@ export async function listProcessSessions(workspacePath: string): Promise<Proces
       };
     })
     .filter((item): item is ProcessSessionInfo => Boolean(item))
-    .filter((item) =>
-      item.name.includes(`:${workspaceId}:`) &&
-      (item.workspacePath === workspacePath || item.workspacePath.startsWith(workspacePath))
-    );
+    .filter((item) => isWorkspaceMatch(item.workspacePath));
 }
 
 export function loadWorkspaceProcesses(workspacePath: string): ProcessesConfig {

--- a/src/lib/processes/manager.ts
+++ b/src/lib/processes/manager.ts
@@ -1,0 +1,134 @@
+/**
+ * Workspace process manager
+ */
+
+import { join } from 'path';
+import { listSessions, createSession, killSession } from '../tmux-lite/cli.js';
+import type { ProcessInstanceSpec, ProcessDefinition, ProcessesConfig } from '../../types/processes.js';
+import { getProcessInstances, loadProcessesConfig } from './config.js';
+import { buildProcessSessionName, parseProcessSessionName } from './names.js';
+import { enableProcessRestart, disableProcessRestart } from './control.js';
+import { markProcessStarted, clearProcessExit } from './state.js';
+
+export interface ProcessSessionInfo {
+  sessionId: string;
+  name: string;
+  workspacePath: string;
+  processName: string;
+  instance: number;
+}
+
+export interface ProcessRunResult {
+  sessionId: string;
+  created: boolean;
+}
+
+export async function listProcessSessions(workspacePath: string): Promise<ProcessSessionInfo[]> {
+  const sessions = await listSessions();
+  const workspaceId = workspacePath.split('/').pop() ?? workspacePath;
+  return sessions
+    .filter((session) => session.name.startsWith('proc:'))
+    .map((session) => {
+      const parsed = parseProcessSessionName(session.name);
+      if (!parsed) return null;
+      return {
+        sessionId: session.id,
+        name: session.name,
+        workspacePath: session.cwd,
+        processName: parsed.processName,
+        instance: parsed.instance,
+      };
+    })
+    .filter((item): item is ProcessSessionInfo => Boolean(item))
+    .filter((item) =>
+      item.name.includes(`:${workspaceId}:`) &&
+      (item.workspacePath === workspacePath || item.workspacePath.startsWith(workspacePath))
+    );
+}
+
+export function loadWorkspaceProcesses(workspacePath: string): ProcessesConfig {
+  return loadProcessesConfig(workspacePath);
+}
+
+export async function startProcessInstance(
+  workspacePath: string,
+  spec: ProcessInstanceSpec
+): Promise<ProcessRunResult> {
+  const existing = await listProcessSessions(workspacePath);
+  const target = existing.find(
+    (item) => item.processName === spec.name && item.instance === spec.instance
+  );
+
+  if (target) {
+    enableProcessRestart(workspacePath, spec.name, spec.instance);
+    markProcessStarted(workspacePath, spec.name, spec.instance);
+    clearProcessExit(workspacePath, spec.name, spec.instance);
+    return { sessionId: target.sessionId, created: false };
+  }
+
+  if (!spec.definition.command) {
+    throw new Error(`Process ${spec.name} is missing a command`);
+  }
+
+  const workspaceId = workspacePath.split('/').pop() ?? workspacePath;
+  const sessionName = buildProcessSessionName(workspaceId, spec.name, spec.instance);
+  const cwd = spec.definition.cwd
+    ? join(workspacePath, spec.definition.cwd)
+    : workspacePath;
+
+  const runnerArgs = [
+    "--internal-process-runner",
+    "--workspace",
+    workspacePath,
+    "--process",
+    spec.name,
+    "--instance",
+    String(spec.instance),
+  ];
+
+  const devScript = process.execPath.endsWith('bun')
+    ? [join(import.meta.dir, "../../index.ts"), ...runnerArgs]
+    : runnerArgs;
+
+  const session = await createSession(sessionName, cwd, {
+    command: process.execPath,
+    args: devScript,
+    env: spec.definition.env,
+  });
+
+  enableProcessRestart(workspacePath, spec.name, spec.instance);
+  markProcessStarted(workspacePath, spec.name, spec.instance);
+  clearProcessExit(workspacePath, spec.name, spec.instance);
+
+  return { sessionId: session.id, created: true };
+}
+
+export async function stopProcessInstance(
+  workspacePath: string,
+  spec: ProcessInstanceSpec
+): Promise<void> {
+  const sessions = await listProcessSessions(workspacePath);
+  const target = sessions.find(
+    (item) => item.processName === spec.name && item.instance === spec.instance
+  );
+  if (!target) return;
+  disableProcessRestart(workspacePath, spec.name, spec.instance);
+  clearProcessExit(workspacePath, spec.name, spec.instance);
+  await killSession(target.sessionId);
+}
+
+export function getRestartConfig(definition: ProcessDefinition) {
+  return {
+    policy: definition.restart?.policy ?? 'never',
+    maxAttempts: definition.restart?.maxAttempts ?? 5,
+    backoffMs: definition.restart?.backoffMs ?? 2000,
+    maxBackoffMs: definition.restart?.maxBackoffMs ?? 30000,
+  };
+}
+
+export function getProcessSpecs(workspacePath: string): ProcessInstanceSpec[] {
+  const config = loadProcessesConfig(workspacePath);
+  return getProcessInstances(config);
+}
+
+export { buildProcessSessionName, parseProcessSessionName } from './names.js';

--- a/src/lib/processes/names.ts
+++ b/src/lib/processes/names.ts
@@ -1,0 +1,32 @@
+/**
+ * Process session naming helpers
+ */
+
+export const PROCESS_SESSION_PREFIX = 'proc';
+export const PROCESS_SESSION_MAX_NAME = 64;
+
+export function buildProcessSessionName(
+  workspaceId: string,
+  processName: string,
+  instance: number
+): string {
+  const base = `${PROCESS_SESSION_PREFIX}:${workspaceId}:${processName}:${instance}`;
+  if (base.length <= PROCESS_SESSION_MAX_NAME) {
+    return base;
+  }
+  return base.slice(0, PROCESS_SESSION_MAX_NAME);
+}
+
+export function parseProcessSessionName(name: string): {
+  workspaceId: string;
+  processName: string;
+  instance: number;
+} | null {
+  if (!name.startsWith(`${PROCESS_SESSION_PREFIX}:`)) return null;
+  const parts = name.split(':');
+  if (parts.length < 4) return null;
+  const [, workspaceId, processName, instanceRaw] = parts;
+  const instance = Number(instanceRaw);
+  if (!workspaceId || !processName || Number.isNaN(instance)) return null;
+  return { workspaceId, processName, instance };
+}

--- a/src/lib/processes/names.ts
+++ b/src/lib/processes/names.ts
@@ -17,13 +17,45 @@ export function buildProcessSessionName(
   processName: string,
   instance: number
 ): string {
-  const base = `${PROCESS_SESSION_PREFIX}:${workspaceId}:${processName}:${instance}`;
-  if (base.length <= PROCESS_SESSION_MAX_NAME) {
-    return base;
+  const instancePart = String(instance);
+  const prefix = `${PROCESS_SESSION_PREFIX}:`;
+  let workspacePart = workspaceId;
+  let processPart = processName;
+
+  const build = () => `${prefix}${workspacePart}:${processPart}:${instancePart}`;
+
+  let candidate = build();
+  if (candidate.length <= PROCESS_SESSION_MAX_NAME) {
+    return candidate;
   }
-  return base.slice(0, PROCESS_SESSION_MAX_NAME);
+
+  const maxWorkspaceLength = Math.max(
+    1,
+    PROCESS_SESSION_MAX_NAME - (prefix.length + 2 + instancePart.length + processPart.length)
+  );
+  if (workspacePart.length > maxWorkspaceLength) {
+    workspacePart = workspacePart.slice(0, maxWorkspaceLength);
+    candidate = build();
+  }
+
+  if (candidate.length > PROCESS_SESSION_MAX_NAME) {
+    const maxProcessLength = Math.max(
+      1,
+      PROCESS_SESSION_MAX_NAME - (prefix.length + 2 + instancePart.length + workspacePart.length)
+    );
+    processPart = processPart.slice(0, maxProcessLength);
+    candidate = build();
+  }
+
+  return candidate;
 }
 
+/**
+ * Parse a process session name in the format:
+ * `proc:<workspaceId>:<processName>:<instance>`
+ *
+ * Note: `<workspaceId>` and `<processName>` must not contain `:`.
+ */
 export function parseProcessSessionName(name: string): {
   workspaceId: string;
   processName: string;

--- a/src/lib/processes/names.ts
+++ b/src/lib/processes/names.ts
@@ -5,6 +5,13 @@
 export const PROCESS_SESSION_PREFIX = 'proc';
 export const PROCESS_SESSION_MAX_NAME = 64;
 
+/**
+ * Encode a process name for use as a single filesystem path segment.
+ */
+export function encodeProcessNameForPath(processName: string): string {
+  return encodeURIComponent(processName);
+}
+
 export function buildProcessSessionName(
   workspaceId: string,
   processName: string,

--- a/src/lib/processes/registry.ts
+++ b/src/lib/processes/registry.ts
@@ -1,0 +1,26 @@
+/**
+ * Process registry helpers
+ */
+
+import { join } from 'path';
+import type { ProcessDefinition, ProcessInstanceSpec } from '../../types/processes.js';
+import { loadProcessesConfig, getProcessInstances } from './config.js';
+
+export interface WorkspaceProcessRegistry {
+  workspacePath: string;
+  processes: ProcessDefinition[];
+  instances: ProcessInstanceSpec[];
+}
+
+export function loadProcessRegistry(workspacePath: string): WorkspaceProcessRegistry {
+  const config = loadProcessesConfig(workspacePath);
+  return {
+    workspacePath,
+    processes: config.processes,
+    instances: getProcessInstances(config),
+  };
+}
+
+export function resolveProcessCwd(workspacePath: string, cwd?: string): string {
+  return cwd ? join(workspacePath, cwd) : workspacePath;
+}

--- a/src/lib/processes/runner.ts
+++ b/src/lib/processes/runner.ts
@@ -1,0 +1,207 @@
+#!/usr/bin/env bun
+/**
+ * Process runner + event collector
+ */
+
+import { spawn } from "bun";
+import { readFileSync } from "fs";
+import { join } from "path";
+import { WideEventCollector } from "../events/collector.js";
+import { buildProcessEventsConfig } from "./events-config.js";
+import { loadProcessesConfig, getProcessDefinition } from "./config.js";
+import { recordProcessExit } from "./state.js";
+import type { WideEvent } from "../../types/events.js";
+
+interface RunnerOptions {
+  workspacePath: string;
+  processName: string;
+  instance: number;
+}
+
+function parseArgs(argv: string[]): RunnerOptions {
+  const args = new Map<string, string>();
+  const filtered = argv.filter((arg) => arg !== "--internal-process-runner");
+  for (let i = 0; i < filtered.length; i += 2) {
+    const key = filtered[i];
+    const value = filtered[i + 1];
+    if (!key || !value) {
+      continue;
+    }
+    args.set(key, value);
+  }
+
+  const workspacePath = args.get("--workspace");
+  const processName = args.get("--process");
+  const instanceRaw = args.get("--instance");
+
+  if (!workspacePath || !processName || !instanceRaw) {
+    throw new Error("Usage: --workspace <path> --process <name> --instance <n>");
+  }
+
+  const instance = Number.parseInt(instanceRaw, 10);
+  if (!Number.isFinite(instance) || instance <= 0) {
+    throw new Error(`Invalid instance value: ${instanceRaw}`);
+  }
+
+  return { workspacePath, processName, instance };
+}
+
+function printEventLine(event: WideEvent): void {
+  const level = event.level.toUpperCase();
+  const message = event.message.trim();
+  const label = `${event.eventName} (${event.eventId})`;
+  console.log(`[event:${level}] ${label} — ${message}`);
+}
+
+function shouldSuppressRaw(definition: ReturnType<typeof getProcessDefinition>): boolean {
+  if (!definition) return true;
+  if (definition.events?.enabled === false) return true;
+  if (definition.events?.mode === "json") return false;
+  return definition.events?.keepRawOutput === true ? false : true;
+}
+
+async function run(): Promise<void> {
+  const opts = parseArgs(process.argv.slice(2));
+  const config = loadProcessesConfig(opts.workspacePath);
+  const definition = getProcessDefinition(config, opts.processName);
+
+  if (!definition?.command) {
+    throw new Error(`Process ${opts.processName} is missing command`);
+  }
+
+  const cwd = definition.cwd ? join(opts.workspacePath, definition.cwd) : opts.workspacePath;
+  const commandArgs = [definition.command, ...(definition.args ?? [])];
+  const env = {
+    ...process.env,
+    ...(definition.env ?? {}),
+    GITSPACE_PROCESS_NAME: opts.processName,
+    GITSPACE_PROCESS_INSTANCE: String(opts.instance),
+    TMUX_LITE: process.env.TMUX_LITE ?? "runner",
+  } as Record<string, string>;
+
+  const processName = opts.processName;
+  const workspaceId = opts.workspacePath.split("/").pop() ?? opts.workspacePath;
+  const projectName = opts.workspacePath.split("/").slice(-3, -2)[0] ?? "";
+  const eventsConfig = buildProcessEventsConfig(projectName, definition);
+
+  const collector = new WideEventCollector({
+    config: eventsConfig,
+    sessionId: "",
+    workspacePath: opts.workspacePath,
+    workspaceId,
+    projectName,
+    processName,
+    processInstance: opts.instance,
+  });
+
+  const suppressRaw = shouldSuppressRaw(definition);
+  const prefix = eventsConfig.prefix || "@event";
+
+  let stdoutBuffer = "";
+  let stderrBuffer = "";
+
+  const child = spawn({
+    cmd: commandArgs,
+    cwd,
+    env,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const handleChunk = (data: Uint8Array, stream: "stdout" | "stderr") => {
+    const buffer = Buffer.from(data);
+    const rawText = buffer.toString("utf-8");
+
+    const pending = stream === "stdout" ? stdoutBuffer : stderrBuffer;
+    const combined = pending + rawText;
+    const parts = combined.split("\n");
+
+    let remainder = "";
+    if (combined.endsWith("\n")) {
+      parts.pop();
+    } else {
+      remainder = parts.pop() ?? "";
+    }
+
+    if (stream === "stdout") {
+      stdoutBuffer = remainder;
+    } else {
+      stderrBuffer = remainder;
+    }
+
+    const eventLines: string[] = [];
+    let nonEventPayload = "";
+    let hasNonEventContent = false;
+
+    for (const line of parts) {
+      const trimmed = line.trim();
+      if (trimmed.startsWith(prefix)) {
+        eventLines.push(trimmed);
+      } else {
+        nonEventPayload += `${line}\n`;
+        if (trimmed.length > 0) {
+          hasNonEventContent = true;
+        }
+      }
+    }
+
+    if (!suppressRaw) {
+      if (stream === "stderr") {
+        process.stderr.write(buffer);
+      } else {
+        process.stdout.write(buffer);
+      }
+    } else if (hasNonEventContent) {
+      if (stream === "stderr") {
+        process.stderr.write(nonEventPayload);
+      } else {
+        process.stdout.write(nonEventPayload);
+      }
+    }
+
+    if (eventLines.length > 0) {
+      const eventBuffer = Buffer.from(eventLines.join("\n") + "\n");
+      const events = collector.handleChunk(eventBuffer);
+      for (const event of events) {
+        printEventLine(event);
+      }
+    }
+  };
+
+  const stdoutStream = child.stdout as ReadableStream<Uint8Array> | null;
+  if (stdoutStream) {
+    const reader = stdoutStream.getReader();
+    (async () => {
+      while (true) {
+        const { value, done } = await reader.read();
+        if (done || !value) break;
+        handleChunk(value, "stdout");
+      }
+    })();
+  }
+
+  const stderrStream = child.stderr as ReadableStream<Uint8Array> | null;
+  if (stderrStream) {
+    const reader = stderrStream.getReader();
+    (async () => {
+      while (true) {
+        const { value, done } = await reader.read();
+        if (done || !value) break;
+        handleChunk(value, "stderr");
+      }
+    })();
+  }
+
+  const exitCode = await child.exited;
+  collector.finalize();
+  try {
+    recordProcessExit(opts.workspacePath, opts.processName, opts.instance, exitCode ?? 0);
+  } catch {}
+  process.exit(exitCode ?? 0);
+}
+
+run().catch((error) => {
+  const message = error instanceof Error ? error.message : String(error);
+  console.error(`process runner failed: ${message}`);
+  process.exit(1);
+});

--- a/src/lib/processes/runner.ts
+++ b/src/lib/processes/runner.ts
@@ -169,30 +169,34 @@ async function run(): Promise<void> {
   };
 
   const stdoutStream = child.stdout as ReadableStream<Uint8Array> | null;
+  const streamDrains: Array<Promise<void>> = [];
   if (stdoutStream) {
     const reader = stdoutStream.getReader();
-    (async () => {
+    const drain = (async () => {
       while (true) {
         const { value, done } = await reader.read();
         if (done || !value) break;
         handleChunk(value, "stdout");
       }
     })();
+    streamDrains.push(drain);
   }
 
   const stderrStream = child.stderr as ReadableStream<Uint8Array> | null;
   if (stderrStream) {
     const reader = stderrStream.getReader();
-    (async () => {
+    const drain = (async () => {
       while (true) {
         const { value, done } = await reader.read();
         if (done || !value) break;
         handleChunk(value, "stderr");
       }
     })();
+    streamDrains.push(drain);
   }
 
   const exitCode = await child.exited;
+  await Promise.all(streamDrains);
   collector.finalize();
   try {
     recordProcessExit(opts.workspacePath, opts.processName, opts.instance, exitCode ?? 0);

--- a/src/lib/processes/scheduler.ts
+++ b/src/lib/processes/scheduler.ts
@@ -1,0 +1,17 @@
+/**
+ * Process scheduler loop
+ */
+
+import { getProcessSpecs } from './manager.js';
+import { reconcileProcessRestarts } from './watchdog.js';
+
+const DEFAULT_INTERVAL_MS = 5000;
+
+export function startProcessScheduler(workspacePath: string, intervalMs = DEFAULT_INTERVAL_MS): NodeJS.Timer {
+  const timer = setInterval(() => {
+    const specs = getProcessSpecs(workspacePath);
+    void reconcileProcessRestarts(workspacePath, specs);
+  }, intervalMs);
+
+  return timer;
+}

--- a/src/lib/processes/schema.ts
+++ b/src/lib/processes/schema.ts
@@ -32,6 +32,12 @@ export function validateProcessesConfig(config: ProcessesConfig): ProcessValidat
       errors.push(`process ${process.name} missing command`);
     }
 
+    if (process.instances !== undefined) {
+      if (!Number.isInteger(process.instances) || process.instances < 0) {
+        errors.push(`process ${process.name} instances must be a non-negative integer`);
+      }
+    }
+
     if (process.events?.keepRawOutput !== undefined && typeof process.events.keepRawOutput !== 'boolean') {
       errors.push(`process ${process.name} keepRawOutput must be a boolean`);
     }

--- a/src/lib/processes/schema.ts
+++ b/src/lib/processes/schema.ts
@@ -1,0 +1,68 @@
+/**
+ * Process schema utilities
+ */
+
+import type { ProcessesConfig, ProcessDefinition } from '../../types/processes.js';
+
+export interface ProcessValidationResult {
+  valid: boolean;
+  errors: string[];
+}
+
+export function validateProcessesConfig(config: ProcessesConfig): ProcessValidationResult {
+  const errors: string[] = [];
+
+  if (!Array.isArray(config.processes)) {
+    errors.push('processes must be an array');
+    return { valid: false, errors };
+  }
+
+  const names = new Set<string>();
+  for (const process of config.processes) {
+    if (!process.name) {
+      errors.push('process is missing name');
+      continue;
+    }
+    if (names.has(process.name)) {
+      errors.push(`duplicate process name: ${process.name}`);
+    }
+    names.add(process.name);
+
+    if (!process.command) {
+      errors.push(`process ${process.name} missing command`);
+    }
+
+    if (process.events?.keepRawOutput !== undefined && typeof process.events.keepRawOutput !== 'boolean') {
+      errors.push(`process ${process.name} keepRawOutput must be a boolean`);
+    }
+
+    if (process.ports !== undefined) {
+      if (!Array.isArray(process.ports)) {
+        errors.push(`process ${process.name} ports must be an array`);
+      } else {
+        for (const port of process.ports) {
+          if (!port || typeof port !== 'object') {
+            errors.push(`process ${process.name} port entries must be objects`);
+            continue;
+          }
+          if (!Number.isInteger(port.port) || port.port <= 0 || port.port > 65535) {
+            errors.push(`process ${process.name} port must be a number between 1 and 65535`);
+          }
+          if (port.name !== undefined && typeof port.name !== 'string') {
+            errors.push(`process ${process.name} port name must be a string`);
+          }
+          if (port.protocol !== undefined && port.protocol !== 'http' && port.protocol !== 'tcp') {
+            errors.push(`process ${process.name} port protocol must be http or tcp`);
+          }
+        }
+      }
+    }
+  }
+
+  return { valid: errors.length === 0, errors };
+}
+
+export function describeProcess(process: ProcessDefinition): string {
+  const args = process.args?.join(' ') ?? '';
+  return `${process.name}: ${process.command} ${args}`.trim();
+}

--- a/src/lib/processes/session-list.ts
+++ b/src/lib/processes/session-list.ts
@@ -1,0 +1,15 @@
+/**
+ * Process session list helpers
+ */
+
+import type { Session } from '../tmux-lite/protocol.js';
+import { parseProcessSessionName } from './manager.js';
+
+export function decorateSessionWithProcess(session: Session) {
+  const parsed = parseProcessSessionName(session.name);
+  return {
+    ...session,
+    processName: parsed?.processName,
+    processInstance: parsed?.instance,
+  };
+}

--- a/src/lib/processes/state.ts
+++ b/src/lib/processes/state.ts
@@ -1,0 +1,81 @@
+/**
+ * Process state helpers (started + last exit)
+ */
+
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { getProcessControlDir } from './control.js';
+
+export interface ProcessExitInfo {
+  exitCode: number;
+  exitedAt: number;
+}
+
+function getStartedDir(workspacePath: string): string {
+  return join(getProcessControlDir(workspacePath), 'started');
+}
+
+function getExitDir(workspacePath: string): string {
+  return join(getProcessControlDir(workspacePath), 'exit');
+}
+
+function getStartedPath(workspacePath: string, name: string, instance: number): string {
+  return join(getStartedDir(workspacePath), `${name}-${instance}`);
+}
+
+function getExitPath(workspacePath: string, name: string, instance: number): string {
+  return join(getExitDir(workspacePath), `${name}-${instance}.json`);
+}
+
+export function markProcessStarted(workspacePath: string, name: string, instance: number): void {
+  const dir = getStartedDir(workspacePath);
+  mkdirSync(dir, { recursive: true });
+  const file = getStartedPath(workspacePath, name, instance);
+  writeFileSync(file, String(Date.now()), 'utf-8');
+}
+
+export function hasProcessStarted(workspacePath: string, name: string, instance: number): boolean {
+  return existsSync(getStartedPath(workspacePath, name, instance));
+}
+
+export function recordProcessExit(
+  workspacePath: string,
+  name: string,
+  instance: number,
+  exitCode: number,
+  exitedAt = Date.now()
+): void {
+  const dir = getExitDir(workspacePath);
+  mkdirSync(dir, { recursive: true });
+  const file = getExitPath(workspacePath, name, instance);
+  const payload = JSON.stringify({ exitCode, exitedAt });
+  writeFileSync(file, payload, 'utf-8');
+}
+
+export function readProcessExit(
+  workspacePath: string,
+  name: string,
+  instance: number
+): ProcessExitInfo | null {
+  const file = getExitPath(workspacePath, name, instance);
+  if (!existsSync(file)) return null;
+  try {
+    const raw = readFileSync(file, 'utf-8');
+    const parsed = JSON.parse(raw) as ProcessExitInfo;
+    if (
+      parsed &&
+      typeof parsed.exitCode === 'number' &&
+      typeof parsed.exitedAt === 'number'
+    ) {
+      return parsed;
+    }
+  } catch {}
+  return null;
+}
+
+export function clearProcessExit(workspacePath: string, name: string, instance: number): void {
+  const file = getExitPath(workspacePath, name, instance);
+  if (existsSync(file)) {
+    rmSync(file, { force: true });
+  }
+}

--- a/src/lib/processes/state.ts
+++ b/src/lib/processes/state.ts
@@ -5,6 +5,7 @@
 import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import { getProcessControlDir } from './control.js';
+import { encodeProcessNameForPath } from './names.js';
 
 export interface ProcessExitInfo {
   exitCode: number;
@@ -20,11 +21,11 @@ function getExitDir(workspacePath: string): string {
 }
 
 function getStartedPath(workspacePath: string, name: string, instance: number): string {
-  return join(getStartedDir(workspacePath), `${name}-${instance}`);
+  return join(getStartedDir(workspacePath), `${encodeProcessNameForPath(name)}-${instance}`);
 }
 
 function getExitPath(workspacePath: string, name: string, instance: number): string {
-  return join(getExitDir(workspacePath), `${name}-${instance}.json`);
+  return join(getExitDir(workspacePath), `${encodeProcessNameForPath(name)}-${instance}.json`);
 }
 
 export function markProcessStarted(workspacePath: string, name: string, instance: number): void {

--- a/src/lib/processes/watchdog.test.ts
+++ b/src/lib/processes/watchdog.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, test } from "bun:test";
+import type { ProcessInstanceSpec } from "../../types/processes.js";
+import { reconcileProcessRestarts, type ProcessWatchdogDeps } from "./watchdog.js";
+
+function buildSpec(name: string, policy: "never" | "on-failure" | "always"): ProcessInstanceSpec {
+  return {
+    name,
+    instance: 1,
+    definition: {
+      name,
+      command: "echo",
+      restart: {
+        policy,
+        maxAttempts: 3,
+        backoffMs: 10,
+        maxBackoffMs: 100,
+      },
+    },
+  };
+}
+
+describe("process watchdog", () => {
+  test("does not restart when never started", async () => {
+    const spec = buildSpec("never-started", "always");
+    const started: string[] = [];
+
+    const deps: ProcessWatchdogDeps = {
+      listSessions: async () => [],
+      startProcessInstance: async (_workspace, target) => {
+        started.push(`${target.name}:${target.instance}`);
+        return { sessionId: "s1", created: true };
+      },
+      isProcessRestartDisabled: () => false,
+      hasProcessStarted: () => false,
+    };
+
+    await reconcileProcessRestarts("/tmp/workspace", [spec], deps);
+    expect(started.length).toBe(0);
+  });
+
+  test("restarts missing session when started and exit was non-zero", async () => {
+    const spec = buildSpec("crashed-process", "on-failure");
+    const started: string[] = [];
+
+    const deps: ProcessWatchdogDeps = {
+      listSessions: async () => [],
+      startProcessInstance: async (_workspace, target) => {
+        started.push(`${target.name}:${target.instance}`);
+        return { sessionId: "s2", created: true };
+      },
+      isProcessRestartDisabled: () => false,
+      hasProcessStarted: () => true,
+      readProcessExit: () => ({ exitCode: 1, exitedAt: 123 }),
+      now: () => 1000,
+    };
+
+    await reconcileProcessRestarts("/tmp/workspace", [spec], deps);
+    expect(started).toEqual(["crashed-process:1"]);
+  });
+
+  test("does not restart on-failure when last exit was clean", async () => {
+    const spec = buildSpec("clean-exit", "on-failure");
+    const started: string[] = [];
+
+    const deps: ProcessWatchdogDeps = {
+      listSessions: async () => [],
+      startProcessInstance: async (_workspace, target) => {
+        started.push(`${target.name}:${target.instance}`);
+        return { sessionId: "s3", created: true };
+      },
+      isProcessRestartDisabled: () => false,
+      hasProcessStarted: () => true,
+      readProcessExit: () => ({ exitCode: 0, exitedAt: 456 }),
+    };
+
+    await reconcileProcessRestarts("/tmp/workspace", [spec], deps);
+    expect(started.length).toBe(0);
+  });
+});

--- a/src/lib/processes/watchdog.ts
+++ b/src/lib/processes/watchdog.ts
@@ -27,8 +27,8 @@ export interface ProcessWatchdogDeps {
 
 const restartState = new Map<string, ProcessRestartState>();
 
-function getRestartKey(spec: ProcessInstanceSpec): string {
-  return `${spec.name}:${spec.instance}`;
+function getRestartKey(workspacePath: string, spec: ProcessInstanceSpec): string {
+  return `${workspacePath}:${spec.name}:${spec.instance}`;
 }
 
 export async function reconcileProcessRestarts(
@@ -47,7 +47,7 @@ export async function reconcileProcessRestarts(
   const sessions = await listSessionsFn();
 
   for (const spec of specs) {
-    const key = getRestartKey(spec);
+    const key = getRestartKey(workspacePath, spec);
     const restart = getRestartConfig(spec.definition);
     if (restart.policy === 'never') continue;
 

--- a/src/lib/processes/watchdog.ts
+++ b/src/lib/processes/watchdog.ts
@@ -1,0 +1,100 @@
+/**
+ * Process watchdog for restart policies
+ */
+
+import type { ProcessInstanceSpec } from '../../types/processes.js';
+import { listSessions } from '../tmux-lite/cli.js';
+import { parseProcessSessionName, startProcessInstance, getRestartConfig } from './manager.js';
+import { isProcessRestartDisabled, disableProcessRestart } from './control.js';
+import { hasProcessStarted, readProcessExit } from './state.js';
+
+export interface ProcessRestartState {
+  attempts: number;
+  lastStart: number;
+  nextDelay: number;
+  disabled?: boolean;
+}
+
+export interface ProcessWatchdogDeps {
+  listSessions?: typeof listSessions;
+  startProcessInstance?: typeof startProcessInstance;
+  isProcessRestartDisabled?: typeof isProcessRestartDisabled;
+  disableProcessRestart?: typeof disableProcessRestart;
+  hasProcessStarted?: typeof hasProcessStarted;
+  readProcessExit?: typeof readProcessExit;
+  now?: () => number;
+}
+
+const restartState = new Map<string, ProcessRestartState>();
+
+function getRestartKey(spec: ProcessInstanceSpec): string {
+  return `${spec.name}:${spec.instance}`;
+}
+
+export async function reconcileProcessRestarts(
+  workspacePath: string,
+  specs: ProcessInstanceSpec[],
+  deps: ProcessWatchdogDeps = {}
+): Promise<void> {
+  const listSessionsFn = deps.listSessions ?? listSessions;
+  const startProcessInstanceFn = deps.startProcessInstance ?? startProcessInstance;
+  const isProcessRestartDisabledFn = deps.isProcessRestartDisabled ?? isProcessRestartDisabled;
+  const disableProcessRestartFn = deps.disableProcessRestart ?? disableProcessRestart;
+  const hasProcessStartedFn = deps.hasProcessStarted ?? hasProcessStarted;
+  const readProcessExitFn = deps.readProcessExit ?? readProcessExit;
+  const nowFn = deps.now ?? Date.now;
+
+  const sessions = await listSessionsFn();
+
+  for (const spec of specs) {
+    const key = getRestartKey(spec);
+    const restart = getRestartConfig(spec.definition);
+    if (restart.policy === 'never') continue;
+
+    const existing = sessions.find((session) => {
+      const parsed = parseProcessSessionName(session.name);
+      return parsed?.processName === spec.name && parsed.instance === spec.instance;
+    });
+
+    if (isProcessRestartDisabledFn(workspacePath, spec.name, spec.instance)) {
+      continue;
+    }
+
+    const state = restartState.get(key) ?? { attempts: 0, lastStart: 0, nextDelay: restart.backoffMs };
+    if (state.disabled) {
+      continue;
+    }
+
+    if (existing) {
+      restartState.set(key, { ...state, lastStart: nowFn() });
+      continue;
+    }
+
+    if (!hasProcessStartedFn(workspacePath, spec.name, spec.instance)) {
+      continue;
+    }
+
+    if (restart.policy === 'on-failure') {
+      const exitInfo = readProcessExitFn(workspacePath, spec.name, spec.instance);
+      if (exitInfo?.exitCode === 0) {
+        restartState.delete(key);
+        continue;
+      }
+    }
+
+    if (state.attempts >= restart.maxAttempts) {
+      restartState.set(key, { ...state, disabled: true });
+      disableProcessRestartFn(workspacePath, spec.name, spec.instance);
+      continue;
+    }
+
+    const now = nowFn();
+    if (state.lastStart > 0 && now - state.lastStart < state.nextDelay) {
+      continue;
+    }
+
+    await startProcessInstanceFn(workspacePath, spec);
+    const nextDelay = Math.min(state.nextDelay * 2, restart.maxBackoffMs);
+    restartState.set(key, { attempts: state.attempts + 1, lastStart: now, nextDelay });
+  }
+}

--- a/src/lib/processes/watchdog.ts
+++ b/src/lib/processes/watchdog.ts
@@ -53,7 +53,13 @@ export async function reconcileProcessRestarts(
 
     const existing = sessions.find((session) => {
       const parsed = parseProcessSessionName(session.name);
-      return parsed?.processName === spec.name && parsed.instance === spec.instance;
+      const inWorkspace =
+        session.cwd === workspacePath || session.cwd.startsWith(`${workspacePath}/`);
+      return (
+        inWorkspace &&
+        parsed?.processName === spec.name &&
+        parsed.instance === spec.instance
+      );
     });
 
     if (isProcessRestartDisabledFn(workspacePath, spec.name, spec.instance)) {

--- a/src/lib/remote-session/__tests__/protocol.test.ts
+++ b/src/lib/remote-session/__tests__/protocol.test.ts
@@ -1,0 +1,291 @@
+/**
+ * Remote session protocol tests - serialization, parsing, message type coverage
+ */
+
+import { describe, expect, it } from 'bun:test';
+import {
+  parseRemoteMessage,
+  serializeRemoteMessage,
+  isBrowseMessage,
+  type ClientToMachineMessage,
+  type MachineToClientMessage,
+  type GetEventsRequest,
+  type StartProcessRequest,
+  type StopProcessRequest,
+  type EventsListResponse,
+  type ProcessStartedResponse,
+  type ProcessStoppedResponse,
+} from '../protocol.js';
+
+// ============================================================================
+// parseRemoteMessage
+// ============================================================================
+
+describe('parseRemoteMessage', () => {
+  it('should parse valid JSON with type field', () => {
+    const msg = parseRemoteMessage('{"type":"list_workspaces"}');
+    expect(msg).not.toBeNull();
+    expect(msg!.type).toBe('list_workspaces');
+  });
+
+  it('should return null for invalid JSON', () => {
+    expect(parseRemoteMessage('not json')).toBeNull();
+  });
+
+  it('should return null for JSON without type field', () => {
+    expect(parseRemoteMessage('{"foo":"bar"}')).toBeNull();
+  });
+
+  it('should return null for null type', () => {
+    expect(parseRemoteMessage('{"type":null}')).toBeNull();
+  });
+
+  it('should return null for numeric type', () => {
+    expect(parseRemoteMessage('{"type":123}')).toBeNull();
+  });
+});
+
+// ============================================================================
+// serializeRemoteMessage
+// ============================================================================
+
+describe('serializeRemoteMessage', () => {
+  it('should serialize message to JSON', () => {
+    const msg: MachineToClientMessage = {
+      type: 'workspace_list',
+      workspaces: [],
+    };
+    const json = serializeRemoteMessage(msg);
+    const parsed = JSON.parse(json);
+    expect(parsed.type).toBe('workspace_list');
+    expect(parsed.workspaces).toEqual([]);
+  });
+});
+
+// ============================================================================
+// Round-trip: serialize then parse
+// ============================================================================
+
+describe('round-trip serialization', () => {
+  it('should round-trip a GetEventsRequest', () => {
+    const original: GetEventsRequest = {
+      type: 'get_events',
+      workspacePath: '/home/user/workspace',
+      processName: 'web',
+      limit: 100,
+      sinceMs: 1700000000000,
+    };
+    const json = serializeRemoteMessage(original);
+    const parsed = parseRemoteMessage(json) as GetEventsRequest;
+    expect(parsed.type).toBe('get_events');
+    expect(parsed.workspacePath).toBe('/home/user/workspace');
+    expect(parsed.processName).toBe('web');
+    expect(parsed.limit).toBe(100);
+    expect(parsed.sinceMs).toBe(1700000000000);
+  });
+
+  it('should round-trip a StartProcessRequest', () => {
+    const original: StartProcessRequest = {
+      type: 'start_process',
+      workspaceId: 'project:feature-branch',
+      processName: 'dev-server',
+    };
+    const json = serializeRemoteMessage(original);
+    const parsed = parseRemoteMessage(json) as StartProcessRequest;
+    expect(parsed.type).toBe('start_process');
+    expect(parsed.workspaceId).toBe('project:feature-branch');
+    expect(parsed.processName).toBe('dev-server');
+  });
+
+  it('should round-trip a StopProcessRequest', () => {
+    const original: StopProcessRequest = {
+      type: 'stop_process',
+      workspaceId: 'project:feature-branch',
+      processName: 'dev-server',
+    };
+    const json = serializeRemoteMessage(original);
+    const parsed = parseRemoteMessage(json) as StopProcessRequest;
+    expect(parsed.type).toBe('stop_process');
+    expect(parsed.workspaceId).toBe('project:feature-branch');
+    expect(parsed.processName).toBe('dev-server');
+  });
+
+  it('should round-trip an EventsListResponse', () => {
+    const original: EventsListResponse = {
+      type: 'events_list',
+      workspaceId: 'my-workspace',
+      events: [],
+      liveEventIds: ['evt-1', 'evt-2'],
+    };
+    const json = serializeRemoteMessage(original);
+    const parsed = parseRemoteMessage(json) as EventsListResponse;
+    expect(parsed.type).toBe('events_list');
+    expect(parsed.workspaceId).toBe('my-workspace');
+    expect(parsed.events).toEqual([]);
+    expect(parsed.liveEventIds).toEqual(['evt-1', 'evt-2']);
+  });
+
+  it('should round-trip a ProcessStartedResponse', () => {
+    const original: ProcessStartedResponse = {
+      type: 'process_started',
+      workspaceId: 'project:workspace',
+      processName: 'web',
+      sessionId: 'sess-123',
+    };
+    const json = serializeRemoteMessage(original);
+    const parsed = parseRemoteMessage(json) as ProcessStartedResponse;
+    expect(parsed.type).toBe('process_started');
+    expect(parsed.workspaceId).toBe('project:workspace');
+    expect(parsed.processName).toBe('web');
+    expect(parsed.sessionId).toBe('sess-123');
+  });
+
+  it('should round-trip a ProcessStoppedResponse', () => {
+    const original: ProcessStoppedResponse = {
+      type: 'process_stopped',
+      workspaceId: 'project:workspace',
+      processName: 'web',
+    };
+    const json = serializeRemoteMessage(original);
+    const parsed = parseRemoteMessage(json) as ProcessStoppedResponse;
+    expect(parsed.type).toBe('process_stopped');
+    expect(parsed.workspaceId).toBe('project:workspace');
+    expect(parsed.processName).toBe('web');
+  });
+});
+
+// ============================================================================
+// isBrowseMessage
+// ============================================================================
+
+describe('isBrowseMessage', () => {
+  it('should return true for list_workspaces', () => {
+    expect(isBrowseMessage({ type: 'list_workspaces' })).toBe(true);
+  });
+
+  it('should return true for list_sessions', () => {
+    expect(isBrowseMessage({ type: 'list_sessions' })).toBe(true);
+  });
+
+  it('should return true for attach_session', () => {
+    expect(isBrowseMessage({ type: 'attach_session' })).toBe(true);
+  });
+
+  it('should return true for get_events', () => {
+    const msg: GetEventsRequest = {
+      type: 'get_events',
+      workspacePath: '/tmp',
+    };
+    expect(isBrowseMessage(msg)).toBe(true);
+  });
+
+  it('should return false for start_process', () => {
+    const msg: StartProcessRequest = {
+      type: 'start_process',
+      workspaceId: 'ws',
+      processName: 'web',
+    };
+    expect(isBrowseMessage(msg)).toBe(false);
+  });
+
+  it('should return false for stop_process', () => {
+    const msg: StopProcessRequest = {
+      type: 'stop_process',
+      workspaceId: 'ws',
+      processName: 'web',
+    };
+    expect(isBrowseMessage(msg)).toBe(false);
+  });
+
+  it('should return false for response messages', () => {
+    const msg: EventsListResponse = {
+      type: 'events_list',
+      workspaceId: 'ws',
+      events: [],
+      liveEventIds: [],
+    };
+    expect(isBrowseMessage(msg)).toBe(false);
+  });
+});
+
+// ============================================================================
+// ClientToMachineMessage union type coverage
+// ============================================================================
+
+describe('ClientToMachineMessage type coverage', () => {
+  const clientMessages: ClientToMachineMessage[] = [
+    { type: 'list_workspaces' },
+    { type: 'list_sessions' },
+    { type: 'attach_session' },
+    { type: 'list_projects' },
+    { type: 'kill_session', sessionId: 's1' },
+    { type: 'delete_workspace', workspaceId: 'w1', projectName: 'p1' },
+    { type: 'get_inbox' },
+    { type: 'clear_inbox' },
+    { type: 'mark_inbox_read', id: 'i1' },
+    { type: 'get_notification_config' },
+    { type: 'update_notification_config', config: { enabled: true, minCommandDurationMs: 10000, types: { exit: true, idle: true, bell: true, title: true, osc: true }, toast: { enabled: true, holdWhenIdleMs: 15000 } } },
+    { type: 'get_bundle_refresh_plan', projectName: 'p1', workspaceId: 'w1' },
+    { type: 'apply_bundle_refresh', projectName: 'p1', workspaceId: 'w1', submission: { inputValues: {}, secretValues: {}, confirmResults: {} } },
+    { type: 'get_events', workspacePath: '/tmp' },
+    { type: 'start_process', workspaceId: 'w1', processName: 'web' },
+    { type: 'stop_process', workspaceId: 'w1', processName: 'web' },
+  ];
+
+  it('should include all 16 client message types', () => {
+    const types = new Set(clientMessages.map(m => m.type));
+    expect(types.size).toBe(16);
+  });
+
+  it('should all parse successfully via round-trip', () => {
+    for (const msg of clientMessages) {
+      const json = JSON.stringify(msg);
+      const parsed = parseRemoteMessage(json);
+      expect(parsed).not.toBeNull();
+      expect(parsed!.type).toBe(msg.type);
+    }
+  });
+});
+
+// ============================================================================
+// MachineToClientMessage union type coverage
+// ============================================================================
+
+describe('MachineToClientMessage type coverage', () => {
+  const machineMessages: MachineToClientMessage[] = [
+    { type: 'workspace_list', workspaces: [] },
+    { type: 'session_list', sessions: [] },
+    { type: 'attached', sessionId: 's1', sessionName: 'test', cols: 80, rows: 24 },
+    { type: 'detached' },
+    { type: 'session_exited', sessionId: 's1', exitCode: 0 },
+    { type: 'error', code: 'TEST', message: 'test error' },
+    { type: 'project_list', projects: [] },
+    { type: 'session_killed', sessionId: 's1', workspaceId: 'w1' },
+    { type: 'workspace_deleted', workspaceId: 'w1' },
+    { type: 'inbox_list', items: [], unreadCount: 0 },
+    { type: 'inbox_cleared' },
+    { type: 'inbox_marked_read', id: 'i1' },
+    { type: 'notification_config', config: { enabled: true, minCommandDurationMs: 10000, types: { exit: true, idle: true, bell: true, title: true, osc: true }, toast: { enabled: true, holdWhenIdleMs: 15000 } } },
+    { type: 'notification_config_updated', config: { enabled: true, minCommandDurationMs: 10000, types: { exit: true, idle: true, bell: true, title: true, osc: true }, toast: { enabled: true, holdWhenIdleMs: 15000 } } },
+    { type: 'script_output', phase: 'setup', data: '' },
+    { type: 'bundle_refresh_plan', plan: { projectName: 'p1', workspaceId: 'w1', workspaceName: 'w1', workspacePath: '/tmp', hasBundle: false, hasChanged: false, details: '', steps: [], autoConfirmResults: {} } },
+    { type: 'bundle_refresh_applied', projectName: 'p1', workspaceId: 'w1' },
+    { type: 'events_list', workspaceId: 'w1', events: [], liveEventIds: [] },
+    { type: 'process_started', workspaceId: 'w1', processName: 'web' },
+    { type: 'process_stopped', workspaceId: 'w1', processName: 'web' },
+  ];
+
+  it('should include all 20 machine message types', () => {
+    const types = new Set(machineMessages.map(m => m.type));
+    expect(types.size).toBe(20);
+  });
+
+  it('should all parse successfully via round-trip', () => {
+    for (const msg of machineMessages) {
+      const json = serializeRemoteMessage(msg);
+      const parsed = parseRemoteMessage(json);
+      expect(parsed).not.toBeNull();
+      expect(parsed!.type).toBe(msg.type);
+    }
+  });
+});

--- a/src/lib/remote-session/index.ts
+++ b/src/lib/remote-session/index.ts
@@ -4,4 +4,4 @@
 
 export * from "./protocol";
 export * from "./workspace-scanner";
-export { RemoteSessionHandler, type RemoteClientSession, type ClientState } from "./session-handler";
+export { RemoteSessionHandler, type RemoteClientSession, type ClientState, type RemoteSessionHandlerOptions } from "./session-handler";

--- a/src/lib/remote-session/protocol.ts
+++ b/src/lib/remote-session/protocol.ts
@@ -170,6 +170,7 @@ export interface WorkspaceInfo {
   isStale?: boolean;    // No activity for 30+ days
   serveDomain?: string; // Hosting domain for process ports
   processes?: { name: string; instances?: number; ports?: import("../../types/processes.js").ProcessPortConfig[] }[];
+  processConfigError?: string;
 }
 
 /** Session information */

--- a/src/lib/remote-session/protocol.ts
+++ b/src/lib/remote-session/protocol.ts
@@ -54,6 +54,8 @@ export interface AttachSessionRequest {
   command?: string;       // Command to run (process sessions)
   args?: string[];        // Command arguments
   env?: Record<string, string>;  // Environment variables
+  /** When true, the server blocks PTY writes from this client */
+  viewOnly?: boolean;
 }
 
 /** Request wide events for a workspace */

--- a/src/lib/remote-session/protocol.ts
+++ b/src/lib/remote-session/protocol.ts
@@ -330,6 +330,7 @@ export interface EventsListResponse {
   workspaceId: string;
   events: import("../../types/events.js").WideEvent[];
   liveEventIds: string[];
+  savedEventFilters?: import("../../types/events.js").SavedEventFilter[];
   requestId?: string;
   chunkIndex?: number;
   totalChunks?: number;

--- a/src/lib/remote-session/protocol.ts
+++ b/src/lib/remote-session/protocol.ts
@@ -341,6 +341,7 @@ export interface ProcessStartedResponse {
   workspaceId: string;
   processName: string;
   sessionId?: string;
+  sessionIds?: string[];
 }
 
 /** Process stopped response */

--- a/src/lib/remote-session/protocol.ts
+++ b/src/lib/remote-session/protocol.ts
@@ -51,6 +51,33 @@ export interface AttachSessionRequest {
   cols?: number;          // Terminal dimensions
   rows?: number;
   scriptPolicy?: 'auto' | 'skip';
+  command?: string;       // Command to run (process sessions)
+  args?: string[];        // Command arguments
+  env?: Record<string, string>;  // Environment variables
+}
+
+/** Request wide events for a workspace */
+export interface GetEventsRequest {
+  type: "get_events";
+  workspacePath: string;
+  processName?: string;
+  filter?: import("../../types/events.js").WideEventFilter;
+  limit?: number;
+  sinceMs?: number;
+}
+
+/** Start a process in a workspace */
+export interface StartProcessRequest {
+  type: "start_process";
+  workspaceId: string;
+  processName: string;
+}
+
+/** Stop a process in a workspace */
+export interface StopProcessRequest {
+  type: "stop_process";
+  workspaceId: string;
+  processName: string;
 }
 
 /** Request list of projects on the machine */
@@ -139,6 +166,8 @@ export interface WorkspaceInfo {
   branch?: string;      // Git branch if available
   sessionCount: number; // Number of active sessions
   isStale?: boolean;    // No activity for 30+ days
+  serveDomain?: string; // Hosting domain for process ports
+  processes?: { name: string; instances?: number; ports?: import("../../types/processes.js").ProcessPortConfig[] }[];
 }
 
 /** Session information */
@@ -150,12 +179,15 @@ export interface SessionInfo {
   createdAt: number;
   processTitle?: string;  // Current process (e.g., "vim", "npm run dev")
   exitCode?: number;      // If session has exited
+  processName?: string;   // Managed process name
+  processInstance?: number; // Managed process instance number
 }
 
 /** Response with workspace list */
 export interface WorkspaceListResponse {
   type: "workspace_list";
   workspaces: WorkspaceInfo[];
+  savedEventFilters?: import("../../types/events.js").SavedEventFilter[];
 }
 
 /** Response with session list */
@@ -288,6 +320,29 @@ export interface ReviewResponse {
   error?: { code: string; message: string };
 }
 
+/** Response with wide events list */
+export interface EventsListResponse {
+  type: "events_list";
+  workspaceId: string;
+  events: import("../../types/events.js").WideEvent[];
+  liveEventIds: string[];
+}
+
+/** Process started response */
+export interface ProcessStartedResponse {
+  type: "process_started";
+  workspaceId: string;
+  processName: string;
+  sessionId?: string;
+}
+
+/** Process stopped response */
+export interface ProcessStoppedResponse {
+  type: "process_stopped";
+  workspaceId: string;
+  processName: string;
+}
+
 // ============================================================================
 // Union Types
 // ============================================================================
@@ -307,7 +362,10 @@ export type ClientToMachineMessage =
   | UpdateNotificationConfigRequest
   | GetBundleRefreshPlanRequest
   | ApplyBundleRefreshRequest
-  | ReviewRequest;
+  | ReviewRequest
+  | GetEventsRequest
+  | StartProcessRequest
+  | StopProcessRequest;
 
 /** All messages from machine to client (browsing mode) */
 export type MachineToClientMessage =
@@ -328,7 +386,10 @@ export type MachineToClientMessage =
   | ScriptOutputResponse
   | BundleRefreshPlanResponse
   | BundleRefreshAppliedResponse
-  | ReviewResponse;
+  | ReviewResponse
+  | EventsListResponse
+  | ProcessStartedResponse
+  | ProcessStoppedResponse;
 
 /** All remote session messages */
 export type RemoteSessionMessage =
@@ -368,5 +429,5 @@ export function isBrowseMessage(msg: RemoteSessionMessage): msg is
   | ListWorkspacesRequest
   | ListSessionsRequest
   | AttachSessionRequest {
-  return ["list_workspaces", "list_sessions", "attach_session"].includes(msg.type);
+  return ["list_workspaces", "list_sessions", "attach_session", "get_events"].includes(msg.type);
 }

--- a/src/lib/remote-session/protocol.ts
+++ b/src/lib/remote-session/protocol.ts
@@ -73,6 +73,7 @@ export interface StartProcessRequest {
   type: "start_process";
   workspaceId: string;
   processName: string;
+  instance?: number;
 }
 
 /** Stop a process in a workspace */
@@ -434,6 +435,7 @@ export function serializeRemoteMessage(msg: RemoteSessionMessage): string {
 export function isBrowseMessage(msg: RemoteSessionMessage): msg is
   | ListWorkspacesRequest
   | ListSessionsRequest
-  | AttachSessionRequest {
+  | AttachSessionRequest
+  | GetEventsRequest {
   return ["list_workspaces", "list_sessions", "attach_session", "get_events"].includes(msg.type);
 }

--- a/src/lib/remote-session/protocol.ts
+++ b/src/lib/remote-session/protocol.ts
@@ -328,6 +328,9 @@ export interface EventsListResponse {
   workspaceId: string;
   events: import("../../types/events.js").WideEvent[];
   liveEventIds: string[];
+  requestId?: string;
+  chunkIndex?: number;
+  totalChunks?: number;
 }
 
 /** Process started response */

--- a/src/lib/remote-session/session-handler.ts
+++ b/src/lib/remote-session/session-handler.ts
@@ -343,7 +343,7 @@ export class RemoteSessionHandler {
           await this.sendError(session, sendResponse, "PERMISSION_DENIED", "Requires full access to start processes");
           return;
         }
-        await this.handleStartProcess(session, msg.workspaceId, msg.processName, sendResponse);
+        await this.handleStartProcess(session, msg.workspaceId, msg.processName, msg.instance, sendResponse);
         break;
 
       case "stop_process":
@@ -1172,6 +1172,7 @@ export class RemoteSessionHandler {
     session: RemoteClientSession,
     workspaceId: string,
     processName: string,
+    instance: number | undefined,
     sendResponse: (data: Uint8Array) => void
   ): Promise<void> {
     try {
@@ -1182,7 +1183,9 @@ export class RemoteSessionHandler {
         return;
       }
 
-      const specs = getProcessSpecs(workspace.path).filter(spec => spec.name === processName);
+      const specs = getProcessSpecs(workspace.path).filter(
+        (spec) => spec.name === processName && (instance === undefined || spec.instance === instance)
+      );
       if (specs.length === 0) {
         await this.sendError(session, sendResponse, "NOT_FOUND", "Process not found");
         return;

--- a/src/lib/remote-session/session-handler.ts
+++ b/src/lib/remote-session/session-handler.ts
@@ -55,7 +55,7 @@ import { loadSavedEventFilters } from "../events/filters.js";
 import { getProcessSpecs, startProcessInstance, stopProcessInstance } from "../processes/manager.js";
 import { autostartProcesses } from "../processes/autostart.js";
 import { startProcessScheduler } from "../processes/scheduler.js";
-import { loadProcessesConfig } from "../processes/config.js";
+import { loadProcessesConfigWithDiagnostics } from "../processes/config.js";
 import { readProjectConfig } from "../../core/config.js";
 import { existsSync } from "fs";
 
@@ -384,12 +384,13 @@ export class RemoteSessionHandler {
           workspace.sessionCount = workspaceSessions.length;
 
           // Load process config for the workspace
-          const processConfig = loadProcessesConfig(workspace.path);
-          workspace.processes = processConfig.processes.map((process) => ({
+          const processConfig = loadProcessesConfigWithDiagnostics(workspace.path);
+          workspace.processes = processConfig.config.processes.map((process) => ({
             name: process.name,
             instances: process.instances,
             ports: process.ports,
           }));
+          workspace.processConfigError = processConfig.error ?? undefined;
         }
       } catch {
         // Ignore errors - just use 0 session counts

--- a/src/lib/remote-session/session-handler.ts
+++ b/src/lib/remote-session/session-handler.ts
@@ -1114,36 +1114,49 @@ export class RemoteSessionHandler {
 
       // Chunk responses to stay under payload limit
       const maxPayloadBytes = 900_000;
-      const buildPayload = (chunk: import("../../types/events.js").WideEvent[]) => ({
+      const requestId = `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+      const buildPayload = (
+        chunk: import("../../types/events.js").WideEvent[],
+        chunkIndex: number,
+        totalChunks: number,
+      ) => ({
         type: "events_list" as const,
         workspaceId: workspaceRef.workspaceId,
         events: chunk,
         liveEventIds: [] as string[],
+        requestId,
+        chunkIndex,
+        totalChunks,
       });
 
-      if (events.length === 0) {
-        await this.sendMessage(session, sendResponse, buildPayload([]));
-        return;
-      }
-
+      const chunks: import("../../types/events.js").WideEvent[][] = [];
       let chunk: import("../../types/events.js").WideEvent[] = [];
       for (const event of events) {
         chunk.push(event);
-        const payloadSize = Buffer.byteLength(JSON.stringify(buildPayload(chunk)));
+        const payloadSize = Buffer.byteLength(JSON.stringify(buildPayload(chunk, 0, 1)));
         if (payloadSize > maxPayloadBytes) {
           if (chunk.length === 1) {
-            await this.sendMessage(session, sendResponse, buildPayload(chunk));
+            chunks.push(chunk);
             chunk = [];
             continue;
           }
           const last = chunk.pop();
-          await this.sendMessage(session, sendResponse, buildPayload(chunk));
+          chunks.push(chunk);
           chunk = last ? [last] : [];
         }
       }
 
       if (chunk.length > 0) {
-        await this.sendMessage(session, sendResponse, buildPayload(chunk));
+        chunks.push(chunk);
+      }
+
+      if (chunks.length === 0) {
+        chunks.push([]);
+      }
+
+      const totalChunks = chunks.length;
+      for (let i = 0; i < totalChunks; i += 1) {
+        await this.sendMessage(session, sendResponse, buildPayload(chunks[i], i, totalChunks));
       }
     } catch (e) {
       console.error("[remote-session] Failed to get events:", e);
@@ -1162,7 +1175,7 @@ export class RemoteSessionHandler {
   ): Promise<void> {
     try {
       const workspaces = await scanWorkspaces();
-      const workspace = workspaces.find(w => w.id === workspaceId);
+      const workspace = workspaces.find((w) => matchesWorkspaceId(w, workspaceId));
       if (!workspace) {
         await this.sendError(session, sendResponse, "NOT_FOUND", "Workspace not found");
         return;
@@ -1209,7 +1222,7 @@ export class RemoteSessionHandler {
   ): Promise<void> {
     try {
       const workspaces = await scanWorkspaces();
-      const workspace = workspaces.find(w => w.id === workspaceId);
+      const workspace = workspaces.find((w) => matchesWorkspaceId(w, workspaceId));
       if (!workspace) {
         await this.sendError(session, sendResponse, "NOT_FOUND", "Workspace not found");
         return;

--- a/src/lib/remote-session/session-handler.ts
+++ b/src/lib/remote-session/session-handler.ts
@@ -55,7 +55,12 @@ import { loadSavedEventFilters } from "../events/filters.js";
 import { getProcessSpecs, startProcessInstance, stopProcessInstance } from "../processes/manager.js";
 import { autostartProcesses } from "../processes/autostart.js";
 import { startProcessScheduler } from "../processes/scheduler.js";
-import { loadProcessesConfigWithDiagnostics } from "../processes/config.js";
+import {
+  loadProcessesConfigWithDiagnostics,
+  loadProcessesConfig,
+  getProcessDefinition,
+} from "../processes/config.js";
+import { normalizeProcessInstanceCount } from "../processes/instances.js";
 import { readProjectConfig } from "../../core/config.js";
 import { existsSync } from "fs";
 
@@ -1188,6 +1193,17 @@ export class RemoteSessionHandler {
       const workspace = workspaces.find((w) => matchesWorkspaceId(w, workspaceId));
       if (!workspace) {
         await this.sendError(session, sendResponse, "NOT_FOUND", "Workspace not found");
+        return;
+      }
+
+      const processConfig = loadProcessesConfig(workspace.path);
+      const processDefinition = getProcessDefinition(processConfig, processName);
+      if (!processDefinition) {
+        await this.sendError(session, sendResponse, "NOT_FOUND", "Process not found");
+        return;
+      }
+      if (normalizeProcessInstanceCount(processDefinition.instances) === 0) {
+        await this.sendError(session, sendResponse, "PROCESS_DISABLED", `Process is disabled (instances: 0): ${processName}`);
         return;
       }
 

--- a/src/lib/remote-session/session-handler.ts
+++ b/src/lib/remote-session/session-handler.ts
@@ -423,7 +423,6 @@ export class RemoteSessionHandler {
         ...workspace,
         id: toCanonicalWorkspaceId(workspace),
       })),
-      savedEventFilters: workspaces.length > 0 ? loadSavedEventFilters(workspaces[0].path) : [],
     });
   }
 
@@ -1082,6 +1081,8 @@ export class RemoteSessionHandler {
         return;
       }
 
+      const savedEventFilters = loadSavedEventFilters(workspaceRef.workspacePath);
+
       const projectConfig = readProjectConfig(workspaceRef.projectName);
       const snapshots = readWorkspaceSnapshots(workspaceRef.workspacePath, {
         maxBytes: projectConfig.events?.snapshotCacheMaxBytes,
@@ -1138,6 +1139,7 @@ export class RemoteSessionHandler {
         workspaceId: workspaceRef.workspaceId,
         events: chunk,
         liveEventIds: [] as string[],
+        savedEventFilters,
         requestId,
         chunkIndex,
         totalChunks,

--- a/src/lib/remote-session/session-handler.ts
+++ b/src/lib/remote-session/session-handler.ts
@@ -122,6 +122,14 @@ function isMutatingReviewOperation(operation: ReviewOperation): boolean {
   return MUTATING_REVIEW_OPERATIONS.has(operation.op);
 }
 
+function normalizeWorkspaceIdToken(workspaceId: string): string {
+  return workspaceId.includes(':') ? workspaceId.split(':').pop() ?? workspaceId : workspaceId;
+}
+
+function matchesWorkspaceIdToken(parsedWorkspaceId: string, workspaceId: string): boolean {
+  return normalizeWorkspaceIdToken(parsedWorkspaceId) === normalizeWorkspaceIdToken(workspaceId);
+}
+
 export interface RemoteSessionHandlerOptions {
   processHostDomain?: string;
   onProcessesChanged?: (workspacePath: string) => void | Promise<void>;
@@ -437,7 +445,7 @@ export class RemoteSessionHandler {
             if (!workspaceId) return true;
             // Try process session name first
             const parsed = parseProcessSessionName(s.name);
-            if (parsed) return parsed.workspaceId === workspaceId;
+            if (parsed) return matchesWorkspaceIdToken(parsed.workspaceId, workspaceId);
             // Fall back to cwd matching
             const ws = workspacePathMap.get(s.cwd);
             return ws ? matchesWorkspaceId(ws, workspaceId) : false;
@@ -446,7 +454,7 @@ export class RemoteSessionHandler {
             const parsed = parseProcessSessionName(s.name);
             let ws = workspacePathMap.get(s.cwd);
             if (!ws && parsed) {
-              ws = workspaces.find(workspace => workspace.id === parsed.workspaceId);
+              ws = workspaces.find(workspace => matchesWorkspaceId(workspace, parsed.workspaceId));
             }
             if (!ws) {
               ws = workspaces.find(workspace => s.cwd.startsWith(workspace.path));
@@ -1208,6 +1216,7 @@ export class RemoteSessionHandler {
         workspaceId,
         processName,
         sessionId: sessions[0],
+        sessionIds: sessions,
       });
     } catch (e) {
       console.error("[remote-session] Failed to start process:", e);

--- a/src/lib/remote-session/session-handler.ts
+++ b/src/lib/remote-session/session-handler.ts
@@ -78,6 +78,8 @@ export interface RemoteClientSession {
   attachedSessionId?: string;
   /** Path to tmux-lite session socket (set after attach_session) */
   sessionSocketPath?: string;
+  /** When true, PTY writes from this client are blocked server-side */
+  viewOnly?: boolean;
 }
 
 // ============================================================================
@@ -483,6 +485,10 @@ export class RemoteSessionHandler {
       cols?: number;
       rows?: number;
       scriptPolicy?: 'auto' | 'skip';
+      viewOnly?: boolean;
+      command?: string;
+      args?: string[];
+      env?: Record<string, string>;
     },
     sendResponse: (data: Uint8Array) => void
   ): Promise<void> {
@@ -514,67 +520,6 @@ export class RemoteSessionHandler {
           return;
         }
 
-        // Run setup/select scripts for the workspace with output streaming.
-        console.log(`[remote-session] Running workspace scripts for: ${workspace.id}`);
-
-        // Track current phase for script_output messages
-        let currentPhase: 'pre' | 'setup' | 'select' = 'pre';
-
-        const scriptResult = await prepareWorkspaceForSession({
-          projectName: workspace.projectName,
-          workspacePath: workspace.path,
-          workspaceName: workspace.id,
-          interactiveScripts: false,
-          bundleMode: 'error-if-changed',
-          scriptPolicy: msg.scriptPolicy ?? 'auto',
-          onOutput: (data) => {
-            void this.sendMessage(session, sendResponse, {
-              type: 'script_output',
-              phase: currentPhase,
-              data: data.toString('base64'),
-            }).catch((error) => {
-              logger.debug(`[remote-session] Failed to stream script output: ${error instanceof Error ? error.message : String(error)}`);
-            });
-          },
-          onPhaseStart: (phase) => {
-            currentPhase = phase;
-          },
-        });
-
-        if (!scriptResult.success) {
-          console.error(`[remote-session] ${scriptResult.phase} scripts failed:`, scriptResult.error);
-          await this.sendMessage(session, sendResponse, {
-            type: 'script_output',
-            phase: scriptResult.phase,
-            data: '',
-            done: true,
-            error: scriptResult.error,
-          });
-          const code =
-            'bundleNeedsRefresh' in scriptResult && scriptResult.bundleNeedsRefresh
-              ? 'BUNDLE_REFRESH_REQUIRED'
-              : scriptResult.phase === 'setup'
-                ? 'SETUP_SCRIPT_FAILED'
-                : scriptResult.phase === 'select'
-                  ? 'SELECT_SCRIPT_FAILED'
-                  : 'PRE_SCRIPT_FAILED';
-          await this.sendError(
-            session,
-            sendResponse,
-            code,
-            `Workspace scripts failed during ${scriptResult.phase} phase: ${scriptResult.error}`
-          );
-          return;
-        }
-
-        // Send final script_output indicating success
-        await this.sendMessage(session, sendResponse, {
-          type: 'script_output',
-          phase: currentPhase,
-          data: '',
-          done: true,
-        });
-
         const sessions = await listSessions();
         const sessionName = buildSessionName({
           projectName: workspace.projectName,
@@ -584,10 +529,81 @@ export class RemoteSessionHandler {
         });
         console.log(`[remote-session] Selected session name: ${sessionName}`);
 
-        targetSession = await createSession(sessionName, workspace.path, {
-          hooks: buildWorkspaceSessionHooks(workspace.projectName, workspace.id),
-        });
-        console.log(`[remote-session] Created session: ${targetSession.name} (id: ${targetSession.id})`)
+        if (msg.command) {
+          // Skip workspace scripts when a custom command is specified
+          targetSession = await createSession(sessionName, workspace.path, {
+            command: msg.command,
+            args: msg.args,
+            env: msg.env,
+          });
+          console.log(`[remote-session] Created session (custom cmd): ${targetSession.name} (id: ${targetSession.id})`);
+        } else {
+          // Run setup/select scripts for the workspace with output streaming.
+          console.log(`[remote-session] Running workspace scripts for: ${workspace.id}`);
+
+          // Track current phase for script_output messages
+          let currentPhase: 'pre' | 'setup' | 'select' = 'pre';
+
+          const scriptResult = await prepareWorkspaceForSession({
+            projectName: workspace.projectName,
+            workspacePath: workspace.path,
+            workspaceName: workspace.id,
+            interactiveScripts: false,
+            bundleMode: 'error-if-changed',
+            scriptPolicy: msg.scriptPolicy ?? 'auto',
+            onOutput: (data) => {
+              void this.sendMessage(session, sendResponse, {
+                type: 'script_output',
+                phase: currentPhase,
+                data: data.toString('base64'),
+              }).catch((error) => {
+                logger.debug(`[remote-session] Failed to stream script output: ${error instanceof Error ? error.message : String(error)}`);
+              });
+            },
+            onPhaseStart: (phase) => {
+              currentPhase = phase;
+            },
+          });
+
+          if (!scriptResult.success) {
+            console.error(`[remote-session] ${scriptResult.phase} scripts failed:`, scriptResult.error);
+            await this.sendMessage(session, sendResponse, {
+              type: 'script_output',
+              phase: scriptResult.phase,
+              data: '',
+              done: true,
+              error: scriptResult.error,
+            });
+            const code =
+              'bundleNeedsRefresh' in scriptResult && scriptResult.bundleNeedsRefresh
+                ? 'BUNDLE_REFRESH_REQUIRED'
+                : scriptResult.phase === 'setup'
+                  ? 'SETUP_SCRIPT_FAILED'
+                  : scriptResult.phase === 'select'
+                    ? 'SELECT_SCRIPT_FAILED'
+                    : 'PRE_SCRIPT_FAILED';
+            await this.sendError(
+              session,
+              sendResponse,
+              code,
+              `Workspace scripts failed during ${scriptResult.phase} phase: ${scriptResult.error}`
+            );
+            return;
+          }
+
+          // Send final script_output indicating success
+          await this.sendMessage(session, sendResponse, {
+            type: 'script_output',
+            phase: currentPhase,
+            data: '',
+            done: true,
+          });
+
+          targetSession = await createSession(sessionName, workspace.path, {
+            hooks: buildWorkspaceSessionHooks(workspace.projectName, workspace.id),
+          });
+          console.log(`[remote-session] Created session: ${targetSession.name} (id: ${targetSession.id})`);
+        }
       } else if (msg.sessionId) {
         // Security: Check if client can attach to this session
         if (!canAttachSession(session.accessType, session.grantedSessionId, msg.sessionId)) {
@@ -608,6 +624,7 @@ export class RemoteSessionHandler {
       session.state = "attached";
       session.attachedSessionId = targetSession.id;
       session.sessionSocketPath = targetSession.socketPath;
+      session.viewOnly = msg.viewOnly ?? false;
 
       // Send confirmation - ClientSessionManager will connect to the socket
       await this.sendMessage(session, sendResponse, {

--- a/src/lib/remote-session/session-handler.ts
+++ b/src/lib/remote-session/session-handler.ts
@@ -47,6 +47,18 @@ import { buildSessionName } from '../../session/session-name.js';
 import { buildWorkspaceSessionHooks } from '../../session/workspace-shell-hooks.js';
 import { matchesWorkspaceId, toCanonicalWorkspaceId } from '../../utils/workspace-id.js';
 
+// Process & events imports
+import { parseProcessSessionName } from "../processes/names.js";
+import { readWorkspaceSnapshots } from "../events/reader.js";
+import { resolveWorkspaceRef } from "../events/paths.js";
+import { loadSavedEventFilters } from "../events/filters.js";
+import { getProcessSpecs, startProcessInstance, stopProcessInstance } from "../processes/manager.js";
+import { autostartProcesses } from "../processes/autostart.js";
+import { startProcessScheduler } from "../processes/scheduler.js";
+import { loadProcessesConfig } from "../processes/config.js";
+import { readProjectConfig } from "../../core/config.js";
+import { existsSync } from "fs";
+
 import { logger } from "../../utils/logger.js";
 
 /**
@@ -108,11 +120,24 @@ function isMutatingReviewOperation(operation: ReviewOperation): boolean {
   return MUTATING_REVIEW_OPERATIONS.has(operation.op);
 }
 
+export interface RemoteSessionHandlerOptions {
+  processHostDomain?: string;
+  onProcessesChanged?: (workspacePath: string) => void | Promise<void>;
+}
+
 /**
  * Remote session handler
  */
 export class RemoteSessionHandler {
   private tmuxLiteAvailable = false;
+  private processSchedulers = new Map<string, NodeJS.Timer>();
+  private processHostDomain?: string;
+  private onProcessesChanged?: (workspacePath: string) => void | Promise<void>;
+
+  constructor(options: RemoteSessionHandlerOptions = {}) {
+    this.processHostDomain = options.processHostDomain;
+    this.onProcessesChanged = options.onProcessesChanged;
+  }
 
   /**
    * Initialize - check if tmux-lite is available
@@ -298,6 +323,35 @@ export class RemoteSessionHandler {
         );
         break;
 
+      case "get_events":
+        await this.handleGetEvents(
+          session,
+          msg.workspacePath,
+          msg.processName,
+          undefined,
+          msg.filter,
+          msg.limit,
+          msg.sinceMs,
+          sendResponse
+        );
+        break;
+
+      case "start_process":
+        if (!canManage(session.accessType)) {
+          await this.sendError(session, sendResponse, "PERMISSION_DENIED", "Requires full access to start processes");
+          return;
+        }
+        await this.handleStartProcess(session, msg.workspaceId, msg.processName, sendResponse);
+        break;
+
+      case "stop_process":
+        if (!canManage(session.accessType)) {
+          await this.sendError(session, sendResponse, "PERMISSION_DENIED", "Requires full access to stop processes");
+          return;
+        }
+        await this.handleStopProcess(session, msg.workspaceId, msg.processName, sendResponse);
+        break;
+
       default: {
         // Exhaustiveness check - log unknown message types
         const unknownMsg = msg as { type: string };
@@ -324,10 +378,26 @@ export class RemoteSessionHandler {
           // Note: Session cwd is set once at creation time and does NOT change
           // as users navigate within the shell. This is intentional - we want to
           // show sessions that were *created for* this workspace.
-          workspace.sessionCount = sessions.filter(s => s.cwd === workspace.path).length;
+          const workspaceSessions = sessions.filter(s => s.cwd === workspace.path);
+          workspace.sessionCount = workspaceSessions.length;
+
+          // Load process config for the workspace
+          const processConfig = loadProcessesConfig(workspace.path);
+          workspace.processes = processConfig.processes.map((process) => ({
+            name: process.name,
+            instances: process.instances,
+            ports: process.ports,
+          }));
         }
       } catch {
         // Ignore errors - just use 0 session counts
+      }
+    }
+
+    // Attach serve domain if configured
+    if (this.processHostDomain) {
+      for (const workspace of workspaces) {
+        workspace.serveDomain = this.processHostDomain;
       }
     }
 
@@ -337,6 +407,7 @@ export class RemoteSessionHandler {
         ...workspace,
         id: toCanonicalWorkspaceId(workspace),
       })),
+      savedEventFilters: workspaces.length > 0 ? loadSavedEventFilters(workspaces[0].path) : [],
     });
   }
 
@@ -361,23 +432,32 @@ export class RemoteSessionHandler {
         sessions = allSessions
           .filter(s => {
             if (!workspaceId) return true;
-            // Filter by workspace using cwd matching
-            // Note: Session cwd is set once at creation time and does NOT change
-            // as users navigate within the shell.
+            // Try process session name first
+            const parsed = parseProcessSessionName(s.name);
+            if (parsed) return parsed.workspaceId === workspaceId;
+            // Fall back to cwd matching
             const ws = workspacePathMap.get(s.cwd);
             return ws ? matchesWorkspaceId(ws, workspaceId) : false;
           })
           .map(s => {
-            // Find workspace info by cwd
-            const ws = workspacePathMap.get(s.cwd);
+            const parsed = parseProcessSessionName(s.name);
+            let ws = workspacePathMap.get(s.cwd);
+            if (!ws && parsed) {
+              ws = workspaces.find(workspace => workspace.id === parsed.workspaceId);
+            }
+            if (!ws) {
+              ws = workspaces.find(workspace => s.cwd.startsWith(workspace.path));
+            }
             return {
               id: s.id,
               name: s.name,
-              workspaceId: ws ? toCanonicalWorkspaceId(ws) : "unknown",
+              workspaceId: ws ? toCanonicalWorkspaceId(ws) : (parsed?.workspaceId ?? "unknown"),
               attached: s.attached,
               createdAt: s.createdAt,
               processTitle: s.processTitle,
               exitCode: s.exitCode,
+              processName: (s as any).processName ?? parsed?.processName,
+              processInstance: (s as any).processInstance ?? parsed?.instance,
             };
           });
       } catch (e) {
@@ -952,10 +1032,206 @@ export class RemoteSessionHandler {
   }
 
   /**
+   * Handle get_events request
+   */
+  private async handleGetEvents(
+    session: RemoteClientSession,
+    workspacePath: string,
+    processName: string | undefined,
+    _processInstance: number | undefined,
+    filter: import("../../types/events.js").WideEventFilter | undefined,
+    limit: number | undefined,
+    sinceMs: number | undefined,
+    sendResponse: (data: Uint8Array) => void
+  ): Promise<void> {
+    try {
+      const workspaceRef = resolveWorkspaceRef(workspacePath);
+      if (!workspaceRef || !existsSync(workspaceRef.workspacePath)) {
+        await this.sendError(session, sendResponse, "NOT_FOUND", "Workspace not found");
+        return;
+      }
+
+      const projectConfig = readProjectConfig(workspaceRef.projectName);
+      const snapshots = readWorkspaceSnapshots(workspaceRef.workspacePath, {
+        maxBytes: projectConfig.events?.snapshotCacheMaxBytes,
+        maxTimeline: projectConfig.events?.maxTimeline,
+      });
+
+      const resolvedFilter = { ...filter };
+      if (processName && !resolvedFilter.processName) {
+        resolvedFilter.processName = processName;
+      }
+
+      const filtered = snapshots
+        .filter((snapshot) => {
+          if (sinceMs !== undefined && snapshot.updatedAt < sinceMs) return false;
+          if (!resolvedFilter) return true;
+          if (resolvedFilter.processName && snapshot.processName !== resolvedFilter.processName) return false;
+          if (resolvedFilter.level && snapshot.level !== resolvedFilter.level) return false;
+          if (resolvedFilter.message && !snapshot.message.includes(resolvedFilter.message)) return false;
+          if (resolvedFilter.eventName && snapshot.eventName !== resolvedFilter.eventName) return false;
+          if (resolvedFilter.correlationId && snapshot.correlationId !== resolvedFilter.correlationId) return false;
+          return true;
+        })
+        .slice(0, limit ?? 200);
+
+      const events = filtered.map((snapshot) => ({
+        eventId: snapshot.lastEventId,
+        eventName: snapshot.eventName,
+        level: snapshot.level,
+        timestamp: new Date(snapshot.updatedAt).toISOString(),
+        timestampMs: snapshot.updatedAt,
+        message: snapshot.message,
+        sessionId: '',
+        workspaceId: workspaceRef.workspaceId,
+        projectName: workspaceRef.projectName,
+        processName: snapshot.processName,
+        processInstance: snapshot.processInstance,
+        raw: snapshot.raw ?? {},
+        kind: 'wide' as const,
+        correlationId: snapshot.correlationId,
+        timeline: Object.values(snapshot.timelineMap),
+        timelineMap: snapshot.timelineMap,
+        timelineOrder: snapshot.timelineOrder,
+      }));
+
+      // Chunk responses to stay under payload limit
+      const maxPayloadBytes = 900_000;
+      const buildPayload = (chunk: import("../../types/events.js").WideEvent[]) => ({
+        type: "events_list" as const,
+        workspaceId: workspaceRef.workspaceId,
+        events: chunk,
+        liveEventIds: [] as string[],
+      });
+
+      if (events.length === 0) {
+        await this.sendMessage(session, sendResponse, buildPayload([]));
+        return;
+      }
+
+      let chunk: import("../../types/events.js").WideEvent[] = [];
+      for (const event of events) {
+        chunk.push(event);
+        const payloadSize = Buffer.byteLength(JSON.stringify(buildPayload(chunk)));
+        if (payloadSize > maxPayloadBytes) {
+          if (chunk.length === 1) {
+            await this.sendMessage(session, sendResponse, buildPayload(chunk));
+            chunk = [];
+            continue;
+          }
+          const last = chunk.pop();
+          await this.sendMessage(session, sendResponse, buildPayload(chunk));
+          chunk = last ? [last] : [];
+        }
+      }
+
+      if (chunk.length > 0) {
+        await this.sendMessage(session, sendResponse, buildPayload(chunk));
+      }
+    } catch (e) {
+      console.error("[remote-session] Failed to get events:", e);
+      await this.sendError(session, sendResponse, "EVENTS_FAILED", "Failed to get events");
+    }
+  }
+
+  /**
+   * Handle start_process request
+   */
+  private async handleStartProcess(
+    session: RemoteClientSession,
+    workspaceId: string,
+    processName: string,
+    sendResponse: (data: Uint8Array) => void
+  ): Promise<void> {
+    try {
+      const workspaces = await scanWorkspaces();
+      const workspace = workspaces.find(w => w.id === workspaceId);
+      if (!workspace) {
+        await this.sendError(session, sendResponse, "NOT_FOUND", "Workspace not found");
+        return;
+      }
+
+      const specs = getProcessSpecs(workspace.path).filter(spec => spec.name === processName);
+      if (specs.length === 0) {
+        await this.sendError(session, sendResponse, "NOT_FOUND", "Process not found");
+        return;
+      }
+
+      const sessions: string[] = [];
+      for (const spec of specs) {
+        const result = await startProcessInstance(workspace.path, spec);
+        sessions.push(result.sessionId);
+      }
+      if (this.onProcessesChanged) {
+        Promise.resolve(this.onProcessesChanged(workspace.path)).catch(() => undefined);
+      }
+      if (!this.processSchedulers.has(workspace.path)) {
+        this.processSchedulers.set(workspace.path, startProcessScheduler(workspace.path));
+      }
+
+      await this.sendMessage(session, sendResponse, {
+        type: "process_started",
+        workspaceId,
+        processName,
+        sessionId: sessions[0],
+      });
+    } catch (e) {
+      console.error("[remote-session] Failed to start process:", e);
+      await this.sendError(session, sendResponse, "PROCESS_FAILED", "Failed to start process");
+    }
+  }
+
+  /**
+   * Handle stop_process request
+   */
+  private async handleStopProcess(
+    session: RemoteClientSession,
+    workspaceId: string,
+    processName: string,
+    sendResponse: (data: Uint8Array) => void
+  ): Promise<void> {
+    try {
+      const workspaces = await scanWorkspaces();
+      const workspace = workspaces.find(w => w.id === workspaceId);
+      if (!workspace) {
+        await this.sendError(session, sendResponse, "NOT_FOUND", "Workspace not found");
+        return;
+      }
+
+      const specs = getProcessSpecs(workspace.path).filter(spec => spec.name === processName);
+      if (specs.length === 0) {
+        await this.sendError(session, sendResponse, "NOT_FOUND", "Process not found");
+        return;
+      }
+
+      for (const spec of specs) {
+        await stopProcessInstance(workspace.path, spec);
+      }
+
+      if (this.onProcessesChanged) {
+        Promise.resolve(this.onProcessesChanged(workspace.path)).catch(() => undefined);
+      }
+
+      await this.sendMessage(session, sendResponse, {
+        type: "process_stopped",
+        workspaceId,
+        processName,
+      });
+    } catch (e) {
+      console.error("[remote-session] Failed to stop process:", e);
+      await this.sendError(session, sendResponse, "PROCESS_FAILED", "Failed to stop process");
+    }
+  }
+
+  /**
    * Cleanup
    */
   async cleanup(): Promise<void> {
-    // No persistent connection to clean up with the new API
+    // Clean up process schedulers
+    for (const timer of this.processSchedulers.values()) {
+      clearInterval(timer);
+    }
+    this.processSchedulers.clear();
     this.tmuxLiteAvailable = false;
   }
 }

--- a/src/lib/tmux-lite/cli.ts
+++ b/src/lib/tmux-lite/cli.ts
@@ -284,10 +284,23 @@ export async function listSessions(): Promise<Session[]> {
 export async function createSession(
   name: string,
   cwd: string,
-  options?: { hooks?: SessionCreateHooks }
+  options?: {
+    hooks?: SessionCreateHooks;
+    command?: string;
+    args?: string[];
+    env?: Record<string, string>;
+  }
 ): Promise<Session> {
   await ensureServer();
-  const res = await send({ type: "new", name, cwd, hooks: options?.hooks });
+  const res = await send({
+    type: "new",
+    name,
+    cwd,
+    hooks: options?.hooks,
+    command: options?.command,
+    args: options?.args,
+    env: options?.env,
+  });
   if (res.type === "session") return res.session;
   if (res.type === "error") throw new Error(res.message);
   throw new Error("Unexpected response");

--- a/src/lib/tmux-lite/process-run.integration.test.ts
+++ b/src/lib/tmux-lite/process-run.integration.test.ts
@@ -1,0 +1,266 @@
+import { describe, expect, test, beforeEach, afterEach } from "bun:test";
+import { spawn } from "bun";
+import { existsSync, mkdirSync, rmSync, unlinkSync } from "fs";
+import { dirname, join } from "path";
+import {
+  encodeRouterMessage,
+  decodeRouterMessages,
+  encodeControl,
+  parseFrames,
+  decodeControl,
+  FrameType,
+} from "./protocol";
+
+const TEST_SOCKET = "/tmp/tmux-lite-test.sock";
+const TEST_SESSION_DIR = "/tmp/tmux-lite-test";
+const TEST_PID_FILE = "/tmp/tmux-lite-test.pid";
+const SERVER_SCRIPT = join(import.meta.dir, "server.ts");
+const SESSION_NAME = "proc:wide-events:sample-events:1";
+const SAMPLE_SCRIPT = join(import.meta.dir, "../../../scripts/sample-events.ts");
+const BUN_PATH = "/opt/homebrew/bin/bun";
+
+function getTestSessionSocketPath(id: string): string {
+  return join(TEST_SESSION_DIR, `tmux-lite-${id}.sock`);
+}
+
+function cleanup(): void {
+  try { unlinkSync(TEST_SOCKET); } catch {}
+  try { unlinkSync(TEST_PID_FILE); } catch {}
+  try { rmSync(TEST_SESSION_DIR, { recursive: true, force: true }); } catch {}
+}
+
+async function waitFor(condition: () => Promise<boolean>, timeoutMs = 5000, intervalMs = 50): Promise<void> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    if (await condition()) return;
+    await Bun.sleep(intervalMs);
+  }
+  throw new Error("Timed out waiting for condition");
+}
+
+async function waitWithTimeout<T>(promise: Promise<T>, timeoutMs: number, label: string): Promise<T> {
+  return await Promise.race([
+    promise,
+    new Promise<T>((_resolve, reject) =>
+      setTimeout(() => reject(new Error(`${label} timed out after ${timeoutMs}ms`)), timeoutMs)
+    ),
+  ]);
+}
+
+async function startServer(): Promise<void> {
+  spawn({
+    cmd: ["bun", "run", SERVER_SCRIPT, "--test"],
+    stdout: "ignore",
+    stderr: "ignore",
+    env: {
+      ...process.env,
+      TMUX_LITE_SOCKET: TEST_SOCKET,
+      TMUX_LITE_SESSION_DIR: TEST_SESSION_DIR,
+      TMUX_LITE_PID_FILE: TEST_PID_FILE,
+    },
+  });
+
+  await waitFor(async () => existsSync(TEST_SOCKET));
+}
+
+async function sendRouterCommand(command: Record<string, unknown>) {
+  return await new Promise<any>((resolve, reject) => {
+    let buffer = Buffer.alloc(0);
+    let settled = false;
+    let socketRef: any;
+
+    const timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      socketRef?.end();
+      reject(new Error(`Router timeout for command ${String(command.type)}`));
+    }, 3000);
+
+    const finish = (fn: () => void) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      socketRef?.end();
+      fn();
+    };
+
+    Bun.connect({
+      unix: TEST_SOCKET,
+      socket: {
+        open(socket) {
+          socketRef = socket;
+          socket.write(encodeRouterMessage(command as any));
+        },
+        data(_socket, data) {
+          buffer = Buffer.concat([buffer, Buffer.from(data)]);
+          try {
+            const decoded = decodeRouterMessages(buffer);
+            buffer = Buffer.from(decoded.remaining as Buffer);
+            if (decoded.messages.length > 0) {
+              finish(() => resolve(decoded.messages[0]));
+            }
+          } catch (err) {
+            finish(() => reject(err));
+          }
+        },
+        close() {
+          finish(() => reject(new Error("Router socket closed before response")));
+        },
+        error(_socket, err) {
+          finish(() => reject(err));
+        },
+        connectError(_socket, err) {
+          finish(() => reject(err));
+        },
+        drain() {},
+      },
+    }).catch((err) => finish(() => reject(err)));
+  });
+}
+
+async function attachAndWaitForEvent(socketPath: string): Promise<{ output: string }> {
+  return await new Promise((resolve, reject) => {
+    let buffer = Buffer.alloc(0);
+    let output = "";
+    let attached = false;
+    let settled = false;
+    let socketRef: any;
+
+    const timeout = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      socketRef?.end();
+      reject(new Error(`Timed out waiting for @event output. Collected output: ${output.slice(-500)}`));
+    }, 2000);
+
+    const finish = (fn: () => void) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      socketRef?.end();
+      fn();
+    };
+
+    const connectOnce = () => {
+    Bun.connect({
+      unix: socketPath,
+      socket: {
+        open(socket) {
+          socketRef = socket;
+          socket.write(encodeControl({ type: "attach-init", cols: 80, rows: 24, clientType: "cli" }));
+        },
+
+          data(_socket, data) {
+            buffer = Buffer.concat([buffer, Buffer.from(data)]);
+            try {
+              const parsed = parseFrames(buffer);
+              buffer = Buffer.from(parsed.remaining as Buffer);
+            for (const frame of parsed.frames) {
+              if (frame.type === FrameType.CONTROL) {
+                const msg = decodeControl(frame.payload);
+                if (msg.type === "attached") {
+                  attached = true;
+                }
+                if (msg.type === "wide_event") {
+                  output += JSON.stringify(msg.event);
+                  if (attached) {
+                    finish(() => resolve({ output }));
+                  }
+                }
+              } else if (frame.type === FrameType.PTY) {
+                const text = frame.payload.toString("utf-8");
+                output += text;
+                if (attached && output.includes("[event:")) {
+                  finish(() => resolve({ output }));
+                }
+              }
+            }
+
+            } catch (err) {
+              finish(() => reject(err));
+            }
+          },
+          close() {
+            finish(() => reject(new Error("Session socket closed before output")));
+          },
+          error(_socket, err) {
+            finish(() => reject(err));
+          },
+          connectError(_socket, err) {
+            if ((err as { code?: string }).code === "ENOENT") {
+              if (!settled) {
+                setTimeout(connectOnce, 50);
+              }
+              return;
+            }
+            finish(() => reject(err));
+          },
+          drain() {},
+        },
+      }).catch((err) => {
+        if ((err as { code?: string }).code === "ENOENT") {
+          if (!settled) {
+            setTimeout(connectOnce, 50);
+          }
+          return;
+        }
+        finish(() => reject(err));
+      });
+    };
+
+    connectOnce();
+  });
+}
+
+describe("tmux-lite process execution", () => {
+  beforeEach(() => {
+    cleanup();
+    mkdirSync(TEST_SESSION_DIR, { recursive: true });
+  });
+
+  afterEach(async () => {
+    try {
+      if (existsSync(TEST_SOCKET)) {
+        await waitWithTimeout(sendRouterCommand({ type: "kill-server" }), 2000, "kill-server");
+      }
+    } catch (err) {
+      console.warn("Failed to kill test server:", err);
+    }
+    await Bun.sleep(200);
+    cleanup();
+  });
+
+  test("starts process session and streams output", async () => {
+    await startServer();
+
+    if (!existsSync(BUN_PATH)) {
+      throw new Error(`bun not found at ${BUN_PATH}`);
+    }
+
+    const response = await sendRouterCommand({
+      type: "new",
+      name: SESSION_NAME,
+      cwd: join(import.meta.dir, "../../.."),
+      command: process.execPath,
+      args: [
+        join(import.meta.dir, "../../index.ts"),
+        "--internal-process-runner",
+        "--workspace",
+        join(import.meta.dir, "../../.."),
+        "--process",
+        "sample-events",
+        "--instance",
+        "1",
+      ],
+    });
+
+    if (response.type !== "session") {
+      throw new Error(`Expected session response, got: ${JSON.stringify(response)}`);
+    }
+
+    const socketPath = getTestSessionSocketPath(response.session.id);
+    const { output } = await waitWithTimeout(attachAndWaitForEvent(socketPath), 8000, "attachAndWaitForEvent");
+    expect(output).toContain("[event:");
+
+  }, 10000);
+});

--- a/src/lib/tmux-lite/protocol.ts
+++ b/src/lib/tmux-lite/protocol.ts
@@ -100,7 +100,15 @@ export interface SessionCreateHooks {
 
 export type Command =
   | { type: "list" }
-  | { type: "new"; name?: string; cwd: string; hooks?: SessionCreateHooks }
+  | {
+      type: "new";
+      name?: string;
+      cwd: string;
+      hooks?: SessionCreateHooks;
+      command?: string;
+      args?: string[];
+      env?: Record<string, string>;
+    }
   | { type: "attach"; id: string; force?: boolean }
   | { type: "kill"; id: string }
   | { type: "kill-server" }
@@ -178,7 +186,8 @@ export type SessionEvent =
   | { type: "attach-ready"; cols: number; rows: number }
   | { type: "attached" }
   | { type: "exited"; code: number }
-  | { type: "kicked" };
+  | { type: "kicked" }
+  | { type: "wide_event"; event: Record<string, unknown> };
 
 /** A decoded frame from the session socket */
 export interface SessionFrame {

--- a/src/lib/tmux-lite/server.ts
+++ b/src/lib/tmux-lite/server.ts
@@ -1071,7 +1071,16 @@ function getShellInitScript(shell: string, hooks?: SessionCreateHooks): string |
 // Main Session Creation
 // ============================================================================
 
-function createSession(name: string | undefined, cwd: string, hooks?: SessionCreateHooks): Session {
+function createSession(
+  name: string | undefined,
+  cwd: string,
+  options?: {
+    hooks?: SessionCreateHooks;
+    command?: string;
+    args?: string[];
+    env?: Record<string, string>;
+  }
+): Session {
   const id = genId();
   const sessionName = name || `session-${id}`;
   const socketPath = getSessionSocketPath(id);
@@ -1137,14 +1146,22 @@ function createSession(name: string | undefined, cwd: string, hooks?: SessionCre
     try { ptyTerminal.write(data); } catch {}
   });
 
-  // Spawn shell process
+  // Spawn shell process (or custom command if provided)
   const shell = process.env.SHELL || "/bin/bash";
+  const hooks = options?.hooks;
   const shellEnv = buildShellEnvironment(id, shell, hooks);
 
-  const proc = Bun.spawn([shell], {
+  const spawnCmd = options?.command
+    ? [options.command, ...(options.args ?? [])]
+    : [shell];
+  const spawnEnv = options?.env
+    ? { ...shellEnv, ...options.env }
+    : shellEnv;
+
+  const proc = Bun.spawn(spawnCmd, {
     terminal: ptyTerminal,
     cwd,
-    env: shellEnv,
+    env: spawnEnv,
   });
 
   const shellInitScript = getShellInitScript(shell, hooks);
@@ -1253,7 +1270,12 @@ Bun.listen({
 
           case "new":
             try {
-              const session = createSession(cmd.name, cmd.cwd, cmd.hooks);
+              const session = createSession(cmd.name, cmd.cwd, {
+                hooks: cmd.hooks,
+                command: cmd.command,
+                args: cmd.args,
+                env: cmd.env,
+              });
               res = { type: "session", session };
             } catch (e) {
               const errMsg = e instanceof Error ? e.message : String(e);

--- a/src/serve/client-session-manager.ts
+++ b/src/serve/client-session-manager.ts
@@ -513,7 +513,6 @@ export class ClientSessionManager {
                   const eventData = new TextEncoder().encode(eventMsg);
                   const encFrame = createFrame(STREAM_ID.DATA, eventData, session.sessionKeys.sendKey);
                   sendToClient(Buffer.from(encFrame));
-                  return;
                 }
                 // Ignore attach-ready and attached - handled by client
               } else if (frame.type === FrameType.PTY) {

--- a/src/serve/client-session-manager.ts
+++ b/src/serve/client-session-manager.ts
@@ -59,7 +59,7 @@ export class ClientSessionManager {
       accessList: options.accessList,
       handshakeTimeoutMs: options.handshakeTimeoutMs,
     });
-    this.remoteSessionHandler = new RemoteSessionHandler();
+    this.remoteSessionHandler = new RemoteSessionHandler(options.remoteSessionOptions);
   }
 
   private writeToTmuxSocket(session: ClientSession, frame: Buffer): void {
@@ -499,6 +499,12 @@ export class ClientSessionManager {
                 } else if (event.type === "kicked") {
                   console.log("[session-manager] Session kicked");
                   this.handleDisconnect(connectionId, "Session kicked");
+                  return;
+                } else if (event.type === "wide_event") {
+                  const eventMsg = JSON.stringify({ type: "wide_event", event: event.event });
+                  const eventData = new TextEncoder().encode(eventMsg);
+                  const encFrame = createFrame(STREAM_ID.DATA, eventData, session.sessionKeys.sendKey);
+                  sendToClient(Buffer.from(encFrame));
                   return;
                 }
                 // Ignore attach-ready and attached - handled by client

--- a/src/serve/client-session-manager.ts
+++ b/src/serve/client-session-manager.ts
@@ -223,6 +223,7 @@ export class ClientSessionManager {
           session.tmuxSocketWriter = undefined;
           session.state = "browsing";
           session.attachedSessionId = undefined;
+          session.viewOnly = undefined;
           session.sessionSocketPath = undefined;
           session.waitingForResize = undefined;
           session.frameBuffer = undefined;
@@ -256,7 +257,7 @@ export class ClientSessionManager {
       } else {
         // Raw PTY input (STREAM_ID.DATA) - send directly to socket
         // Security: Check write permission before forwarding input
-        if (!canWrite(session.accessType)) {
+        if (session.viewOnly || !canWrite(session.accessType)) {
           console.warn(`[session-manager] Read-only client ${connectionId} attempted PTY write - denied`);
           return null; // Silently drop input from read-only clients
         }
@@ -301,9 +302,14 @@ export class ClientSessionManager {
 
     // Create send callback that captures the raw encrypted response
     // Don't wrap in JSON here - serve.ts handles the relay envelope
+    const sendToClient = this.createSendCallback(connectionId);
     let responseData: Uint8Array | null = null;
     const sendResponse = (encryptedFrame: Uint8Array) => {
-      responseData = encryptedFrame;
+      if (responseData === null) {
+        responseData = encryptedFrame;
+        return;
+      }
+      sendToClient(Buffer.from(encryptedFrame));
     };
 
     // Handle the message through RemoteSessionHandler
@@ -313,6 +319,7 @@ export class ClientSessionManager {
     if (remoteSession.state === "attached" && remoteSession.attachedSessionId) {
       session.state = "attached";
       session.attachedSessionId = remoteSession.attachedSessionId;
+      session.viewOnly = remoteSession.viewOnly ?? false;
       session.sessionSocketPath = remoteSession.sessionSocketPath;
 
       // Connect to tmux-lite session socket for PTY I/O
@@ -386,6 +393,7 @@ export class ClientSessionManager {
   ): Uint8Array | null {
     // Update session state - enter browsing mode (not spawning PTY yet)
     session.state = "browsing";
+    session.viewOnly = undefined;
     session.sessionKeys = established.sessionKeys;
     session.accessType = established.accessType;
     session.sessionId = established.sessionId;

--- a/src/serve/types.ts
+++ b/src/serve/types.ts
@@ -7,6 +7,7 @@
 import type { PTYSession } from "./pty-session.js";
 import type { Identity, SessionKeys, AccessType } from "../types/identity.js";
 import type { AccessControlList } from "../lib/tmux-lite/crypto/access-control.js";
+import type { RemoteSessionHandlerOptions } from "../lib/remote-session/index.js";
 import { FrameType } from "../lib/tmux-lite/protocol.js";
 
 // ============================================================================
@@ -63,6 +64,8 @@ export interface ServeOptions {
   identity: Identity;
   /** Access control list for authorized clients */
   accessList: AccessControlList;
+  /** Remote session handler configuration */
+  remoteSessionOptions?: RemoteSessionHandlerOptions;
   /** Shell to spawn (default: $SHELL or /bin/bash) */
   shell?: string;
   /** Extra environment variables for PTY sessions */

--- a/src/serve/types.ts
+++ b/src/serve/types.ts
@@ -111,6 +111,8 @@ export interface ClientSession {
   peerIdentityId?: string;
   /** Attached tmux-lite session ID (when state === "attached") */
   attachedSessionId?: string;
+  /** When true, this attached session is server-enforced read-only */
+  viewOnly?: boolean;
   /** True if waiting for initial resize before sending attach-init */
   waitingForResize?: boolean;
   /** Buffer for incomplete frames from tmux-lite socket */

--- a/src/session/__tests__/local-session-backend.test.ts
+++ b/src/session/__tests__/local-session-backend.test.ts
@@ -186,6 +186,7 @@ describe('LocalSessionBackend', () => {
       type: 'attached',
       sessionId: 'sess-new',
       sessionName: 'alpha:ws-1:2',
+      viewOnly: false,
     });
 
     expect(events).toContainEqual({
@@ -284,7 +285,7 @@ describe('LocalSessionBackend', () => {
     expect(sentControls).toContainEqual({ type: 'resize', cols: 100, rows: 30 });
     expect(sentControls).toContainEqual({ type: 'detach' });
     expect(sentPty).toEqual([new Uint8Array([0x41])]);
-    expect(events).toContainEqual({ type: 'attached', sessionId: 'sess-1', sessionName: 'alpha:ws-1:1' });
+    expect(events).toContainEqual({ type: 'attached', sessionId: 'sess-1', sessionName: 'alpha:ws-1:1', viewOnly: false });
     expect(events).toContainEqual({ type: 'detached' });
   });
 
@@ -645,6 +646,7 @@ describe('LocalSessionBackend', () => {
         type: 'attached',
         sessionId: 'sess-1',
         sessionName: 'alpha:ws-1:1',
+        viewOnly: false,
       },
     ]);
     expect(detachedEvents).toEqual([{ type: 'detached' }]);
@@ -727,6 +729,7 @@ describe('LocalSessionBackend', () => {
       type: 'attached',
       sessionId: 'sess-1',
       sessionName: 'alpha:ws-1:1',
+      viewOnly: false,
     });
   });
 

--- a/src/session/__tests__/local-session-backend.test.ts
+++ b/src/session/__tests__/local-session-backend.test.ts
@@ -204,6 +204,36 @@ describe('LocalSessionBackend', () => {
     ]);
   });
 
+  it('does not include saved filters in workspace list payloads', async () => {
+    const events: BackendEvent[] = [];
+
+    const deps: Partial<LocalSessionBackendDependencies> = {
+      ensureServer: async () => {},
+      scanWorkspaces: async () => [
+        {
+          id: 'ws-1',
+          name: 'ws-1',
+          path: '/tmp/ws-1',
+          projectName: 'alpha',
+          sessionCount: 0,
+        },
+      ],
+      listSessions: async () => [],
+    };
+
+    const backend = new LocalSessionBackend({ deps });
+    backend.onEvent((event) => events.push(event));
+
+    await backend.connect();
+    await backend.listWorkspaces();
+
+    const workspaceEvent = events.find((event) => event.type === 'workspaces');
+    expect(workspaceEvent).toBeDefined();
+    if (workspaceEvent && workspaceEvent.type === 'workspaces') {
+      expect('savedEventFilters' in workspaceEvent).toBe(false);
+    }
+  });
+
   it('streams PTY data and control frames through local socket transport', async () => {
     const events: BackendEvent[] = [];
     const sentControls: Array<{

--- a/src/session/__tests__/remote-session-backend.test.ts
+++ b/src/session/__tests__/remote-session-backend.test.ts
@@ -416,6 +416,110 @@ describe('RemoteSessionBackend', () => {
     expect(callbackTwoOutput).toEqual(['while-cleared', 'after-restore']);
   });
 
+  it('emits workspace-scoped saved filters from events_list', async () => {
+    const socket = createFakeSocket();
+    const events: BackendEvent[] = [];
+
+    const backend = new RemoteSessionBackend({
+      descriptor: {
+        key: buildRemoteBackendKey('wss://relay.test/ws', 'machine-1'),
+        kind: 'remote',
+        label: 'Machine 1',
+        relayUrl: 'wss://relay.test/ws',
+        machineId: 'machine-1',
+      },
+      socket,
+      socketAdapter,
+      identity,
+      machineId: 'machine-1',
+      signer: (message) => ({ ...message, signature: { sig: 'x' } }),
+      crypto: cryptoAdapter,
+      handshake: handshakeAdapter,
+    });
+
+    backend.onEvent((event) => events.push(event));
+    await connectAndHandshake(backend, socket);
+
+    const savedFilters = [{ name: 'Errors', filter: { level: 'error' as const }, sinceMinutes: 30 }];
+
+    socket.handlers?.onMessage(
+      makeRelayDataPayload(cryptoAdapter, {
+        type: 'events_list',
+        workspaceId: 'alpha:ws-2',
+        events: [],
+        liveEventIds: [],
+        savedEventFilters: savedFilters,
+      })
+    );
+    await Bun.sleep(0);
+
+    expect(events).toContainEqual({
+      type: 'events',
+      events: [],
+      liveEventIds: [],
+      savedEventFilters: savedFilters,
+    });
+  });
+
+  it('preserves saved filters when merging chunked events_list payloads', async () => {
+    const socket = createFakeSocket();
+    const events: BackendEvent[] = [];
+
+    const backend = new RemoteSessionBackend({
+      descriptor: {
+        key: buildRemoteBackendKey('wss://relay.test/ws', 'machine-1'),
+        kind: 'remote',
+        label: 'Machine 1',
+        relayUrl: 'wss://relay.test/ws',
+        machineId: 'machine-1',
+      },
+      socket,
+      socketAdapter,
+      identity,
+      machineId: 'machine-1',
+      signer: (message) => ({ ...message, signature: { sig: 'x' } }),
+      crypto: cryptoAdapter,
+      handshake: handshakeAdapter,
+    });
+
+    backend.onEvent((event) => events.push(event));
+    await connectAndHandshake(backend, socket);
+
+    const savedFilters = [{ name: 'Web', filter: { processName: 'web' } }];
+    const common = {
+      type: 'events_list' as const,
+      workspaceId: 'alpha:ws-2',
+      requestId: 'req-1',
+      totalChunks: 2,
+      liveEventIds: [],
+      savedEventFilters: savedFilters,
+    };
+
+    socket.handlers?.onMessage(
+      makeRelayDataPayload(cryptoAdapter, {
+        ...common,
+        chunkIndex: 0,
+        events: [],
+      })
+    );
+
+    socket.handlers?.onMessage(
+      makeRelayDataPayload(cryptoAdapter, {
+        ...common,
+        chunkIndex: 1,
+        events: [],
+      })
+    );
+    await Bun.sleep(0);
+
+    expect(events).toContainEqual({
+      type: 'events',
+      events: [],
+      liveEventIds: [],
+      savedEventFilters: savedFilters,
+    });
+  });
+
   it('refreshes workspace and scoped session list after kill when workspace is known', async () => {
     const socket = createFakeSocket();
 

--- a/src/session/backend.ts
+++ b/src/session/backend.ts
@@ -82,7 +82,7 @@ export interface SessionBackend {
   updateNotificationConfig(config: NotificationConfig): Promise<void>;
 
   sendReviewRequest(operation: ReviewOperation): Promise<ReviewResult>;
-  startProcess?(workspaceId: string, processName: string): Promise<void>;
+  startProcess?(workspaceId: string, processName: string, instance?: number): Promise<void>;
   stopProcess?(workspaceId: string, processName: string): Promise<void>;
   requestEvents?(workspacePath: string, filter?: WideEventFilter, limit?: number, sinceMs?: number): Promise<void>;
 

--- a/src/session/backend.ts
+++ b/src/session/backend.ts
@@ -25,6 +25,14 @@ export interface AttachSessionParams {
   cols?: number;
   rows?: number;
   scriptPolicy?: 'auto' | 'skip';
+  /** When true, the client cannot send input to the PTY (view-only mode) */
+  viewOnly?: boolean;
+  /** Custom command to run (skips workspace scripts when set) */
+  command?: string;
+  /** Arguments for the custom command */
+  args?: string[];
+  /** Environment variables for the custom command */
+  env?: Record<string, string>;
 }
 
 export interface DeleteWorkspaceParams {

--- a/src/session/backend.ts
+++ b/src/session/backend.ts
@@ -5,6 +5,7 @@ import type {
   BundleRefreshSubmission,
 } from '../types/bundle-refresh.js';
 import type { ReviewOperation, ReviewResult } from '../types/review.js';
+import type { WideEventFilter } from '../types/events.js';
 
 export type BackendKey = string;
 export type BackendKind = 'local' | 'remote';
@@ -73,6 +74,9 @@ export interface SessionBackend {
   updateNotificationConfig(config: NotificationConfig): Promise<void>;
 
   sendReviewRequest(operation: ReviewOperation): Promise<ReviewResult>;
+  startProcess?(workspaceId: string, processName: string): Promise<void>;
+  stopProcess?(workspaceId: string, processName: string): Promise<void>;
+  requestEvents?(workspacePath: string, filter?: WideEventFilter, limit?: number, sinceMs?: number): Promise<void>;
 
   writePtyData?(data: Uint8Array): Promise<void>;
   resizePty?(cols: number, rows: number): Promise<void>;

--- a/src/session/backends/local-session-backend.ts
+++ b/src/session/backends/local-session-backend.ts
@@ -753,7 +753,7 @@ export class LocalSessionBackend implements SessionBackend {
     this.emit({ type: 'notification_config', config: updated });
   }
 
-  async startProcess(workspaceId: string, processName: string): Promise<void> {
+  async startProcess(workspaceId: string, processName: string, instance?: number): Promise<void> {
     const workspaces = await this.deps.scanWorkspaces();
     const workspace = workspaces.find(
       (w) => w.id === workspaceId || toCanonicalWorkspaceId(w) === workspaceId
@@ -762,7 +762,9 @@ export class LocalSessionBackend implements SessionBackend {
       throw new SpacesError(`Workspace not found: ${workspaceId}`, 'USER_ERROR', 1);
     }
 
-    const specs = getProcessSpecs(workspace.path).filter((s) => s.name === processName);
+    const specs = getProcessSpecs(workspace.path).filter((s) =>
+      s.name === processName && (instance === undefined || s.instance === instance)
+    );
     if (specs.length === 0) {
       throw new SpacesError(`Process not found: ${processName}`, 'USER_ERROR', 1);
     }

--- a/src/session/backends/local-session-backend.ts
+++ b/src/session/backends/local-session-backend.ts
@@ -335,6 +335,7 @@ export class LocalSessionBackend implements SessionBackend {
   private ptyOutputHandler: ((data: Uint8Array) => void) | null = null;
   private pendingPtyChunks: Uint8Array[] = [];
   private pendingUtf8Bytes = new Uint8Array(0);
+  private viewOnly = false;
 
   constructor(options: LocalSessionBackendOptions = {}) {
     this.descriptor = options.descriptor ?? DEFAULT_DESCRIPTOR;
@@ -464,6 +465,7 @@ export class LocalSessionBackend implements SessionBackend {
     if (!this.connected) {
       await this.connect();
     }
+    this.viewOnly = params.viewOnly ?? false;
 
     let targetSession: TmuxSession | null = null;
 
@@ -486,72 +488,6 @@ export class LocalSessionBackend implements SessionBackend {
         throw new SpacesError(`Workspace not found: ${workspaceId}`, 'USER_ERROR', 1);
       }
 
-      let currentPhase: 'pre' | 'setup' | 'select' = 'pre';
-
-      const scriptResult = await this.deps.prepareWorkspaceForSession({
-        projectName: workspace.projectName,
-        workspacePath: workspace.path,
-        workspaceName: workspace.id,
-        interactiveScripts: false,
-        bundleMode: 'error-if-changed',
-        scriptPolicy: params.scriptPolicy ?? 'auto',
-        onOutput: (data) => {
-          this.emitPtyData(data);
-          this.emit({
-            type: 'script_output',
-            phase: currentPhase,
-            data,
-          });
-        },
-        onPhaseStart: (phase) => {
-          currentPhase = phase;
-        },
-      });
-
-      if (!scriptResult.success) {
-        const bundleNeedsRefresh =
-          'bundleNeedsRefresh' in scriptResult && scriptResult.bundleNeedsRefresh;
-
-        if ('bundleNeedsRefresh' in scriptResult && scriptResult.bundleNeedsRefresh) {
-          this.emit({
-            type: 'command_error',
-            code: 'BUNDLE_REFRESH_REQUIRED',
-            message: scriptResult.error,
-          });
-        } else {
-          this.emit({
-            type: 'command_error',
-            code: scriptFailureCodeForPhase(scriptResult.phase),
-            message: scriptResult.error,
-          });
-        }
-
-        this.emit({
-          type: 'script_output',
-          phase: scriptResult.phase,
-          data: new Uint8Array(0),
-          done: true,
-          error: scriptResult.error,
-        });
-
-        const error = new SpacesError(
-          `Workspace scripts failed during ${scriptResult.phase}: ${scriptResult.error}`
-        ) as Error & { code?: string };
-        if (bundleNeedsRefresh) {
-          error.code = 'BUNDLE_REFRESH_REQUIRED';
-        } else {
-          error.code = scriptFailureCodeForPhase(scriptResult.phase);
-        }
-        throw error;
-      }
-
-      this.emit({
-        type: 'script_output',
-        phase: currentPhase,
-        data: new Uint8Array(0),
-        done: true,
-      });
-
       const sessions = await this.deps.listSessions();
       const fullName = buildSessionName({
         projectName: workspace.projectName,
@@ -559,9 +495,85 @@ export class LocalSessionBackend implements SessionBackend {
         requestedName: params.sessionName,
         sessions,
       });
-      targetSession = await this.deps.createSession(fullName, workspace.path, {
-        hooks: buildWorkspaceSessionHooks(workspace.projectName, workspace.id),
-      });
+
+      if (params.command) {
+        // Skip workspace scripts when a custom command is specified
+        targetSession = await this.deps.createSession(fullName, workspace.path, {
+          command: params.command,
+          args: params.args,
+          env: params.env,
+        });
+      } else {
+        let currentPhase: 'pre' | 'setup' | 'select' = 'pre';
+
+        const scriptResult = await this.deps.prepareWorkspaceForSession({
+          projectName: workspace.projectName,
+          workspacePath: workspace.path,
+          workspaceName: workspace.id,
+          interactiveScripts: false,
+          bundleMode: 'error-if-changed',
+          scriptPolicy: params.scriptPolicy ?? 'auto',
+          onOutput: (data) => {
+            this.emitPtyData(data);
+            this.emit({
+              type: 'script_output',
+              phase: currentPhase,
+              data,
+            });
+          },
+          onPhaseStart: (phase) => {
+            currentPhase = phase;
+          },
+        });
+
+        if (!scriptResult.success) {
+          const bundleNeedsRefresh =
+            'bundleNeedsRefresh' in scriptResult && scriptResult.bundleNeedsRefresh;
+
+          if ('bundleNeedsRefresh' in scriptResult && scriptResult.bundleNeedsRefresh) {
+            this.emit({
+              type: 'command_error',
+              code: 'BUNDLE_REFRESH_REQUIRED',
+              message: scriptResult.error,
+            });
+          } else {
+            this.emit({
+              type: 'command_error',
+              code: scriptFailureCodeForPhase(scriptResult.phase),
+              message: scriptResult.error,
+            });
+          }
+
+          this.emit({
+            type: 'script_output',
+            phase: scriptResult.phase,
+            data: new Uint8Array(0),
+            done: true,
+            error: scriptResult.error,
+          });
+
+          const error = new SpacesError(
+            `Workspace scripts failed during ${scriptResult.phase}: ${scriptResult.error}`
+          ) as Error & { code?: string };
+          if (bundleNeedsRefresh) {
+            error.code = 'BUNDLE_REFRESH_REQUIRED';
+          } else {
+            error.code = scriptFailureCodeForPhase(scriptResult.phase);
+          }
+          throw error;
+        }
+
+        this.emit({
+          type: 'script_output',
+          phase: currentPhase,
+          data: new Uint8Array(0),
+          done: true,
+        });
+
+        targetSession = await this.deps.createSession(fullName, workspace.path, {
+          hooks: buildWorkspaceSessionHooks(workspace.projectName, workspace.id),
+        });
+      }
     } else {
       throw new SpacesError('attachSession requires sessionId or workspaceId', 'USER_ERROR', 1);
     }
@@ -577,12 +589,16 @@ export class LocalSessionBackend implements SessionBackend {
     const hadAttached = this.attachedSessionId !== null;
     await this.closeSessionSocket(false);
     this.attachedSessionId = null;
+    this.viewOnly = false;
     if (hadAttached) {
       this.emit({ type: 'detached' });
     }
   }
 
   async writePtyData(data: Uint8Array): Promise<void> {
+    if (this.viewOnly) {
+      return;
+    }
     const socket = this.sessionSocket;
     if (!socket || !this.attachedSessionId) {
       throw new SpacesError('No attached local session', 'SYSTEM_ERROR', 2);
@@ -909,6 +925,7 @@ export class LocalSessionBackend implements SessionBackend {
                   type: 'attached',
                   sessionId: session.id,
                   sessionName: session.name,
+                  viewOnly: this.viewOnly,
                 });
                 settleResolve();
                 return;

--- a/src/session/backends/local-session-backend.ts
+++ b/src/session/backends/local-session-backend.ts
@@ -52,11 +52,21 @@ import type { NotificationConfig } from '../../notifications/types.js';
 import type { BundleRefreshPlan, BundleRefreshSubmission } from '../../types/bundle-refresh.js';
 import type { ReviewOperation, ReviewResult } from '../../types/review.js';
 import { executeLocalReviewOperation } from '../../core/review-executor.js';
+import type { WideEventFilter } from '../../types/events.js';
 import {
   SpacesError,
   WorkspaceDeleteError,
   type WorkspaceDeleteErrorCode,
 } from '../../types/errors.js';
+import { parseProcessSessionName } from '../../lib/processes/names.js';
+import { loadProcessesConfig } from '../../lib/processes/config.js';
+import { getProcessSpecs, startProcessInstance, stopProcessInstance } from '../../lib/processes/manager.js';
+import { startProcessScheduler } from '../../lib/processes/scheduler.js';
+import { readWorkspaceSnapshots } from '../../lib/events/reader.js';
+import { resolveWorkspaceRef } from '../../lib/events/paths.js';
+import { loadSavedEventFilters } from '../../lib/events/filters.js';
+import { readProjectConfig } from '../../core/config.js';
+import { existsSync } from 'fs';
 
 export interface LocalSessionBackendDependencies {
   listSessions: typeof listSessions;
@@ -390,13 +400,24 @@ export class LocalSessionBackend implements SessionBackend {
       counts.set(session.cwd, current + 1);
     }
 
-    this.emit({
-      type: 'workspaces',
-      workspaces: workspaces.map((workspace) => ({
+    const mappedWorkspaces = workspaces.map((workspace) => {
+      const processConfig = loadProcessesConfig(workspace.path);
+      return {
         ...workspace,
         id: toCanonicalWorkspaceId(workspace),
         sessionCount: counts.get(workspace.path) ?? 0,
-      })),
+        processes: processConfig.processes.map((p) => ({
+          name: p.name,
+          instances: p.instances,
+          ports: p.ports,
+        })),
+      };
+    });
+
+    this.emit({
+      type: 'workspaces',
+      workspaces: mappedWorkspaces,
+      savedEventFilters: workspaces.length > 0 ? loadSavedEventFilters(workspaces[0].path) : [],
     });
   }
 
@@ -410,9 +431,21 @@ export class LocalSessionBackend implements SessionBackend {
 
     const filtered = sessions
       .map((session) => {
-        const workspace = workspaceByPath.get(session.cwd);
-        const id = workspace ? toCanonicalWorkspaceId(workspace) : 'unknown';
-        return toSessionInfo(session, id);
+        const parsed = parseProcessSessionName(session.name);
+        let workspace = workspaceByPath.get(session.cwd);
+        if (!workspace && parsed) {
+          workspace = workspaces.find((w) => w.id === parsed.workspaceId);
+        }
+        if (!workspace) {
+          workspace = workspaces.find((w) => session.cwd.startsWith(w.path));
+        }
+        const id = workspace ? toCanonicalWorkspaceId(workspace) : (parsed?.workspaceId ? `unknown:${parsed.workspaceId}` : 'unknown');
+        const info = toSessionInfo(session, id);
+        return {
+          ...info,
+          processName: parsed?.processName,
+          processInstance: parsed?.instance,
+        };
       })
       .filter((session) => {
         if (!workspaceId) {
@@ -702,6 +735,119 @@ export class LocalSessionBackend implements SessionBackend {
     const updated = this.deps.updateNotificationConfig(config) as NotificationConfig;
     this.emit({ type: 'notification_config', config: updated });
   }
+
+  async startProcess(workspaceId: string, processName: string): Promise<void> {
+    const workspaces = await this.deps.scanWorkspaces();
+    const workspace = workspaces.find(
+      (w) => w.id === workspaceId || toCanonicalWorkspaceId(w) === workspaceId
+    );
+    if (!workspace) {
+      throw new SpacesError(`Workspace not found: ${workspaceId}`, 'USER_ERROR', 1);
+    }
+
+    const specs = getProcessSpecs(workspace.path).filter((s) => s.name === processName);
+    if (specs.length === 0) {
+      throw new SpacesError(`Process not found: ${processName}`, 'USER_ERROR', 1);
+    }
+
+    const sessionIds: string[] = [];
+    for (const spec of specs) {
+      const result = await startProcessInstance(workspace.path, spec);
+      sessionIds.push(result.sessionId);
+    }
+
+    if (!this.processSchedulers.has(workspace.path)) {
+      this.processSchedulers.set(workspace.path, startProcessScheduler(workspace.path));
+    }
+
+    this.emit({
+      type: 'process_started',
+      workspaceId,
+      processName,
+      sessionId: sessionIds[0],
+    });
+  }
+
+  async stopProcess(workspaceId: string, processName: string): Promise<void> {
+    const workspaces = await this.deps.scanWorkspaces();
+    const workspace = workspaces.find(
+      (w) => w.id === workspaceId || toCanonicalWorkspaceId(w) === workspaceId
+    );
+    if (!workspace) {
+      throw new SpacesError(`Workspace not found: ${workspaceId}`, 'USER_ERROR', 1);
+    }
+
+    const specs = getProcessSpecs(workspace.path).filter((s) => s.name === processName);
+    if (specs.length === 0) {
+      throw new SpacesError(`Process not found: ${processName}`, 'USER_ERROR', 1);
+    }
+
+    for (const spec of specs) {
+      await stopProcessInstance(workspace.path, spec);
+    }
+
+    this.emit({
+      type: 'process_stopped',
+      workspaceId,
+      processName,
+    });
+  }
+
+  async requestEvents(
+    workspacePath: string,
+    filter?: WideEventFilter,
+    limit?: number,
+    sinceMs?: number,
+  ): Promise<void> {
+    const workspaceRef = resolveWorkspaceRef(workspacePath);
+    if (!workspaceRef || !existsSync(workspaceRef.workspacePath)) {
+      this.emit({ type: 'events', events: [], liveEventIds: [] });
+      return;
+    }
+
+    const projectConfig = readProjectConfig(workspaceRef.projectName);
+    const snapshots = readWorkspaceSnapshots(workspaceRef.workspacePath, {
+      maxBytes: projectConfig.events?.snapshotCacheMaxBytes,
+      maxTimeline: projectConfig.events?.maxTimeline,
+    });
+
+    const filtered = snapshots
+      .filter((snapshot) => {
+        if (sinceMs !== undefined && snapshot.updatedAt < sinceMs) return false;
+        if (!filter) return true;
+        if (filter.processName && snapshot.processName !== filter.processName) return false;
+        if (filter.level && snapshot.level !== filter.level) return false;
+        if (filter.message && !snapshot.message.includes(filter.message)) return false;
+        if (filter.eventName && snapshot.eventName !== filter.eventName) return false;
+        if (filter.correlationId && snapshot.correlationId !== filter.correlationId) return false;
+        return true;
+      })
+      .slice(0, limit ?? 200);
+
+    const events = filtered.map((snapshot) => ({
+      eventId: snapshot.lastEventId,
+      eventName: snapshot.eventName,
+      level: snapshot.level,
+      timestamp: new Date(snapshot.updatedAt).toISOString(),
+      timestampMs: snapshot.updatedAt,
+      message: snapshot.message,
+      sessionId: '',
+      workspaceId: workspaceRef.workspaceId,
+      projectName: workspaceRef.projectName,
+      processName: snapshot.processName,
+      processInstance: snapshot.processInstance,
+      raw: snapshot.raw ?? {},
+      kind: 'wide' as const,
+      correlationId: snapshot.correlationId,
+      timeline: Object.values(snapshot.timelineMap),
+      timelineMap: snapshot.timelineMap,
+      timelineOrder: snapshot.timelineOrder,
+    }));
+
+    this.emit({ type: 'events', events, liveEventIds: [] });
+  }
+
+  private processSchedulers = new Map<string, NodeJS.Timer>();
 
   private async attachToSessionSocket(
     session: TmuxSession,

--- a/src/session/backends/local-session-backend.ts
+++ b/src/session/backends/local-session-backend.ts
@@ -770,9 +770,22 @@ export class LocalSessionBackend implements SessionBackend {
     }
 
     const sessionIds: string[] = [];
-    for (const spec of specs) {
-      const result = await startProcessInstance(workspace.path, spec);
-      sessionIds.push(result.sessionId);
+    const startedSpecs: typeof specs = [];
+    try {
+      for (const spec of specs) {
+        const result = await startProcessInstance(workspace.path, spec);
+        sessionIds.push(result.sessionId);
+        startedSpecs.push(spec);
+      }
+    } catch (error) {
+      for (const startedSpec of startedSpecs) {
+        try {
+          await stopProcessInstance(workspace.path, startedSpec);
+        } catch {
+          // Best-effort rollback; preserve original start error
+        }
+      }
+      throw error;
     }
 
     if (!this.processSchedulers.has(workspace.path)) {
@@ -784,6 +797,7 @@ export class LocalSessionBackend implements SessionBackend {
       workspaceId,
       processName,
       sessionId: sessionIds[0],
+      sessionIds,
     });
   }
 

--- a/src/session/backends/local-session-backend.ts
+++ b/src/session/backends/local-session-backend.ts
@@ -424,7 +424,6 @@ export class LocalSessionBackend implements SessionBackend {
     this.emit({
       type: 'workspaces',
       workspaces: mappedWorkspaces,
-      savedEventFilters: workspaces.length > 0 ? loadSavedEventFilters(workspaces[0].path) : [],
     });
   }
 
@@ -848,9 +847,11 @@ export class LocalSessionBackend implements SessionBackend {
   ): Promise<void> {
     const workspaceRef = resolveWorkspaceRef(workspacePath);
     if (!workspaceRef || !existsSync(workspaceRef.workspacePath)) {
-      this.emit({ type: 'events', events: [], liveEventIds: [] });
+      this.emit({ type: 'events', events: [], liveEventIds: [], savedEventFilters: [] });
       return;
     }
+
+    const savedEventFilters = loadSavedEventFilters(workspaceRef.workspacePath);
 
     const projectConfig = readProjectConfig(workspaceRef.projectName);
     const snapshots = readWorkspaceSnapshots(workspaceRef.workspacePath, {
@@ -891,7 +892,7 @@ export class LocalSessionBackend implements SessionBackend {
       timelineOrder: snapshot.timelineOrder,
     }));
 
-    this.emit({ type: 'events', events, liveEventIds: [] });
+    this.emit({ type: 'events', events, liveEventIds: [], savedEventFilters });
   }
 
   private processSchedulers = new Map<string, NodeJS.Timer>();

--- a/src/session/backends/local-session-backend.ts
+++ b/src/session/backends/local-session-backend.ts
@@ -59,7 +59,7 @@ import {
   type WorkspaceDeleteErrorCode,
 } from '../../types/errors.js';
 import { parseProcessSessionName } from '../../lib/processes/names.js';
-import { loadProcessesConfig } from '../../lib/processes/config.js';
+import { loadProcessesConfigWithDiagnostics } from '../../lib/processes/config.js';
 import { getProcessSpecs, startProcessInstance, stopProcessInstance } from '../../lib/processes/manager.js';
 import { startProcessScheduler } from '../../lib/processes/scheduler.js';
 import { readWorkspaceSnapshots } from '../../lib/events/reader.js';
@@ -402,16 +402,17 @@ export class LocalSessionBackend implements SessionBackend {
     }
 
     const mappedWorkspaces = workspaces.map((workspace) => {
-      const processConfig = loadProcessesConfig(workspace.path);
+      const processConfig = loadProcessesConfigWithDiagnostics(workspace.path);
       return {
         ...workspace,
         id: toCanonicalWorkspaceId(workspace),
         sessionCount: counts.get(workspace.path) ?? 0,
-        processes: processConfig.processes.map((p) => ({
+        processes: processConfig.config.processes.map((p) => ({
           name: p.name,
           instances: p.instances,
           ports: p.ports,
         })),
+        processConfigError: processConfig.error ?? undefined,
       };
     });
 

--- a/src/session/backends/local-session-backend.ts
+++ b/src/session/backends/local-session-backend.ts
@@ -59,9 +59,14 @@ import {
   type WorkspaceDeleteErrorCode,
 } from '../../types/errors.js';
 import { parseProcessSessionName } from '../../lib/processes/names.js';
-import { loadProcessesConfigWithDiagnostics } from '../../lib/processes/config.js';
+import {
+  loadProcessesConfig,
+  loadProcessesConfigWithDiagnostics,
+  getProcessDefinition,
+} from '../../lib/processes/config.js';
 import { getProcessSpecs, startProcessInstance, stopProcessInstance } from '../../lib/processes/manager.js';
 import { startProcessScheduler } from '../../lib/processes/scheduler.js';
+import { normalizeProcessInstanceCount } from '../../lib/processes/instances.js';
 import { readWorkspaceSnapshots } from '../../lib/events/reader.js';
 import { resolveWorkspaceRef } from '../../lib/events/paths.js';
 import { loadSavedEventFilters } from '../../lib/events/filters.js';
@@ -760,6 +765,15 @@ export class LocalSessionBackend implements SessionBackend {
     );
     if (!workspace) {
       throw new SpacesError(`Workspace not found: ${workspaceId}`, 'USER_ERROR', 1);
+    }
+
+    const processConfig = loadProcessesConfig(workspace.path);
+    const processDefinition = getProcessDefinition(processConfig, processName);
+    if (!processDefinition) {
+      throw new SpacesError(`Process not found: ${processName}`, 'USER_ERROR', 1);
+    }
+    if (normalizeProcessInstanceCount(processDefinition.instances) === 0) {
+      throw new SpacesError(`Process is disabled (instances: 0): ${processName}`, 'USER_ERROR', 1);
     }
 
     const specs = getProcessSpecs(workspace.path).filter((s) =>

--- a/src/session/backends/remote-session-backend.ts
+++ b/src/session/backends/remote-session-backend.ts
@@ -92,6 +92,7 @@ interface PendingEventsChunk {
   totalChunks: number;
   chunks: Map<number, WideEvent[]>;
   liveEventIds: string[];
+  savedEventFilters?: import('../../types/events.js').SavedEventFilter[];
   receivedAtMs: number;
 }
 
@@ -1100,6 +1101,7 @@ export class RemoteSessionBackend<TSocket, THandshakeState, TServerHello, TServe
         type: 'events',
         events: message.events,
         liveEventIds: message.liveEventIds,
+        savedEventFilters: message.savedEventFilters,
       });
       return;
     }
@@ -1111,12 +1113,14 @@ export class RemoteSessionBackend<TSocket, THandshakeState, TServerHello, TServe
       totalChunks,
       chunks: new Map<number, WideEvent[]>(),
       liveEventIds: message.liveEventIds,
+      savedEventFilters: message.savedEventFilters,
       receivedAtMs: Date.now(),
     };
 
     pending.workspaceId = message.workspaceId;
     pending.totalChunks = totalChunks;
     pending.liveEventIds = message.liveEventIds;
+    pending.savedEventFilters = message.savedEventFilters;
     pending.receivedAtMs = Date.now();
     pending.chunks.set(chunkIndex, message.events);
     this.pendingEventChunks.set(requestId, pending);
@@ -1139,6 +1143,7 @@ export class RemoteSessionBackend<TSocket, THandshakeState, TServerHello, TServe
       type: 'events',
       events: merged,
       liveEventIds: pending.liveEventIds,
+      savedEventFilters: pending.savedEventFilters,
     });
   }
 

--- a/src/session/backends/remote-session-backend.ts
+++ b/src/session/backends/remote-session-backend.ts
@@ -8,6 +8,7 @@ import {
   type ClearInboxRequest,
   type ClientToMachineMessage,
   type DeleteWorkspaceRequest,
+  type GetEventsRequest,
   type GetInboxRequest,
   type GetBundleRefreshPlanRequest,
   type GetNotificationConfigRequest,
@@ -21,10 +22,13 @@ import {
   type ReviewResponse,
   type ScriptOutputResponse,
   type SessionCtrl,
+  type StartProcessRequest,
+  type StopProcessRequest,
   type UpdateNotificationConfigRequest,
 } from '../../lib/remote-session/protocol.js';
 import type { BundleRefreshPlan, BundleRefreshSubmission } from '../../types/bundle-refresh.js';
 import type { ReviewOperation, ReviewResult } from '../../types/review.js';
+import type { WideEventFilter } from '../../types/events.js';
 import { findUtf8Boundary } from '../../utils/utf8.js';
 import type { NotificationConfig } from '../../notifications/types.js';
 import {
@@ -169,6 +173,9 @@ const MACHINE_TO_CLIENT_TYPES = new Set<string>([
   'bundle_refresh_plan',
   'bundle_refresh_applied',
   'review_response',
+  'events_list',
+  'process_started',
+  'process_stopped',
 ]);
 
 function isHandshakeEnvelope(value: unknown): value is HandshakeEnvelope {
@@ -647,6 +654,40 @@ export class RemoteSessionBackend<TSocket, THandshakeState, TServerHello, TServe
     });
   }
 
+  async startProcess(workspaceId: string, processName: string): Promise<void> {
+    const command: StartProcessRequest = {
+      type: 'start_process',
+      workspaceId,
+      processName,
+    };
+    await this.sendCommand(command);
+  }
+
+  async stopProcess(workspaceId: string, processName: string): Promise<void> {
+    const command: StopProcessRequest = {
+      type: 'stop_process',
+      workspaceId,
+      processName,
+    };
+    await this.sendCommand(command);
+  }
+
+  async requestEvents(
+    workspacePath: string,
+    filter?: WideEventFilter,
+    limit?: number,
+    sinceMs?: number,
+  ): Promise<void> {
+    const command: GetEventsRequest = {
+      type: 'get_events',
+      workspacePath,
+      filter,
+      limit,
+      sinceMs,
+    };
+    await this.sendCommand(command);
+  }
+
   async writePtyData(data: Uint8Array): Promise<void> {
     this.assertConnected();
 
@@ -895,7 +936,11 @@ export class RemoteSessionBackend<TSocket, THandshakeState, TServerHello, TServe
         this.emit({ type: 'projects', projects: message.projects });
         return;
       case 'workspace_list':
-        this.emit({ type: 'workspaces', workspaces: message.workspaces });
+        this.emit({
+          type: 'workspaces',
+          workspaces: message.workspaces,
+          savedEventFilters: message.savedEventFilters,
+        });
         return;
       case 'session_list':
         this.emit({ type: 'sessions', sessions: message.sessions });
@@ -963,6 +1008,28 @@ export class RemoteSessionBackend<TSocket, THandshakeState, TServerHello, TServe
         this.resolveReviewRequest(message);
         return;
       }
+      case 'events_list':
+        this.emit({
+          type: 'events',
+          events: message.events,
+          liveEventIds: message.liveEventIds,
+        });
+        return;
+      case 'process_started':
+        this.emit({
+          type: 'process_started',
+          workspaceId: message.workspaceId,
+          processName: message.processName,
+          sessionId: message.sessionId,
+        });
+        return;
+      case 'process_stopped':
+        this.emit({
+          type: 'process_stopped',
+          workspaceId: message.workspaceId,
+          processName: message.processName,
+        });
+        return;
       case 'error':
         this.rejectPendingBundleRefreshRequests(message.message);
         if (message.workspaceId) {

--- a/src/session/backends/remote-session-backend.ts
+++ b/src/session/backends/remote-session-backend.ts
@@ -20,6 +20,7 @@ import {
   type MarkInboxReadRequest,
   type ReviewRequest,
   type ReviewResponse,
+  type EventsListResponse,
   type ScriptOutputResponse,
   type SessionCtrl,
   type StartProcessRequest,
@@ -28,7 +29,7 @@ import {
 } from '../../lib/remote-session/protocol.js';
 import type { BundleRefreshPlan, BundleRefreshSubmission } from '../../types/bundle-refresh.js';
 import type { ReviewOperation, ReviewResult } from '../../types/review.js';
-import type { WideEventFilter } from '../../types/events.js';
+import type { WideEvent, WideEventFilter } from '../../types/events.js';
 import { findUtf8Boundary } from '../../utils/utf8.js';
 import type { NotificationConfig } from '../../notifications/types.js';
 import {
@@ -84,6 +85,14 @@ interface SessionEventMessage {
   cols?: number;
   rows?: number;
   code?: number;
+}
+
+interface PendingEventsChunk {
+  workspaceId: string;
+  totalChunks: number;
+  chunks: Map<number, WideEvent[]>;
+  liveEventIds: string[];
+  receivedAtMs: number;
 }
 
 export interface RemoteSessionSocketHandlers {
@@ -340,6 +349,7 @@ export class RemoteSessionBackend<TSocket, THandshakeState, TServerHello, TServe
   private ptyOutputHandler: ((data: Uint8Array) => void) | null = null;
   private pendingPtyChunks: Uint8Array[] = [];
   private pendingUtf8Bytes = new Uint8Array(0);
+  private pendingEventChunks = new Map<string, PendingEventsChunk>();
 
   constructor(options: RemoteSessionBackendOptions<TSocket, THandshakeState, TServerHello, TServerAuth>) {
     this.descriptor = options.descriptor;
@@ -1020,11 +1030,7 @@ export class RemoteSessionBackend<TSocket, THandshakeState, TServerHello, TServe
         return;
       }
       case 'events_list':
-        this.emit({
-          type: 'events',
-          events: message.events,
-          liveEventIds: message.liveEventIds,
-        });
+        this.handleEventsList(message);
         return;
       case 'process_started':
         this.emit({
@@ -1070,6 +1076,67 @@ export class RemoteSessionBackend<TSocket, THandshakeState, TServerHello, TServe
       done: message.done,
       error: message.error,
       exitCode: message.exitCode,
+    });
+  }
+
+  private prunePendingEventChunks(nowMs = Date.now()): void {
+    const ttlMs = 30_000;
+    for (const [requestId, pending] of this.pendingEventChunks) {
+      if (nowMs - pending.receivedAtMs > ttlMs) {
+        this.pendingEventChunks.delete(requestId);
+      }
+    }
+  }
+
+  private handleEventsList(message: EventsListResponse): void {
+    const totalChunks = message.totalChunks ?? 1;
+    const chunkIndex = message.chunkIndex ?? 0;
+    const requestId = message.requestId;
+
+    if (!requestId || totalChunks <= 1) {
+      this.emit({
+        type: 'events',
+        events: message.events,
+        liveEventIds: message.liveEventIds,
+      });
+      return;
+    }
+
+    this.prunePendingEventChunks();
+
+    const pending = this.pendingEventChunks.get(requestId) ?? {
+      workspaceId: message.workspaceId,
+      totalChunks,
+      chunks: new Map<number, WideEvent[]>(),
+      liveEventIds: message.liveEventIds,
+      receivedAtMs: Date.now(),
+    };
+
+    pending.workspaceId = message.workspaceId;
+    pending.totalChunks = totalChunks;
+    pending.liveEventIds = message.liveEventIds;
+    pending.receivedAtMs = Date.now();
+    pending.chunks.set(chunkIndex, message.events);
+    this.pendingEventChunks.set(requestId, pending);
+
+    if (pending.chunks.size < pending.totalChunks) {
+      return;
+    }
+
+    const merged: WideEvent[] = [];
+    for (let idx = 0; idx < pending.totalChunks; idx += 1) {
+      const chunk = pending.chunks.get(idx);
+      if (!chunk) {
+        return;
+      }
+      merged.push(...chunk);
+    }
+
+    this.pendingEventChunks.delete(requestId);
+    this.emit({
+      type: 'events',
+      events: merged,
+      liveEventIds: pending.liveEventIds,
     });
   }
 
@@ -1293,6 +1360,7 @@ export class RemoteSessionBackend<TSocket, THandshakeState, TServerHello, TServe
     this.sessionKeys = null;
     this.pendingPtyChunks = [];
     this.pendingUtf8Bytes = new Uint8Array(0);
+    this.pendingEventChunks.clear();
     this.rejectPendingBundleRefreshRequests('Remote session disconnected');
     this.rejectPendingWorkspaceDelete('DELETE_FAILED', 'Remote session disconnected', undefined, true);
     this.rejectAllPendingReviewRequests('Remote session disconnected');

--- a/src/session/backends/remote-session-backend.ts
+++ b/src/session/backends/remote-session-backend.ts
@@ -1039,6 +1039,7 @@ export class RemoteSessionBackend<TSocket, THandshakeState, TServerHello, TServe
           workspaceId: message.workspaceId,
           processName: message.processName,
           sessionId: message.sessionId,
+          sessionIds: message.sessionIds,
         });
         return;
       case 'process_stopped':

--- a/src/session/backends/remote-session-backend.ts
+++ b/src/session/backends/remote-session-backend.ts
@@ -301,6 +301,7 @@ export class RemoteSessionBackend<TSocket, THandshakeState, TServerHello, TServe
 
   private mode: 'browsing' | 'attached' = 'browsing';
   private attachedSessionId: string | null = null;
+  private viewOnly = false;
   private handshakeState: THandshakeState | null = null;
   private sessionKeys: SessionKeys | null = null;
   private isConnected = false;
@@ -428,6 +429,7 @@ export class RemoteSessionBackend<TSocket, THandshakeState, TServerHello, TServe
   }
 
   async attachSession(params: AttachSessionParams): Promise<void> {
+    this.viewOnly = params.viewOnly ?? false;
     const command: AttachSessionRequest = {
       type: 'attach_session',
       sessionId: params.sessionId,
@@ -436,6 +438,10 @@ export class RemoteSessionBackend<TSocket, THandshakeState, TServerHello, TServe
       cols: params.cols,
       rows: params.rows,
       scriptPolicy: params.scriptPolicy,
+      viewOnly: params.viewOnly,
+      command: params.command,
+      args: params.args,
+      env: params.env,
     };
     await this.sendCommand(command);
   }
@@ -689,6 +695,9 @@ export class RemoteSessionBackend<TSocket, THandshakeState, TServerHello, TServe
   }
 
   async writePtyData(data: Uint8Array): Promise<void> {
+    if (this.viewOnly) {
+      return;
+    }
     this.assertConnected();
 
     const key = this.sessionKeys;
@@ -952,11 +961,13 @@ export class RemoteSessionBackend<TSocket, THandshakeState, TServerHello, TServe
           type: 'attached',
           sessionId: message.sessionId,
           sessionName: message.sessionName,
+          viewOnly: this.viewOnly,
         });
         return;
       case 'detached':
         this.mode = 'browsing';
         this.attachedSessionId = null;
+        this.viewOnly = false;
         this.emit({ type: 'detached' });
         return;
       case 'session_exited':

--- a/src/session/backends/remote-session-backend.ts
+++ b/src/session/backends/remote-session-backend.ts
@@ -670,11 +670,12 @@ export class RemoteSessionBackend<TSocket, THandshakeState, TServerHello, TServe
     });
   }
 
-  async startProcess(workspaceId: string, processName: string): Promise<void> {
+  async startProcess(workspaceId: string, processName: string, instance?: number): Promise<void> {
     const command: StartProcessRequest = {
       type: 'start_process',
       workspaceId,
       processName,
+      instance,
     };
     await this.sendCommand(command);
   }

--- a/src/session/events.ts
+++ b/src/session/events.ts
@@ -31,7 +31,7 @@ export type BackendEvent =
   | { type: 'error'; message: string }
   | { type: 'review_response'; requestId: string; result?: ReviewResult; error?: { code: string; message: string } }
   | { type: 'events'; events: WideEvent[]; liveEventIds: string[] }
-  | { type: 'process_started'; workspaceId: string; processName: string; sessionId?: string }
+  | { type: 'process_started'; workspaceId: string; processName: string; sessionId?: string; sessionIds?: string[] }
   | { type: 'process_stopped'; workspaceId: string; processName: string };
 
 // Re-export for convenience

--- a/src/session/events.ts
+++ b/src/session/events.ts
@@ -24,7 +24,7 @@ export type BackendEvent =
       exitCode?: number;
     }
   | { type: 'notification_config'; config: NotificationConfig }
-  | { type: 'attached'; sessionId: string; sessionName?: string }
+  | { type: 'attached'; sessionId: string; sessionName?: string; viewOnly?: boolean }
   | { type: 'detached' }
   | { type: 'session_exited'; sessionId: string; exitCode?: number }
   | { type: 'command_error'; code?: string; message: string }

--- a/src/session/events.ts
+++ b/src/session/events.ts
@@ -7,11 +7,12 @@ import type {
 } from '../lib/remote-session/protocol.js';
 import type { NotificationConfig } from '../notifications/types.js';
 import type { ReviewOperation, ReviewResult } from '../types/review.js';
+import type { WideEvent, SavedEventFilter } from '../types/events.js';
 
 export type BackendEvent =
   | { type: 'status'; status: 'disconnected' | 'connecting' | 'connected' | 'error'; error?: string }
   | { type: 'projects'; projects: ProjectInfo[] }
-  | { type: 'workspaces'; workspaces: WorkspaceInfo[] }
+  | { type: 'workspaces'; workspaces: WorkspaceInfo[]; savedEventFilters?: SavedEventFilter[] }
   | { type: 'sessions'; sessions: SessionInfo[] }
   | { type: 'inbox'; items: InboxItem[]; unreadCount: number }
   | {
@@ -28,7 +29,10 @@ export type BackendEvent =
   | { type: 'session_exited'; sessionId: string; exitCode?: number }
   | { type: 'command_error'; code?: string; message: string }
   | { type: 'error'; message: string }
-  | { type: 'review_response'; requestId: string; result?: ReviewResult; error?: { code: string; message: string } };
+  | { type: 'review_response'; requestId: string; result?: ReviewResult; error?: { code: string; message: string } }
+  | { type: 'events'; events: WideEvent[]; liveEventIds: string[] }
+  | { type: 'process_started'; workspaceId: string; processName: string; sessionId?: string }
+  | { type: 'process_stopped'; workspaceId: string; processName: string };
 
 // Re-export for convenience
 export type { ReviewOperation, ReviewResult };

--- a/src/session/events.ts
+++ b/src/session/events.ts
@@ -30,7 +30,7 @@ export type BackendEvent =
   | { type: 'command_error'; code?: string; message: string }
   | { type: 'error'; message: string }
   | { type: 'review_response'; requestId: string; result?: ReviewResult; error?: { code: string; message: string } }
-  | { type: 'events'; events: WideEvent[]; liveEventIds: string[] }
+  | { type: 'events'; events: WideEvent[]; liveEventIds: string[]; savedEventFilters?: SavedEventFilter[] }
   | { type: 'process_started'; workspaceId: string; processName: string; sessionId?: string; sessionIds?: string[] }
   | { type: 'process_stopped'; workspaceId: string; processName: string };
 

--- a/src/session/reducer.ts
+++ b/src/session/reducer.ts
@@ -21,6 +21,9 @@ function createBackendState(descriptor: BackendDescriptor): BackendSessionState 
     attachedSessionId: null,
     attachedSessionName: null,
     scriptState: null,
+    events: [],
+    liveEventIds: [],
+    savedEventFilters: [],
   };
 }
 
@@ -229,6 +232,37 @@ export function sessionEngineReducer(
             mode: attached ? 'attached' : 'browsing',
             attachedSessionId: action.sessionId,
             attachedSessionName: nextSessionName,
+          },
+        },
+      };
+    }
+
+    case 'SET_EVENTS': {
+      const backend = state.backends[action.backendKey];
+      if (!backend) return state;
+      return {
+        ...state,
+        backends: {
+          ...state.backends,
+          [action.backendKey]: {
+            ...backend,
+            events: action.events,
+            liveEventIds: action.liveEventIds,
+          },
+        },
+      };
+    }
+
+    case 'SET_SAVED_EVENT_FILTERS': {
+      const backend = state.backends[action.backendKey];
+      if (!backend) return state;
+      return {
+        ...state,
+        backends: {
+          ...state.backends,
+          [action.backendKey]: {
+            ...backend,
+            savedEventFilters: action.filters,
           },
         },
       };

--- a/src/session/types.ts
+++ b/src/session/types.ts
@@ -7,6 +7,7 @@ import type {
 } from '../lib/remote-session/protocol.js';
 import type { NotificationConfig } from '../notifications/types.js';
 import type { BackendDescriptor, BackendKey } from './backend.js';
+import type { WideEvent, SavedEventFilter } from '../types/events.js';
 
 export interface ScriptRuntimeState {
   phase: ScriptOutputResponse['phase'];
@@ -35,6 +36,10 @@ export interface BackendSessionState {
   attachedSessionName: string | null;
 
   scriptState: ScriptRuntimeState | null;
+
+  events: WideEvent[];
+  liveEventIds: string[];
+  savedEventFilters: SavedEventFilter[];
 }
 
 export interface SessionEngineState {
@@ -82,4 +87,15 @@ export type SessionEngineAction =
       type: 'SET_COMMAND_ERROR';
       backendKey: BackendKey;
       commandError: { code?: string; message: string } | null;
+    }
+  | {
+      type: 'SET_EVENTS';
+      backendKey: BackendKey;
+      events: WideEvent[];
+      liveEventIds: string[];
+    }
+  | {
+      type: 'SET_SAVED_EVENT_FILTERS';
+      backendKey: BackendKey;
+      filters: SavedEventFilter[];
     };

--- a/src/session/useBundleRefreshAttachFlow.ts
+++ b/src/session/useBundleRefreshAttachFlow.ts
@@ -15,6 +15,8 @@ export interface BundleRefreshAttachParams {
   cols?: number;
   rows?: number;
   scriptPolicy?: 'auto' | 'skip';
+  /** When true, backend enforces read-only attach */
+  viewOnly?: boolean;
   /** Custom command to run (skips workspace scripts when set) */
   command?: string;
   /** Arguments for the custom command */

--- a/src/session/useBundleRefreshAttachFlow.ts
+++ b/src/session/useBundleRefreshAttachFlow.ts
@@ -15,6 +15,12 @@ export interface BundleRefreshAttachParams {
   cols?: number;
   rows?: number;
   scriptPolicy?: 'auto' | 'skip';
+  /** Custom command to run (skips workspace scripts when set) */
+  command?: string;
+  /** Arguments for the custom command */
+  args?: string[];
+  /** Environment variables for the custom command */
+  env?: Record<string, string>;
 }
 
 interface PendingAttach {

--- a/src/session/useRemoteSessionClient.ts
+++ b/src/session/useRemoteSessionClient.ts
@@ -19,6 +19,7 @@ import type {
 } from '../types/bundle-refresh.js';
 import type { ReviewOperation, ReviewResult } from '../types/review.js';
 import { SpacesError } from '../types/errors.js';
+import type { WideEvent, SavedEventFilter, WideEventFilter } from '../types/events.js';
 import { useSessionEngine } from './useSessionEngine.js';
 
 export type RemoteSessionConnectionStatus =
@@ -94,6 +95,13 @@ export interface UseRemoteSessionClientReturn<ConnectParams> {
 
   scriptState: ScriptRuntimeState | null;
   commandError: { code?: string; message: string } | null;
+
+  events: WideEvent[];
+  liveEventIds: string[];
+  savedEventFilters: SavedEventFilter[];
+  startProcess: (workspaceId: string, processName: string) => void;
+  stopProcess: (workspaceId: string, processName: string) => void;
+  requestEvents: (workspacePath: string, filter?: WideEventFilter, limit?: number, sinceMs?: number) => void;
 }
 
 function defaultStatusMapper(
@@ -320,6 +328,29 @@ export function useRemoteSessionClient<ConnectParams>(
     [engine]
   );
 
+  const startProcess = useCallback((workspaceId: string, processName: string) => {
+    void withActiveBackend((backendKey) =>
+      engine.startProcess(backendKey, workspaceId, processName)
+    );
+  }, [engine, withActiveBackend]);
+
+  const stopProcess = useCallback((workspaceId: string, processName: string) => {
+    void withActiveBackend((backendKey) =>
+      engine.stopProcess(backendKey, workspaceId, processName)
+    );
+  }, [engine, withActiveBackend]);
+
+  const requestEvents = useCallback((
+    workspacePath: string,
+    filter?: WideEventFilter,
+    limit?: number,
+    sinceMs?: number,
+  ) => {
+    void withActiveBackend((backendKey) =>
+      engine.requestEvents(backendKey, workspacePath, filter, limit, sinceMs)
+    );
+  }, [engine, withActiveBackend]);
+
   useEffect(() => {
     return () => {
       const backendKey = activeBackendKeyRef.current;
@@ -376,5 +407,12 @@ export function useRemoteSessionClient<ConnectParams>(
 
     scriptState: activeBackendState?.scriptState ?? null,
     commandError: activeBackendState?.commandError ?? null,
+
+    events: activeBackendState?.events ?? [],
+    liveEventIds: activeBackendState?.liveEventIds ?? [],
+    savedEventFilters: activeBackendState?.savedEventFilters ?? [],
+    startProcess,
+    stopProcess,
+    requestEvents,
   };
 }

--- a/src/session/useRemoteSessionClient.ts
+++ b/src/session/useRemoteSessionClient.ts
@@ -99,7 +99,7 @@ export interface UseRemoteSessionClientReturn<ConnectParams> {
   events: WideEvent[];
   liveEventIds: string[];
   savedEventFilters: SavedEventFilter[];
-  startProcess: (workspaceId: string, processName: string) => void;
+  startProcess: (workspaceId: string, processName: string, instance?: number) => void;
   stopProcess: (workspaceId: string, processName: string) => void;
   requestEvents: (workspacePath: string, filter?: WideEventFilter, limit?: number, sinceMs?: number) => void;
 }
@@ -328,9 +328,9 @@ export function useRemoteSessionClient<ConnectParams>(
     [engine]
   );
 
-  const startProcess = useCallback((workspaceId: string, processName: string) => {
+  const startProcess = useCallback((workspaceId: string, processName: string, instance?: number) => {
     void withActiveBackend((backendKey) =>
-      engine.startProcess(backendKey, workspaceId, processName)
+      engine.startProcess(backendKey, workspaceId, processName, instance)
     );
   }, [engine, withActiveBackend]);
 

--- a/src/session/useRemoteSessionClient.ts
+++ b/src/session/useRemoteSessionClient.ts
@@ -99,8 +99,8 @@ export interface UseRemoteSessionClientReturn<ConnectParams> {
   events: WideEvent[];
   liveEventIds: string[];
   savedEventFilters: SavedEventFilter[];
-  startProcess: (workspaceId: string, processName: string, instance?: number) => void;
-  stopProcess: (workspaceId: string, processName: string) => void;
+  startProcess: (workspaceId: string, processName: string, instance?: number) => Promise<void>;
+  stopProcess: (workspaceId: string, processName: string) => Promise<void>;
   requestEvents: (workspacePath: string, filter?: WideEventFilter, limit?: number, sinceMs?: number) => void;
 }
 
@@ -328,16 +328,22 @@ export function useRemoteSessionClient<ConnectParams>(
     [engine]
   );
 
-  const startProcess = useCallback((workspaceId: string, processName: string, instance?: number) => {
-    void withActiveBackend((backendKey) =>
+  const startProcess = useCallback(async (workspaceId: string, processName: string, instance?: number) => {
+    const result = await withActiveBackend((backendKey) =>
       engine.startProcess(backendKey, workspaceId, processName, instance)
     );
+    if (result === null) {
+      throw new Error('No active backend connection');
+    }
   }, [engine, withActiveBackend]);
 
-  const stopProcess = useCallback((workspaceId: string, processName: string) => {
-    void withActiveBackend((backendKey) =>
+  const stopProcess = useCallback(async (workspaceId: string, processName: string) => {
+    const result = await withActiveBackend((backendKey) =>
       engine.stopProcess(backendKey, workspaceId, processName)
     );
+    if (result === null) {
+      throw new Error('No active backend connection');
+    }
   }, [engine, withActiveBackend]);
 
   const requestEvents = useCallback((

--- a/src/session/useSessionEngine.ts
+++ b/src/session/useSessionEngine.ts
@@ -145,6 +145,9 @@ export function useSessionEngine() {
             events: event.events,
             liveEventIds: event.liveEventIds,
           });
+          if (event.savedEventFilters) {
+            dispatch({ type: 'SET_SAVED_EVENT_FILTERS', backendKey, filters: event.savedEventFilters });
+          }
           break;
         case 'process_started':
         case 'process_stopped':

--- a/src/session/useSessionEngine.ts
+++ b/src/session/useSessionEngine.ts
@@ -12,6 +12,7 @@ import type {
 } from '../types/bundle-refresh.js';
 import type { ReviewOperation, ReviewResult } from '../types/review.js';
 import type { ScriptPhase } from '../types/script-phase.js';
+import type { WideEventFilter } from '../types/events.js';
 import { BackendManager } from './backend-manager.js';
 import {
   createInitialSessionEngineState,
@@ -60,6 +61,9 @@ export function useSessionEngine() {
           break;
         case 'workspaces':
           dispatch({ type: 'SET_WORKSPACES', backendKey, workspaces: event.workspaces });
+          if (event.savedEventFilters) {
+            dispatch({ type: 'SET_SAVED_EVENT_FILTERS', backendKey, filters: event.savedEventFilters });
+          }
           break;
         case 'sessions':
           dispatch({ type: 'SET_SESSIONS', backendKey, sessions: event.sessions });
@@ -133,6 +137,18 @@ export function useSessionEngine() {
           break;
         case 'review_response':
           // Handled directly by RemoteSessionBackend's pending map — no state dispatch needed.
+          break;
+        case 'events':
+          dispatch({
+            type: 'SET_EVENTS',
+            backendKey,
+            events: event.events,
+            liveEventIds: event.liveEventIds,
+          });
+          break;
+        case 'process_started':
+        case 'process_stopped':
+          // Refresh workspaces and sessions to reflect process state changes
           break;
         default:
           break;
@@ -313,6 +329,36 @@ export function useSessionEngine() {
     return result;
   }, [withBackend]);
 
+  const startProcess = useCallback(async (backendKey: BackendKey, workspaceId: string, processName: string) => {
+    await withBackend(backendKey, async (backend) => {
+      if (backend.startProcess) {
+        await backend.startProcess(workspaceId, processName);
+      }
+    });
+  }, [withBackend]);
+
+  const stopProcess = useCallback(async (backendKey: BackendKey, workspaceId: string, processName: string) => {
+    await withBackend(backendKey, async (backend) => {
+      if (backend.stopProcess) {
+        await backend.stopProcess(workspaceId, processName);
+      }
+    });
+  }, [withBackend]);
+
+  const requestEvents = useCallback(async (
+    backendKey: BackendKey,
+    workspacePath: string,
+    filter?: WideEventFilter,
+    limit?: number,
+    sinceMs?: number,
+  ) => {
+    await withBackend(backendKey, async (backend) => {
+      if (backend.requestEvents) {
+        await backend.requestEvents(workspacePath, filter, limit, sinceMs);
+      }
+    });
+  }, [withBackend]);
+
   return useMemo(() => ({
     state,
     activeBackendKey: getActiveBackendKey(state),
@@ -342,6 +388,10 @@ export function useSessionEngine() {
     getNotificationConfig,
     updateNotificationConfig,
     sendReviewRequest,
+
+    startProcess,
+    stopProcess,
+    requestEvents,
   }), [
     state,
     registerBackend,
@@ -364,5 +414,8 @@ export function useSessionEngine() {
     getNotificationConfig,
     updateNotificationConfig,
     sendReviewRequest,
+    startProcess,
+    stopProcess,
+    requestEvents,
   ]);
 }

--- a/src/session/useSessionEngine.ts
+++ b/src/session/useSessionEngine.ts
@@ -148,7 +148,15 @@ export function useSessionEngine() {
           break;
         case 'process_started':
         case 'process_stopped':
-          // Refresh workspaces and sessions to reflect process state changes
+          // Refresh workspaces and sessions to reflect process state changes.
+          // Important for remote/web clients that don't immediately call refresh.
+          {
+            const backend = managerRef.current?.get(backendKey);
+            if (backend) {
+              void backend.listWorkspaces().catch(() => undefined);
+              void backend.listSessions().catch(() => undefined);
+            }
+          }
           break;
         default:
           break;

--- a/src/session/useSessionEngine.ts
+++ b/src/session/useSessionEngine.ts
@@ -329,10 +329,10 @@ export function useSessionEngine() {
     return result;
   }, [withBackend]);
 
-  const startProcess = useCallback(async (backendKey: BackendKey, workspaceId: string, processName: string) => {
+  const startProcess = useCallback(async (backendKey: BackendKey, workspaceId: string, processName: string, instance?: number) => {
     await withBackend(backendKey, async (backend) => {
       if (backend.startProcess) {
-        await backend.startProcess(workspaceId, processName);
+        await backend.startProcess(workspaceId, processName, instance);
       }
     });
   }, [withBackend]);

--- a/src/tui/local-terminal-sync.ts
+++ b/src/tui/local-terminal-sync.ts
@@ -1,4 +1,4 @@
-export type AppView = 'machines' | 'projects' | 'terminal' | 'inbox' | 'scripts'
+export type AppView = 'machines' | 'projects' | 'terminal' | 'inbox' | 'scripts' | 'events'
 
 export type LocalSessionStatus = 'disconnected' | 'connecting' | 'connected' | 'error'
 export type LocalSessionMode = 'browsing' | 'attached'

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -64,6 +64,91 @@ export const DEFAULT_NOTIFICATION_CONFIG: NotificationConfig = {
 };
 
 /**
+ * Wide event ingestion mode
+ */
+export type EventsIngestionMode = 'prefix' | 'json';
+
+/**
+ * Field mapping for wide events
+ */
+export interface EventsFieldConfig {
+  /** Field name for the event name */
+  name: string;
+  /** Field name for the event ID */
+  id: string;
+  /** Field name for the event level */
+  level: string;
+  /** Field name for the timestamp */
+  timestamp: string;
+  /** Field name for the message */
+  message: string;
+}
+
+/**
+ * Rotation settings for wide event logs
+ */
+export interface EventsRotationConfig {
+  /** Max file size in bytes before rotation */
+  maxBytes: number;
+  /** Max file age in minutes before rotation */
+  maxMinutes: number;
+  /** Number of files to retain */
+  keepFiles: number;
+}
+
+/**
+ * Wide event configuration
+ */
+export interface EventsConfig {
+  /** Enable wide event collection */
+  enabled: boolean;
+  /** Ingestion mode (prefix required or json matching) */
+  mode: EventsIngestionMode;
+  /** Prefix for event lines when mode is prefix */
+  prefix: string;
+  /** Field mapping */
+  fields: EventsFieldConfig;
+  /** Rotation settings */
+  rotation: EventsRotationConfig;
+  /** Correlation field for aggregating wide events */
+  correlationField?: string;
+  /** Aggregate wide events as source events stream in */
+  aggregateMode?: 'stream';
+  /** Max timeline entries per wide event */
+  maxTimeline?: number;
+  /** Minimum interval between wide event updates (ms) */
+  updateIntervalMs?: number;
+  /** Snapshot cache size per workspace (bytes) */
+  snapshotCacheMaxBytes?: number;
+}
+
+/**
+ * Default wide event configuration
+ */
+export const DEFAULT_EVENTS_CONFIG: EventsConfig = {
+  enabled: true,
+  mode: 'prefix',
+  prefix: '@event',
+  fields: {
+    name: 'event',
+    id: 'eventId',
+    level: 'level',
+    timestamp: 'timestamp',
+    message: 'message',
+  },
+  rotation: {
+    maxBytes: 25_000_000,
+    maxMinutes: 60,
+    keepFiles: 20,
+  },
+  correlationField: 'requestId',
+  aggregateMode: 'stream',
+  maxTimeline: 200,
+  updateIntervalMs: 250,
+  snapshotCacheMaxBytes: 64 * 1024 * 1024,
+};
+
+/**
  * Linear team info stored in config
  */
 export interface LinearTeamInfo {
@@ -143,6 +228,8 @@ export interface ProjectConfig {
   repository: string;
   /** Base branch for creating worktrees */
   baseBranch: string;
+  /** Wide events configuration */
+  events?: EventsConfig;
   /**
    * @deprecated Use user-level Linear config instead.
    * Kept for backwards compatibility - will be migrated on first access.
@@ -195,5 +282,6 @@ export function createDefaultProjectConfig(
     baseBranch,
     createdAt: now,
     lastAccessed: now,
+    events: { ...DEFAULT_EVENTS_CONFIG },
   };
 }

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -1,0 +1,91 @@
+/**
+ * Types for wide event logging
+ */
+
+export interface WideEventTimelineItem {
+  eventName: string;
+  level: string;
+  timestamp: string;
+  timestampMs: number;
+  message: string;
+  raw: Record<string, unknown>;
+}
+
+export interface WideSnapshotTimelineEntry extends WideEventTimelineItem {
+  key: string;
+  eventId: string;
+  processName?: string;
+  processInstance?: number;
+}
+
+export interface WideSnapshotTimelineMap {
+  [key: string]: WideSnapshotTimelineEntry;
+}
+
+export interface WideSnapshot {
+  correlationId: string;
+  updatedAt: number;
+  processName?: string;
+  processInstance?: number;
+  level: string;
+  message: string;
+  eventName: string;
+  lastEventId: string;
+  timelineMap: WideSnapshotTimelineMap;
+  timelineOrder: string[];
+  raw?: Record<string, unknown>;
+}
+
+export interface WideEvent {
+  eventId: string;
+  eventName: string;
+  level: string;
+  timestamp: string;
+  timestampMs: number;
+  message: string;
+  sessionId: string;
+  workspaceId: string;
+  projectName: string;
+  processName?: string;
+  processInstance?: number;
+  raw: Record<string, unknown>;
+  kind?: 'source' | 'wide';
+  correlationId?: string;
+  timeline?: WideEventTimelineItem[];
+  timelineMap?: WideSnapshotTimelineMap;
+  timelineOrder?: string[];
+}
+
+export interface WideEventFilter {
+  eventName?: string;
+  eventId?: string;
+  level?: string;
+  message?: string;
+  processName?: string;
+  kind?: 'source' | 'wide';
+  correlationId?: string;
+}
+
+export interface SavedEventFilter {
+  name: string;
+  filter: WideEventFilter;
+  sinceMinutes?: number;
+}
+
+export interface EventsConfigFile {
+  savedFilters?: SavedEventFilter[];
+}
+
+export interface WideEventIndex {
+  file: string;
+  minTs: number;
+  maxTs: number;
+  levels: string[];
+  eventNames: string[];
+  count: number;
+}
+
+export interface WideEventQueryResult {
+  events: WideEvent[];
+  liveEventIds: string[];
+}

--- a/src/types/processes.ts
+++ b/src/types/processes.ts
@@ -1,0 +1,45 @@
+/**
+ * Workspace process definitions
+ */
+
+import type { EventsConfig } from './config.js';
+
+export type ProcessRestartPolicy = 'never' | 'on-failure' | 'always';
+
+export type ProcessPortProtocol = 'http' | 'tcp';
+
+export interface ProcessPortConfig {
+  port: number;
+  name?: string;
+  protocol?: ProcessPortProtocol;
+}
+
+export interface ProcessRestartConfig {
+  policy: ProcessRestartPolicy;
+  maxAttempts: number;
+  backoffMs: number;
+  maxBackoffMs: number;
+}
+
+export interface ProcessDefinition {
+  name: string;
+  command: string;
+  args?: string[];
+  cwd?: string;
+  env?: Record<string, string>;
+  instances?: number;
+  autostart?: boolean;
+  restart?: ProcessRestartConfig;
+  events?: Partial<EventsConfig> & { enabled?: boolean; keepRawOutput?: boolean };
+  ports?: ProcessPortConfig[];
+}
+
+export interface ProcessesConfig {
+  processes: ProcessDefinition[];
+}
+
+export interface ProcessInstanceSpec {
+  name: string;
+  instance: number;
+  definition: ProcessDefinition;
+}

--- a/src/utils/hostnames.ts
+++ b/src/utils/hostnames.ts
@@ -1,0 +1,43 @@
+const MAX_LABEL_LENGTH = 63;
+const MAX_HOSTNAME_LENGTH = 253;
+
+function clampLabel(value: string, maxLength: number): string {
+  if (value.length <= maxLength) return value;
+  const trimmed = value.slice(0, maxLength).replace(/-+$/g, '');
+  return trimmed.length > 0 ? trimmed : 'x';
+}
+
+export function normalizeHostLabel(value: string): string {
+  const normalized = value
+    .toLowerCase()
+    .replace(/[^a-z0-9-]/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '');
+  if (!normalized) return 'x';
+  return clampLabel(normalized, MAX_LABEL_LENGTH);
+}
+
+export function buildProcessHostname(
+  serveDomain: string,
+  workspaceId: string,
+  processName: string,
+  instance: number,
+  portLabel: string
+): string {
+  const workspaceSegment = normalizeHostLabel(workspaceId);
+  const processSegment = normalizeHostLabel(processName);
+  const portSegment = normalizeHostLabel(portLabel);
+
+  const base = `${portSegment}.${processSegment}-${instance}`;
+  const suffix = `.${serveDomain}`;
+  let hostname = `${base}.${workspaceSegment}${suffix}`;
+
+  if (hostname.length <= MAX_HOSTNAME_LENGTH) {
+    return hostname;
+  }
+
+  const availableWorkspace = MAX_HOSTNAME_LENGTH - base.length - suffix.length - 1;
+  const trimmedWorkspace = clampLabel(workspaceSegment, Math.max(1, availableWorkspace));
+  hostname = `${base}.${trimmedWorkspace}${suffix}`;
+  return hostname;
+}


### PR DESCRIPTION
## Summary

- **Wide events**: Structured event collection and viewing system — processes emit typed events (port binding, health checks, errors, etc.) captured to `.gitspace/events.json` per workspace; viewable in TUI and web via an Events panel
- **Process management**: `.gitspace/processes.json` config drives named, multi-instance processes with autostart, restart policies, port tracking, and watchdog supervision; `gssh process start/stop/list` CLI commands; `x` key stops running processes in the browser
- **Process config editor**: New `⚙ Edit Processes Config` item in expanded workspaces (TUI + web) spawns `$EDITOR` on `.gitspace/processes.json` via a direct PTY session, bypassing workspace scripts; `command`/`args`/`env` fields threaded through the full attach stack (local + remote backends)
- **View-only attachment**: Running process sessions attach in read-only mode (server-enforced, client cannot send input); `[view only]` label shown in terminal header
- **Contextual status bar hints**: TUI and web footer hints update based on the currently selected tree item type
- **`gssh host` serving improvements**: Process-aware subdomain hosting via cloudflared integration in `gssh serve`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches core session attach/terminal IO paths and adds new Cloudflared tunnel management plus polling UIs, increasing risk of regressions in connectivity, resource usage, and hosting behavior.
> 
> **Overview**
> Adds first-class **process management and observability** across CLI, web, and TUI: the workspace browser now renders configured processes (including disabled/config-error states), supports start/stop/start+attach flows, and introduces a `.gitspace/processes.json` editor entry.
> 
> Introduces a new **wide events** pipeline and UI: a `gssh events` command can list/show/tail aggregated event logs per workspace/process, and new `Events` screens (web + TUI) poll and render wide-event timelines with saved filters from `.gitspace/events.json`.
> 
> Improves session safety by threading a `viewOnly` attach flag end-to-end and enforcing read-only terminals for process sessions (plus UI hints and input blocking), and extends `gssh host/serve` to manage a separate “serve” subdomain/token and dynamically generate/refresh Cloudflared ingress routes for process port hosting.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bf6da3f7811b2b9bc076a675c497c54aa4d22d56. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI: manage processes (list/start/stop/attach) and query events (list/show/tail).
  * UI: Events view with timeline, saved filters, search, and view-only terminal mode.
  * Process hosting & runner: per-workspace process lifecycle, autostart, restart/watchdog scheduling, and serve integration.
  * Edit workflow: in-app edit flow for workspace process configs.

* **Chores**
  * Added sample processes/events configs and a synthetic event emitter for demos.

* **Tests**
  * Extensive unit and integration tests for events, processes, scheduler, session flows, and protocol.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->