### PR TITLE
Add workspace review workflow and scoped session commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ temp/
 
 # GitSpace marker files
 gitspace.lock
+
+# gssh review — workspace review notes
+.gitspace/review/

--- a/README.md
+++ b/README.md
@@ -106,6 +106,22 @@ gssh switch
 gssh switch my-feature
 ```
 
+### Workspace Session Mode (`space`)
+
+When GitSpace opens a workspace-scoped terminal session, it injects a `space` shell function (bash/zsh).
+
+- Use `space ...` for workspace operations without repeating `--project` and `--workspace`
+- `gssh` commands are restricted in this mode to avoid cross-workspace mistakes
+- `gssh tmux ...` is blocked inside workspace sessions
+
+Examples:
+
+```bash
+space context --json
+space review hunks src/app.ts --format json
+space review add-hunk src/app.ts --index 1 --approve --body "Looks good"
+```
+
 ## Repo Config Bundles
 
 Repo config bundles allow repository owners to share onboarding configurations with their team. When someone clones a project that contains a bundle, they'll be guided through setup steps and have scripts automatically installed.

--- a/src/app.web.tsx
+++ b/src/app.web.tsx
@@ -799,14 +799,12 @@ export default function App() {
               Loading review for <span className="text-[#58a6ff]">{reviewWorkspace.workspaceName}</span>
             </div>
             <div className="text-sm text-[#8b949e]">{statusMessage}</div>
-            {terminal.status === 'error' && (
-              <button
-                onClick={() => { setView('machines'); setReviewWorkspace(null); }}
-                className="mt-4 px-6 py-3 text-base bg-[#21262d] hover:bg-[#30363d] rounded-lg text-[#e6edf3] min-h-[48px] border border-[#30363d]"
-              >
-                Back to Machines
-              </button>
-            )}
+            <button
+              onClick={() => { setView('machines'); setReviewWorkspace(null); }}
+              className="mt-4 px-6 py-3 text-base bg-[#21262d] hover:bg-[#30363d] rounded-lg text-[#e6edf3] min-h-[48px] border border-[#30363d]"
+            >
+              Back to Machines
+            </button>
           </div>
         </div>
         <Toaster theme="dark" position="top-right" richColors />

--- a/src/app.web.tsx
+++ b/src/app.web.tsx
@@ -28,6 +28,7 @@ import {
   useFlow,
   getDefaultShortcuts,
   type MachineInfo,
+  type WorkspaceInfo,
 } from "./components/index.js";
 import { MachineListWeb } from "./components/MachineList.web.js";
 import { SpacesBrowserWeb } from "./components/SpacesBrowser.web.js";
@@ -90,7 +91,11 @@ export default function App() {
   } | null>(null);
 
   // Review workspace/project state
-  const [reviewWorkspace, setReviewWorkspace] = useState<{ projectName: string; workspaceName: string } | null>(null);
+  const [reviewWorkspace, setReviewWorkspace] = useState<{
+    projectName: string;
+    workspaceId: string;
+    workspaceLabel?: string;
+  } | null>(null);
 
   // Relay connection (for machine list)
   const relay = useRelayConnection();
@@ -258,7 +263,7 @@ export default function App() {
       const ws = params.get('workspace');
       const proj = params.get('project');
       if (ws && proj) {
-        setReviewWorkspace({ projectName: proj, workspaceName: ws });
+        setReviewWorkspace({ projectName: proj, workspaceId: ws, workspaceLabel: ws });
         setView('review');
       }
     }
@@ -434,8 +439,12 @@ export default function App() {
   }, [attachController]);
 
   // Handle opening review for a workspace
-  const handleOpenReview = useCallback((workspace: { projectName: string; name: string }) => {
-    setReviewWorkspace({ projectName: workspace.projectName, workspaceName: workspace.name });
+  const handleOpenReview = useCallback((workspace: WorkspaceInfo) => {
+    setReviewWorkspace({
+      projectName: workspace.projectName,
+      workspaceId: workspace.id,
+      workspaceLabel: workspace.name,
+    });
     setView('review');
   }, []);
 
@@ -767,7 +776,8 @@ export default function App() {
         <>
           <ReviewPage
             projectName={reviewWorkspace.projectName}
-            workspaceName={reviewWorkspace.workspaceName}
+            workspaceName={reviewWorkspace.workspaceId}
+            workspaceLabel={reviewWorkspace.workspaceLabel}
             machineName={selectedMachine?.label || selectedMachine?.machineId}
             sendReviewRequest={terminal.sendReviewRequest}
             onBack={() => {
@@ -796,7 +806,7 @@ export default function App() {
         <div className="h-screen w-screen flex flex-col items-center justify-center bg-[#0d1117] px-4">
           <div className="text-center">
             <div className="text-lg text-[#e6edf3] mb-2">
-              Loading review for <span className="text-[#58a6ff]">{reviewWorkspace.workspaceName}</span>
+              Loading review for <span className="text-[#58a6ff]">{reviewWorkspace.workspaceLabel ?? reviewWorkspace.workspaceId}</span>
             </div>
             <div className="text-sm text-[#8b949e]">{statusMessage}</div>
             <button

--- a/src/app.web.tsx
+++ b/src/app.web.tsx
@@ -19,6 +19,7 @@ import { useUserActivity } from "./hooks/index.js";
 import { useBundleRefreshAttachFlow } from './session/useBundleRefreshAttachFlow.js';
 import { useAttachController } from './app/session/useAttachController.js';
 import { useWorkspaceDeleteFlow } from './app/session/useWorkspaceDeleteFlow.js';
+import { ReviewPage } from './pages/ReviewPage.web.js';
 
 // Import shared components and hooks
 import {
@@ -46,7 +47,7 @@ import {
   resolveSessionBrowserCommand,
 } from './app/input/sessionCommands.js';
 
-type View = "machines" | "terminal";
+type View = "machines" | "terminal" | "review";
 
 const PAGE_UP = '\x1b[5~';
 const PAGE_DOWN = '\x1b[6~';
@@ -87,6 +88,9 @@ export default function App() {
     inviteId?: string;
     inviteToken?: string;
   } | null>(null);
+
+  // Review workspace/project state
+  const [reviewWorkspace, setReviewWorkspace] = useState<{ projectName: string; workspaceName: string } | null>(null);
 
   // Relay connection (for machine list)
   const relay = useRelayConnection();
@@ -234,7 +238,7 @@ export default function App() {
     setLocalNotificationConfig(terminal.notificationConfig);
   }, [terminal.notificationConfig]);
 
-  // Parse invite from URL hash on load
+  // Parse invite from URL hash on load, and review params from query string
   useEffect(() => {
     const hash = window.location.hash;
     if (hash.startsWith("#invite=")) {
@@ -247,6 +251,16 @@ export default function App() {
           });
         }
       });
+    }
+
+    const params = new URLSearchParams(window.location.search);
+    if (params.get('view') === 'review') {
+      const ws = params.get('workspace');
+      const proj = params.get('project');
+      if (ws && proj) {
+        setReviewWorkspace({ projectName: proj, workspaceName: ws });
+        setView('review');
+      }
     }
   }, []);
 
@@ -418,6 +432,12 @@ export default function App() {
   const handleAttachSession = useCallback(async (params: { sessionId?: string; workspaceId?: string }) => {
     await attachController.attachFromSelection(params);
   }, [attachController]);
+
+  // Handle opening review for a workspace
+  const handleOpenReview = useCallback((workspace: { projectName: string; name: string }) => {
+    setReviewWorkspace({ projectName: workspace.projectName, workspaceName: workspace.name });
+    setView('review');
+  }, []);
 
   // Spaces browser hook
   const spacesBrowserProps = useSpacesBrowser({
@@ -740,6 +760,60 @@ export default function App() {
     return () => window.removeEventListener("keydown", handleKeyDown);
   }, [notifications.activeToast, notifications.attachToActiveToast, flow]);
 
+  // ========== Review View ==========
+  if (view === 'review' && reviewWorkspace) {
+    if (terminal.status === 'established') {
+      return (
+        <>
+          <ReviewPage
+            projectName={reviewWorkspace.projectName}
+            workspaceName={reviewWorkspace.workspaceName}
+            machineName={selectedMachine?.label || selectedMachine?.machineId}
+            sendReviewRequest={terminal.sendReviewRequest}
+            onBack={() => {
+              setView('terminal');
+              setReviewWorkspace(null);
+            }}
+          />
+          <Toaster theme="dark" position="top-right" richColors />
+        </>
+      );
+    }
+
+    // Connection not yet established — show a targeted connecting screen
+    // rather than falling through to the generic machine list.
+    const statusMessage = {
+      disconnected: "Disconnected",
+      connecting: "Connecting to relay...",
+      connected: "Connected, authenticating...",
+      handshaking: "Establishing secure connection...",
+      established: "Connected!",
+      error: "Connection failed",
+    }[terminal.status];
+
+    return (
+      <>
+        <div className="h-screen w-screen flex flex-col items-center justify-center bg-[#0d1117] px-4">
+          <div className="text-center">
+            <div className="text-lg text-[#e6edf3] mb-2">
+              Loading review for <span className="text-[#58a6ff]">{reviewWorkspace.workspaceName}</span>
+            </div>
+            <div className="text-sm text-[#8b949e]">{statusMessage}</div>
+            {terminal.status === 'error' && (
+              <button
+                onClick={() => { setView('machines'); setReviewWorkspace(null); }}
+                className="mt-4 px-6 py-3 text-base bg-[#21262d] hover:bg-[#30363d] rounded-lg text-[#e6edf3] min-h-[48px] border border-[#30363d]"
+              >
+                Back to Machines
+              </button>
+            )}
+          </div>
+        </div>
+        <Toaster theme="dark" position="top-right" richColors />
+      </>
+    );
+  }
+
   // ========== Spaces Browser View (browsing mode) ==========
   if (
     view === 'terminal' &&
@@ -819,7 +893,7 @@ export default function App() {
             </div>
           </div>
           <div className="flex-1 overflow-hidden">
-            <SpacesBrowserWeb {...spacesBrowserProps} />
+            <SpacesBrowserWeb {...spacesBrowserProps} onReview={handleOpenReview} />
           </div>
         </div>
         <FlowWeb flow={flow} />

--- a/src/commands/bundle.ts
+++ b/src/commands/bundle.ts
@@ -8,15 +8,16 @@ import { exec } from 'child_process';
 import { promisify } from 'util';
 import { logger } from '../utils/logger.js';
 import { SpacesError } from '../types/errors.js';
-import { getCurrentProject, getProjectBaseDir, getProjectWorkspacesDir } from '../core/config.js';
+import { getCurrentProject, getGitspaceDir, getProjectBaseDir, getProjectWorkspacesDir } from '../core/config.js';
 import {
   detectBundleChanges,
   formatBundleChangeDetails,
   refreshBundle,
   type BundleRefreshOptions,
 } from '../core/bundle-refresh.js';
-import { join, resolve } from 'path';
+import { join } from 'path';
 import { existsSync } from 'fs';
+import { detectWorkspaceContextFromCwd } from '../utils/workspace-id.js';
 
 const execAsync = promisify(exec);
 
@@ -43,24 +44,16 @@ export interface BundleStatusOptions {
  * Returns the workspace path if found, undefined otherwise
  */
 function detectWorkspaceFromCwd(projectName: string): string | undefined {
-  const cwd = process.cwd();
   const workspacesDir = getProjectWorkspacesDir(projectName);
 
-  // Check if cwd is inside the workspaces directory
-  const resolvedCwd = resolve(cwd);
-  const resolvedWorkspacesDir = resolve(workspacesDir);
+  const context = detectWorkspaceContextFromCwd(process.cwd(), getGitspaceDir());
+  if (!context || context.projectName !== projectName) {
+    return undefined;
+  }
 
-  if (resolvedCwd.startsWith(resolvedWorkspacesDir + '/') || resolvedCwd === resolvedWorkspacesDir) {
-    // Extract the workspace name (first path segment after workspaces/)
-    const relativePath = resolvedCwd.slice(resolvedWorkspacesDir.length + 1);
-    const workspaceName = relativePath.split('/')[0];
-
-    if (workspaceName) {
-      const workspacePath = join(workspacesDir, workspaceName);
-      if (existsSync(workspacePath)) {
-        return workspacePath;
-      }
-    }
+  const workspacePath = join(workspacesDir, context.workspaceName);
+  if (existsSync(workspacePath)) {
+    return workspacePath;
   }
 
   return undefined;

--- a/src/commands/review.ts
+++ b/src/commands/review.ts
@@ -292,7 +292,13 @@ function resolveChangedFile(
  */
 function openBrowser(url: string): void {
   const platform = process.platform;
-  const cmd = platform === 'darwin' ? 'open' : platform === 'win32' ? 'start' : 'xdg-open';
+  if (platform === 'win32') {
+    // `start` is a cmd.exe builtin on Windows, not a standalone executable.
+    spawnSync('cmd', ['/c', 'start', '', url], { stdio: 'ignore' });
+    return;
+  }
+
+  const cmd = platform === 'darwin' ? 'open' : 'xdg-open';
   spawnSync(cmd, [url], { stdio: 'ignore' });
 }
 
@@ -776,7 +782,7 @@ export async function importReview(options: ReviewImportOptions = {}): Promise<v
     process.exit(1);
   }
 
-  logger.success(`Imported ${result.imported} comment(s) as ${result.threads.length} thread(s).`);
+  logger.success(`Imported ${result.imported} new thread(s) from GitHub (${result.threads.length} total).`);
 }
 
 // ============================================================================

--- a/src/commands/review.ts
+++ b/src/commands/review.ts
@@ -79,7 +79,7 @@ function detectWorkspaceFromCwd(): { projectName: string; workspaceName: string 
   return { projectName, workspaceName };
 }
 
-export function resolveCurrentWorkspace(options: {
+function resolveCurrentWorkspace(options: {
   workspace?: string;
   project?: string;
 }): { projectName: string; workspaceName: string } | null {

--- a/src/commands/review.ts
+++ b/src/commands/review.ts
@@ -32,6 +32,7 @@ import { isAbsolute, relative, resolve, sep } from 'path';
 import { readProjectConfig, readGlobalConfig, getGitspaceDir } from '../core/config.js';
 import { executeLocalReviewOperation } from '../core/review-executor.js';
 import { logger } from '../utils/logger.js';
+import { normalizeHunkHeader } from '../utils/hunk-header.js';
 import type { HunkDecision, ReviewChangedFile, ReviewThread } from '../types/review.js';
 
 // Match the port used by `gssh serve` local relay (overridable via RELAY_PORT env)
@@ -170,11 +171,12 @@ function parseHunksFromDiff(diff: string): Array<{
   let index = 1;
   for (const line of lines) {
     if (!line.startsWith('@@')) continue;
-    const contextMatch = line.match(/^@@[^@]*@@\s*(.*)$/);
+    const header = normalizeHunkHeader(line);
+    const contextMatch = header.match(/^@@[^@]*@@(?:\s+(.*))?$/);
     const context = contextMatch && contextMatch[1] ? contextMatch[1] : null;
     hunks.push({
       index,
-      header: line,
+      header,
       context,
       targetRef: `hunk:${index}`,
     });
@@ -505,6 +507,7 @@ export async function addHunkReview(file: string, options: ReviewAddHunkOptions)
     logger.error(`Hunk index ${options.index} not found in ${resolvedFile.filePath}.`);
     process.exit(1);
   }
+  const chosenHeader = normalizeHunkHeader(chosen.header);
 
   const threadsResult = await executeLocalReviewOperation({
     op: 'get_threads',
@@ -521,7 +524,7 @@ export async function addHunkReview(file: string, options: ReviewAddHunkOptions)
     (thread) =>
       thread.target.kind === 'hunk' &&
       thread.target.file === resolvedFile.filePath &&
-      thread.target.hunkHeader === chosen.header
+      normalizeHunkHeader(thread.target.hunkHeader) === chosenHeader
   );
 
   let createdOrUpdatedThreadId = existing?.id;
@@ -554,7 +557,7 @@ export async function addHunkReview(file: string, options: ReviewAddHunkOptions)
       target: {
         kind: 'hunk',
         file: resolvedFile.filePath,
-        hunkHeader: chosen.header,
+        hunkHeader: chosenHeader,
       },
       body: body || defaultDecisionBody(decision),
       decision,
@@ -574,7 +577,7 @@ export async function addHunkReview(file: string, options: ReviewAddHunkOptions)
           ok: true,
           file: resolvedFile.filePath,
           hunkIndex: chosen.index,
-          hunkHeader: chosen.header,
+          hunkHeader: chosenHeader,
           targetRef: `hunk:${resolvedFile.filePath}:${chosen.index}`,
           decision: decision ?? null,
           threadId: createdOrUpdatedThreadId ?? null,
@@ -589,7 +592,7 @@ export async function addHunkReview(file: string, options: ReviewAddHunkOptions)
   }
 
   logger.success(
-    `${existing ? 'Updated' : 'Added'} hunk review on ${resolvedFile.filePath} [${chosen.index}] (${chosen.header})`
+    `${existing ? 'Updated' : 'Added'} hunk review on ${resolvedFile.filePath} [${chosen.index}] (${chosenHeader})`
   );
 }
 

--- a/src/commands/review.ts
+++ b/src/commands/review.ts
@@ -28,11 +28,11 @@
  */
 
 import open from 'open';
-import { isAbsolute, relative, resolve, sep } from 'path';
 import { readProjectConfig, readGlobalConfig, getGitspaceDir } from '../core/config.js';
 import { executeLocalReviewOperation } from '../core/review-executor.js';
 import { logger } from '../utils/logger.js';
 import { normalizeHunkHeader } from '../utils/hunk-header.js';
+import { detectWorkspaceContextFromCwd } from '../utils/workspace-id.js';
 import type { HunkDecision, ReviewChangedFile, ReviewThread } from '../types/review.js';
 
 // Match the port used by `gssh serve` local relay (overridable via RELAY_PORT env)
@@ -47,36 +47,7 @@ const DEFAULT_PORT = parseInt(process.env.RELAY_PORT ?? '4480', 10);
  * Returns null if no workspace context is available.
  */
 function detectWorkspaceFromCwd(): { projectName: string; workspaceName: string } | null {
-  const cwd = resolve(process.cwd());
-  const gitspaceDir = resolve(getGitspaceDir());
-
-  const cwdRelativeToGitspace = relative(gitspaceDir, cwd);
-  if (
-    cwdRelativeToGitspace === '' ||
-    cwdRelativeToGitspace === '.' ||
-    cwdRelativeToGitspace.startsWith('..') ||
-    isAbsolute(cwdRelativeToGitspace)
-  ) {
-    return null;
-  }
-
-  const WORKSPACES_SEGMENT = 'workspaces';
-  const PROJECT_INDEX = 0;
-  const WORKSPACES_INDEX = 1;
-  const WORKSPACE_INDEX = 2;
-
-  const parts = cwdRelativeToGitspace.split(sep).filter(Boolean);
-  if (parts.length < 3 || parts[WORKSPACES_INDEX] !== WORKSPACES_SEGMENT) {
-    return null;
-  }
-
-  const projectName = parts[PROJECT_INDEX];
-  const workspaceName = parts[WORKSPACE_INDEX];
-  if (!projectName || !workspaceName) {
-    return null;
-  }
-
-  return { projectName, workspaceName };
+  return detectWorkspaceContextFromCwd(process.cwd(), getGitspaceDir());
 }
 
 function resolveCurrentWorkspace(options: {

--- a/src/commands/review.ts
+++ b/src/commands/review.ts
@@ -13,12 +13,26 @@
  *
  *   gssh review push [--pr <number>] [--workspace <name>] [--project <name>]
  *     Push local review decisions to GitHub as a formal PR review.
+ *
+ *   gssh review hunks <file>
+ *     List hunks in a changed file with stable index and header.
+ *
+ *   gssh review add-hunk <file> --index <n> [--approve|--reject|--pending] [--body <text>]
+ *     Add or update a hunk-level review decision/comment.
+ *
+ *   gssh review add-file <file> --body <text>
+ *     Add a file-level review thread.
+ *
+ *   gssh review add-line <file> --start <n> [--end <n>] [--side LEFT|RIGHT] --body <text>
+ *     Add a line-range review thread.
  */
 
 import { spawnSync } from 'child_process';
-import { readProjectConfig, readGlobalConfig } from '../core/config.js';
+import { resolve } from 'path';
+import { readProjectConfig, readGlobalConfig, getGitspaceDir } from '../core/config.js';
 import { executeLocalReviewOperation } from '../core/review-executor.js';
 import { logger } from '../utils/logger.js';
+import type { HunkDecision, ReviewChangedFile, ReviewThread } from '../types/review.js';
 
 // Match the port used by `gssh serve` local relay (overridable via RELAY_PORT env)
 const DEFAULT_PORT = parseInt(process.env.RELAY_PORT ?? '4480', 10);
@@ -31,12 +45,47 @@ const DEFAULT_PORT = parseInt(process.env.RELAY_PORT ?? '4480', 10);
  * Resolve the current workspace name from the global config / cwd.
  * Returns null if no workspace context is available.
  */
-function resolveCurrentWorkspace(options: {
+function detectWorkspaceFromCwd(): { projectName: string; workspaceName: string } | null {
+  const cwd = resolve(process.cwd());
+  const gitspaceDir = resolve(getGitspaceDir());
+
+  if (!(cwd === gitspaceDir || cwd.startsWith(`${gitspaceDir}/`))) {
+    return null;
+  }
+
+  const relative = cwd.slice(gitspaceDir.length).replace(/^\//, '');
+  if (!relative) {
+    return null;
+  }
+
+  const parts = relative.split('/').filter(Boolean);
+  if (parts.length < 3 || parts[1] !== 'workspaces') {
+    return null;
+  }
+
+  const projectName = parts[0];
+  const workspaceName = parts[2];
+  if (!projectName || !workspaceName) {
+    return null;
+  }
+
+  return { projectName, workspaceName };
+}
+
+export function resolveCurrentWorkspace(options: {
   workspace?: string;
   project?: string;
 }): { projectName: string; workspaceName: string } | null {
+  const envProject = process.env.GSSH_SPACE_PROJECT;
+  const envWorkspace = process.env.GSSH_SPACE_WORKSPACE;
+  const cwdContext = detectWorkspaceFromCwd();
   const globalConfig = readGlobalConfig();
-  const projectName = options.project ?? globalConfig.currentProject ?? null;
+  const projectName =
+    options.project ??
+    envProject ??
+    cwdContext?.projectName ??
+    globalConfig.currentProject ??
+    null;
 
   if (!projectName) {
     return null;
@@ -44,6 +93,14 @@ function resolveCurrentWorkspace(options: {
 
   if (options.workspace) {
     return { projectName, workspaceName: options.workspace };
+  }
+
+  if (envWorkspace && (!envProject || envProject === projectName)) {
+    return { projectName, workspaceName: envWorkspace };
+  }
+
+  if (cwdContext && cwdContext.projectName === projectName) {
+    return { projectName, workspaceName: cwdContext.workspaceName };
   }
 
   // Try to derive workspace name from the global state marker
@@ -59,6 +116,167 @@ function resolveCurrentWorkspace(options: {
   }
 
   return null;
+}
+
+export interface SpaceContextOptions {
+  workspace?: string;
+  project?: string;
+  json?: boolean;
+}
+
+export async function showSpaceContext(options: SpaceContextOptions = {}): Promise<void> {
+  const context = resolveCurrentWorkspace(options);
+  const payload = {
+    mode: process.env.GSSH_SESSION_MODE ?? null,
+    tmuxSessionId: process.env.TMUX_LITE ?? null,
+    context,
+  };
+
+  if (options.json) {
+    console.log(JSON.stringify(payload, null, 2));
+    return;
+  }
+
+  if (!context) {
+    logger.log('No workspace context resolved.');
+    return;
+  }
+
+  logger.log(`Project: ${context.projectName}`);
+  logger.log(`Workspace: ${context.workspaceName}`);
+}
+
+function parseHunksFromDiff(diff: string): Array<{
+  index: number;
+  header: string;
+  context: string | null;
+  targetRef: string;
+}> {
+  const lines = diff.split('\n');
+  const hunks: Array<{
+    index: number;
+    header: string;
+    context: string | null;
+    targetRef: string;
+  }> = [];
+
+  let index = 1;
+  for (const line of lines) {
+    if (!line.startsWith('@@')) continue;
+    const contextMatch = line.match(/^@@[^@]*@@\s*(.*)$/);
+    const context = contextMatch && contextMatch[1] ? contextMatch[1] : null;
+    hunks.push({
+      index,
+      header: line,
+      context,
+      targetRef: `hunk:${index}`,
+    });
+    index++;
+  }
+
+  return hunks;
+}
+
+function formatThreadTarget(
+  target: ReviewThread['target']
+): { targetRef: string; targetSummary: string } {
+  switch (target.kind) {
+    case 'hunk':
+      return {
+        targetRef: `hunk:${target.file}:${target.hunkHeader}`,
+        targetSummary: `hunk in ${target.file} (${target.hunkHeader})`,
+      };
+    case 'line':
+      return {
+        targetRef: `line:${target.file}:${target.side}:${target.startLine}-${target.endLine}`,
+        targetSummary: `lines ${target.startLine}-${target.endLine} (${target.side}) in ${target.file}`,
+      };
+    case 'file':
+      return {
+        targetRef: `file:${target.file}`,
+        targetSummary: `file ${target.file}`,
+      };
+    case 'workspace':
+      return {
+        targetRef: 'workspace',
+        targetSummary: 'workspace',
+      };
+  }
+}
+
+function parseDecisionFlags(options: {
+  approve?: boolean;
+  reject?: boolean;
+  pending?: boolean;
+}): HunkDecision | undefined {
+  const selected = [
+    options.approve ? 'approved' : null,
+    options.reject ? 'rejected' : null,
+    options.pending ? 'pending' : null,
+  ].filter((value): value is HunkDecision => value !== null);
+
+  if (selected.length > 1) {
+    throw new Error('Choose only one decision flag: --approve, --reject, or --pending.');
+  }
+
+  return selected[0];
+}
+
+function defaultDecisionBody(decision?: HunkDecision): string {
+  if (decision === 'approved') return 'Approved hunk via CLI.';
+  if (decision === 'rejected') return 'Rejected hunk via CLI.';
+  if (decision === 'pending') return 'Marked hunk as pending via CLI.';
+  return '';
+}
+
+async function getChangedFilesForContext(ctx: {
+  projectName: string;
+  workspaceName: string;
+}): Promise<ReviewChangedFile[]> {
+  const result = await executeLocalReviewOperation({
+    op: 'get_changed_files',
+    projectName: ctx.projectName,
+    workspaceName: ctx.workspaceName,
+  });
+
+  if (result.op !== 'changed_files') {
+    throw new Error(`Unexpected response from get_changed_files: ${result.op}`);
+  }
+
+  return result.files;
+}
+
+function resolveChangedFile(
+  changedFiles: ReviewChangedFile[],
+  inputFile: string
+): ReviewChangedFile {
+  const exact = changedFiles.find(
+    (file) => file.filePath === inputFile || file.prevFilePath === inputFile
+  );
+  if (exact) return exact;
+
+  const suffixMatches = changedFiles.filter(
+    (file) =>
+      file.filePath.endsWith(`/${inputFile}`) ||
+      file.filePath === inputFile ||
+      (file.prevFilePath ? file.prevFilePath.endsWith(`/${inputFile}`) : false)
+  );
+
+  if (suffixMatches.length === 1) {
+    return suffixMatches[0];
+  }
+
+  if (suffixMatches.length > 1) {
+    const choices = suffixMatches.slice(0, 8).map((file) => `- ${file.filePath}`).join('\n');
+    throw new Error(
+      `File path is ambiguous: ${inputFile}\nMatches:\n${choices}\nPlease provide a full path.`
+    );
+  }
+
+  const sample = changedFiles.slice(0, 12).map((file) => `- ${file.filePath}`).join('\n');
+  throw new Error(
+    `File is not changed in this workspace: ${inputFile}\nChanged files:\n${sample}`
+  );
 }
 
 /**
@@ -124,24 +342,31 @@ export async function showReviewNotes(options: ReviewNotesOptions = {}): Promise
 
   const { threads } = result;
 
+  const formatted = threads.map((thread) => {
+    const { targetRef, targetSummary } = formatThreadTarget(thread.target);
+    return {
+      ...thread,
+      targetRef,
+      targetSummary,
+      targetKind: thread.target.kind,
+      ...(thread.target.kind === 'hunk' ? { hunkHeader: thread.target.hunkHeader } : {}),
+    };
+  });
+
   if (options.format === 'text') {
     if (threads.length === 0) {
       logger.log('No review threads found.');
       return;
     }
-    for (const thread of threads) {
-      const targetStr =
-        thread.target.kind === 'hunk'
-          ? `hunk ${thread.target.hunkHeader} in ${thread.target.file}`
-          : thread.target.kind === 'line'
-            ? `lines ${thread.target.startLine}-${thread.target.endLine} in ${thread.target.file}`
-            : thread.target.kind === 'file'
-              ? `file ${thread.target.file}`
-              : 'workspace';
+    for (const thread of formatted) {
       const decision = thread.decision ? ` [${thread.decision.toUpperCase()}]` : '';
       const resolved = thread.resolved ? ' (resolved)' : '';
       logger.log(`\n--- Thread: ${thread.id}${decision}${resolved} ---`);
-      logger.log(`Target: ${targetStr}`);
+      logger.log(`Target: ${thread.targetSummary}`);
+      logger.log(`Target Ref: ${thread.targetRef}`);
+      if (thread.targetKind === 'hunk' && thread.hunkHeader) {
+        logger.log(`Hunk Header: ${thread.hunkHeader}`);
+      }
       for (const comment of thread.comments) {
         logger.log(`  [${comment.author} @ ${comment.createdAt}]: ${comment.body}`);
       }
@@ -150,7 +375,365 @@ export async function showReviewNotes(options: ReviewNotesOptions = {}): Promise
   }
 
   // Default: JSON output for LLM consumption
-  console.log(JSON.stringify({ threads }, null, 2));
+  console.log(JSON.stringify({ threads: formatted }, null, 2));
+}
+
+// ============================================================================
+// gssh review hunks
+// ============================================================================
+
+export interface ReviewHunksOptions {
+  workspace?: string;
+  project?: string;
+  format?: 'json' | 'text';
+}
+
+export async function listReviewHunks(file: string, options: ReviewHunksOptions = {}): Promise<void> {
+  const ctx = resolveCurrentWorkspace(options);
+  if (!ctx) {
+    logger.error('Could not determine current project/workspace. Use --project and --workspace flags.');
+    process.exit(1);
+  }
+
+  const changed = await getChangedFilesForContext(ctx);
+  const resolvedFile = resolveChangedFile(changed, file);
+
+  const result = await executeLocalReviewOperation({
+    op: 'get_file_diff',
+    projectName: ctx.projectName,
+    workspaceName: ctx.workspaceName,
+    filePath: resolvedFile.filePath,
+    prevFilePath: resolvedFile.prevFilePath,
+  });
+
+  if (result.op !== 'file_diff') {
+    logger.error('Unexpected response from get_file_diff operation');
+    process.exit(1);
+  }
+
+  const hunks = parseHunksFromDiff(result.diff).map((hunk) => ({
+    ...hunk,
+    file: resolvedFile.filePath,
+    targetRef: `hunk:${resolvedFile.filePath}:${hunk.index}`,
+  }));
+
+  if (options.format === 'text') {
+    if (hunks.length === 0) {
+      logger.log(`No hunks found in ${resolvedFile.filePath}.`);
+      return;
+    }
+    logger.log(`Hunks in ${resolvedFile.filePath}:`);
+    for (const hunk of hunks) {
+      const context = hunk.context ? `  ${hunk.context}` : '';
+      logger.log(`  [${hunk.index}] ${hunk.header}${context}`);
+    }
+    return;
+  }
+
+  console.log(
+    JSON.stringify(
+      {
+        file: resolvedFile.filePath,
+        prevFilePath: resolvedFile.prevFilePath,
+        hunks,
+      },
+      null,
+      2
+    )
+  );
+}
+
+// ============================================================================
+// gssh review add-hunk
+// ============================================================================
+
+export interface ReviewAddHunkOptions {
+  workspace?: string;
+  project?: string;
+  index: number;
+  body?: string;
+  approve?: boolean;
+  reject?: boolean;
+  pending?: boolean;
+  json?: boolean;
+}
+
+export async function addHunkReview(file: string, options: ReviewAddHunkOptions): Promise<void> {
+  const ctx = resolveCurrentWorkspace(options);
+  if (!ctx) {
+    logger.error('Could not determine current project/workspace. Use --project and --workspace flags.');
+    process.exit(1);
+  }
+
+  if (!Number.isFinite(options.index) || options.index < 1) {
+    logger.error('--index must be a positive integer (1-based).');
+    process.exit(1);
+  }
+
+  const decision = parseDecisionFlags(options);
+  const body = options.body?.trim() ?? '';
+  if (!decision && !body) {
+    logger.error('Provide at least one of: --approve/--reject/--pending or --body <text>.');
+    process.exit(1);
+  }
+
+  const changed = await getChangedFilesForContext(ctx);
+  const resolvedFile = resolveChangedFile(changed, file);
+
+  const diffResult = await executeLocalReviewOperation({
+    op: 'get_file_diff',
+    projectName: ctx.projectName,
+    workspaceName: ctx.workspaceName,
+    filePath: resolvedFile.filePath,
+    prevFilePath: resolvedFile.prevFilePath,
+  });
+
+  if (diffResult.op !== 'file_diff') {
+    logger.error('Unexpected response from get_file_diff operation');
+    process.exit(1);
+  }
+
+  const hunks = parseHunksFromDiff(diffResult.diff);
+  const chosen = hunks.find((hunk) => hunk.index === options.index);
+  if (!chosen) {
+    logger.error(`Hunk index ${options.index} not found in ${resolvedFile.filePath}.`);
+    process.exit(1);
+  }
+
+  const threadsResult = await executeLocalReviewOperation({
+    op: 'get_threads',
+    projectName: ctx.projectName,
+    workspaceName: ctx.workspaceName,
+  });
+
+  if (threadsResult.op !== 'threads') {
+    logger.error('Unexpected response from get_threads operation');
+    process.exit(1);
+  }
+
+  const existing = threadsResult.threads.find(
+    (thread) =>
+      thread.target.kind === 'hunk' &&
+      thread.target.file === resolvedFile.filePath &&
+      thread.target.hunkHeader === chosen.header
+  );
+
+  let createdOrUpdatedThreadId = existing?.id;
+
+  if (existing && decision) {
+    await executeLocalReviewOperation({
+      op: 'update_thread',
+      projectName: ctx.projectName,
+      workspaceName: ctx.workspaceName,
+      threadId: existing.id,
+      decision,
+    });
+  }
+
+  if (existing && body) {
+    await executeLocalReviewOperation({
+      op: 'add_reply',
+      projectName: ctx.projectName,
+      workspaceName: ctx.workspaceName,
+      threadId: existing.id,
+      body,
+    });
+  }
+
+  if (!existing) {
+    const createResult = await executeLocalReviewOperation({
+      op: 'create_thread',
+      projectName: ctx.projectName,
+      workspaceName: ctx.workspaceName,
+      target: {
+        kind: 'hunk',
+        file: resolvedFile.filePath,
+        hunkHeader: chosen.header,
+      },
+      body: body || defaultDecisionBody(decision),
+      decision,
+    });
+
+    if (createResult.op !== 'thread_created') {
+      logger.error('Unexpected response from create_thread operation');
+      process.exit(1);
+    }
+    createdOrUpdatedThreadId = createResult.thread.id;
+  }
+
+  if (options.json) {
+    console.log(
+      JSON.stringify(
+        {
+          ok: true,
+          file: resolvedFile.filePath,
+          hunkIndex: chosen.index,
+          hunkHeader: chosen.header,
+          targetRef: `hunk:${resolvedFile.filePath}:${chosen.index}`,
+          decision: decision ?? null,
+          threadId: createdOrUpdatedThreadId ?? null,
+          reusedThread: Boolean(existing),
+          bodyAdded: body.length > 0,
+        },
+        null,
+        2
+      )
+    );
+    return;
+  }
+
+  logger.success(
+    `${existing ? 'Updated' : 'Added'} hunk review on ${resolvedFile.filePath} [${chosen.index}] (${chosen.header})`
+  );
+}
+
+// ============================================================================
+// gssh review add-file
+// ============================================================================
+
+export interface ReviewAddFileOptions {
+  workspace?: string;
+  project?: string;
+  body: string;
+  json?: boolean;
+}
+
+export async function addFileReview(file: string, options: ReviewAddFileOptions): Promise<void> {
+  const ctx = resolveCurrentWorkspace(options);
+  if (!ctx) {
+    logger.error('Could not determine current project/workspace. Use --project and --workspace flags.');
+    process.exit(1);
+  }
+
+  const body = options.body?.trim();
+  if (!body) {
+    logger.error('--body is required for add-file.');
+    process.exit(1);
+  }
+
+  const changed = await getChangedFilesForContext(ctx);
+  const resolvedFile = resolveChangedFile(changed, file);
+
+  const result = await executeLocalReviewOperation({
+    op: 'create_thread',
+    projectName: ctx.projectName,
+    workspaceName: ctx.workspaceName,
+    target: { kind: 'file', file: resolvedFile.filePath },
+    body,
+  });
+
+  if (result.op !== 'thread_created') {
+    logger.error('Unexpected response from create_thread operation');
+    process.exit(1);
+  }
+
+  if (options.json) {
+    console.log(
+      JSON.stringify(
+        {
+          ok: true,
+          threadId: result.thread.id,
+          targetRef: `file:${resolvedFile.filePath}`,
+          file: resolvedFile.filePath,
+        },
+        null,
+        2
+      )
+    );
+    return;
+  }
+
+  logger.success(`Added file review thread for ${resolvedFile.filePath}.`);
+}
+
+// ============================================================================
+// gssh review add-line
+// ============================================================================
+
+export interface ReviewAddLineOptions {
+  workspace?: string;
+  project?: string;
+  start: number;
+  end?: number;
+  side?: 'LEFT' | 'RIGHT' | string;
+  body: string;
+  json?: boolean;
+}
+
+export async function addLineReview(file: string, options: ReviewAddLineOptions): Promise<void> {
+  const ctx = resolveCurrentWorkspace(options);
+  if (!ctx) {
+    logger.error('Could not determine current project/workspace. Use --project and --workspace flags.');
+    process.exit(1);
+  }
+
+  if (!Number.isFinite(options.start) || options.start < 1) {
+    logger.error('--start must be a positive integer.');
+    process.exit(1);
+  }
+
+  const normalizedEnd = options.end && Number.isFinite(options.end)
+    ? Math.max(options.start, options.end)
+    : options.start;
+
+  const normalizedSide = String(options.side ?? 'RIGHT').toUpperCase();
+  if (normalizedSide !== 'LEFT' && normalizedSide !== 'RIGHT') {
+    logger.error('--side must be LEFT or RIGHT.');
+    process.exit(1);
+  }
+
+  const body = options.body?.trim();
+  if (!body) {
+    logger.error('--body is required for add-line.');
+    process.exit(1);
+  }
+
+  const changed = await getChangedFilesForContext(ctx);
+  const resolvedFile = resolveChangedFile(changed, file);
+
+  const result = await executeLocalReviewOperation({
+    op: 'create_thread',
+    projectName: ctx.projectName,
+    workspaceName: ctx.workspaceName,
+    target: {
+      kind: 'line',
+      file: resolvedFile.filePath,
+      startLine: options.start,
+      endLine: normalizedEnd,
+      side: normalizedSide,
+    },
+    body,
+  });
+
+  if (result.op !== 'thread_created') {
+    logger.error('Unexpected response from create_thread operation');
+    process.exit(1);
+  }
+
+  const targetRef = `line:${resolvedFile.filePath}:${normalizedSide}:${options.start}-${normalizedEnd}`;
+
+  if (options.json) {
+    console.log(
+      JSON.stringify(
+        {
+          ok: true,
+          threadId: result.thread.id,
+          targetRef,
+          file: resolvedFile.filePath,
+          side: normalizedSide,
+          start: options.start,
+          end: normalizedEnd,
+        },
+        null,
+        2
+      )
+    );
+    return;
+  }
+
+  logger.success(
+    `Added line review thread for ${resolvedFile.filePath}:${options.start}-${normalizedEnd} (${normalizedSide}).`
+  );
 }
 
 // ============================================================================

--- a/src/commands/review.ts
+++ b/src/commands/review.ts
@@ -406,8 +406,7 @@ export async function listReviewHunks(file: string, options: ReviewHunksOptions 
     }
     logger.log(`Hunks in ${resolvedFile.filePath}:`);
     for (const hunk of hunks) {
-      const context = hunk.context ? `  ${hunk.context}` : '';
-      logger.log(`  [${hunk.index}] ${hunk.header}${context}`);
+      logger.log(`  [${hunk.index}] ${hunk.header}`);
     }
     return;
   }

--- a/src/commands/review.ts
+++ b/src/commands/review.ts
@@ -1,0 +1,222 @@
+/**
+ * Review command — open or interact with the diff review system
+ *
+ * Primary entry point: `gssh review`
+ *   Opens the browser-based review UI at http://localhost:<port>?view=review&workspace=<current>
+ *
+ * Sub-commands:
+ *   gssh review notes [--workspace <name>] [--project <name>]
+ *     Print saved review threads as structured JSON (LLM-friendly).
+ *
+ *   gssh review import [--pr <number>] [--workspace <name>] [--project <name>]
+ *     Import GitHub PR review comments as local threads.
+ *
+ *   gssh review push [--pr <number>] [--workspace <name>] [--project <name>]
+ *     Push local review decisions to GitHub as a formal PR review.
+ */
+
+import { spawnSync } from 'child_process';
+import { readProjectConfig, readGlobalConfig } from '../core/config.js';
+import { executeLocalReviewOperation } from '../core/review-executor.js';
+import { logger } from '../utils/logger.js';
+
+// Match the port used by `gssh serve` local relay (overridable via RELAY_PORT env)
+const DEFAULT_PORT = parseInt(process.env.RELAY_PORT ?? '4480', 10);
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/**
+ * Resolve the current workspace name from the global config / cwd.
+ * Returns null if no workspace context is available.
+ */
+function resolveCurrentWorkspace(options: {
+  workspace?: string;
+  project?: string;
+}): { projectName: string; workspaceName: string } | null {
+  const globalConfig = readGlobalConfig();
+  const projectName = options.project ?? globalConfig.currentProject ?? null;
+
+  if (!projectName) {
+    return null;
+  }
+
+  if (options.workspace) {
+    return { projectName, workspaceName: options.workspace };
+  }
+
+  // Try to derive workspace name from the global state marker
+  // (reads from <project>/.config.json currentWorkspace if set)
+  try {
+    const projectConfig = readProjectConfig(projectName);
+    const workspaceName = (projectConfig as unknown as Record<string, unknown>).currentWorkspace as string | undefined;
+    if (workspaceName) {
+      return { projectName, workspaceName };
+    }
+  } catch {
+    // ignore
+  }
+
+  return null;
+}
+
+/**
+ * Open a URL in the default browser (macOS / Linux / Windows).
+ */
+function openBrowser(url: string): void {
+  const platform = process.platform;
+  const cmd = platform === 'darwin' ? 'open' : platform === 'win32' ? 'start' : 'xdg-open';
+  spawnSync(cmd, [url], { stdio: 'ignore' });
+}
+
+// ============================================================================
+// Main review command (opens browser)
+// ============================================================================
+
+export interface ReviewOptions {
+  workspace?: string;
+  project?: string;
+  port?: number;
+}
+
+export async function openReview(options: ReviewOptions = {}): Promise<void> {
+  const port = options.port ?? DEFAULT_PORT;
+  const ctx = resolveCurrentWorkspace(options);
+
+  let url = `http://localhost:${port}?view=review`;
+  if (ctx) {
+    url += `&workspace=${encodeURIComponent(ctx.workspaceName)}&project=${encodeURIComponent(ctx.projectName)}`;
+  }
+
+  logger.log(`Opening review UI: ${url}`);
+  logger.log('(Requires `gssh serve start` to be running)');
+  openBrowser(url);
+}
+
+// ============================================================================
+// gssh review notes
+// ============================================================================
+
+export interface ReviewNotesOptions {
+  workspace?: string;
+  project?: string;
+  format?: 'json' | 'text';
+}
+
+export async function showReviewNotes(options: ReviewNotesOptions = {}): Promise<void> {
+  const ctx = resolveCurrentWorkspace(options);
+  if (!ctx) {
+    logger.error('Could not determine current project/workspace. Use --project and --workspace flags.');
+    process.exit(1);
+  }
+
+  const result = await executeLocalReviewOperation({
+    op: 'get_threads',
+    projectName: ctx.projectName,
+    workspaceName: ctx.workspaceName,
+  });
+
+  if (result.op !== 'threads') {
+    logger.error('Unexpected response from review operation');
+    process.exit(1);
+  }
+
+  const { threads } = result;
+
+  if (options.format === 'text') {
+    if (threads.length === 0) {
+      logger.log('No review threads found.');
+      return;
+    }
+    for (const thread of threads) {
+      const targetStr =
+        thread.target.kind === 'hunk'
+          ? `hunk ${thread.target.hunkHeader} in ${thread.target.file}`
+          : thread.target.kind === 'line'
+            ? `lines ${thread.target.startLine}-${thread.target.endLine} in ${thread.target.file}`
+            : thread.target.kind === 'file'
+              ? `file ${thread.target.file}`
+              : 'workspace';
+      const decision = thread.decision ? ` [${thread.decision.toUpperCase()}]` : '';
+      const resolved = thread.resolved ? ' (resolved)' : '';
+      logger.log(`\n--- Thread: ${thread.id}${decision}${resolved} ---`);
+      logger.log(`Target: ${targetStr}`);
+      for (const comment of thread.comments) {
+        logger.log(`  [${comment.author} @ ${comment.createdAt}]: ${comment.body}`);
+      }
+    }
+    return;
+  }
+
+  // Default: JSON output for LLM consumption
+  console.log(JSON.stringify({ threads }, null, 2));
+}
+
+// ============================================================================
+// gssh review import
+// ============================================================================
+
+export interface ReviewImportOptions {
+  workspace?: string;
+  project?: string;
+  pr?: number;
+}
+
+export async function importReview(options: ReviewImportOptions = {}): Promise<void> {
+  const ctx = resolveCurrentWorkspace(options);
+  if (!ctx) {
+    logger.error('Could not determine current project/workspace. Use --project and --workspace flags.');
+    process.exit(1);
+  }
+
+  logger.log(`Importing GitHub PR review for ${ctx.projectName}:${ctx.workspaceName}...`);
+
+  const result = await executeLocalReviewOperation({
+    op: 'import_github',
+    projectName: ctx.projectName,
+    workspaceName: ctx.workspaceName,
+    prNumber: options.pr,
+  });
+
+  if (result.op !== 'github_imported') {
+    logger.error('Unexpected response from import operation');
+    process.exit(1);
+  }
+
+  logger.success(`Imported ${result.imported} comment(s) as ${result.threads.length} thread(s).`);
+}
+
+// ============================================================================
+// gssh review push
+// ============================================================================
+
+export interface ReviewPushOptions {
+  workspace?: string;
+  project?: string;
+  pr?: number;
+}
+
+export async function pushReview(options: ReviewPushOptions = {}): Promise<void> {
+  const ctx = resolveCurrentWorkspace(options);
+  if (!ctx) {
+    logger.error('Could not determine current project/workspace. Use --project and --workspace flags.');
+    process.exit(1);
+  }
+
+  logger.log(`Pushing review for ${ctx.projectName}:${ctx.workspaceName} to GitHub...`);
+
+  const result = await executeLocalReviewOperation({
+    op: 'push_github',
+    projectName: ctx.projectName,
+    workspaceName: ctx.workspaceName,
+    prNumber: options.pr,
+  });
+
+  if (result.op !== 'github_pushed') {
+    logger.error('Unexpected response from push operation');
+    process.exit(1);
+  }
+
+  logger.success(`Review submitted to GitHub: ${result.url}`);
+}

--- a/src/commands/review.ts
+++ b/src/commands/review.ts
@@ -27,7 +27,7 @@
  *     Add a line-range review thread.
  */
 
-import { spawnSync } from 'child_process';
+import open from 'open';
 import { isAbsolute, relative, resolve, sep } from 'path';
 import { readProjectConfig, readGlobalConfig, getGitspaceDir } from '../core/config.js';
 import { executeLocalReviewOperation } from '../core/review-executor.js';
@@ -288,18 +288,15 @@ function resolveChangedFile(
 }
 
 /**
- * Open a URL in the default browser (macOS / Linux / Windows).
+ * Open a URL in the default browser.
  */
-function openBrowser(url: string): void {
-  const platform = process.platform;
-  if (platform === 'win32') {
-    // `start` is a cmd.exe builtin on Windows, not a standalone executable.
-    spawnSync('cmd', ['/c', 'start', '', url], { stdio: 'ignore' });
-    return;
+async function openBrowser(url: string): Promise<void> {
+  try {
+    await open(url, { wait: false });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    logger.warning(`Could not open browser automatically: ${message}`);
   }
-
-  const cmd = platform === 'darwin' ? 'open' : 'xdg-open';
-  spawnSync(cmd, [url], { stdio: 'ignore' });
 }
 
 // ============================================================================
@@ -323,7 +320,7 @@ export async function openReview(options: ReviewOptions = {}): Promise<void> {
 
   logger.log(`Opening review UI: ${url}`);
   logger.log('(Requires `gssh serve start` to be running)');
-  openBrowser(url);
+  await openBrowser(url);
 }
 
 // ============================================================================

--- a/src/commands/review.ts
+++ b/src/commands/review.ts
@@ -28,7 +28,7 @@
  */
 
 import { spawnSync } from 'child_process';
-import { resolve } from 'path';
+import { isAbsolute, relative, resolve, sep } from 'path';
 import { readProjectConfig, readGlobalConfig, getGitspaceDir } from '../core/config.js';
 import { executeLocalReviewOperation } from '../core/review-executor.js';
 import { logger } from '../utils/logger.js';
@@ -49,22 +49,28 @@ function detectWorkspaceFromCwd(): { projectName: string; workspaceName: string 
   const cwd = resolve(process.cwd());
   const gitspaceDir = resolve(getGitspaceDir());
 
-  if (!(cwd === gitspaceDir || cwd.startsWith(`${gitspaceDir}/`))) {
+  const cwdRelativeToGitspace = relative(gitspaceDir, cwd);
+  if (
+    cwdRelativeToGitspace === '' ||
+    cwdRelativeToGitspace === '.' ||
+    cwdRelativeToGitspace.startsWith('..') ||
+    isAbsolute(cwdRelativeToGitspace)
+  ) {
     return null;
   }
 
-  const relative = cwd.slice(gitspaceDir.length).replace(/^\//, '');
-  if (!relative) {
+  const WORKSPACES_SEGMENT = 'workspaces';
+  const PROJECT_INDEX = 0;
+  const WORKSPACES_INDEX = 1;
+  const WORKSPACE_INDEX = 2;
+
+  const parts = cwdRelativeToGitspace.split(sep).filter(Boolean);
+  if (parts.length < 3 || parts[WORKSPACES_INDEX] !== WORKSPACES_SEGMENT) {
     return null;
   }
 
-  const parts = relative.split('/').filter(Boolean);
-  if (parts.length < 3 || parts[1] !== 'workspaces') {
-    return null;
-  }
-
-  const projectName = parts[0];
-  const workspaceName = parts[2];
+  const projectName = parts[PROJECT_INDEX];
+  const workspaceName = parts[WORKSPACE_INDEX];
   if (!projectName || !workspaceName) {
     return null;
   }
@@ -107,7 +113,8 @@ export function resolveCurrentWorkspace(options: {
   // (reads from <project>/.config.json currentWorkspace if set)
   try {
     const projectConfig = readProjectConfig(projectName);
-    const workspaceName = (projectConfig as unknown as Record<string, unknown>).currentWorkspace as string | undefined;
+    const workspaceValue = (projectConfig as { currentWorkspace?: unknown }).currentWorkspace;
+    const workspaceName = typeof workspaceValue === 'string' ? workspaceValue : undefined;
     if (workspaceName) {
       return { projectName, workspaceName };
     }

--- a/src/commands/review.ts
+++ b/src/commands/review.ts
@@ -265,7 +265,6 @@ function resolveChangedFile(
   const suffixMatches = changedFiles.filter(
     (file) =>
       file.filePath.endsWith(`/${inputFile}`) ||
-      file.filePath === inputFile ||
       (file.prevFilePath ? file.prevFilePath.endsWith(`/${inputFile}`) : false)
   );
 

--- a/src/components/DiffViewer.web.tsx
+++ b/src/components/DiffViewer.web.tsx
@@ -785,7 +785,7 @@ export function DiffViewer({
         </div>
       </div>
     );
-  }, [onThreadClick, onThreadHover, openHunkCommentForm, onHunkFocus, selectedFile?.filePath, setHunkDecision]);
+  }, [onThreadClick, onThreadHover, openHunkCommentForm, onHunkFocus, selectedFile, setHunkDecision]);
 
   const fileDiffOptions = useMemo((): FileDiffOptions<InlineAnnotationMeta> => ({
     diffStyle: 'unified',

--- a/src/components/DiffViewer.web.tsx
+++ b/src/components/DiffViewer.web.tsx
@@ -15,6 +15,7 @@ import {
 import type { HunkDecision, ReviewChangedFile, ReviewThread, ThreadTarget } from '../types/review.js';
 import { SpacesError, toSpacesError } from '../types/errors.js';
 import { normalizeHunkHeader } from '../utils/hunk-header.js';
+import { getReviewDecisionColor } from './review-decision-colors.js';
 
 export interface HunkFocusTarget {
   filePath: string;
@@ -490,6 +491,8 @@ export function DiffViewer({
       await onCreateThread(commentForm.target, commentBody.trim(), commentForm.decision);
       setCommentForm(null);
       setCommentBody('');
+    } catch {
+      // Error is surfaced via review hook state; avoid unhandled promise rejections.
     } finally {
       setSubmitting(false);
     }
@@ -513,7 +516,11 @@ export function DiffViewer({
     const existingThreads = hunkThreadByHeader.get(normalizedHeader) ?? [];
     const primary = pickPrimaryThread(existingThreads);
     if (primary) {
-      await onUpdateThread(primary.id, { decision });
+      try {
+        await onUpdateThread(primary.id, { decision });
+      } catch {
+        // Error is surfaced via review hook state; avoid unhandled promise rejections.
+      }
       return;
     }
 
@@ -521,13 +528,17 @@ export function DiffViewer({
       return;
     }
 
-    await onCreateThread(
-      { kind: 'hunk', file: selectedFile.filePath, hunkHeader: normalizedHeader },
-      decision === 'approved'
-        ? 'Approved hunk via inline controls.'
-        : 'Rejected hunk via inline controls.',
-      decision
-    );
+    try {
+      await onCreateThread(
+        { kind: 'hunk', file: selectedFile.filePath, hunkHeader: normalizedHeader },
+        decision === 'approved'
+          ? 'Approved hunk via inline controls.'
+          : 'Rejected hunk via inline controls.',
+        decision
+      );
+    } catch {
+      // Error is surfaced via review hook state; avoid unhandled promise rejections.
+    }
   }, [selectedFile, hunkThreadByHeader, onUpdateThread, onCreateThread, onHunkFocus]);
 
   const openHunkCommentForm = useCallback((hunkMeta: HunkControlMeta) => {
@@ -620,7 +631,7 @@ export function DiffViewer({
 
     if (meta.kind === 'thread') {
       const thread = meta.thread;
-      const color = thread.decision ? decisionColor(thread.decision) : '#58a6ff';
+      const color = thread.decision ? getReviewDecisionColor(thread.decision) : '#58a6ff';
       const count = thread.comments.length;
 
       return (
@@ -657,7 +668,7 @@ export function DiffViewer({
       );
     }
 
-    const tint = decisionColor(meta.decision);
+    const tint = getReviewDecisionColor(meta.decision);
     return (
       <div style={{ position: 'relative', zIndex: 10, height: 0, overflow: 'visible', pointerEvents: 'none' }}>
         <div
@@ -681,14 +692,18 @@ export function DiffViewer({
         >
           <button
             title="Reject hunk"
-            onClick={() => void setHunkDecision(meta, 'rejected')}
+            onClick={() => {
+              void setHunkDecision(meta, 'rejected').catch(() => {});
+            }}
             style={actionButtonStyle(meta.decision === 'rejected', '#f85149')}
           >
             Reject
           </button>
           <button
             title="Approve hunk"
-            onClick={() => void setHunkDecision(meta, 'approved')}
+            onClick={() => {
+              void setHunkDecision(meta, 'approved').catch(() => {});
+            }}
             style={actionButtonStyle(meta.decision === 'approved', '#22c55e', true)}
           >
             Approve
@@ -962,7 +977,7 @@ export function DiffViewer({
                     setCommentBody('');
                   }
                   if (event.key === 'Enter' && (event.metaKey || event.ctrlKey)) {
-                    void handleSubmitComment();
+                    void handleSubmitComment().catch(() => {});
                   }
                 }}
               />
@@ -970,7 +985,9 @@ export function DiffViewer({
 
             <div style={{ display: 'flex', flexDirection: 'column', gap: '6px' }}>
               <button
-                onClick={() => void handleSubmitComment()}
+                onClick={() => {
+                  void handleSubmitComment().catch(() => {});
+                }}
                 disabled={submitting}
                 style={{
                   padding: '8px 16px',
@@ -1087,16 +1104,6 @@ function expandToAbsoluteLines(lines: string[], start: number, total: number): s
     output[absoluteIndex] = lines[index] ?? '';
   }
   return output;
-}
-
-function decisionColor(decision: HunkDecision): string {
-  if (decision === 'approved') {
-    return '#22c55e';
-  }
-  if (decision === 'rejected') {
-    return '#f85149';
-  }
-  return '#d29922';
 }
 
 function actionButtonStyle(active: boolean, color: string, success = false): CSSProperties {

--- a/src/components/DiffViewer.web.tsx
+++ b/src/components/DiffViewer.web.tsx
@@ -170,6 +170,22 @@ export function DiffViewer({
     return files[0] ?? null;
   }, [selectedFileKey, fileByKey, files]);
 
+  useEffect(() => {
+    if (!commentForm) {
+      return;
+    }
+
+    if (commentForm.target.kind === 'workspace') {
+      return;
+    }
+
+    const selectedFilePath = selectedFile?.filePath;
+    if (!selectedFilePath || commentForm.target.file !== selectedFilePath) {
+      setCommentForm(null);
+      setCommentBody('');
+    }
+  }, [commentForm, selectedFile?.filePath]);
+
   const selectedKey = selectedFile ? fileKey(selectedFile.filePath, selectedFile.prevFilePath) : null;
   const selectedDiffState = selectedKey ? fileDiffStateByKey[selectedKey] ?? ({ status: 'idle' } as const) : null;
   const selectedContextState = selectedKey ? contextStateByKey[selectedKey] ?? ({ status: 'idle' } as const) : null;

--- a/src/components/DiffViewer.web.tsx
+++ b/src/components/DiffViewer.web.tsx
@@ -13,6 +13,16 @@ import {
   type SelectedLineRange,
 } from '@pierre/diffs';
 import type { HunkDecision, ReviewChangedFile, ReviewThread, ThreadTarget } from '../types/review.js';
+import { SpacesError } from '../types/errors.js';
+
+export interface HunkFocusTarget {
+  filePath: string;
+  hunkHeader: string;
+  oldStart: number;
+  oldEnd: number;
+  newStart: number;
+  newEnd: number;
+}
 
 export interface DiffViewerProps {
   files: ReviewChangedFile[];
@@ -34,6 +44,9 @@ export interface DiffViewerProps {
   }>;
   onThreadClick?: (threadId: string) => void;
   onThreadHover?: (threadId: string | null) => void;
+  onSelectedFileChange?: (filePath: string | null) => void;
+  onHunkFocus?: (target: HunkFocusTarget | null) => void;
+  focusRequest?: { threadId: string; nonce: number } | null;
 }
 
 interface CommentFormState {
@@ -45,6 +58,10 @@ interface HunkInfo {
   header: string;
   anchorSide: AnnotationSide;
   anchorLine: number;
+  oldStart: number;
+  oldEnd: number;
+  newStart: number;
+  newEnd: number;
 }
 
 interface LoadedFileDiff {
@@ -56,7 +73,7 @@ type FileDiffState =
   | { status: 'idle' }
   | { status: 'loading' }
   | { status: 'ready'; data: LoadedFileDiff }
-  | { status: 'error'; message: string };
+  | { status: 'error'; error: SpacesError };
 
 type FileContextState =
   | { status: 'idle' }
@@ -69,7 +86,7 @@ type FileContextState =
       newTotal: number;
       contextHash: string;
     }
-  | { status: 'error'; message: string };
+  | { status: 'error'; error: SpacesError };
 
 type InlineAnnotationMeta =
   | { kind: 'thread'; thread: ReviewThread }
@@ -78,8 +95,15 @@ type InlineAnnotationMeta =
       hunkHeader: string;
       decision: HunkDecision;
       threadId?: string;
+      threadIds: string[];
       commentCount: number;
+      oldStart: number;
+      oldEnd: number;
+      newStart: number;
+      newEnd: number;
     };
+
+type HunkControlMeta = Extract<InlineAnnotationMeta, { kind: 'hunk-control' }>;
 
 const CHANGE_COLOR: Record<ReviewChangedFile['changeType'], string> = {
   new: '#22c55e',
@@ -104,6 +128,9 @@ export function DiffViewer({
   onRequestFileContextRange,
   onThreadClick,
   onThreadHover,
+  onSelectedFileChange,
+  onHunkFocus,
+  focusRequest,
 }: DiffViewerProps) {
   const [selectedFileKey, setSelectedFileKey] = useState<string | null>(null);
   const [fileDiffStateByKey, setFileDiffStateByKey] = useState<Record<string, FileDiffState>>({});
@@ -138,6 +165,10 @@ export function DiffViewer({
   const selectedKey = selectedFile ? fileKey(selectedFile.filePath, selectedFile.prevFilePath) : null;
   const selectedDiffState = selectedKey ? fileDiffStateByKey[selectedKey] ?? ({ status: 'idle' } as const) : null;
   const selectedContextState = selectedKey ? contextStateByKey[selectedKey] ?? ({ status: 'idle' } as const) : null;
+
+  useEffect(() => {
+    onSelectedFileChange?.(selectedFile?.filePath ?? null);
+  }, [onSelectedFileChange, selectedFile]);
 
   useEffect(() => {
     fileDiffStateByKeyRef.current = fileDiffStateByKey;
@@ -197,10 +228,10 @@ export function DiffViewer({
         [key]: { status: 'ready', data: parsed },
       }));
     } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
+      const typed = toSpacesError(error, 'Failed to load file diff');
       setFileDiffStateByKey((prev) => ({
         ...prev,
-        [key]: { status: 'error', message },
+        [key]: { status: 'error', error: typed },
       }));
     } finally {
       loadingFileDiffKeysRef.current.delete(key);
@@ -216,6 +247,64 @@ export function DiffViewer({
       void loadFileDiff(selectedFile);
     }
   }, [selectedFile, selectedKey, fileDiffStateByKey, loadFileDiff]);
+
+  useEffect(() => {
+    if (!focusRequest) {
+      return;
+    }
+
+    const thread = threads.find((entry) => entry.id === focusRequest.threadId);
+    if (!thread || thread.target.kind === 'workspace') {
+      return;
+    }
+    const target = thread.target;
+
+    const targetFile = files.find((entry) => (
+      entry.filePath === target.file || entry.prevFilePath === target.file
+    ));
+    if (!targetFile) {
+      return;
+    }
+
+    const key = fileKey(targetFile.filePath, targetFile.prevFilePath);
+    setSelectedFileKey(key);
+  }, [files, focusRequest, threads]);
+
+  useEffect(() => {
+    if (!focusRequest || !selectedFile || !selectedKey) {
+      return;
+    }
+
+    const thread = threads.find((entry) => entry.id === focusRequest.threadId);
+    if (!thread || thread.target.kind === 'workspace') {
+      return;
+    }
+
+    if (thread.target.file !== selectedFile.filePath && thread.target.file !== selectedFile.prevFilePath) {
+      return;
+    }
+
+    if (selectedDiffState?.status !== 'ready') {
+      return;
+    }
+
+    const host = diffHostRef.current;
+    if (!host) {
+      return;
+    }
+
+    const marker = host.querySelector<HTMLElement>(`[data-thread-id="${thread.id}"]`);
+    if (marker) {
+      marker.scrollIntoView({ block: 'center', behavior: 'smooth' });
+      marker.focus?.();
+      return;
+    }
+
+    const scrollContainer = host.querySelector<HTMLElement>('[data-diff-scroll-container]');
+    if (scrollContainer) {
+      scrollContainer.scrollTo({ top: 0, behavior: 'smooth' });
+    }
+  }, [focusRequest, selectedDiffState?.status, selectedFile, selectedKey, threads]);
 
   const ensureContextLoaded = useCallback(async () => {
     if (!selectedFile || !selectedKey) {
@@ -250,10 +339,10 @@ export function DiffViewer({
         },
       }));
     } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
+      const typed = toSpacesError(error, 'Failed to load file context');
       setContextStateByKey((prev) => ({
         ...prev,
-        [selectedKey]: { status: 'error', message },
+        [selectedKey]: { status: 'error', error: typed },
       }));
     }
   }, [selectedFile, selectedKey, contextStateByKey, onRequestFileContextRange]);
@@ -300,7 +389,7 @@ export function DiffViewer({
   const selectedContextReady = selectedContextState?.status === 'ready' ? selectedContextState : null;
 
   const hunkThreadByHeader = useMemo(() => {
-    const map = new Map<string, ReviewThread>();
+    const map = new Map<string, ReviewThread[]>();
     if (!selectedFile) {
       return map;
     }
@@ -312,9 +401,9 @@ export function DiffViewer({
       if (thread.target.file !== selectedFile.filePath) {
         continue;
       }
-      if (!map.has(thread.target.hunkHeader)) {
-        map.set(thread.target.hunkHeader, thread);
-      }
+      const list = map.get(thread.target.hunkHeader) ?? [];
+      list.push(thread);
+      map.set(thread.target.hunkHeader, list);
     }
 
     return map;
@@ -328,16 +417,22 @@ export function DiffViewer({
     const annotations: DiffLineAnnotation<InlineAnnotationMeta>[] = [];
 
     for (const hunk of selectedLoadedDiff.hunks) {
-      const existing = hunkThreadByHeader.get(hunk.header);
+      const existingThreads = hunkThreadByHeader.get(hunk.header) ?? [];
+      const primaryThread = pickPrimaryThread(existingThreads);
       annotations.push({
         side: hunk.anchorSide,
         lineNumber: hunk.anchorLine,
         metadata: {
           kind: 'hunk-control',
           hunkHeader: hunk.header,
-          decision: existing?.decision ?? 'pending',
-          threadId: existing?.id,
-          commentCount: existing?.comments.length ?? 0,
+          decision: aggregateHunkDecision(existingThreads),
+          threadId: primaryThread?.id,
+          threadIds: existingThreads.map((thread) => thread.id),
+          commentCount: existingThreads.reduce((sum, thread) => sum + thread.comments.length, 0),
+          oldStart: hunk.oldStart,
+          oldEnd: hunk.oldEnd,
+          newStart: hunk.newStart,
+          newEnd: hunk.newEnd,
         },
       });
     }
@@ -370,14 +465,24 @@ export function DiffViewer({
     }
   }, [commentForm, commentBody, onCreateThread]);
 
-  const setHunkDecision = useCallback(async (hunkHeader: string, decision: HunkDecision) => {
+  const setHunkDecision = useCallback(async (hunkMeta: HunkControlMeta, decision: HunkDecision) => {
     if (!selectedFile) {
       return;
     }
 
-    const existing = hunkThreadByHeader.get(hunkHeader);
-    if (existing) {
-      await onUpdateThread(existing.id, { decision });
+    onHunkFocus?.({
+      filePath: selectedFile.filePath,
+      hunkHeader: hunkMeta.hunkHeader,
+      oldStart: hunkMeta.oldStart,
+      oldEnd: hunkMeta.oldEnd,
+      newStart: hunkMeta.newStart,
+      newEnd: hunkMeta.newEnd,
+    });
+
+    const existingThreads = hunkThreadByHeader.get(hunkMeta.hunkHeader) ?? [];
+    const primary = pickPrimaryThread(existingThreads);
+    if (primary) {
+      await onUpdateThread(primary.id, { decision });
       return;
     }
 
@@ -386,21 +491,29 @@ export function DiffViewer({
     }
 
     await onCreateThread(
-      { kind: 'hunk', file: selectedFile.filePath, hunkHeader },
+      { kind: 'hunk', file: selectedFile.filePath, hunkHeader: hunkMeta.hunkHeader },
       decision === 'approved'
         ? 'Approved hunk via inline controls.'
         : 'Rejected hunk via inline controls.',
       decision
     );
-  }, [selectedFile, hunkThreadByHeader, onUpdateThread, onCreateThread]);
+  }, [selectedFile, hunkThreadByHeader, onUpdateThread, onCreateThread, onHunkFocus]);
 
-  const openHunkCommentForm = useCallback((hunkHeader: string) => {
+  const openHunkCommentForm = useCallback((hunkMeta: HunkControlMeta) => {
     if (!selectedFile) {
       return;
     }
-    setCommentForm({ target: { kind: 'hunk', file: selectedFile.filePath, hunkHeader } });
+    onHunkFocus?.({
+      filePath: selectedFile.filePath,
+      hunkHeader: hunkMeta.hunkHeader,
+      oldStart: hunkMeta.oldStart,
+      oldEnd: hunkMeta.oldEnd,
+      newStart: hunkMeta.newStart,
+      newEnd: hunkMeta.newEnd,
+    });
+    setCommentForm({ target: { kind: 'hunk', file: selectedFile.filePath, hunkHeader: hunkMeta.hunkHeader } });
     setCommentBody('');
-  }, [selectedFile]);
+  }, [selectedFile, onHunkFocus]);
 
   const handleLineSelectionEnd = useCallback((range: SelectedLineRange | null) => {
     if (!range || !selectedFile) {
@@ -424,6 +537,8 @@ export function DiffViewer({
   ) => {
     return (
       <button
+        type="button"
+        aria-label="Add line comment"
         title="Add comment"
         onMouseDown={(event) => {
           event.preventDefault();
@@ -478,6 +593,7 @@ export function DiffViewer({
             onClick={() => onThreadClick?.(thread.id)}
             onMouseEnter={() => onThreadHover?.(thread.id)}
             onMouseLeave={() => onThreadHover?.(null)}
+            data-thread-id={thread.id}
             style={{
               position: 'absolute',
               top: '-9px',
@@ -508,6 +624,7 @@ export function DiffViewer({
     return (
       <div style={{ position: 'relative', zIndex: 10, height: 0, overflow: 'visible', pointerEvents: 'none' }}>
         <div
+          data-thread-id={meta.threadId}
           style={{
             position: 'absolute',
             top: '4px',
@@ -527,22 +644,46 @@ export function DiffViewer({
         >
           <button
             title="Reject hunk"
-            onClick={() => void setHunkDecision(meta.hunkHeader, 'rejected')}
+            onClick={() => void setHunkDecision(meta, 'rejected')}
             style={actionButtonStyle(meta.decision === 'rejected', '#f85149')}
           >
             Reject
           </button>
           <button
             title="Approve hunk"
-            onClick={() => void setHunkDecision(meta.hunkHeader, 'approved')}
+            onClick={() => void setHunkDecision(meta, 'approved')}
             style={actionButtonStyle(meta.decision === 'approved', '#22c55e', true)}
           >
             Approve
           </button>
+          {meta.threadId && (
+            <button
+              title="Open hunk thread"
+              onClick={() => {
+                if (!selectedFile) {
+                  return;
+                }
+                onHunkFocus?.({
+                  filePath: selectedFile.filePath,
+                  hunkHeader: meta.hunkHeader,
+                  oldStart: meta.oldStart,
+                  oldEnd: meta.oldEnd,
+                  newStart: meta.newStart,
+                  newEnd: meta.newEnd,
+                });
+                if (meta.threadId) {
+                  onThreadClick?.(meta.threadId);
+                }
+              }}
+              style={actionButtonStyle(false, '#58a6ff')}
+            >
+              Threads {meta.threadIds.length > 1 ? `(${meta.threadIds.length})` : ''}
+            </button>
+          )}
           {!meta.threadId && (
             <button
               title="Comment on hunk"
-              onClick={() => openHunkCommentForm(meta.hunkHeader)}
+              onClick={() => openHunkCommentForm(meta)}
               style={actionButtonStyle(false, '#58a6ff')}
             >
               Comment
@@ -551,7 +692,7 @@ export function DiffViewer({
         </div>
       </div>
     );
-  }, [onThreadClick, onThreadHover, openHunkCommentForm, setHunkDecision]);
+  }, [onThreadClick, onThreadHover, openHunkCommentForm, onHunkFocus, selectedFile?.filePath, setHunkDecision]);
 
   const fileDiffOptions = useMemo((): FileDiffOptions<InlineAnnotationMeta> => ({
     diffStyle: 'unified',
@@ -588,9 +729,9 @@ export function DiffViewer({
   }
 
   const selectedDiffLoading = selectedDiffState?.status === 'loading' || selectedDiffState?.status === 'idle';
-  const selectedDiffError = selectedDiffState?.status === 'error' ? selectedDiffState.message : null;
+  const selectedDiffError = selectedDiffState?.status === 'error' ? selectedDiffState.error.message : null;
   const contextLoading = selectedContextState?.status === 'loading';
-  const contextError = selectedContextState?.status === 'error' ? selectedContextState.message : null;
+  const contextError = selectedContextState?.status === 'error' ? selectedContextState.error.message : null;
   const contextReady = selectedContextState?.status === 'ready';
 
   return (
@@ -719,7 +860,7 @@ export function DiffViewer({
             Failed to load file diff: {selectedDiffError}
           </div>
         ) : renderedFileDiff ? (
-          <div style={{ flex: 1, overflow: 'auto' }}>
+          <div data-diff-scroll-container style={{ flex: 1, overflow: 'auto' }}>
             <FileDiff
               fileDiff={renderedFileDiff}
               options={fileDiffOptions}
@@ -846,20 +987,28 @@ function parseSingleFileDiff(diff: string, file: ReviewChangedFile): LoadedFileD
       return true;
     }
     return false;
-  }) ?? parsed.flatMap((patch) => patch.files)[0];
+  });
 
   if (!parsedFile) {
-    throw new Error('No parseable file diff returned for selected file');
+    throw new SpacesError('No parseable file diff returned for selected file', 'SYSTEM_ERROR', 2);
   }
 
   const hunks: HunkInfo[] = parsedFile.hunks.map((hunk) => {
     const anchorSide: AnnotationSide = hunk.additionCount > 0 ? 'additions' : 'deletions';
     const anchorLine = Math.max(1, anchorSide === 'additions' ? hunk.additionStart : hunk.deletionStart);
+    const oldStart = Math.max(1, hunk.deletionStart);
+    const newStart = Math.max(1, hunk.additionStart);
+    const oldEnd = oldStart + Math.max(hunk.deletionCount, 1) - 1;
+    const newEnd = newStart + Math.max(hunk.additionCount, 1) - 1;
 
     return {
       header: formatHunkHeader(hunk),
       anchorSide,
       anchorLine,
+      oldStart,
+      oldEnd,
+      newStart,
+      newEnd,
     };
   });
 
@@ -928,4 +1077,37 @@ function actionButtonStyle(active: boolean, color: string, success = false): CSS
     fontWeight: 600,
     cursor: 'pointer',
   };
+}
+
+function toSpacesError(error: unknown, fallbackMessage: string): SpacesError {
+  if (error instanceof SpacesError) {
+    return error;
+  }
+  if (error instanceof Error) {
+    return new SpacesError(error.message, 'SYSTEM_ERROR', 2);
+  }
+  return new SpacesError(fallbackMessage, 'SYSTEM_ERROR', 2);
+}
+
+function pickPrimaryThread(threads: ReviewThread[]): ReviewThread | undefined {
+  if (threads.length === 0) {
+    return undefined;
+  }
+  const unresolved = threads
+    .filter((thread) => !thread.resolved)
+    .sort((left, right) => Date.parse(right.updatedAt) - Date.parse(left.updatedAt));
+  if (unresolved.length > 0) {
+    return unresolved[0];
+  }
+  return [...threads].sort((left, right) => Date.parse(right.updatedAt) - Date.parse(left.updatedAt))[0];
+}
+
+function aggregateHunkDecision(threads: ReviewThread[]): HunkDecision {
+  if (threads.some((thread) => thread.decision === 'rejected')) {
+    return 'rejected';
+  }
+  if (threads.length > 0 && threads.every((thread) => thread.decision === 'approved')) {
+    return 'approved';
+  }
+  return 'pending';
 }

--- a/src/components/DiffViewer.web.tsx
+++ b/src/components/DiffViewer.web.tsx
@@ -13,7 +13,7 @@ import {
   type SelectedLineRange,
 } from '@pierre/diffs';
 import type { HunkDecision, ReviewChangedFile, ReviewThread, ThreadTarget } from '../types/review.js';
-import { SpacesError } from '../types/errors.js';
+import { SpacesError, toSpacesError } from '../types/errors.js';
 
 export interface HunkFocusTarget {
   filePath: string;
@@ -1077,16 +1077,6 @@ function actionButtonStyle(active: boolean, color: string, success = false): CSS
     fontWeight: 600,
     cursor: 'pointer',
   };
-}
-
-function toSpacesError(error: unknown, fallbackMessage: string): SpacesError {
-  if (error instanceof SpacesError) {
-    return error;
-  }
-  if (error instanceof Error) {
-    return new SpacesError(error.message, 'SYSTEM_ERROR', 2);
-  }
-  return new SpacesError(fallbackMessage, 'SYSTEM_ERROR', 2);
 }
 
 function pickPrimaryThread(threads: ReviewThread[]): ReviewThread | undefined {

--- a/src/components/DiffViewer.web.tsx
+++ b/src/components/DiffViewer.web.tsx
@@ -142,7 +142,9 @@ export function DiffViewer({
 
   const diffHostRef = useRef<HTMLDivElement | null>(null);
   const loadingFileDiffKeysRef = useRef<Set<string>>(new Set());
+  const loadingContextKeysRef = useRef<Set<string>>(new Set());
   const fileDiffStateByKeyRef = useRef<Record<string, FileDiffState>>({});
+  const contextStateByKeyRef = useRef<Record<string, FileContextState>>({});
 
   const fileByKey = useMemo(() => {
     const map = new Map<string, ReviewChangedFile>();
@@ -175,7 +177,22 @@ export function DiffViewer({
   }, [fileDiffStateByKey]);
 
   useEffect(() => {
+    contextStateByKeyRef.current = contextStateByKey;
+  }, [contextStateByKey]);
+
+  useEffect(() => {
     const valid = new Set(files.map((file) => fileKey(file.filePath, file.prevFilePath)));
+
+    for (const key of [...loadingFileDiffKeysRef.current]) {
+      if (!valid.has(key)) {
+        loadingFileDiffKeysRef.current.delete(key);
+      }
+    }
+    for (const key of [...loadingContextKeysRef.current]) {
+      if (!valid.has(key)) {
+        loadingContextKeysRef.current.delete(key);
+      }
+    }
 
     setFileDiffStateByKey((prev) => {
       const next: Record<string, FileDiffState> = {};
@@ -311,10 +328,16 @@ export function DiffViewer({
       return;
     }
 
-    const current = contextStateByKey[selectedKey] ?? { status: 'idle' as const };
+    const current = contextStateByKeyRef.current[selectedKey] ?? { status: 'idle' as const };
     if (current.status === 'loading' || current.status === 'ready') {
       return;
     }
+
+    if (loadingContextKeysRef.current.has(selectedKey)) {
+      return;
+    }
+
+    loadingContextKeysRef.current.add(selectedKey);
 
     setContextStateByKey((prev) => ({
       ...prev,
@@ -344,8 +367,10 @@ export function DiffViewer({
         ...prev,
         [selectedKey]: { status: 'error', error: typed },
       }));
+    } finally {
+      loadingContextKeysRef.current.delete(selectedKey);
     }
-  }, [selectedFile, selectedKey, contextStateByKey, onRequestFileContextRange]);
+  }, [selectedFile, selectedKey, onRequestFileContextRange]);
 
   // On-demand expansion trigger: clicking line-info separators when context is
   // not loaded will load context first, then user can click again to expand.
@@ -356,7 +381,7 @@ export function DiffViewer({
     }
 
     const onCaptureClick = (event: MouseEvent) => {
-      const current = contextStateByKey[selectedKey] ?? { status: 'idle' as const };
+      const current = contextStateByKeyRef.current[selectedKey] ?? { status: 'idle' as const };
       if (current.status === 'loading' || current.status === 'ready') {
         return;
       }
@@ -383,7 +408,7 @@ export function DiffViewer({
     return () => {
       host.removeEventListener('click', onCaptureClick, true);
     };
-  }, [selectedKey, contextStateByKey, ensureContextLoaded]);
+  }, [selectedKey, ensureContextLoaded]);
 
   const selectedLoadedDiff = selectedDiffState?.status === 'ready' ? selectedDiffState.data : null;
   const selectedContextReady = selectedContextState?.status === 'ready' ? selectedContextState : null;

--- a/src/components/DiffViewer.web.tsx
+++ b/src/components/DiffViewer.web.tsx
@@ -1077,8 +1077,8 @@ function parseSingleFileDiff(diff: string, file: ReviewChangedFile): LoadedFileD
     const anchorLine = Math.max(1, anchorSide === 'additions' ? hunk.additionStart : hunk.deletionStart);
     const oldStart = Math.max(1, hunk.deletionStart);
     const newStart = Math.max(1, hunk.additionStart);
-    const oldEnd = oldStart + Math.max(hunk.deletionCount, 1) - 1;
-    const newEnd = newStart + Math.max(hunk.additionCount, 1) - 1;
+    const oldEnd = hunk.deletionCount > 0 ? oldStart + hunk.deletionCount - 1 : oldStart - 1;
+    const newEnd = hunk.additionCount > 0 ? newStart + hunk.additionCount - 1 : newStart - 1;
 
     return {
       header: formatHunkHeader(hunk),

--- a/src/components/DiffViewer.web.tsx
+++ b/src/components/DiffViewer.web.tsx
@@ -147,8 +147,10 @@ export function DiffViewer({
   const diffHostRef = useRef<HTMLDivElement | null>(null);
   const loadingFileDiffKeysRef = useRef<Set<string>>(new Set());
   const loadingContextKeysRef = useRef<Set<string>>(new Set());
+  const decidingHunkKeysRef = useRef<Set<string>>(new Set());
   const fileDiffStateByKeyRef = useRef<Record<string, FileDiffState>>({});
   const contextStateByKeyRef = useRef<Record<string, FileContextState>>({});
+  const hunkThreadByHeaderRef = useRef<Map<string, ReviewThread[]>>(new Map());
 
   const fileByKey = useMemo(() => {
     const map = new Map<string, ReviewChangedFile>();
@@ -186,6 +188,7 @@ export function DiffViewer({
 
   useEffect(() => {
     const valid = new Set(files.map((file) => fileKey(file.filePath, file.prevFilePath)));
+    const validFilePaths = new Set(files.map((file) => file.filePath));
 
     for (const key of [...loadingFileDiffKeysRef.current]) {
       if (!valid.has(key)) {
@@ -195,6 +198,13 @@ export function DiffViewer({
     for (const key of [...loadingContextKeysRef.current]) {
       if (!valid.has(key)) {
         loadingContextKeysRef.current.delete(key);
+      }
+    }
+    for (const key of [...decidingHunkKeysRef.current]) {
+      const separator = key.indexOf('::');
+      const filePath = separator >= 0 ? key.slice(0, separator) : key;
+      if (!validFilePaths.has(filePath)) {
+        decidingHunkKeysRef.current.delete(key);
       }
     }
 
@@ -439,6 +449,10 @@ export function DiffViewer({
     return map;
   }, [threads, selectedFile]);
 
+  useEffect(() => {
+    hunkThreadByHeaderRef.current = hunkThreadByHeader;
+  }, [hunkThreadByHeader]);
+
   const lineAnnotations = useMemo((): DiffLineAnnotation<InlineAnnotationMeta>[] => {
     if (!selectedLoadedDiff || !selectedFile) {
       return [];
@@ -503,43 +517,54 @@ export function DiffViewer({
       return;
     }
 
-    onHunkFocus?.({
-      filePath: selectedFile.filePath,
-      hunkHeader: hunkMeta.hunkHeader,
-      oldStart: hunkMeta.oldStart,
-      oldEnd: hunkMeta.oldEnd,
-      newStart: hunkMeta.newStart,
-      newEnd: hunkMeta.newEnd,
-    });
-
     const normalizedHeader = normalizeHunkHeader(hunkMeta.hunkHeader);
-    const existingThreads = hunkThreadByHeader.get(normalizedHeader) ?? [];
-    const primary = pickPrimaryThread(existingThreads);
-    if (primary) {
+    const hunkKey = `${selectedFile.filePath}::${normalizedHeader}`;
+    if (decidingHunkKeysRef.current.has(hunkKey)) {
+      return;
+    }
+
+    decidingHunkKeysRef.current.add(hunkKey);
+
+    try {
+      onHunkFocus?.({
+        filePath: selectedFile.filePath,
+        hunkHeader: hunkMeta.hunkHeader,
+        oldStart: hunkMeta.oldStart,
+        oldEnd: hunkMeta.oldEnd,
+        newStart: hunkMeta.newStart,
+        newEnd: hunkMeta.newEnd,
+      });
+
+      const existingThreads = hunkThreadByHeaderRef.current.get(normalizedHeader) ?? [];
+      const primary = pickPrimaryThread(existingThreads);
+      if (primary) {
+        try {
+          await onUpdateThread(primary.id, { decision });
+        } catch {
+          // Error is surfaced via review hook state; avoid unhandled promise rejections.
+        }
+        return;
+      }
+
+      if (decision === 'pending') {
+        return;
+      }
+
       try {
-        await onUpdateThread(primary.id, { decision });
+        await onCreateThread(
+          { kind: 'hunk', file: selectedFile.filePath, hunkHeader: normalizedHeader },
+          decision === 'approved'
+            ? 'Approved hunk via inline controls.'
+            : 'Rejected hunk via inline controls.',
+          decision
+        );
       } catch {
         // Error is surfaced via review hook state; avoid unhandled promise rejections.
       }
-      return;
+    } finally {
+      decidingHunkKeysRef.current.delete(hunkKey);
     }
-
-    if (decision === 'pending') {
-      return;
-    }
-
-    try {
-      await onCreateThread(
-        { kind: 'hunk', file: selectedFile.filePath, hunkHeader: normalizedHeader },
-        decision === 'approved'
-          ? 'Approved hunk via inline controls.'
-          : 'Rejected hunk via inline controls.',
-        decision
-      );
-    } catch {
-      // Error is surfaced via review hook state; avoid unhandled promise rejections.
-    }
-  }, [selectedFile, hunkThreadByHeader, onUpdateThread, onCreateThread, onHunkFocus]);
+  }, [selectedFile, onUpdateThread, onCreateThread, onHunkFocus]);
 
   const openHunkCommentForm = useCallback((hunkMeta: HunkControlMeta) => {
     if (!selectedFile) {

--- a/src/components/DiffViewer.web.tsx
+++ b/src/components/DiffViewer.web.tsx
@@ -14,6 +14,7 @@ import {
 } from '@pierre/diffs';
 import type { HunkDecision, ReviewChangedFile, ReviewThread, ThreadTarget } from '../types/review.js';
 import { SpacesError, toSpacesError } from '../types/errors.js';
+import { normalizeHunkHeader } from '../utils/hunk-header.js';
 
 export interface HunkFocusTarget {
   filePath: string;
@@ -109,6 +110,7 @@ const CHANGE_COLOR: Record<ReviewChangedFile['changeType'], string> = {
   new: '#22c55e',
   deleted: '#f85149',
   renamed: '#d29922',
+  copied: '#3fb950',
   modified: '#58a6ff',
 };
 
@@ -116,6 +118,7 @@ const CHANGE_LABEL: Record<ReviewChangedFile['changeType'], string> = {
   new: 'A',
   deleted: 'D',
   renamed: 'R',
+  copied: 'C',
   modified: 'M',
 };
 
@@ -426,9 +429,10 @@ export function DiffViewer({
       if (thread.target.file !== selectedFile.filePath) {
         continue;
       }
-      const list = map.get(thread.target.hunkHeader) ?? [];
+      const normalizedHeader = normalizeHunkHeader(thread.target.hunkHeader);
+      const list = map.get(normalizedHeader) ?? [];
       list.push(thread);
-      map.set(thread.target.hunkHeader, list);
+      map.set(normalizedHeader, list);
     }
 
     return map;
@@ -442,14 +446,15 @@ export function DiffViewer({
     const annotations: DiffLineAnnotation<InlineAnnotationMeta>[] = [];
 
     for (const hunk of selectedLoadedDiff.hunks) {
-      const existingThreads = hunkThreadByHeader.get(hunk.header) ?? [];
+      const normalizedHeader = normalizeHunkHeader(hunk.header);
+      const existingThreads = hunkThreadByHeader.get(normalizedHeader) ?? [];
       const primaryThread = pickPrimaryThread(existingThreads);
       annotations.push({
         side: hunk.anchorSide,
         lineNumber: hunk.anchorLine,
         metadata: {
           kind: 'hunk-control',
-          hunkHeader: hunk.header,
+          hunkHeader: normalizedHeader,
           decision: aggregateHunkDecision(existingThreads),
           threadId: primaryThread?.id,
           threadIds: existingThreads.map((thread) => thread.id),
@@ -504,7 +509,8 @@ export function DiffViewer({
       newEnd: hunkMeta.newEnd,
     });
 
-    const existingThreads = hunkThreadByHeader.get(hunkMeta.hunkHeader) ?? [];
+    const normalizedHeader = normalizeHunkHeader(hunkMeta.hunkHeader);
+    const existingThreads = hunkThreadByHeader.get(normalizedHeader) ?? [];
     const primary = pickPrimaryThread(existingThreads);
     if (primary) {
       await onUpdateThread(primary.id, { decision });
@@ -516,7 +522,7 @@ export function DiffViewer({
     }
 
     await onCreateThread(
-      { kind: 'hunk', file: selectedFile.filePath, hunkHeader: hunkMeta.hunkHeader },
+      { kind: 'hunk', file: selectedFile.filePath, hunkHeader: normalizedHeader },
       decision === 'approved'
         ? 'Approved hunk via inline controls.'
         : 'Rejected hunk via inline controls.',
@@ -536,7 +542,13 @@ export function DiffViewer({
       newStart: hunkMeta.newStart,
       newEnd: hunkMeta.newEnd,
     });
-    setCommentForm({ target: { kind: 'hunk', file: selectedFile.filePath, hunkHeader: hunkMeta.hunkHeader } });
+    setCommentForm({
+      target: {
+        kind: 'hunk',
+        file: selectedFile.filePath,
+        hunkHeader: normalizeHunkHeader(hunkMeta.hunkHeader),
+      },
+    });
     setCommentBody('');
   }, [selectedFile, onHunkFocus]);
 
@@ -1047,11 +1059,15 @@ function formatHunkHeader(hunk: Hunk): string {
   const specs = (hunk.hunkSpecs ?? '').trim();
   const context = hunk.hunkContext ?? '';
 
-  if (!specs) {
-    return context ? `@@ @@ ${context}` : '@@ @@';
+  if (specs.startsWith('@@')) {
+    return normalizeHunkHeader(specs);
   }
 
-  return `@@ ${specs} @@${context ? ` ${context}` : ''}`;
+  if (!specs) {
+    return normalizeHunkHeader(context ? `@@ @@ ${context}` : '@@ @@');
+  }
+
+  return normalizeHunkHeader(`@@ ${specs} @@${context ? ` ${context}` : ''}`);
 }
 
 function expandToAbsoluteLines(lines: string[], start: number, total: number): string[] {

--- a/src/components/DiffViewer.web.tsx
+++ b/src/components/DiffViewer.web.tsx
@@ -1017,13 +1017,13 @@ function fileKey(filePath: string, prevFilePath?: string): string {
 function parseSingleFileDiff(diff: string, file: ReviewChangedFile): LoadedFileDiff {
   const parsed = parsePatchFiles(diff);
   const parsedFile = parsed.flatMap((patch) => patch.files).find((entry) => {
-    if (entry.name === file.filePath) {
-      return true;
-    }
-    if (file.prevFilePath && entry.prevName === file.prevFilePath && entry.name === file.filePath) {
-      return true;
-    }
-    return false;
+    const matchesCurrentOrPreviousName =
+      entry.name === file.filePath ||
+      (file.prevFilePath !== undefined && entry.name === file.prevFilePath);
+    const matchesCurrentOrPreviousPrevName =
+      entry.prevName === file.filePath ||
+      (file.prevFilePath !== undefined && entry.prevName === file.prevFilePath);
+    return matchesCurrentOrPreviousName || matchesCurrentOrPreviousPrevName;
   });
 
   if (!parsedFile) {

--- a/src/components/DiffViewer.web.tsx
+++ b/src/components/DiffViewer.web.tsx
@@ -115,6 +115,7 @@ export function DiffViewer({
 
   const diffHostRef = useRef<HTMLDivElement | null>(null);
   const loadingFileDiffKeysRef = useRef<Set<string>>(new Set());
+  const fileDiffStateByKeyRef = useRef<Record<string, FileDiffState>>({});
 
   const fileByKey = useMemo(() => {
     const map = new Map<string, ReviewChangedFile>();
@@ -137,6 +138,10 @@ export function DiffViewer({
   const selectedKey = selectedFile ? fileKey(selectedFile.filePath, selectedFile.prevFilePath) : null;
   const selectedDiffState = selectedKey ? fileDiffStateByKey[selectedKey] ?? ({ status: 'idle' } as const) : null;
   const selectedContextState = selectedKey ? contextStateByKey[selectedKey] ?? ({ status: 'idle' } as const) : null;
+
+  useEffect(() => {
+    fileDiffStateByKeyRef.current = fileDiffStateByKey;
+  }, [fileDiffStateByKey]);
 
   useEffect(() => {
     const valid = new Set(files.map((file) => fileKey(file.filePath, file.prevFilePath)));
@@ -165,7 +170,7 @@ export function DiffViewer({
   const loadFileDiff = useCallback(async (file: ReviewChangedFile) => {
     const key = fileKey(file.filePath, file.prevFilePath);
 
-    const current = fileDiffStateByKey[key];
+    const current = fileDiffStateByKeyRef.current[key];
     if (current?.status === 'loading' || current?.status === 'ready') {
       return;
     }
@@ -200,7 +205,7 @@ export function DiffViewer({
     } finally {
       loadingFileDiffKeysRef.current.delete(key);
     }
-  }, [fileDiffStateByKey, onRequestFileDiff]);
+  }, [onRequestFileDiff]);
 
   useEffect(() => {
     if (!selectedFile || !selectedKey) {

--- a/src/components/DiffViewer.web.tsx
+++ b/src/components/DiffViewer.web.tsx
@@ -1,0 +1,311 @@
+/** @jsxImportSource react */
+/**
+ * DiffViewer — wraps @pierre/diffs PatchDiff component.
+ *
+ * Shows the unified diff with per-hunk approve/reject buttons
+ * and comment count badges. Clicking a line opens a comment form.
+ */
+
+import { useState, useCallback } from 'react';
+import { PatchDiff } from '@pierre/diffs/react';
+import type { DiffLineAnnotation, AnnotationSide } from '@pierre/diffs';
+import type { ReviewThread, ThreadTarget, HunkDecision } from '../types/review.js';
+
+export interface DiffViewerProps {
+  diff: string;
+  threads: ReviewThread[];
+  onCreateThread: (target: ThreadTarget, body: string, decision?: HunkDecision) => Promise<void>;
+  onUpdateThread: (threadId: string, updates: { decision?: HunkDecision }) => Promise<void>;
+  onThreadClick?: (threadId: string) => void;
+}
+
+interface CommentFormState {
+  target: ThreadTarget;
+  decision?: HunkDecision;
+}
+
+export function DiffViewer({ diff, threads, onCreateThread, onUpdateThread, onThreadClick }: DiffViewerProps) {
+  const [commentForm, setCommentForm] = useState<CommentFormState | null>(null);
+  const [commentBody, setCommentBody] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+
+  const handleSubmitComment = useCallback(async () => {
+    if (!commentForm || !commentBody.trim()) return;
+    setSubmitting(true);
+    try {
+      await onCreateThread(commentForm.target, commentBody.trim(), commentForm.decision);
+      setCommentForm(null);
+      setCommentBody('');
+    } finally {
+      setSubmitting(false);
+    }
+  }, [commentForm, commentBody, onCreateThread]);
+
+  const handleApproveHunk = useCallback(async (hunkHeader: string, file: string) => {
+    // Find existing hunk thread
+    const existing = threads.find(
+      (t) => t.target.kind === 'hunk' && t.target.hunkHeader === hunkHeader && t.target.file === file
+    );
+    if (existing) {
+      await onUpdateThread(existing.id, { decision: 'approved' });
+    } else {
+      setCommentForm({ target: { kind: 'hunk', file, hunkHeader }, decision: 'approved' });
+      setCommentBody('');
+    }
+  }, [threads, onUpdateThread]);
+
+  const handleRejectHunk = useCallback(async (hunkHeader: string, file: string) => {
+    const existing = threads.find(
+      (t) => t.target.kind === 'hunk' && t.target.hunkHeader === hunkHeader && t.target.file === file
+    );
+    if (existing) {
+      await onUpdateThread(existing.id, { decision: 'rejected' });
+    } else {
+      setCommentForm({ target: { kind: 'hunk', file, hunkHeader }, decision: 'rejected' });
+      setCommentBody('');
+    }
+  }, [threads, onUpdateThread]);
+
+  // Map threads to badge annotations for @pierre/diffs
+  // AnnotationSide uses "deletions"/"additions" (not "LEFT"/"RIGHT")
+  const annotations: DiffLineAnnotation<ReviewThread>[] = threads
+    .filter((t) => t.target.kind === 'line' || t.target.kind === 'hunk')
+    .map((t) => {
+      const side: AnnotationSide = t.target.kind === 'line'
+        ? (t.target.side === 'LEFT' ? 'deletions' : 'additions')
+        : 'additions';
+      const lineNumber = t.target.kind === 'line' ? t.target.startLine : 1;
+      return { side, lineNumber, metadata: t };
+    });
+
+  const renderAnnotation = useCallback((annotation: DiffLineAnnotation<ReviewThread>) => {
+    const thread = annotation.metadata;
+    const count = thread.comments.length;
+    const decision = thread.decision;
+    const color =
+      decision === 'approved' ? '#22c55e' :
+      decision === 'rejected' ? '#f85149' :
+      '#58a6ff';
+
+    return (
+      <button
+        style={{
+          display: 'inline-flex',
+          alignItems: 'center',
+          gap: '4px',
+          fontSize: '11px',
+          padding: '1px 6px',
+          borderRadius: '10px',
+          background: color + '22',
+          color,
+          border: `1px solid ${color}44`,
+          cursor: 'pointer',
+        }}
+        onClick={() => onThreadClick?.(thread.id)}
+      >
+        {decision === 'approved' ? '✓' : decision === 'rejected' ? '✗' : '💬'}
+        {count > 1 && ` ${count}`}
+      </button>
+    );
+  }, [onThreadClick]);
+
+  if (!diff) {
+    return (
+      <div style={{ padding: '32px', textAlign: 'center', color: '#8b949e' }}>
+        No diff available.
+      </div>
+    );
+  }
+
+  // Parse hunk headers from the diff for approve/reject buttons
+  const hunkHeaders = extractHunkHeaders(diff);
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', height: '100%', overflow: 'hidden' }}>
+      {/* Hunk approve/reject toolbar — scrollable, shows all hunks */}
+      {hunkHeaders.length > 0 && (
+        <div style={{
+          padding: '8px 12px',
+          borderBottom: '1px solid #30363d',
+          display: 'flex',
+          gap: '6px',
+          flexShrink: 0,
+          overflowX: 'auto',
+        }}>
+          {hunkHeaders.map(({ header, file }) => {
+            const thread = threads.find(
+              (t) => t.target.kind === 'hunk' && t.target.hunkHeader === header && t.target.file === file
+            );
+            const decision = thread?.decision;
+            return (
+              <div key={`${file}:${header}`} style={{ display: 'flex', gap: '4px', alignItems: 'center', flexShrink: 0 }}>
+                <span style={{ fontSize: '11px', color: '#6e7681', maxWidth: '120px', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                  {header.replace(/@@.*@@\s*/, '').trim() || header.slice(0, 30)}
+                </span>
+                <button
+                  onClick={() => void handleApproveHunk(header, file)}
+                  style={{
+                    fontSize: '11px',
+                    padding: '2px 8px',
+                    borderRadius: '4px',
+                    border: '1px solid',
+                    cursor: 'pointer',
+                    background: decision === 'approved' ? '#22c55e33' : '#21262d',
+                    color: decision === 'approved' ? '#22c55e' : '#8b949e',
+                    borderColor: decision === 'approved' ? '#22c55e66' : '#30363d',
+                  }}
+                >
+                  ✓ Approve
+                </button>
+                <button
+                  onClick={() => void handleRejectHunk(header, file)}
+                  style={{
+                    fontSize: '11px',
+                    padding: '2px 8px',
+                    borderRadius: '4px',
+                    border: '1px solid',
+                    cursor: 'pointer',
+                    background: decision === 'rejected' ? '#f8514933' : '#21262d',
+                    color: decision === 'rejected' ? '#f85149' : '#8b949e',
+                    borderColor: decision === 'rejected' ? '#f8514966' : '#30363d',
+                  }}
+                >
+                  ✗ Reject
+                </button>
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      {/* Diff viewer */}
+      <div style={{ flex: 1, overflow: 'auto' }}>
+        <PatchDiff
+          patch={diff}
+          lineAnnotations={annotations}
+          renderAnnotation={renderAnnotation}
+          className="diff-viewer"
+        />
+      </div>
+
+      {/* Inline comment form */}
+      {commentForm && (
+        <div style={{
+          position: 'fixed',
+          bottom: 0,
+          left: 0,
+          right: 0,
+          background: '#161b22',
+          borderTop: '1px solid #30363d',
+          padding: '12px 16px',
+          zIndex: 100,
+        }}>
+          <div style={{ display: 'flex', gap: '8px', alignItems: 'flex-start', maxWidth: '800px', margin: '0 auto' }}>
+            <div style={{ flex: 1 }}>
+              {commentForm.decision && (
+                <div style={{
+                  marginBottom: '6px',
+                  fontSize: '12px',
+                  color: commentForm.decision === 'approved' ? '#22c55e' : '#f85149',
+                }}>
+                  {commentForm.decision === 'approved' ? '✓ Approving hunk' : '✗ Requesting changes on hunk'}
+                  {commentForm.target.kind === 'hunk' && (
+                    <span style={{ color: '#6e7681', marginLeft: '8px' }}>{commentForm.target.hunkHeader.slice(0, 50)}</span>
+                  )}
+                </div>
+              )}
+              <textarea
+                value={commentBody}
+                onChange={(e) => setCommentBody(e.target.value)}
+                placeholder="Add a comment (optional)..."
+                rows={3}
+                style={{
+                  width: '100%',
+                  background: '#0d1117',
+                  border: '1px solid #30363d',
+                  borderRadius: '6px',
+                  color: '#e6edf3',
+                  padding: '8px',
+                  fontSize: '13px',
+                  resize: 'vertical',
+                  boxSizing: 'border-box',
+                }}
+                autoFocus
+                onKeyDown={(e) => {
+                  if (e.key === 'Escape') {
+                    setCommentForm(null);
+                    setCommentBody('');
+                  }
+                  if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+                    void handleSubmitComment();
+                  }
+                }}
+              />
+            </div>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: '6px' }}>
+              <button
+                onClick={() => void handleSubmitComment()}
+                disabled={submitting}
+                style={{
+                  padding: '8px 16px',
+                  background: '#22c55e',
+                  color: '#0d1117',
+                  border: 'none',
+                  borderRadius: '6px',
+                  cursor: submitting ? 'wait' : 'pointer',
+                  fontSize: '13px',
+                  fontWeight: 500,
+                }}
+              >
+                {submitting ? '...' : 'Submit'}
+              </button>
+              <button
+                onClick={() => { setCommentForm(null); setCommentBody(''); }}
+                style={{
+                  padding: '8px 16px',
+                  background: '#21262d',
+                  color: '#8b949e',
+                  border: '1px solid #30363d',
+                  borderRadius: '6px',
+                  cursor: 'pointer',
+                  fontSize: '13px',
+                }}
+              >
+                Cancel
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+interface HunkInfo {
+  header: string;
+  file: string;
+}
+
+function extractHunkHeaders(patch: string): HunkInfo[] {
+  const lines = patch.split('\n');
+  const result: HunkInfo[] = [];
+  let currentFile = '';
+
+  for (const line of lines) {
+    if (line.startsWith('diff --git')) {
+      // e.g. "diff --git a/src/foo.ts b/src/foo.ts"
+      const match = line.match(/b\/(.+)$/);
+      if (match) {
+        currentFile = match[1];
+      }
+    } else if (line.startsWith('@@')) {
+      result.push({ header: line, file: currentFile });
+    }
+  }
+
+  return result;
+}

--- a/src/components/DiffViewer.web.tsx
+++ b/src/components/DiffViewer.web.tsx
@@ -1,22 +1,39 @@
 /** @jsxImportSource react */
-/**
- * DiffViewer — wraps @pierre/diffs PatchDiff component.
- *
- * Shows the unified diff with per-hunk approve/reject buttons
- * and comment count badges. Clicking a line opens a comment form.
- */
 
-import { useState, useCallback } from 'react';
-import { PatchDiff } from '@pierre/diffs/react';
-import type { DiffLineAnnotation, AnnotationSide } from '@pierre/diffs';
-import type { ReviewThread, ThreadTarget, HunkDecision } from '../types/review.js';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import type { CSSProperties } from 'react';
+import { FileDiff } from '@pierre/diffs/react';
+import {
+  parsePatchFiles,
+  type AnnotationSide,
+  type DiffLineAnnotation,
+  type FileDiffMetadata,
+  type FileDiffOptions,
+  type Hunk,
+  type SelectedLineRange,
+} from '@pierre/diffs';
+import type { HunkDecision, ReviewChangedFile, ReviewThread, ThreadTarget } from '../types/review.js';
 
 export interface DiffViewerProps {
-  diff: string;
+  files: ReviewChangedFile[];
   threads: ReviewThread[];
   onCreateThread: (target: ThreadTarget, body: string, decision?: HunkDecision) => Promise<void>;
   onUpdateThread: (threadId: string, updates: { decision?: HunkDecision }) => Promise<void>;
+  onRequestFileDiff: (filePath: string, prevFilePath?: string) => Promise<string>;
+  onRequestFileContextRange: (
+    filePath: string,
+    prevFilePath?: string,
+    range?: { oldStart?: number; oldEnd?: number; newStart?: number; newEnd?: number }
+  ) => Promise<{
+    oldStart: number;
+    oldLines: string[];
+    oldTotal: number;
+    newStart: number;
+    newLines: string[];
+    newTotal: number;
+  }>;
   onThreadClick?: (threadId: string) => void;
+  onThreadHover?: (threadId: string | null) => void;
 }
 
 interface CommentFormState {
@@ -24,13 +41,306 @@ interface CommentFormState {
   decision?: HunkDecision;
 }
 
-export function DiffViewer({ diff, threads, onCreateThread, onUpdateThread, onThreadClick }: DiffViewerProps) {
+interface HunkInfo {
+  header: string;
+  anchorSide: AnnotationSide;
+  anchorLine: number;
+}
+
+interface LoadedFileDiff {
+  fileDiff: FileDiffMetadata;
+  hunks: HunkInfo[];
+}
+
+type FileDiffState =
+  | { status: 'idle' }
+  | { status: 'loading' }
+  | { status: 'ready'; data: LoadedFileDiff }
+  | { status: 'error'; message: string };
+
+type FileContextState =
+  | { status: 'idle' }
+  | { status: 'loading' }
+  | {
+      status: 'ready';
+      oldLines: string[];
+      newLines: string[];
+      oldTotal: number;
+      newTotal: number;
+      contextHash: string;
+    }
+  | { status: 'error'; message: string };
+
+type InlineAnnotationMeta =
+  | { kind: 'thread'; thread: ReviewThread }
+  | {
+      kind: 'hunk-control';
+      hunkHeader: string;
+      decision: HunkDecision;
+      threadId?: string;
+      commentCount: number;
+    };
+
+const CHANGE_COLOR: Record<ReviewChangedFile['changeType'], string> = {
+  new: '#22c55e',
+  deleted: '#f85149',
+  renamed: '#d29922',
+  modified: '#58a6ff',
+};
+
+const CHANGE_LABEL: Record<ReviewChangedFile['changeType'], string> = {
+  new: 'A',
+  deleted: 'D',
+  renamed: 'R',
+  modified: 'M',
+};
+
+export function DiffViewer({
+  files,
+  threads,
+  onCreateThread,
+  onUpdateThread,
+  onRequestFileDiff,
+  onRequestFileContextRange,
+  onThreadClick,
+  onThreadHover,
+}: DiffViewerProps) {
+  const [selectedFileKey, setSelectedFileKey] = useState<string | null>(null);
+  const [fileDiffStateByKey, setFileDiffStateByKey] = useState<Record<string, FileDiffState>>({});
+  const [contextStateByKey, setContextStateByKey] = useState<Record<string, FileContextState>>({});
+
   const [commentForm, setCommentForm] = useState<CommentFormState | null>(null);
   const [commentBody, setCommentBody] = useState('');
   const [submitting, setSubmitting] = useState(false);
 
+  const diffHostRef = useRef<HTMLDivElement | null>(null);
+
+  const fileByKey = useMemo(() => {
+    const map = new Map<string, ReviewChangedFile>();
+    for (const file of files) {
+      map.set(fileKey(file.filePath, file.prevFilePath), file);
+    }
+    return map;
+  }, [files]);
+
+  const selectedFile = useMemo(() => {
+    if (selectedFileKey) {
+      const match = fileByKey.get(selectedFileKey);
+      if (match) {
+        return match;
+      }
+    }
+    return files[0] ?? null;
+  }, [selectedFileKey, fileByKey, files]);
+
+  const selectedKey = selectedFile ? fileKey(selectedFile.filePath, selectedFile.prevFilePath) : null;
+  const selectedDiffState = selectedKey ? fileDiffStateByKey[selectedKey] ?? ({ status: 'idle' } as const) : null;
+  const selectedContextState = selectedKey ? contextStateByKey[selectedKey] ?? ({ status: 'idle' } as const) : null;
+
+  useEffect(() => {
+    const valid = new Set(files.map((file) => fileKey(file.filePath, file.prevFilePath)));
+
+    setFileDiffStateByKey((prev) => {
+      const next: Record<string, FileDiffState> = {};
+      for (const [key, value] of Object.entries(prev)) {
+        if (valid.has(key)) {
+          next[key] = value;
+        }
+      }
+      return next;
+    });
+
+    setContextStateByKey((prev) => {
+      const next: Record<string, FileContextState> = {};
+      for (const [key, value] of Object.entries(prev)) {
+        if (valid.has(key)) {
+          next[key] = value;
+        }
+      }
+      return next;
+    });
+  }, [files]);
+
+  const loadFileDiff = useCallback(async (file: ReviewChangedFile) => {
+    const key = fileKey(file.filePath, file.prevFilePath);
+
+    setFileDiffStateByKey((prev) => {
+      const current = prev[key];
+      if (current?.status === 'loading' || current?.status === 'ready') {
+        return prev;
+      }
+      return { ...prev, [key]: { status: 'loading' } };
+    });
+
+    try {
+      const diff = await onRequestFileDiff(file.filePath, file.prevFilePath);
+      const parsed = parseSingleFileDiff(diff, file);
+      setFileDiffStateByKey((prev) => ({
+        ...prev,
+        [key]: { status: 'ready', data: parsed },
+      }));
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      setFileDiffStateByKey((prev) => ({
+        ...prev,
+        [key]: { status: 'error', message },
+      }));
+    }
+  }, [onRequestFileDiff]);
+
+  useEffect(() => {
+    if (!selectedFile || !selectedKey) {
+      return;
+    }
+    const state = fileDiffStateByKey[selectedKey] ?? { status: 'idle' as const };
+    if (state.status === 'idle') {
+      void loadFileDiff(selectedFile);
+    }
+  }, [selectedFile, selectedKey, fileDiffStateByKey, loadFileDiff]);
+
+  const ensureContextLoaded = useCallback(async () => {
+    if (!selectedFile || !selectedKey) {
+      return;
+    }
+
+    const current = contextStateByKey[selectedKey] ?? { status: 'idle' as const };
+    if (current.status === 'loading' || current.status === 'ready') {
+      return;
+    }
+
+    setContextStateByKey((prev) => ({
+      ...prev,
+      [selectedKey]: { status: 'loading' },
+    }));
+
+    try {
+      const context = await onRequestFileContextRange(
+        selectedFile.filePath,
+        selectedFile.prevFilePath
+      );
+
+      setContextStateByKey((prev) => ({
+        ...prev,
+        [selectedKey]: {
+          status: 'ready',
+          oldLines: expandToAbsoluteLines(context.oldLines, context.oldStart, context.oldTotal),
+          newLines: expandToAbsoluteLines(context.newLines, context.newStart, context.newTotal),
+          oldTotal: context.oldTotal,
+          newTotal: context.newTotal,
+          contextHash: `${context.oldTotal}:${context.newTotal}:${context.oldLines.length}:${context.newLines.length}`,
+        },
+      }));
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      setContextStateByKey((prev) => ({
+        ...prev,
+        [selectedKey]: { status: 'error', message },
+      }));
+    }
+  }, [selectedFile, selectedKey, contextStateByKey, onRequestFileContextRange]);
+
+  // On-demand expansion trigger: clicking line-info separators when context is
+  // not loaded will load context first, then user can click again to expand.
+  useEffect(() => {
+    const host = diffHostRef.current;
+    if (!host || !selectedKey) {
+      return;
+    }
+
+    const onCaptureClick = (event: MouseEvent) => {
+      const current = contextStateByKey[selectedKey] ?? { status: 'idle' as const };
+      if (current.status === 'loading' || current.status === 'ready') {
+        return;
+      }
+
+      const path = event.composedPath();
+      const clickedSeparator = path.some((node) => {
+        return node instanceof HTMLElement && (
+          node.hasAttribute('data-unmodified-lines') ||
+          node.hasAttribute('data-separator-content') ||
+          node.getAttribute('data-separator') === 'line-info'
+        );
+      });
+
+      if (!clickedSeparator) {
+        return;
+      }
+
+      event.preventDefault();
+      event.stopPropagation();
+      void ensureContextLoaded();
+    };
+
+    host.addEventListener('click', onCaptureClick, true);
+    return () => {
+      host.removeEventListener('click', onCaptureClick, true);
+    };
+  }, [selectedKey, contextStateByKey, ensureContextLoaded]);
+
+  const selectedLoadedDiff = selectedDiffState?.status === 'ready' ? selectedDiffState.data : null;
+  const selectedContextReady = selectedContextState?.status === 'ready' ? selectedContextState : null;
+
+  const hunkThreadByHeader = useMemo(() => {
+    const map = new Map<string, ReviewThread>();
+    if (!selectedFile) {
+      return map;
+    }
+
+    for (const thread of threads) {
+      if (thread.target.kind !== 'hunk') {
+        continue;
+      }
+      if (thread.target.file !== selectedFile.filePath) {
+        continue;
+      }
+      if (!map.has(thread.target.hunkHeader)) {
+        map.set(thread.target.hunkHeader, thread);
+      }
+    }
+
+    return map;
+  }, [threads, selectedFile]);
+
+  const lineAnnotations = useMemo((): DiffLineAnnotation<InlineAnnotationMeta>[] => {
+    if (!selectedLoadedDiff || !selectedFile) {
+      return [];
+    }
+
+    const annotations: DiffLineAnnotation<InlineAnnotationMeta>[] = [];
+
+    for (const hunk of selectedLoadedDiff.hunks) {
+      const existing = hunkThreadByHeader.get(hunk.header);
+      annotations.push({
+        side: hunk.anchorSide,
+        lineNumber: hunk.anchorLine,
+        metadata: {
+          kind: 'hunk-control',
+          hunkHeader: hunk.header,
+          decision: existing?.decision ?? 'pending',
+          threadId: existing?.id,
+          commentCount: existing?.comments.length ?? 0,
+        },
+      });
+    }
+
+    for (const thread of threads) {
+      if (thread.target.kind === 'line' && thread.target.file === selectedFile.filePath) {
+        annotations.push({
+          side: thread.target.side === 'LEFT' ? 'deletions' : 'additions',
+          lineNumber: thread.target.startLine,
+          metadata: { kind: 'thread', thread },
+        });
+      }
+    }
+
+    return annotations;
+  }, [selectedLoadedDiff, selectedFile, hunkThreadByHeader, threads]);
+
   const handleSubmitComment = useCallback(async () => {
-    if (!commentForm || !commentBody.trim()) return;
+    if (!commentForm || !commentBody.trim()) {
+      return;
+    }
+
     setSubmitting(true);
     try {
       await onCreateThread(commentForm.target, commentBody.trim(), commentForm.decision);
@@ -41,154 +351,370 @@ export function DiffViewer({ diff, threads, onCreateThread, onUpdateThread, onTh
     }
   }, [commentForm, commentBody, onCreateThread]);
 
-  const handleApproveHunk = useCallback(async (hunkHeader: string, file: string) => {
-    // Find existing hunk thread
-    const existing = threads.find(
-      (t) => t.target.kind === 'hunk' && t.target.hunkHeader === hunkHeader && t.target.file === file
-    );
-    if (existing) {
-      await onUpdateThread(existing.id, { decision: 'approved' });
-    } else {
-      setCommentForm({ target: { kind: 'hunk', file, hunkHeader }, decision: 'approved' });
-      setCommentBody('');
+  const setHunkDecision = useCallback(async (hunkHeader: string, decision: HunkDecision) => {
+    if (!selectedFile) {
+      return;
     }
-  }, [threads, onUpdateThread]);
 
-  const handleRejectHunk = useCallback(async (hunkHeader: string, file: string) => {
-    const existing = threads.find(
-      (t) => t.target.kind === 'hunk' && t.target.hunkHeader === hunkHeader && t.target.file === file
-    );
+    const existing = hunkThreadByHeader.get(hunkHeader);
     if (existing) {
-      await onUpdateThread(existing.id, { decision: 'rejected' });
-    } else {
-      setCommentForm({ target: { kind: 'hunk', file, hunkHeader }, decision: 'rejected' });
-      setCommentBody('');
+      await onUpdateThread(existing.id, { decision });
+      return;
     }
-  }, [threads, onUpdateThread]);
 
-  // Map threads to badge annotations for @pierre/diffs
-  // AnnotationSide uses "deletions"/"additions" (not "LEFT"/"RIGHT")
-  const annotations: DiffLineAnnotation<ReviewThread>[] = threads
-    .filter((t) => t.target.kind === 'line' || t.target.kind === 'hunk')
-    .map((t) => {
-      const side: AnnotationSide = t.target.kind === 'line'
-        ? (t.target.side === 'LEFT' ? 'deletions' : 'additions')
-        : 'additions';
-      const lineNumber = t.target.kind === 'line' ? t.target.startLine : 1;
-      return { side, lineNumber, metadata: t };
+    if (decision === 'pending') {
+      return;
+    }
+
+    await onCreateThread(
+      { kind: 'hunk', file: selectedFile.filePath, hunkHeader },
+      decision === 'approved'
+        ? 'Approved hunk via inline controls.'
+        : 'Rejected hunk via inline controls.',
+      decision
+    );
+  }, [selectedFile, hunkThreadByHeader, onUpdateThread, onCreateThread]);
+
+  const openHunkCommentForm = useCallback((hunkHeader: string) => {
+    if (!selectedFile) {
+      return;
+    }
+    setCommentForm({ target: { kind: 'hunk', file: selectedFile.filePath, hunkHeader } });
+    setCommentBody('');
+  }, [selectedFile]);
+
+  const handleLineSelectionEnd = useCallback((range: SelectedLineRange | null) => {
+    if (!range || !selectedFile) {
+      return;
+    }
+
+    setCommentForm({
+      target: {
+        kind: 'line',
+        file: selectedFile.filePath,
+        startLine: Math.min(range.start, range.end),
+        endLine: Math.max(range.start, range.end),
+        side: (range.side ?? 'additions') === 'deletions' ? 'LEFT' : 'RIGHT',
+      },
     });
+    setCommentBody('');
+  }, [selectedFile]);
 
-  const renderAnnotation = useCallback((annotation: DiffLineAnnotation<ReviewThread>) => {
-    const thread = annotation.metadata;
-    const count = thread.comments.length;
-    const decision = thread.decision;
-    const color =
-      decision === 'approved' ? '#22c55e' :
-      decision === 'rejected' ? '#f85149' :
-      '#58a6ff';
-
+  const renderHoverUtility = useCallback((
+    getHoveredLine: () => { lineNumber: number; side: AnnotationSide } | undefined
+  ) => {
     return (
       <button
+        title="Add comment"
+        onMouseDown={(event) => {
+          event.preventDefault();
+          const hovered = getHoveredLine();
+          if (!hovered || !selectedFile) {
+            return;
+          }
+          setCommentForm({
+            target: {
+              kind: 'line',
+              file: selectedFile.filePath,
+              startLine: hovered.lineNumber,
+              endLine: hovered.lineNumber,
+              side: hovered.side === 'deletions' ? 'LEFT' : 'RIGHT',
+            },
+          });
+          setCommentBody('');
+        }}
         style={{
+          width: '20px',
+          height: '20px',
+          borderRadius: '999px',
+          border: 'none',
+          background: '#1a76d4',
+          color: '#0d1117',
+          cursor: 'pointer',
+          fontSize: '14px',
+          fontWeight: 700,
           display: 'inline-flex',
           alignItems: 'center',
-          gap: '4px',
-          fontSize: '11px',
-          padding: '1px 6px',
-          borderRadius: '10px',
-          background: color + '22',
-          color,
-          border: `1px solid ${color}44`,
-          cursor: 'pointer',
+          justifyContent: 'center',
+          lineHeight: 1,
         }}
-        onClick={() => onThreadClick?.(thread.id)}
       >
-        {decision === 'approved' ? '✓' : decision === 'rejected' ? '✗' : '💬'}
-        {count > 1 && ` ${count}`}
+        +
       </button>
     );
-  }, [onThreadClick]);
+  }, [selectedFile]);
 
-  if (!diff) {
+  const renderAnnotation = useCallback((annotation: DiffLineAnnotation<InlineAnnotationMeta>) => {
+    const meta = annotation.metadata;
+
+    if (meta.kind === 'thread') {
+      const thread = meta.thread;
+      const color = thread.decision ? decisionColor(thread.decision) : '#58a6ff';
+      const count = thread.comments.length;
+
+      return (
+        <div style={{ position: 'relative', height: 0, overflow: 'visible', pointerEvents: 'none' }}>
+          <button
+            title={`Open thread (${count} comment${count === 1 ? '' : 's'})`}
+            onClick={() => onThreadClick?.(thread.id)}
+            onMouseEnter={() => onThreadHover?.(thread.id)}
+            onMouseLeave={() => onThreadHover?.(null)}
+            style={{
+              position: 'absolute',
+              top: '-9px',
+              right: '8px',
+              width: '16px',
+              height: '16px',
+              borderRadius: '999px',
+              border: `1px solid ${color}66`,
+              background: `${color}33`,
+              color,
+              cursor: 'pointer',
+              fontSize: '10px',
+              fontWeight: 700,
+              lineHeight: 1,
+              display: 'inline-flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              pointerEvents: 'auto',
+            }}
+          >
+            {count > 1 ? String(Math.min(count, 9)) : '•'}
+          </button>
+        </div>
+      );
+    }
+
+    const tint = decisionColor(meta.decision);
+    return (
+      <div style={{ position: 'relative', zIndex: 10, height: 0, overflow: 'visible', pointerEvents: 'none' }}>
+        <div
+          style={{
+            position: 'absolute',
+            top: '4px',
+            right: '28px',
+            display: 'inline-flex',
+            alignItems: 'center',
+            gap: '4px',
+            pointerEvents: 'auto',
+            boxShadow: '0 1px 3px rgba(0, 0, 0, 0.2)',
+            borderRadius: '4px',
+            border: `1px solid ${tint}33`,
+            background: '#161b22',
+            padding: '1px',
+          }}
+          onMouseEnter={() => meta.threadId && onThreadHover?.(meta.threadId)}
+          onMouseLeave={() => onThreadHover?.(null)}
+        >
+          <button
+            title="Reject hunk"
+            onClick={() => void setHunkDecision(meta.hunkHeader, 'rejected')}
+            style={actionButtonStyle(meta.decision === 'rejected', '#f85149')}
+          >
+            Reject
+          </button>
+          <button
+            title="Approve hunk"
+            onClick={() => void setHunkDecision(meta.hunkHeader, 'approved')}
+            style={actionButtonStyle(meta.decision === 'approved', '#22c55e', true)}
+          >
+            Approve
+          </button>
+          {!meta.threadId && (
+            <button
+              title="Comment on hunk"
+              onClick={() => openHunkCommentForm(meta.hunkHeader)}
+              style={actionButtonStyle(false, '#58a6ff')}
+            >
+              Comment
+            </button>
+          )}
+        </div>
+      </div>
+    );
+  }, [onThreadClick, onThreadHover, openHunkCommentForm, setHunkDecision]);
+
+  const fileDiffOptions = useMemo((): FileDiffOptions<InlineAnnotationMeta> => ({
+    diffStyle: 'unified',
+    hunkSeparators: 'line-info',
+    enableHoverUtility: true,
+    enableLineSelection: true,
+    onLineSelectionEnd: handleLineSelectionEnd,
+  }), [handleLineSelectionEnd]);
+
+  const renderedFileDiff = useMemo((): FileDiffMetadata | null => {
+    if (!selectedLoadedDiff) {
+      return null;
+    }
+
+    const base = selectedLoadedDiff.fileDiff;
+    if (selectedContextReady && selectedContextReady.oldTotal > 0 && selectedContextReady.newTotal > 0) {
+      return {
+        ...base,
+        cacheKey: `${base.cacheKey ?? selectedKey}:context:${selectedContextReady.contextHash}`,
+        oldLines: selectedContextReady.oldLines,
+        newLines: selectedContextReady.newLines,
+      };
+    }
+
+    return base;
+  }, [selectedLoadedDiff, selectedContextReady, selectedKey]);
+
+  if (files.length === 0) {
     return (
       <div style={{ padding: '32px', textAlign: 'center', color: '#8b949e' }}>
-        No diff available.
+        No changed files.
       </div>
     );
   }
 
-  // Parse hunk headers from the diff for approve/reject buttons
-  const hunkHeaders = extractHunkHeaders(diff);
+  const selectedDiffLoading = selectedDiffState?.status === 'loading' || selectedDiffState?.status === 'idle';
+  const selectedDiffError = selectedDiffState?.status === 'error' ? selectedDiffState.message : null;
+  const contextLoading = selectedContextState?.status === 'loading';
+  const contextError = selectedContextState?.status === 'error' ? selectedContextState.message : null;
+  const contextReady = selectedContextState?.status === 'ready';
 
   return (
-    <div style={{ display: 'flex', flexDirection: 'column', height: '100%', overflow: 'hidden' }}>
-      {/* Hunk approve/reject toolbar — scrollable, shows all hunks */}
-      {hunkHeaders.length > 0 && (
+    <div style={{ display: 'flex', height: '100%', overflow: 'hidden' }}>
+      <div style={{
+        width: '220px',
+        flexShrink: 0,
+        borderRight: '1px solid #30363d',
+        overflow: 'auto',
+        background: '#0d1117',
+        display: 'flex',
+        flexDirection: 'column',
+      }}>
         <div style={{
-          padding: '8px 12px',
-          borderBottom: '1px solid #30363d',
-          display: 'flex',
-          gap: '6px',
+          padding: '8px 10px 6px',
+          fontSize: '11px',
+          color: '#6e7681',
+          fontWeight: 600,
+          textTransform: 'uppercase',
+          letterSpacing: '0.06em',
+          borderBottom: '1px solid #21262d',
           flexShrink: 0,
-          overflowX: 'auto',
         }}>
-          {hunkHeaders.map(({ header, file }) => {
-            const thread = threads.find(
-              (t) => t.target.kind === 'hunk' && t.target.hunkHeader === header && t.target.file === file
-            );
-            const decision = thread?.decision;
+          {files.length} file{files.length !== 1 ? 's' : ''}
+        </div>
+
+        <div style={{ flex: 1, overflow: 'auto' }}>
+          {files.map((file) => {
+            const key = fileKey(file.filePath, file.prevFilePath);
+            const isSelected = selectedKey === key;
+            const color = CHANGE_COLOR[file.changeType];
+            const label = CHANGE_LABEL[file.changeType];
+            const lastSlash = file.filePath.lastIndexOf('/');
+            const dirPart = lastSlash >= 0 ? file.filePath.slice(0, lastSlash + 1) : '';
+            const basePart = lastSlash >= 0 ? file.filePath.slice(lastSlash + 1) : file.filePath;
+
             return (
-              <div key={`${file}:${header}`} style={{ display: 'flex', gap: '4px', alignItems: 'center', flexShrink: 0 }}>
-                <span style={{ fontSize: '11px', color: '#6e7681', maxWidth: '120px', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-                  {header.replace(/@@.*@@\s*/, '').trim() || header.slice(0, 30)}
+              <button
+                key={key}
+                onClick={() => setSelectedFileKey(key)}
+                title={file.filePath}
+                style={{
+                  width: '100%',
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: '6px',
+                  padding: '5px 10px',
+                  background: isSelected ? '#161b22' : 'transparent',
+                  borderLeft: isSelected ? '2px solid #58a6ff' : '2px solid transparent',
+                  border: 'none',
+                  borderRight: 'none',
+                  cursor: 'pointer',
+                  textAlign: 'left',
+                  minWidth: 0,
+                }}
+              >
+                <span style={{ fontSize: '10px', fontWeight: 700, color, flexShrink: 0, width: '12px', textAlign: 'center' }}>
+                  {label}
                 </span>
-                <button
-                  onClick={() => void handleApproveHunk(header, file)}
-                  style={{
-                    fontSize: '11px',
-                    padding: '2px 8px',
-                    borderRadius: '4px',
-                    border: '1px solid',
-                    cursor: 'pointer',
-                    background: decision === 'approved' ? '#22c55e33' : '#21262d',
-                    color: decision === 'approved' ? '#22c55e' : '#8b949e',
-                    borderColor: decision === 'approved' ? '#22c55e66' : '#30363d',
-                  }}
-                >
-                  ✓ Approve
-                </button>
-                <button
-                  onClick={() => void handleRejectHunk(header, file)}
-                  style={{
-                    fontSize: '11px',
-                    padding: '2px 8px',
-                    borderRadius: '4px',
-                    border: '1px solid',
-                    cursor: 'pointer',
-                    background: decision === 'rejected' ? '#f8514933' : '#21262d',
-                    color: decision === 'rejected' ? '#f85149' : '#8b949e',
-                    borderColor: decision === 'rejected' ? '#f8514966' : '#30363d',
-                  }}
-                >
-                  ✗ Reject
-                </button>
-              </div>
+                <span style={{
+                  flex: 1,
+                  minWidth: 0,
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  whiteSpace: 'nowrap',
+                  fontSize: '12px',
+                  color: isSelected ? '#e6edf3' : '#8b949e',
+                  fontFamily: 'monospace',
+                }}>
+                  {dirPart && <span style={{ color: '#6e7681' }}>{dirPart}</span>}
+                  {basePart}
+                </span>
+              </button>
             );
           })}
         </div>
-      )}
-
-      {/* Diff viewer */}
-      <div style={{ flex: 1, overflow: 'auto' }}>
-        <PatchDiff
-          patch={diff}
-          lineAnnotations={annotations}
-          renderAnnotation={renderAnnotation}
-          className="diff-viewer"
-        />
       </div>
 
-      {/* Inline comment form */}
+      <div ref={diffHostRef} style={{ flex: 1, display: 'flex', flexDirection: 'column', overflow: 'hidden', minWidth: 0 }}>
+        <div style={{
+          padding: '8px 12px',
+          borderBottom: '1px solid #30363d',
+          background: '#161b22',
+          color: '#8b949e',
+          fontSize: '12px',
+          display: 'flex',
+          gap: '14px',
+          flexWrap: 'wrap',
+          alignItems: 'center',
+        }}>
+          <span>Hover a line and click <b>+</b> to comment</span>
+          <span>Drag line numbers to comment on a range</span>
+          <span>
+            Hunk actions: <span style={{ color: '#22c55e' }}>Approve</span> / <span style={{ color: '#f85149' }}>Reject</span>
+          </span>
+
+          {!contextReady && (
+            <button
+              onClick={() => void ensureContextLoaded()}
+              disabled={contextLoading || !selectedFile || !selectedLoadedDiff}
+              style={{
+                fontSize: '11px',
+                padding: '2px 8px',
+                borderRadius: '4px',
+                border: '1px solid #30363d',
+                background: '#21262d',
+                color: '#8b949e',
+                cursor: contextLoading ? 'wait' : 'pointer',
+              }}
+            >
+              {contextLoading ? 'Loading context...' : 'Enable context expansion'}
+            </button>
+          )}
+
+          {contextReady && <span style={{ color: '#22c55e' }}>Context expansion ready</span>}
+          {contextError && <span style={{ color: '#f85149' }}>Context load failed: {contextError}</span>}
+        </div>
+
+        {selectedDiffLoading ? (
+          <div style={{ flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center', color: '#8b949e', fontSize: '13px' }}>
+            Loading file diff...
+          </div>
+        ) : selectedDiffError ? (
+          <div style={{ flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center', color: '#f85149', fontSize: '13px', padding: '16px' }}>
+            Failed to load file diff: {selectedDiffError}
+          </div>
+        ) : renderedFileDiff ? (
+          <div style={{ flex: 1, overflow: 'auto' }}>
+            <FileDiff
+              fileDiff={renderedFileDiff}
+              options={fileDiffOptions}
+              lineAnnotations={lineAnnotations}
+              renderAnnotation={renderAnnotation}
+              renderHoverUtility={renderHoverUtility}
+            />
+          </div>
+        ) : (
+          <div style={{ flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center', color: '#8b949e' }}>
+            Select a file to view its diff.
+          </div>
+        )}
+      </div>
+
       {commentForm && (
         <div style={{
           position: 'fixed',
@@ -200,24 +726,25 @@ export function DiffViewer({ diff, threads, onCreateThread, onUpdateThread, onTh
           padding: '12px 16px',
           zIndex: 100,
         }}>
-          <div style={{ display: 'flex', gap: '8px', alignItems: 'flex-start', maxWidth: '800px', margin: '0 auto' }}>
+          <div style={{ display: 'flex', gap: '8px', alignItems: 'flex-start', maxWidth: '860px', margin: '0 auto' }}>
             <div style={{ flex: 1 }}>
-              {commentForm.decision && (
-                <div style={{
-                  marginBottom: '6px',
-                  fontSize: '12px',
-                  color: commentForm.decision === 'approved' ? '#22c55e' : '#f85149',
-                }}>
-                  {commentForm.decision === 'approved' ? '✓ Approving hunk' : '✗ Requesting changes on hunk'}
-                  {commentForm.target.kind === 'hunk' && (
-                    <span style={{ color: '#6e7681', marginLeft: '8px' }}>{commentForm.target.hunkHeader.slice(0, 50)}</span>
-                  )}
+              {commentForm.target.kind === 'hunk' && (
+                <div style={{ marginBottom: '6px', fontSize: '12px', color: '#8b949e' }}>
+                  Commenting on hunk
+                </div>
+              )}
+              {commentForm.target.kind === 'line' && (
+                <div style={{ marginBottom: '6px', fontSize: '12px', color: '#8b949e' }}>
+                  Commenting on line {commentForm.target.startLine}
+                  {commentForm.target.startLine !== commentForm.target.endLine
+                    ? `-${commentForm.target.endLine}`
+                    : ''}
                 </div>
               )}
               <textarea
                 value={commentBody}
-                onChange={(e) => setCommentBody(e.target.value)}
-                placeholder="Add a comment (optional)..."
+                onChange={(event) => setCommentBody(event.target.value)}
+                placeholder="Add a comment..."
                 rows={3}
                 style={{
                   width: '100%',
@@ -231,17 +758,18 @@ export function DiffViewer({ diff, threads, onCreateThread, onUpdateThread, onTh
                   boxSizing: 'border-box',
                 }}
                 autoFocus
-                onKeyDown={(e) => {
-                  if (e.key === 'Escape') {
+                onKeyDown={(event) => {
+                  if (event.key === 'Escape') {
                     setCommentForm(null);
                     setCommentBody('');
                   }
-                  if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+                  if (event.key === 'Enter' && (event.metaKey || event.ctrlKey)) {
                     void handleSubmitComment();
                   }
                 }}
               />
             </div>
+
             <div style={{ display: 'flex', flexDirection: 'column', gap: '6px' }}>
               <button
                 onClick={() => void handleSubmitComment()}
@@ -260,7 +788,10 @@ export function DiffViewer({ diff, threads, onCreateThread, onUpdateThread, onTh
                 {submitting ? '...' : 'Submit'}
               </button>
               <button
-                onClick={() => { setCommentForm(null); setCommentBody(''); }}
+                onClick={() => {
+                  setCommentForm(null);
+                  setCommentBody('');
+                }}
                 style={{
                   padding: '8px 16px',
                   background: '#21262d',
@@ -281,31 +812,100 @@ export function DiffViewer({ diff, threads, onCreateThread, onUpdateThread, onTh
   );
 }
 
-// ============================================================================
-// Helpers
-// ============================================================================
-
-interface HunkInfo {
-  header: string;
-  file: string;
+function fileKey(filePath: string, prevFilePath?: string): string {
+  return `${prevFilePath ?? ''}=>${filePath}`;
 }
 
-function extractHunkHeaders(patch: string): HunkInfo[] {
-  const lines = patch.split('\n');
-  const result: HunkInfo[] = [];
-  let currentFile = '';
-
-  for (const line of lines) {
-    if (line.startsWith('diff --git')) {
-      // e.g. "diff --git a/src/foo.ts b/src/foo.ts"
-      const match = line.match(/b\/(.+)$/);
-      if (match) {
-        currentFile = match[1];
-      }
-    } else if (line.startsWith('@@')) {
-      result.push({ header: line, file: currentFile });
+function parseSingleFileDiff(diff: string, file: ReviewChangedFile): LoadedFileDiff {
+  const parsed = parsePatchFiles(diff);
+  const parsedFile = parsed.flatMap((patch) => patch.files).find((entry) => {
+    if (entry.name === file.filePath) {
+      return true;
     }
+    if (file.prevFilePath && entry.prevName === file.prevFilePath && entry.name === file.filePath) {
+      return true;
+    }
+    return false;
+  }) ?? parsed.flatMap((patch) => patch.files)[0];
+
+  if (!parsedFile) {
+    throw new Error('No parseable file diff returned for selected file');
   }
 
-  return result;
+  const hunks: HunkInfo[] = parsedFile.hunks.map((hunk) => {
+    const anchorSide: AnnotationSide = hunk.additionCount > 0 ? 'additions' : 'deletions';
+    const anchorLine = Math.max(1, anchorSide === 'additions' ? hunk.additionStart : hunk.deletionStart);
+
+    return {
+      header: formatHunkHeader(hunk),
+      anchorSide,
+      anchorLine,
+    };
+  });
+
+  return {
+    fileDiff: parsedFile,
+    hunks,
+  };
+}
+
+function formatHunkHeader(hunk: Hunk): string {
+  const specs = (hunk.hunkSpecs ?? '').trim();
+  const context = hunk.hunkContext ?? '';
+
+  if (!specs) {
+    return context ? `@@ @@ ${context}` : '@@ @@';
+  }
+
+  return `@@ ${specs} @@${context ? ` ${context}` : ''}`;
+}
+
+function expandToAbsoluteLines(lines: string[], start: number, total: number): string[] {
+  if (total <= 0) {
+    return [];
+  }
+
+  // When backend returns full file range, this is effectively identity with a
+  // defensive fallback for non-1 starts.
+  const output = new Array<string>(total).fill('');
+  const offset = Math.max(0, start - 1);
+  for (let index = 0; index < lines.length; index++) {
+    const absoluteIndex = offset + index;
+    if (absoluteIndex >= output.length) {
+      break;
+    }
+    output[absoluteIndex] = lines[index] ?? '';
+  }
+  return output;
+}
+
+function decisionColor(decision: HunkDecision): string {
+  if (decision === 'approved') {
+    return '#22c55e';
+  }
+  if (decision === 'rejected') {
+    return '#f85149';
+  }
+  return '#d29922';
+}
+
+function actionButtonStyle(active: boolean, color: string, success = false): CSSProperties {
+  return {
+    border: success
+      ? `1px solid ${active ? `${color}88` : `${color}66`}`
+      : `1px solid ${active ? `${color}66` : '#30363d'}`,
+    background: success
+      ? active
+        ? color
+        : `${color}cc`
+      : active
+        ? `${color}33`
+        : '#21262d',
+    color: success ? '#0d1117' : active ? color : '#c9d1d9',
+    borderRadius: '4px',
+    fontSize: '11px',
+    padding: '1px 8px',
+    fontWeight: 600,
+    cursor: 'pointer',
+  };
 }

--- a/src/components/DiffViewer.web.tsx
+++ b/src/components/DiffViewer.web.tsx
@@ -114,6 +114,7 @@ export function DiffViewer({
   const [submitting, setSubmitting] = useState(false);
 
   const diffHostRef = useRef<HTMLDivElement | null>(null);
+  const loadingFileDiffKeysRef = useRef<Set<string>>(new Set());
 
   const fileByKey = useMemo(() => {
     const map = new Map<string, ReviewChangedFile>();
@@ -164,9 +165,20 @@ export function DiffViewer({
   const loadFileDiff = useCallback(async (file: ReviewChangedFile) => {
     const key = fileKey(file.filePath, file.prevFilePath);
 
+    const current = fileDiffStateByKey[key];
+    if (current?.status === 'loading' || current?.status === 'ready') {
+      return;
+    }
+
+    if (loadingFileDiffKeysRef.current.has(key)) {
+      return;
+    }
+
+    loadingFileDiffKeysRef.current.add(key);
+
     setFileDiffStateByKey((prev) => {
-      const current = prev[key];
-      if (current?.status === 'loading' || current?.status === 'ready') {
+      const existing = prev[key];
+      if (existing?.status === 'loading' || existing?.status === 'ready') {
         return prev;
       }
       return { ...prev, [key]: { status: 'loading' } };
@@ -185,8 +197,10 @@ export function DiffViewer({
         ...prev,
         [key]: { status: 'error', message },
       }));
+    } finally {
+      loadingFileDiffKeysRef.current.delete(key);
     }
-  }, [onRequestFileDiff]);
+  }, [fileDiffStateByKey, onRequestFileDiff]);
 
   useEffect(() => {
     if (!selectedFile || !selectedKey) {
@@ -621,8 +635,9 @@ export function DiffViewer({
                   padding: '5px 10px',
                   background: isSelected ? '#161b22' : 'transparent',
                   borderLeft: isSelected ? '2px solid #58a6ff' : '2px solid transparent',
-                  border: 'none',
+                  borderTop: 'none',
                   borderRight: 'none',
+                  borderBottom: 'none',
                   cursor: 'pointer',
                   textAlign: 'left',
                   minWidth: 0,

--- a/src/components/SpacesBrowser.web.tsx
+++ b/src/components/SpacesBrowser.web.tsx
@@ -8,12 +8,17 @@
 
 import type { UseSpacesBrowserReturn } from './SpacesBrowser.js';
 import { formatTime } from './SpacesBrowser.js';
+import type { WorkspaceInfo } from '../lib/remote-session/protocol.js';
 
 // ============================================================================
 // Component
 // ============================================================================
 
-export function SpacesBrowserWeb(props: UseSpacesBrowserReturn) {
+export interface SpacesBrowserWebProps extends UseSpacesBrowserReturn {
+  onReview?: (workspace: WorkspaceInfo) => void;
+}
+
+export function SpacesBrowserWeb(props: SpacesBrowserWebProps) {
   const {
     items,
     machineName,
@@ -23,6 +28,7 @@ export function SpacesBrowserWeb(props: UseSpacesBrowserReturn) {
     attachSession,
     refresh,
     back,
+    onReview,
   } = props;
 
   // Empty state
@@ -91,11 +97,22 @@ export function SpacesBrowserWeb(props: UseSpacesBrowserReturn) {
                     )}
                   </div>
                 </div>
-                <div className="text-right flex-shrink-0 ml-2">
+                <div className="flex items-center gap-2 flex-shrink-0 ml-2">
                   {ws.sessionCount > 0 && (
                     <span className="text-xs px-2 py-1 rounded bg-[#238636] text-[#e6edf3]">
                       {ws.sessionCount}
                     </span>
+                  )}
+                  {onReview && (
+                    <button
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        onReview(ws);
+                      }}
+                      className="text-xs px-2 py-1 rounded bg-[#21262d] hover:bg-[#30363d] text-[#8b949e] hover:text-[#58a6ff] border border-[#30363d] hover:border-[#58a6ff] transition-colors"
+                    >
+                      Review
+                    </button>
                   )}
                 </div>
               </div>

--- a/src/components/ThreadPanel.web.tsx
+++ b/src/components/ThreadPanel.web.tsx
@@ -8,12 +8,13 @@
  * - Editing/deleting own comments
  */
 
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useEffect, useRef } from 'react';
 import type { ReviewThread, HunkDecision } from '../types/review.js';
 
 export interface ThreadPanelProps {
   threads: ReviewThread[];
   selectedThreadId?: string | null;
+  hoveredThreadId?: string | null;
   onResolveThread: (threadId: string, resolved: boolean) => Promise<void>;
   onAddReply: (threadId: string, body: string) => Promise<void>;
   onUpdateComment: (threadId: string, commentId: string, body: string) => Promise<void>;
@@ -48,6 +49,7 @@ function targetLabel(thread: ReviewThread): string {
 export function ThreadPanel({
   threads,
   selectedThreadId,
+  hoveredThreadId,
   onResolveThread,
   onAddReply,
   onUpdateComment,
@@ -59,6 +61,17 @@ export function ThreadPanel({
   const [replyBody, setReplyBody] = useState('');
   const [editingComment, setEditingComment] = useState<{ threadId: string; commentId: string; body: string } | null>(null);
   const [submitting, setSubmitting] = useState(false);
+  const threadRefs = useRef<Record<string, HTMLDivElement | null>>({});
+
+  useEffect(() => {
+    const focusId = hoveredThreadId ?? selectedThreadId;
+    if (!focusId) return;
+
+    const el = threadRefs.current[focusId];
+    if (!el) return;
+
+    el.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
+  }, [hoveredThreadId, selectedThreadId]);
 
   const handleAddReply = useCallback(async (threadId: string) => {
     if (!replyBody.trim()) return;
@@ -149,14 +162,17 @@ export function ThreadPanel({
       <div style={{ flex: 1, overflowY: 'auto' }}>
         {threads.map((thread) => {
           const isSelected = thread.id === selectedThreadId;
+          const isHovered = thread.id === hoveredThreadId;
           const decision = thread.decision;
 
           return (
             <div
               key={thread.id}
+              ref={(el) => { threadRefs.current[thread.id] = el; }}
               style={{
                 borderBottom: '1px solid #21262d',
-                background: isSelected ? '#161b22' : 'transparent',
+                background: isSelected ? '#161b22' : isHovered ? '#1b2230' : 'transparent',
+                boxShadow: isHovered ? 'inset 2px 0 0 #58a6ff' : undefined,
               }}
             >
               {/* Thread header */}

--- a/src/components/ThreadPanel.web.tsx
+++ b/src/components/ThreadPanel.web.tsx
@@ -12,6 +12,7 @@ import { Fragment, useState, useCallback, useEffect, useMemo, useRef, type React
 import type { ReviewThread, HunkDecision } from '../types/review.js';
 import type { HunkFocusTarget } from './DiffViewer.web.js';
 import { normalizeHunkHeader } from '../utils/hunk-header.js';
+import { REVIEW_DECISION_COLORS } from './review-decision-colors.js';
 
 export interface ThreadPanelProps {
   threads: ReviewThread[];
@@ -29,12 +30,6 @@ export interface ThreadPanelProps {
   onOpenThreadTarget?: (threadId: string) => void;
   onClose?: () => void;
 }
-
-const DECISION_COLORS: Record<string, string> = {
-  approved: '#22c55e',
-  rejected: '#f85149',
-  pending: '#d29922',
-};
 
 const SAFE_LINK_SCHEMES = new Set(['http', 'https', 'mailto', 'tel']);
 
@@ -280,6 +275,8 @@ export function ThreadPanel({
       await onAddReply(threadId, replyBody.trim());
       setReplyBody('');
       setReplyingTo(null);
+    } catch {
+      // Error is surfaced via review hook state; avoid unhandled promise rejections.
     } finally {
       setSubmitting(false);
     }
@@ -291,6 +288,8 @@ export function ThreadPanel({
     try {
       await onUpdateComment(editingComment.threadId, editingComment.commentId, editingComment.body.trim());
       setEditingComment(null);
+    } catch {
+      // Error is surfaced via review hook state; avoid unhandled promise rejections.
     } finally {
       setSubmitting(false);
     }
@@ -467,9 +466,9 @@ export function ThreadPanel({
                       fontSize: '11px',
                       padding: '1px 6px',
                       borderRadius: '10px',
-                      background: DECISION_COLORS[decision] + '22',
-                      color: DECISION_COLORS[decision],
-                      border: `1px solid ${DECISION_COLORS[decision]}44`,
+                      background: REVIEW_DECISION_COLORS[decision] + '22',
+                      color: REVIEW_DECISION_COLORS[decision],
+                      border: `1px solid ${REVIEW_DECISION_COLORS[decision]}44`,
                     }}>
                       {decision === 'approved' ? '✓ Approved' : decision === 'rejected' ? '✗ Changes requested' : '⏳ Pending'}
                     </span>
@@ -505,16 +504,18 @@ export function ThreadPanel({
                     {(['approved', 'rejected', 'pending'] as const).map((d) => (
                       <button
                         key={d}
-                        onClick={() => void onUpdateDecision(thread.id, d)}
+                        onClick={() => {
+                          void onUpdateDecision(thread.id, d).catch(() => {});
+                        }}
                         style={{
                           fontSize: '11px',
                           padding: '2px 8px',
                           borderRadius: '4px',
                           border: '1px solid',
                           cursor: 'pointer',
-                          background: decision === d ? DECISION_COLORS[d] + '33' : '#21262d',
-                          color: decision === d ? DECISION_COLORS[d] : '#8b949e',
-                          borderColor: decision === d ? DECISION_COLORS[d] + '66' : '#30363d',
+                          background: decision === d ? REVIEW_DECISION_COLORS[d] + '33' : '#21262d',
+                          color: decision === d ? REVIEW_DECISION_COLORS[d] : '#8b949e',
+                          borderColor: decision === d ? REVIEW_DECISION_COLORS[d] + '66' : '#30363d',
                         }}
                       >
                         {d === 'approved' ? '✓ Approve' : d === 'rejected' ? '✗ Reject' : '⏳ Pending'}
@@ -562,7 +563,9 @@ export function ThreadPanel({
                         />
                         <div style={{ display: 'flex', gap: '6px', marginTop: '4px' }}>
                           <button
-                            onClick={() => void handleSaveEdit()}
+                            onClick={() => {
+                              void handleSaveEdit().catch(() => {});
+                            }}
                             disabled={submitting}
                             style={{
                               fontSize: '11px',
@@ -622,7 +625,9 @@ export function ThreadPanel({
                               Edit
                             </button>
                             <button
-                              onClick={() => void onDeleteComment(thread.id, comment.id)}
+                              onClick={() => {
+                                void onDeleteComment(thread.id, comment.id).catch(() => {});
+                              }}
                               style={{
                                 fontSize: '10px',
                                 padding: '1px 5px',
@@ -664,12 +669,16 @@ export function ThreadPanel({
                       autoFocus
                       onKeyDown={(e) => {
                         if (e.key === 'Escape') { setReplyingTo(null); setReplyBody(''); }
-                        if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) void handleAddReply(thread.id);
+                        if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+                          void handleAddReply(thread.id).catch(() => {});
+                        }
                       }}
                     />
                     <div style={{ display: 'flex', gap: '6px', marginTop: '4px' }}>
                       <button
-                        onClick={() => void handleAddReply(thread.id)}
+                        onClick={() => {
+                          void handleAddReply(thread.id).catch(() => {});
+                        }}
                         disabled={submitting || !replyBody.trim()}
                         style={{
                           fontSize: '11px',
@@ -716,7 +725,9 @@ export function ThreadPanel({
                       Reply
                     </button>
                     <button
-                      onClick={() => void onResolveThread(thread.id, !thread.resolved)}
+                      onClick={() => {
+                        void onResolveThread(thread.id, !thread.resolved).catch(() => {});
+                      }}
                       style={{
                         fontSize: '11px',
                         padding: '2px 8px',

--- a/src/components/ThreadPanel.web.tsx
+++ b/src/components/ThreadPanel.web.tsx
@@ -35,6 +35,17 @@ const DECISION_COLORS: Record<string, string> = {
   pending: '#d29922',
 };
 
+const SAFE_LINK_SCHEMES = new Set(['http', 'https', 'mailto', 'tel']);
+
+function isSafeMarkdownHref(href: string): boolean {
+  const trimmed = href.trim();
+  const scheme = trimmed.match(/^([a-zA-Z][a-zA-Z\d+.-]*):/);
+  if (!scheme?.[1]) {
+    return false;
+  }
+  return SAFE_LINK_SCHEMES.has(scheme[1].toLowerCase());
+}
+
 function formatDate(iso: string): string {
   try {
     const d = new Date(iso);
@@ -87,6 +98,9 @@ function renderMarkdownInline(text: string, keyPrefix: string): ReactNode[] {
     if (linkMatch) {
       const label = linkMatch[1] ?? token;
       const href = linkMatch[2] ?? '#';
+      if (!isSafeMarkdownHref(href)) {
+        return <Fragment key={key}>{label}</Fragment>;
+      }
       return (
         <a
           key={key}

--- a/src/components/ThreadPanel.web.tsx
+++ b/src/components/ThreadPanel.web.tsx
@@ -8,11 +8,16 @@
  * - Editing/deleting own comments
  */
 
-import { useState, useCallback, useEffect, useRef } from 'react';
+import { Fragment, useState, useCallback, useEffect, useMemo, useRef, type ReactNode } from 'react';
 import type { ReviewThread, HunkDecision } from '../types/review.js';
+import type { HunkFocusTarget } from './DiffViewer.web.js';
 
 export interface ThreadPanelProps {
   threads: ReviewThread[];
+  currentFilePath?: string | null;
+  hunkFocus?: HunkFocusTarget | null;
+  filterMode?: 'all' | 'current-file' | 'current-hunk';
+  onFilterModeChange?: (mode: 'all' | 'current-file' | 'current-hunk') => void;
   selectedThreadId?: string | null;
   hoveredThreadId?: string | null;
   onResolveThread: (threadId: string, resolved: boolean) => Promise<void>;
@@ -20,6 +25,7 @@ export interface ThreadPanelProps {
   onUpdateComment: (threadId: string, commentId: string, body: string) => Promise<void>;
   onDeleteComment: (threadId: string, commentId: string) => Promise<void>;
   onUpdateDecision: (threadId: string, decision: HunkDecision) => Promise<void>;
+  onOpenThreadTarget?: (threadId: string) => void;
   onClose?: () => void;
 }
 
@@ -46,8 +52,158 @@ function targetLabel(thread: ReviewThread): string {
   return 'Overall';
 }
 
+function renderMarkdownInline(text: string, keyPrefix: string): ReactNode[] {
+  const tokenPattern = /(\[[^\]]+\]\([^\)]+\)|`[^`]+`|\*\*[^*]+\*\*|\*[^*]+\*)/g;
+  const tokens = text.split(tokenPattern);
+
+  return tokens.map((token, index) => {
+    const key = `${keyPrefix}-inline-${index}`;
+
+    if (token.startsWith('`') && token.endsWith('`')) {
+      return (
+        <code key={key} style={{
+          fontFamily: 'ui-monospace, SFMono-Regular, Menlo, Consolas, monospace',
+          fontSize: '11px',
+          background: '#0d1117',
+          border: '1px solid #30363d',
+          borderRadius: '3px',
+          padding: '0 4px',
+          color: '#c9d1d9',
+        }}>
+          {token.slice(1, -1)}
+        </code>
+      );
+    }
+
+    if (token.startsWith('**') && token.endsWith('**')) {
+      return <strong key={key}>{token.slice(2, -2)}</strong>;
+    }
+
+    if (token.startsWith('*') && token.endsWith('*')) {
+      return <em key={key}>{token.slice(1, -1)}</em>;
+    }
+
+    const linkMatch = token.match(/^\[([^\]]+)\]\(([^\)]+)\)$/);
+    if (linkMatch) {
+      const label = linkMatch[1] ?? token;
+      const href = linkMatch[2] ?? '#';
+      return (
+        <a
+          key={key}
+          href={href}
+          target="_blank"
+          rel="noopener noreferrer"
+          style={{ color: '#58a6ff' }}
+        >
+          {label}
+        </a>
+      );
+    }
+
+    return <Fragment key={key}>{token}</Fragment>;
+  });
+}
+
+function renderMarkdownBody(markdown: string, keyPrefix: string): ReactNode[] {
+  const lines = markdown.replace(/\r/g, '').split('\n');
+  const nodes: ReactNode[] = [];
+  let paragraph: string[] = [];
+  let listItems: string[] = [];
+  let inCodeBlock = false;
+  let codeLines: string[] = [];
+
+  const flushParagraph = () => {
+    if (paragraph.length === 0) return;
+    const text = paragraph.join(' ');
+    nodes.push(
+      <p key={`${keyPrefix}-p-${nodes.length}`} style={{ margin: '0 0 6px 0' }}>
+        {renderMarkdownInline(text, `${keyPrefix}-p-${nodes.length}`)}
+      </p>
+    );
+    paragraph = [];
+  };
+
+  const flushList = () => {
+    if (listItems.length === 0) return;
+    nodes.push(
+      <ul key={`${keyPrefix}-ul-${nodes.length}`} style={{ margin: '0 0 6px 16px', padding: 0 }}>
+        {listItems.map((item, index) => (
+          <li key={`${keyPrefix}-li-${index}`} style={{ marginBottom: '2px' }}>
+            {renderMarkdownInline(item, `${keyPrefix}-li-${index}`)}
+          </li>
+        ))}
+      </ul>
+    );
+    listItems = [];
+  };
+
+  const flushCodeBlock = () => {
+    if (codeLines.length === 0) return;
+    nodes.push(
+      <pre key={`${keyPrefix}-code-${nodes.length}`} style={{
+        margin: '0 0 6px 0',
+        padding: '8px',
+        borderRadius: '6px',
+        background: '#0d1117',
+        border: '1px solid #30363d',
+        overflowX: 'auto',
+      }}>
+        <code style={{ fontFamily: 'ui-monospace, SFMono-Regular, Menlo, Consolas, monospace', fontSize: '11px' }}>
+          {codeLines.join('\n')}
+        </code>
+      </pre>
+    );
+    codeLines = [];
+  };
+
+  for (const line of lines) {
+    if (line.trim().startsWith('```')) {
+      flushParagraph();
+      flushList();
+      if (inCodeBlock) {
+        flushCodeBlock();
+      }
+      inCodeBlock = !inCodeBlock;
+      continue;
+    }
+
+    if (inCodeBlock) {
+      codeLines.push(line);
+      continue;
+    }
+
+    if (!line.trim()) {
+      flushParagraph();
+      flushList();
+      continue;
+    }
+
+    if (line.trimStart().startsWith('- ')) {
+      flushParagraph();
+      listItems.push(line.trimStart().slice(2));
+      continue;
+    }
+
+    paragraph.push(line.trim());
+  }
+
+  flushParagraph();
+  flushList();
+  flushCodeBlock();
+
+  if (nodes.length === 0) {
+    nodes.push(<p key={`${keyPrefix}-empty`} style={{ margin: 0 }} />);
+  }
+
+  return nodes;
+}
+
 export function ThreadPanel({
   threads,
+  currentFilePath,
+  hunkFocus,
+  filterMode = 'all',
+  onFilterModeChange,
   selectedThreadId,
   hoveredThreadId,
   onResolveThread,
@@ -55,6 +211,7 @@ export function ThreadPanel({
   onUpdateComment,
   onDeleteComment,
   onUpdateDecision,
+  onOpenThreadTarget,
   onClose,
 }: ThreadPanelProps) {
   const [replyingTo, setReplyingTo] = useState<string | null>(null);
@@ -62,6 +219,31 @@ export function ThreadPanel({
   const [editingComment, setEditingComment] = useState<{ threadId: string; commentId: string; body: string } | null>(null);
   const [submitting, setSubmitting] = useState(false);
   const threadRefs = useRef<Record<string, HTMLDivElement | null>>({});
+
+  const visibleThreads = useMemo(() => {
+    if (filterMode === 'current-file' && currentFilePath) {
+      return threads.filter((thread) => {
+        if (thread.target.kind === 'workspace') {
+          return true;
+        }
+        return thread.target.file === currentFilePath;
+      });
+    }
+
+    if (filterMode === 'current-hunk' && hunkFocus) {
+      return threads.filter((thread) => {
+        if (thread.target.kind === 'hunk') {
+          return thread.target.file === hunkFocus.filePath && thread.target.hunkHeader === hunkFocus.hunkHeader;
+        }
+        if (thread.target.kind === 'line') {
+          return doesLineThreadOverlapHunk(thread, hunkFocus);
+        }
+        return false;
+      });
+    }
+
+    return threads;
+  }, [currentFilePath, filterMode, hunkFocus, threads]);
 
   useEffect(() => {
     const focusId = hoveredThreadId ?? selectedThreadId;
@@ -96,7 +278,7 @@ export function ThreadPanel({
     }
   }, [editingComment, onUpdateComment]);
 
-  if (threads.length === 0) {
+  if (visibleThreads.length === 0) {
     return (
       <div style={{
         height: '100%',
@@ -118,7 +300,11 @@ export function ThreadPanel({
           )}
         </div>
         <div style={{ flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center', color: '#8b949e', fontSize: '13px' }}>
-          No threads yet. Click a diff line or hunk to add a comment.
+          {filterMode === 'current-file'
+            ? 'No threads for the current file.'
+            : filterMode === 'current-hunk'
+              ? 'No threads for the selected hunk.'
+              : 'No threads yet. Click a diff line or hunk to add a comment.'}
         </div>
       </div>
     );
@@ -145,22 +331,101 @@ export function ThreadPanel({
         <span style={{ fontSize: '13px', fontWeight: 600, color: '#e6edf3' }}>
           Review Threads
           <span style={{ marginLeft: '8px', fontSize: '11px', color: '#8b949e', fontWeight: 400 }}>
-            ({threads.filter((t) => !t.resolved).length} open)
+            ({visibleThreads.filter((t) => !t.resolved).length} open)
           </span>
         </span>
-        {onClose && (
+        <div style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
           <button
-            onClick={onClose}
-            style={{ background: 'none', border: 'none', color: '#8b949e', cursor: 'pointer', fontSize: '16px', padding: '0 4px' }}
+            onClick={() => onFilterModeChange?.('all')}
+            style={{
+              fontSize: '10px',
+              padding: '2px 8px',
+              borderRadius: '999px',
+              border: '1px solid #30363d',
+              background: filterMode === 'all' ? '#1f6feb33' : '#21262d',
+              color: filterMode === 'all' ? '#58a6ff' : '#8b949e',
+              cursor: 'pointer',
+            }}
           >
-            ×
+            All
           </button>
-        )}
+          <button
+            onClick={() => onFilterModeChange?.('current-file')}
+            disabled={!currentFilePath}
+            style={{
+              fontSize: '10px',
+              padding: '2px 8px',
+              borderRadius: '999px',
+              border: '1px solid #30363d',
+              background: filterMode === 'current-file' ? '#1f6feb33' : '#21262d',
+              color: filterMode === 'current-file' ? '#58a6ff' : '#8b949e',
+              cursor: currentFilePath ? 'pointer' : 'not-allowed',
+            }}
+          >
+            Current file
+          </button>
+          <button
+            onClick={() => onFilterModeChange?.('current-hunk')}
+            disabled={!hunkFocus}
+            style={{
+              fontSize: '10px',
+              padding: '2px 8px',
+              borderRadius: '999px',
+              border: '1px solid #30363d',
+              background: filterMode === 'current-hunk' ? '#1f6feb33' : '#21262d',
+              color: filterMode === 'current-hunk' ? '#58a6ff' : '#8b949e',
+              cursor: hunkFocus ? 'pointer' : 'not-allowed',
+            }}
+          >
+            Current hunk
+          </button>
+          {onClose && (
+            <button
+              onClick={onClose}
+              style={{ background: 'none', border: 'none', color: '#8b949e', cursor: 'pointer', fontSize: '16px', padding: '0 4px' }}
+            >
+              ×
+            </button>
+          )}
+        </div>
       </div>
+
+      {filterMode === 'current-hunk' && hunkFocus && (
+        <div style={{
+          padding: '8px 12px',
+          borderBottom: '1px solid #21262d',
+          fontSize: '11px',
+          color: '#8b949e',
+          background: '#11161d',
+          display: 'flex',
+          gap: '6px',
+          alignItems: 'center',
+        }}>
+          <span style={{ color: '#58a6ff', fontWeight: 600 }}>Hunk filter</span>
+          <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+            {hunkFocus.hunkHeader}
+          </span>
+          <button
+            onClick={() => onFilterModeChange?.('all')}
+            style={{
+              marginLeft: 'auto',
+              fontSize: '10px',
+              padding: '1px 6px',
+              borderRadius: '3px',
+              border: '1px solid #30363d',
+              background: '#21262d',
+              color: '#8b949e',
+              cursor: 'pointer',
+            }}
+          >
+            Clear
+          </button>
+        </div>
+      )}
 
       {/* Thread list */}
       <div style={{ flex: 1, overflowY: 'auto' }}>
-        {threads.map((thread) => {
+        {visibleThreads.map((thread) => {
           const isSelected = thread.id === selectedThreadId;
           const isHovered = thread.id === hoveredThreadId;
           const decision = thread.decision;
@@ -198,6 +463,22 @@ export function ThreadPanel({
                   <span style={{ fontSize: '11px', color: '#6e7681', marginLeft: 'auto' }}>
                     {targetLabel(thread)}
                   </span>
+                  {thread.target.kind !== 'workspace' && (
+                    <button
+                      onClick={() => onOpenThreadTarget?.(thread.id)}
+                      style={{
+                        fontSize: '10px',
+                        padding: '1px 6px',
+                        borderRadius: '3px',
+                        border: '1px solid #30363d',
+                        background: '#21262d',
+                        color: '#58a6ff',
+                        cursor: 'pointer',
+                      }}
+                    >
+                      Go to code
+                    </button>
+                  )}
                 </div>
 
                 {/* Hunk decision buttons */}
@@ -295,9 +576,17 @@ export function ThreadPanel({
                       </div>
                     ) : (
                       <div style={{ display: 'flex', gap: '6px', alignItems: 'flex-start' }}>
-                        <p style={{ flex: 1, fontSize: '12px', color: '#e6edf3', margin: 0, whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>
-                          {comment.body}
-                        </p>
+                        <div style={{
+                          flex: 1,
+                          fontSize: '12px',
+                          color: '#e6edf3',
+                          margin: 0,
+                          whiteSpace: 'normal',
+                          wordBreak: 'break-word',
+                          lineHeight: 1.45,
+                        }}>
+                          {renderMarkdownBody(comment.body, comment.id)}
+                        </div>
                         {comment.author === 'local' && (
                           <div style={{ display: 'flex', gap: '4px', flexShrink: 0 }}>
                             <button
@@ -431,4 +720,24 @@ export function ThreadPanel({
       </div>
     </div>
   );
+}
+
+function doesLineThreadOverlapHunk(thread: ReviewThread, hunkFocus: HunkFocusTarget): boolean {
+  if (thread.target.kind !== 'line' || thread.target.file !== hunkFocus.filePath) {
+    return false;
+  }
+
+  if (thread.target.side === 'LEFT') {
+    return rangesOverlap(thread.target.startLine, thread.target.endLine, hunkFocus.oldStart, hunkFocus.oldEnd);
+  }
+
+  return rangesOverlap(thread.target.startLine, thread.target.endLine, hunkFocus.newStart, hunkFocus.newEnd);
+}
+
+function rangesOverlap(startA: number, endA: number, startB: number, endB: number): boolean {
+  const minA = Math.min(startA, endA);
+  const maxA = Math.max(startA, endA);
+  const minB = Math.min(startB, endB);
+  const maxB = Math.max(startB, endB);
+  return Math.max(minA, minB) <= Math.min(maxA, maxB);
 }

--- a/src/components/ThreadPanel.web.tsx
+++ b/src/components/ThreadPanel.web.tsx
@@ -772,7 +772,14 @@ function doesLineThreadOverlapHunk(thread: ReviewThread, hunkFocus: HunkFocusTar
   }
 
   if (thread.target.side === 'LEFT') {
+    if (hunkFocus.oldEnd < hunkFocus.oldStart) {
+      return false;
+    }
     return rangesOverlap(thread.target.startLine, thread.target.endLine, hunkFocus.oldStart, hunkFocus.oldEnd);
+  }
+
+  if (hunkFocus.newEnd < hunkFocus.newStart) {
+    return false;
   }
 
   return rangesOverlap(thread.target.startLine, thread.target.endLine, hunkFocus.newStart, hunkFocus.newEnd);

--- a/src/components/ThreadPanel.web.tsx
+++ b/src/components/ThreadPanel.web.tsx
@@ -35,10 +35,25 @@ const SAFE_LINK_SCHEMES = new Set(['http', 'https', 'mailto', 'tel']);
 
 function isSafeMarkdownHref(href: string): boolean {
   const trimmed = href.trim();
-  const scheme = trimmed.match(/^([a-zA-Z][a-zA-Z\d+.-]*):/);
-  if (!scheme?.[1]) {
+  if (!trimmed) {
     return false;
   }
+
+  if (
+    trimmed.startsWith('#') ||
+    trimmed.startsWith('/') ||
+    trimmed.startsWith('./') ||
+    trimmed.startsWith('../')
+  ) {
+    return true;
+  }
+
+  const scheme = trimmed.match(/^([a-zA-Z][a-zA-Z\d+.-]*):/);
+  if (!scheme?.[1]) {
+    // Relative paths without a URI scheme are safe.
+    return true;
+  }
+
   return SAFE_LINK_SCHEMES.has(scheme[1].toLowerCase());
 }
 

--- a/src/components/ThreadPanel.web.tsx
+++ b/src/components/ThreadPanel.web.tsx
@@ -11,6 +11,7 @@
 import { Fragment, useState, useCallback, useEffect, useMemo, useRef, type ReactNode } from 'react';
 import type { ReviewThread, HunkDecision } from '../types/review.js';
 import type { HunkFocusTarget } from './DiffViewer.web.js';
+import { normalizeHunkHeader } from '../utils/hunk-header.js';
 
 export interface ThreadPanelProps {
   threads: ReviewThread[];
@@ -247,7 +248,10 @@ export function ThreadPanel({
     if (filterMode === 'current-hunk' && hunkFocus) {
       return threads.filter((thread) => {
         if (thread.target.kind === 'hunk') {
-          return thread.target.file === hunkFocus.filePath && thread.target.hunkHeader === hunkFocus.hunkHeader;
+          return (
+            thread.target.file === hunkFocus.filePath &&
+            normalizeHunkHeader(thread.target.hunkHeader) === normalizeHunkHeader(hunkFocus.hunkHeader)
+          );
         }
         if (thread.target.kind === 'line') {
           return doesLineThreadOverlapHunk(thread, hunkFocus);
@@ -417,7 +421,7 @@ export function ThreadPanel({
         }}>
           <span style={{ color: '#58a6ff', fontWeight: 600 }}>Hunk filter</span>
           <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-            {hunkFocus.hunkHeader}
+            {normalizeHunkHeader(hunkFocus.hunkHeader)}
           </span>
           <button
             onClick={() => onFilterModeChange?.('all')}

--- a/src/components/ThreadPanel.web.tsx
+++ b/src/components/ThreadPanel.web.tsx
@@ -1,0 +1,418 @@
+/** @jsxImportSource react */
+/**
+ * ThreadPanel — right-side panel listing all review threads.
+ *
+ * Shows thread targets, decisions, comments, and allows:
+ * - Resolving/unresolving threads
+ * - Adding replies
+ * - Editing/deleting own comments
+ */
+
+import { useState, useCallback } from 'react';
+import type { ReviewThread, HunkDecision } from '../types/review.js';
+
+export interface ThreadPanelProps {
+  threads: ReviewThread[];
+  selectedThreadId?: string | null;
+  onResolveThread: (threadId: string, resolved: boolean) => Promise<void>;
+  onAddReply: (threadId: string, body: string) => Promise<void>;
+  onUpdateComment: (threadId: string, commentId: string, body: string) => Promise<void>;
+  onDeleteComment: (threadId: string, commentId: string) => Promise<void>;
+  onUpdateDecision: (threadId: string, decision: HunkDecision) => Promise<void>;
+  onClose?: () => void;
+}
+
+const DECISION_COLORS: Record<string, string> = {
+  approved: '#22c55e',
+  rejected: '#f85149',
+  pending: '#d29922',
+};
+
+function formatDate(iso: string): string {
+  try {
+    const d = new Date(iso);
+    return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' });
+  } catch {
+    return iso;
+  }
+}
+
+function targetLabel(thread: ReviewThread): string {
+  const t = thread.target;
+  if (t.kind === 'hunk') return `Hunk · ${t.file.split('/').pop()}`;
+  if (t.kind === 'line') return `L${t.startLine}–${t.endLine} · ${t.file.split('/').pop()}`;
+  if (t.kind === 'file') return `File · ${t.file.split('/').pop()}`;
+  return 'Overall';
+}
+
+export function ThreadPanel({
+  threads,
+  selectedThreadId,
+  onResolveThread,
+  onAddReply,
+  onUpdateComment,
+  onDeleteComment,
+  onUpdateDecision,
+  onClose,
+}: ThreadPanelProps) {
+  const [replyingTo, setReplyingTo] = useState<string | null>(null);
+  const [replyBody, setReplyBody] = useState('');
+  const [editingComment, setEditingComment] = useState<{ threadId: string; commentId: string; body: string } | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  const handleAddReply = useCallback(async (threadId: string) => {
+    if (!replyBody.trim()) return;
+    setSubmitting(true);
+    try {
+      await onAddReply(threadId, replyBody.trim());
+      setReplyBody('');
+      setReplyingTo(null);
+    } finally {
+      setSubmitting(false);
+    }
+  }, [replyBody, onAddReply]);
+
+  const handleSaveEdit = useCallback(async () => {
+    if (!editingComment || !editingComment.body.trim()) return;
+    setSubmitting(true);
+    try {
+      await onUpdateComment(editingComment.threadId, editingComment.commentId, editingComment.body.trim());
+      setEditingComment(null);
+    } finally {
+      setSubmitting(false);
+    }
+  }, [editingComment, onUpdateComment]);
+
+  if (threads.length === 0) {
+    return (
+      <div style={{
+        height: '100%',
+        display: 'flex',
+        flexDirection: 'column',
+        background: '#0d1117',
+        borderLeft: '1px solid #30363d',
+      }}>
+        <div style={{
+          padding: '12px 16px',
+          borderBottom: '1px solid #30363d',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+        }}>
+          <span style={{ fontSize: '13px', fontWeight: 600, color: '#e6edf3' }}>Review Threads</span>
+          {onClose && (
+            <button onClick={onClose} style={{ background: 'none', border: 'none', color: '#8b949e', cursor: 'pointer', fontSize: '16px' }}>×</button>
+          )}
+        </div>
+        <div style={{ flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center', color: '#8b949e', fontSize: '13px' }}>
+          No threads yet. Click a diff line or hunk to add a comment.
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div style={{
+      height: '100%',
+      display: 'flex',
+      flexDirection: 'column',
+      background: '#0d1117',
+      borderLeft: '1px solid #30363d',
+      overflow: 'hidden',
+    }}>
+      {/* Header */}
+      <div style={{
+        padding: '12px 16px',
+        borderBottom: '1px solid #30363d',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        flexShrink: 0,
+      }}>
+        <span style={{ fontSize: '13px', fontWeight: 600, color: '#e6edf3' }}>
+          Review Threads
+          <span style={{ marginLeft: '8px', fontSize: '11px', color: '#8b949e', fontWeight: 400 }}>
+            ({threads.filter((t) => !t.resolved).length} open)
+          </span>
+        </span>
+        {onClose && (
+          <button
+            onClick={onClose}
+            style={{ background: 'none', border: 'none', color: '#8b949e', cursor: 'pointer', fontSize: '16px', padding: '0 4px' }}
+          >
+            ×
+          </button>
+        )}
+      </div>
+
+      {/* Thread list */}
+      <div style={{ flex: 1, overflowY: 'auto' }}>
+        {threads.map((thread) => {
+          const isSelected = thread.id === selectedThreadId;
+          const decision = thread.decision;
+
+          return (
+            <div
+              key={thread.id}
+              style={{
+                borderBottom: '1px solid #21262d',
+                background: isSelected ? '#161b22' : 'transparent',
+              }}
+            >
+              {/* Thread header */}
+              <div style={{ padding: '10px 14px 6px' }}>
+                <div style={{ display: 'flex', alignItems: 'center', gap: '8px', marginBottom: '6px' }}>
+                  {/* Decision badge */}
+                  {decision && (
+                    <span style={{
+                      fontSize: '11px',
+                      padding: '1px 6px',
+                      borderRadius: '10px',
+                      background: DECISION_COLORS[decision] + '22',
+                      color: DECISION_COLORS[decision],
+                      border: `1px solid ${DECISION_COLORS[decision]}44`,
+                    }}>
+                      {decision === 'approved' ? '✓ Approved' : decision === 'rejected' ? '✗ Changes requested' : '⏳ Pending'}
+                    </span>
+                  )}
+                  {/* Resolved badge */}
+                  {thread.resolved && (
+                    <span style={{ fontSize: '11px', color: '#6e7681' }}>✓ Resolved</span>
+                  )}
+                  <span style={{ fontSize: '11px', color: '#6e7681', marginLeft: 'auto' }}>
+                    {targetLabel(thread)}
+                  </span>
+                </div>
+
+                {/* Hunk decision buttons */}
+                {thread.target.kind === 'hunk' && !thread.resolved && (
+                  <div style={{ display: 'flex', gap: '6px', marginBottom: '6px' }}>
+                    {(['approved', 'rejected', 'pending'] as const).map((d) => (
+                      <button
+                        key={d}
+                        onClick={() => void onUpdateDecision(thread.id, d)}
+                        style={{
+                          fontSize: '11px',
+                          padding: '2px 8px',
+                          borderRadius: '4px',
+                          border: '1px solid',
+                          cursor: 'pointer',
+                          background: decision === d ? DECISION_COLORS[d] + '33' : '#21262d',
+                          color: decision === d ? DECISION_COLORS[d] : '#8b949e',
+                          borderColor: decision === d ? DECISION_COLORS[d] + '66' : '#30363d',
+                        }}
+                      >
+                        {d === 'approved' ? '✓ Approve' : d === 'rejected' ? '✗ Reject' : '⏳ Pending'}
+                      </button>
+                    ))}
+                  </div>
+                )}
+
+                {/* Comments */}
+                {thread.comments.map((comment, idx) => (
+                  <div
+                    key={comment.id}
+                    style={{
+                      marginBottom: '8px',
+                      paddingLeft: idx > 0 ? '12px' : 0,
+                      borderLeft: idx > 0 ? '2px solid #21262d' : 'none',
+                    }}
+                  >
+                    <div style={{ display: 'flex', alignItems: 'center', gap: '6px', marginBottom: '3px' }}>
+                      <span style={{ fontSize: '12px', fontWeight: 600, color: '#58a6ff' }}>{comment.author}</span>
+                      <span style={{ fontSize: '11px', color: '#6e7681' }}>{formatDate(comment.createdAt)}</span>
+                      {comment.githubId && (
+                        <span style={{ fontSize: '10px', color: '#6e7681' }}>· GH</span>
+                      )}
+                    </div>
+
+                    {editingComment?.commentId === comment.id ? (
+                      <div>
+                        <textarea
+                          value={editingComment.body}
+                          onChange={(e) => setEditingComment({ ...editingComment, body: e.target.value })}
+                          rows={3}
+                          style={{
+                            width: '100%',
+                            background: '#161b22',
+                            border: '1px solid #30363d',
+                            borderRadius: '4px',
+                            color: '#e6edf3',
+                            padding: '6px',
+                            fontSize: '12px',
+                            resize: 'vertical',
+                            boxSizing: 'border-box',
+                          }}
+                          autoFocus
+                        />
+                        <div style={{ display: 'flex', gap: '6px', marginTop: '4px' }}>
+                          <button
+                            onClick={() => void handleSaveEdit()}
+                            disabled={submitting}
+                            style={{
+                              fontSize: '11px',
+                              padding: '3px 10px',
+                              background: '#22c55e',
+                              color: '#0d1117',
+                              border: 'none',
+                              borderRadius: '4px',
+                              cursor: 'pointer',
+                            }}
+                          >
+                            Save
+                          </button>
+                          <button
+                            onClick={() => setEditingComment(null)}
+                            style={{
+                              fontSize: '11px',
+                              padding: '3px 10px',
+                              background: '#21262d',
+                              color: '#8b949e',
+                              border: '1px solid #30363d',
+                              borderRadius: '4px',
+                              cursor: 'pointer',
+                            }}
+                          >
+                            Cancel
+                          </button>
+                        </div>
+                      </div>
+                    ) : (
+                      <div style={{ display: 'flex', gap: '6px', alignItems: 'flex-start' }}>
+                        <p style={{ flex: 1, fontSize: '12px', color: '#e6edf3', margin: 0, whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>
+                          {comment.body}
+                        </p>
+                        {comment.author === 'local' && (
+                          <div style={{ display: 'flex', gap: '4px', flexShrink: 0 }}>
+                            <button
+                              onClick={() => setEditingComment({ threadId: thread.id, commentId: comment.id, body: comment.body })}
+                              style={{
+                                fontSize: '10px',
+                                padding: '1px 5px',
+                                background: 'none',
+                                color: '#6e7681',
+                                border: '1px solid #30363d',
+                                borderRadius: '3px',
+                                cursor: 'pointer',
+                              }}
+                            >
+                              Edit
+                            </button>
+                            <button
+                              onClick={() => void onDeleteComment(thread.id, comment.id)}
+                              style={{
+                                fontSize: '10px',
+                                padding: '1px 5px',
+                                background: 'none',
+                                color: '#f85149',
+                                border: '1px solid #f8514944',
+                                borderRadius: '3px',
+                                cursor: 'pointer',
+                              }}
+                            >
+                              Del
+                            </button>
+                          </div>
+                        )}
+                      </div>
+                    )}
+                  </div>
+                ))}
+
+                {/* Reply form */}
+                {replyingTo === thread.id ? (
+                  <div style={{ marginTop: '6px' }}>
+                    <textarea
+                      value={replyBody}
+                      onChange={(e) => setReplyBody(e.target.value)}
+                      placeholder="Write a reply..."
+                      rows={2}
+                      style={{
+                        width: '100%',
+                        background: '#161b22',
+                        border: '1px solid #30363d',
+                        borderRadius: '4px',
+                        color: '#e6edf3',
+                        padding: '6px',
+                        fontSize: '12px',
+                        resize: 'vertical',
+                        boxSizing: 'border-box',
+                      }}
+                      autoFocus
+                      onKeyDown={(e) => {
+                        if (e.key === 'Escape') { setReplyingTo(null); setReplyBody(''); }
+                        if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) void handleAddReply(thread.id);
+                      }}
+                    />
+                    <div style={{ display: 'flex', gap: '6px', marginTop: '4px' }}>
+                      <button
+                        onClick={() => void handleAddReply(thread.id)}
+                        disabled={submitting || !replyBody.trim()}
+                        style={{
+                          fontSize: '11px',
+                          padding: '3px 10px',
+                          background: '#22c55e',
+                          color: '#0d1117',
+                          border: 'none',
+                          borderRadius: '4px',
+                          cursor: 'pointer',
+                        }}
+                      >
+                        Reply
+                      </button>
+                      <button
+                        onClick={() => { setReplyingTo(null); setReplyBody(''); }}
+                        style={{
+                          fontSize: '11px',
+                          padding: '3px 10px',
+                          background: '#21262d',
+                          color: '#8b949e',
+                          border: '1px solid #30363d',
+                          borderRadius: '4px',
+                          cursor: 'pointer',
+                        }}
+                      >
+                        Cancel
+                      </button>
+                    </div>
+                  </div>
+                ) : (
+                  <div style={{ display: 'flex', gap: '6px', marginTop: '6px' }}>
+                    <button
+                      onClick={() => { setReplyingTo(thread.id); setReplyBody(''); }}
+                      style={{
+                        fontSize: '11px',
+                        padding: '2px 8px',
+                        background: 'none',
+                        color: '#58a6ff',
+                        border: '1px solid #30363d',
+                        borderRadius: '4px',
+                        cursor: 'pointer',
+                      }}
+                    >
+                      Reply
+                    </button>
+                    <button
+                      onClick={() => void onResolveThread(thread.id, !thread.resolved)}
+                      style={{
+                        fontSize: '11px',
+                        padding: '2px 8px',
+                        background: 'none',
+                        color: thread.resolved ? '#6e7681' : '#22c55e',
+                        border: '1px solid #30363d',
+                        borderRadius: '4px',
+                        cursor: 'pointer',
+                      }}
+                    >
+                      {thread.resolved ? 'Re-open' : 'Resolve'}
+                    </button>
+                  </div>
+                )}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/components/ThreadPanel.web.tsx
+++ b/src/components/ThreadPanel.web.tsx
@@ -39,6 +39,10 @@ function isSafeMarkdownHref(href: string): boolean {
     return false;
   }
 
+  if (trimmed.startsWith('//')) {
+    return false;
+  }
+
   if (
     trimmed.startsWith('#') ||
     trimmed.startsWith('/') ||

--- a/src/components/review-decision-colors.ts
+++ b/src/components/review-decision-colors.ts
@@ -1,0 +1,11 @@
+import type { HunkDecision } from '../types/review.js';
+
+export const REVIEW_DECISION_COLORS: Record<HunkDecision, string> = {
+  approved: '#22c55e',
+  rejected: '#f85149',
+  pending: '#d29922',
+};
+
+export function getReviewDecisionColor(decision: HunkDecision): string {
+  return REVIEW_DECISION_COLORS[decision];
+}

--- a/src/core/__tests__/github-review.test.ts
+++ b/src/core/__tests__/github-review.test.ts
@@ -1,0 +1,408 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { importGitHubReview, pushGitHubReview } from '../github-review.js';
+import { readReviewSession, writeReviewSession } from '../review.js';
+import type { ReviewComment, ReviewThread } from '../../types/review.js';
+
+const OWNER = 'acme';
+const REPO = 'widget';
+const PR_NUMBER = 7;
+const WORKSPACE_NAME = 'review-workspace';
+const BASE_BRANCH = 'main';
+
+type EnvSnapshot = {
+  PATH?: string;
+  GH_STUB_IMPORT_FILE?: string;
+  GH_STUB_CALL_LOG?: string;
+  GH_STUB_PAYLOAD_LOG?: string;
+  GH_STUB_REPLY_COUNTER_FILE?: string;
+  GH_STUB_REVIEW_COUNTER_FILE?: string;
+};
+
+function captureEnv(): EnvSnapshot {
+  return {
+    PATH: process.env.PATH,
+    GH_STUB_IMPORT_FILE: process.env.GH_STUB_IMPORT_FILE,
+    GH_STUB_CALL_LOG: process.env.GH_STUB_CALL_LOG,
+    GH_STUB_PAYLOAD_LOG: process.env.GH_STUB_PAYLOAD_LOG,
+    GH_STUB_REPLY_COUNTER_FILE: process.env.GH_STUB_REPLY_COUNTER_FILE,
+    GH_STUB_REVIEW_COUNTER_FILE: process.env.GH_STUB_REVIEW_COUNTER_FILE,
+  };
+}
+
+function restoreEnv(env: EnvSnapshot): void {
+  if (env.PATH === undefined) delete process.env.PATH;
+  else process.env.PATH = env.PATH;
+
+  if (env.GH_STUB_IMPORT_FILE === undefined) delete process.env.GH_STUB_IMPORT_FILE;
+  else process.env.GH_STUB_IMPORT_FILE = env.GH_STUB_IMPORT_FILE;
+
+  if (env.GH_STUB_CALL_LOG === undefined) delete process.env.GH_STUB_CALL_LOG;
+  else process.env.GH_STUB_CALL_LOG = env.GH_STUB_CALL_LOG;
+
+  if (env.GH_STUB_PAYLOAD_LOG === undefined) delete process.env.GH_STUB_PAYLOAD_LOG;
+  else process.env.GH_STUB_PAYLOAD_LOG = env.GH_STUB_PAYLOAD_LOG;
+
+  if (env.GH_STUB_REPLY_COUNTER_FILE === undefined) delete process.env.GH_STUB_REPLY_COUNTER_FILE;
+  else process.env.GH_STUB_REPLY_COUNTER_FILE = env.GH_STUB_REPLY_COUNTER_FILE;
+
+  if (env.GH_STUB_REVIEW_COUNTER_FILE === undefined) delete process.env.GH_STUB_REVIEW_COUNTER_FILE;
+  else process.env.GH_STUB_REVIEW_COUNTER_FILE = env.GH_STUB_REVIEW_COUNTER_FILE;
+}
+
+function writeGhStub(binPath: string): void {
+  const script = String.raw`#!/usr/bin/env bun
+import { appendFileSync, existsSync, readFileSync, writeFileSync } from 'fs';
+
+const args = process.argv.slice(2);
+const callLog = process.env.GH_STUB_CALL_LOG;
+if (callLog) {
+  appendFileSync(callLog, JSON.stringify({ args }) + '\n', 'utf-8');
+}
+
+function readFlag(name) {
+  const index = args.indexOf(name);
+  if (index === -1) return null;
+  return args[index + 1] ?? null;
+}
+
+function readInputPayload() {
+  const inputFile = readFlag('--input');
+  if (!inputFile || !existsSync(inputFile)) return null;
+  return JSON.parse(readFileSync(inputFile, 'utf-8'));
+}
+
+function nextCounter(file, start) {
+  let current = start;
+  if (existsSync(file)) {
+    current = parseInt(readFileSync(file, 'utf-8').trim(), 10);
+    if (Number.isNaN(current)) current = start;
+  }
+  const next = current + 1;
+  writeFileSync(file, String(next), 'utf-8');
+  return next;
+}
+
+const payloadLog = process.env.GH_STUB_PAYLOAD_LOG;
+
+if (args[0] === 'repo' && args[1] === 'view') {
+  if (args.includes('owner')) {
+    process.stdout.write('${OWNER}\n');
+  } else {
+    process.stdout.write('${REPO}\n');
+  }
+  process.exit(0);
+}
+
+if (args[0] !== 'api') {
+  process.stderr.write('Unsupported gh invocation: ' + args.join(' ') + '\n');
+  process.exit(1);
+}
+
+const endpoint = args[1] ?? '';
+const method = readFlag('--method') ?? 'GET';
+
+if (method === 'GET' && endpoint === 'repos/${OWNER}/${REPO}/pulls/${PR_NUMBER}/comments') {
+  const importFile = process.env.GH_STUB_IMPORT_FILE;
+  if (importFile && existsSync(importFile)) {
+    process.stdout.write(readFileSync(importFile, 'utf-8'));
+  } else {
+    process.stdout.write('[]');
+  }
+  process.exit(0);
+}
+
+if (method === 'POST' && endpoint === 'repos/${OWNER}/${REPO}/pulls/${PR_NUMBER}/comments') {
+  const payload = readInputPayload() ?? {};
+  if (payloadLog) {
+    appendFileSync(payloadLog, JSON.stringify({ kind: 'reply', endpoint, payload }) + '\n', 'utf-8');
+  }
+  const counterFile = process.env.GH_STUB_REPLY_COUNTER_FILE;
+  const id = counterFile ? nextCounter(counterFile, 5000) : 5001;
+  process.stdout.write(JSON.stringify({ id, html_url: 'https://example.invalid/discussion/' + id }));
+  process.exit(0);
+}
+
+if (method === 'POST' && endpoint === 'repos/${OWNER}/${REPO}/pulls/${PR_NUMBER}/reviews') {
+  const payload = readInputPayload() ?? {};
+  if (payloadLog) {
+    appendFileSync(payloadLog, JSON.stringify({ kind: 'review', endpoint, payload }) + '\n', 'utf-8');
+  }
+  const counterFile = process.env.GH_STUB_REVIEW_COUNTER_FILE;
+  const id = counterFile ? nextCounter(counterFile, 9000) : 9001;
+  process.stdout.write(JSON.stringify({ id, html_url: 'https://example.invalid/review/' + id }));
+  process.exit(0);
+}
+
+process.stderr.write('Unhandled gh api endpoint: ' + endpoint + ' method=' + method + '\n');
+process.exit(1);
+`;
+
+  writeFileSync(binPath, script, 'utf-8');
+  chmodSync(binPath, 0o755);
+}
+
+function setImportComments(importFile: string, comments: unknown[]): void {
+  writeFileSync(importFile, JSON.stringify(comments), 'utf-8');
+}
+
+function setImportPayload(importFile: string, payload: unknown): void {
+  writeFileSync(importFile, JSON.stringify(payload), 'utf-8');
+}
+
+function readPayloadLog(payloadLog: string): Array<{ kind: string; endpoint: string; payload: any }> {
+  if (!existsSync(payloadLog)) return [];
+  const raw = readFileSync(payloadLog, 'utf-8').trim();
+  if (!raw) return [];
+  return raw.split('\n').filter(Boolean).map((line) => JSON.parse(line));
+}
+
+describe('github-review sync behavior', () => {
+  let envSnapshot: EnvSnapshot;
+  let tempRoot: string;
+  let workspacePath: string;
+  let importFile: string;
+  let callLog: string;
+  let payloadLog: string;
+  let replyCounter: string;
+  let reviewCounter: string;
+
+  beforeEach(() => {
+    envSnapshot = captureEnv();
+
+    tempRoot = mkdtempSync(join(tmpdir(), 'github-review-sync-'));
+    workspacePath = join(tempRoot, 'workspace');
+    const binDir = join(tempRoot, 'bin');
+    mkdirSync(workspacePath, { recursive: true });
+    mkdirSync(binDir, { recursive: true });
+
+    importFile = join(tempRoot, 'import-comments.json');
+    callLog = join(tempRoot, 'gh-calls.log');
+    payloadLog = join(tempRoot, 'gh-payloads.log');
+    replyCounter = join(tempRoot, 'reply-counter.txt');
+    reviewCounter = join(tempRoot, 'review-counter.txt');
+
+    setImportComments(importFile, []);
+    writeFileSync(callLog, '', 'utf-8');
+    writeFileSync(payloadLog, '', 'utf-8');
+
+    const ghPath = join(binDir, 'gh');
+    writeGhStub(ghPath);
+
+    process.env.PATH = `${binDir}:${envSnapshot.PATH ?? ''}`;
+    process.env.GH_STUB_IMPORT_FILE = importFile;
+    process.env.GH_STUB_CALL_LOG = callLog;
+    process.env.GH_STUB_PAYLOAD_LOG = payloadLog;
+    process.env.GH_STUB_REPLY_COUNTER_FILE = replyCounter;
+    process.env.GH_STUB_REVIEW_COUNTER_FILE = reviewCounter;
+  });
+
+  afterEach(() => {
+    restoreEnv(envSnapshot);
+    rmSync(tempRoot, { recursive: true, force: true });
+  });
+
+  it('imports incrementally without duplicating existing comments', async () => {
+    setImportComments(importFile, [
+      {
+        id: 101,
+        body: 'Root from GitHub',
+        path: 'src/main.ts',
+        line: 12,
+        original_line: 12,
+        side: 'RIGHT',
+        start_line: 12,
+        original_start_line: 12,
+        diff_hunk: '@@ -10,2 +10,3 @@ context',
+        user: { login: 'octocat' },
+        created_at: '2026-02-19T10:00:00Z',
+        pull_request_review_id: 10,
+      },
+    ]);
+
+    const first = await importGitHubReview(workspacePath, WORKSPACE_NAME, BASE_BRANCH, PR_NUMBER);
+    expect(first.imported).toBe(1);
+    expect(first.threads).toHaveLength(1);
+    expect(first.threads[0]?.comments).toHaveLength(1);
+
+    setImportComments(importFile, [
+      {
+        id: 101,
+        body: 'Root from GitHub',
+        path: 'src/main.ts',
+        line: 12,
+        original_line: 12,
+        side: 'RIGHT',
+        start_line: 12,
+        original_start_line: 12,
+        diff_hunk: '@@ -10,2 +10,3 @@ context',
+        user: { login: 'octocat' },
+        created_at: '2026-02-19T10:00:00Z',
+        pull_request_review_id: 10,
+      },
+      {
+        id: 102,
+        body: 'Follow-up reply from GitHub',
+        path: 'src/main.ts',
+        line: 12,
+        original_line: 12,
+        side: 'RIGHT',
+        start_line: 12,
+        original_start_line: 12,
+        diff_hunk: '@@ -10,2 +10,3 @@ context',
+        user: { login: 'maintainer' },
+        created_at: '2026-02-19T11:00:00Z',
+        in_reply_to_id: 101,
+        pull_request_review_id: 10,
+      },
+    ]);
+
+    const second = await importGitHubReview(workspacePath, WORKSPACE_NAME, BASE_BRANCH, PR_NUMBER);
+    expect(second.imported).toBe(0);
+    expect(second.threads).toHaveLength(1);
+    expect(second.threads[0]?.comments).toHaveLength(2);
+
+    const third = await importGitHubReview(workspacePath, WORKSPACE_NAME, BASE_BRANCH, PR_NUMBER);
+    expect(third.imported).toBe(0);
+    expect(third.threads[0]?.comments).toHaveLength(2);
+  });
+
+  it('imports paginated slurp responses by flattening pages', async () => {
+    setImportPayload(importFile, [
+      [
+        {
+          id: 401,
+          body: 'Page one comment',
+          path: 'src/one.ts',
+          line: 3,
+          original_line: 3,
+          side: 'RIGHT',
+          start_line: 3,
+          original_start_line: 3,
+          diff_hunk: '@@ -1,1 +1,3 @@',
+          user: { login: 'alice' },
+          created_at: '2026-02-19T15:00:00Z',
+          pull_request_review_id: 30,
+        },
+      ],
+      [
+        {
+          id: 402,
+          body: 'Page two comment',
+          path: 'src/two.ts',
+          line: 9,
+          original_line: 9,
+          side: 'RIGHT',
+          start_line: 9,
+          original_start_line: 9,
+          diff_hunk: '@@ -8,1 +8,2 @@',
+          user: { login: 'bob' },
+          created_at: '2026-02-19T15:05:00Z',
+          pull_request_review_id: 30,
+        },
+      ],
+    ]);
+
+    const result = await importGitHubReview(workspacePath, WORKSPACE_NAME, BASE_BRANCH, PR_NUMBER);
+    expect(result.imported).toBe(2);
+    expect(result.threads).toHaveLength(2);
+  });
+
+  it('pushes only unsynced local comments and avoids replay on repeat push', async () => {
+    setImportComments(importFile, [
+      {
+        id: 201,
+        body: 'Imported root comment',
+        path: 'src/main.ts',
+        line: 8,
+        original_line: 8,
+        side: 'RIGHT',
+        start_line: 8,
+        original_start_line: 8,
+        diff_hunk: '@@ -6,2 +6,3 @@ context',
+        user: { login: 'octocat' },
+        created_at: '2026-02-19T12:00:00Z',
+        pull_request_review_id: 20,
+      },
+    ]);
+
+    await importGitHubReview(workspacePath, WORKSPACE_NAME, BASE_BRANCH, PR_NUMBER);
+
+    const session = readReviewSession(workspacePath, WORKSPACE_NAME, BASE_BRANCH);
+    const importedThread = session.threads[0] as ReviewThread;
+    importedThread.comments.push({
+      id: 'local-reply-1',
+      threadId: importedThread.id,
+      body: 'Local reply back to the imported thread',
+      author: 'local',
+      createdAt: '2026-02-19T12:30:00Z',
+    });
+
+    session.threads.push({
+      id: 'local-line-thread',
+      target: {
+        kind: 'line',
+        file: 'src/feature.ts',
+        startLine: 14,
+        endLine: 16,
+        side: 'RIGHT',
+      },
+      resolved: false,
+      comments: [
+        {
+          id: 'local-line-root',
+          threadId: 'local-line-thread',
+          body: 'A brand new local review note',
+          author: 'local',
+          createdAt: '2026-02-19T12:31:00Z',
+        },
+      ],
+      createdAt: '2026-02-19T12:31:00Z',
+      updatedAt: '2026-02-19T12:31:00Z',
+    });
+
+    writeReviewSession(workspacePath, WORKSPACE_NAME, session);
+
+    const pushed = await pushGitHubReview(workspacePath, WORKSPACE_NAME, BASE_BRANCH, PR_NUMBER);
+    expect(pushed.prNumber).toBe(PR_NUMBER);
+    expect(pushed.url).toContain('review');
+
+    const payloads = readPayloadLog(payloadLog);
+    const replyPayload = payloads.find((entry) => entry.kind === 'reply');
+    const reviewPayload = payloads.find((entry) => entry.kind === 'review');
+
+    expect(replyPayload).toBeDefined();
+    expect(replyPayload?.payload.in_reply_to).toBe(201);
+    expect(replyPayload?.payload.body).toBe('Local reply back to the imported thread');
+
+    expect(reviewPayload).toBeDefined();
+    expect(Array.isArray(reviewPayload?.payload.comments)).toBe(true);
+    expect(reviewPayload?.payload.comments).toHaveLength(1);
+    expect(reviewPayload?.payload.comments[0]?.body).toContain('A brand new local review note');
+    expect(reviewPayload?.payload.comments[0]?.body).not.toContain('Imported root comment');
+    expect(reviewPayload?.payload.comments[0]?.start_line).toBe(14);
+    expect(reviewPayload?.payload.comments[0]?.start_side).toBe('RIGHT');
+
+    const afterFirstPush = readReviewSession(workspacePath, WORKSPACE_NAME, BASE_BRANCH);
+    const pushedImportedReply = afterFirstPush.threads
+      .flatMap((thread) => thread.comments)
+      .find((comment) => comment.id === 'local-reply-1') as ReviewComment;
+    expect(pushedImportedReply.githubId).toBeDefined();
+    expect(pushedImportedReply.syncedToGitHubAt).toBeDefined();
+
+    const pushedLocalLineRoot = afterFirstPush.threads
+      .flatMap((thread) => thread.comments)
+      .find((comment) => comment.id === 'local-line-root') as ReviewComment;
+    expect(pushedLocalLineRoot.githubId).toBeUndefined();
+    expect(pushedLocalLineRoot.syncedToGitHubAt).toBeDefined();
+
+    writeFileSync(payloadLog, '', 'utf-8');
+    const secondPush = await pushGitHubReview(workspacePath, WORKSPACE_NAME, BASE_BRANCH, PR_NUMBER);
+    expect(secondPush.url).toContain(`/pull/${PR_NUMBER}`);
+
+    const payloadsAfterSecondPush = readPayloadLog(payloadLog);
+    expect(payloadsAfterSecondPush).toHaveLength(0);
+  });
+});

--- a/src/core/__tests__/github-review.test.ts
+++ b/src/core/__tests__/github-review.test.ts
@@ -109,6 +109,11 @@ if (args[0] !== 'api') {
 const endpoint = args[1] ?? '';
 const method = readFlag('--method') ?? 'GET';
 
+if (method === 'GET' && endpoint === 'repos/${OWNER}/${REPO}/pulls/${PR_NUMBER}') {
+  process.stdout.write(JSON.stringify({ head: { sha: '1111111111111111111111111111111111111111' } }));
+  process.exit(0);
+}
+
 if (method === 'GET' && endpoint === 'repos/${OWNER}/${REPO}/pulls/${PR_NUMBER}/comments') {
   const importFile = process.env.GH_STUB_IMPORT_FILE;
   if (importFile && existsSync(importFile)) {
@@ -122,7 +127,8 @@ if (method === 'GET' && endpoint === 'repos/${OWNER}/${REPO}/pulls/${PR_NUMBER}/
 if (method === 'POST' && endpoint === 'repos/${OWNER}/${REPO}/pulls/${PR_NUMBER}/comments') {
   const payload = readInputPayload() ?? {};
   if (payloadLog) {
-    appendFileSync(payloadLog, JSON.stringify({ kind: 'reply', endpoint, payload }) + '\n', 'utf-8');
+    const kind = payload.in_reply_to != null ? 'reply' : 'top_comment';
+    appendFileSync(payloadLog, JSON.stringify({ kind, endpoint, payload }) + '\n', 'utf-8');
   }
   const counterFile = process.env.GH_STUB_REPLY_COUNTER_FILE;
   const id = counterFile ? nextCounter(counterFile, 5000) : 5001;
@@ -525,6 +531,88 @@ describe('github-review sync behavior', () => {
     await pushGitHubReview(workspacePath, WORKSPACE_NAME, BASE_BRANCH, PR_NUMBER);
     const payloadsAfterSecondPush = readPayloadLog(payloadLog);
     expect(payloadsAfterSecondPush).toHaveLength(0);
+  });
+
+  it('posts file-target threads as top-level file comments', async () => {
+    const now = '2026-02-19T13:30:00Z';
+    const session = readReviewSession(workspacePath, WORKSPACE_NAME, BASE_BRANCH);
+    session.threads.push({
+      id: 'file-thread',
+      target: {
+        kind: 'file',
+        file: 'src/file-note.ts',
+      },
+      resolved: false,
+      comments: [
+        {
+          id: 'file-root',
+          threadId: 'file-thread',
+          body: 'File-level note',
+          author: 'local',
+          createdAt: now,
+        },
+      ],
+      createdAt: now,
+      updatedAt: now,
+    });
+    writeReviewSession(workspacePath, WORKSPACE_NAME, session);
+
+    await pushGitHubReview(workspacePath, WORKSPACE_NAME, BASE_BRANCH, PR_NUMBER);
+
+    const payloads = readPayloadLog(payloadLog);
+    const topCommentPayload = payloads.find((entry) => entry.kind === 'top_comment');
+    const reviewPayload = payloads.find((entry) => entry.kind === 'review');
+
+    expect(topCommentPayload).toBeDefined();
+    expect(topCommentPayload?.payload.path).toBe('src/file-note.ts');
+    expect(topCommentPayload?.payload.subject_type).toBe('file');
+    expect(topCommentPayload?.payload.commit_id).toBe('1111111111111111111111111111111111111111');
+    expect(reviewPayload).toBeUndefined();
+
+    const afterPush = readReviewSession(workspacePath, WORKSPACE_NAME, BASE_BRANCH);
+    const root = afterPush.threads
+      .flatMap((thread) => thread.comments)
+      .find((comment) => comment.id === 'file-root') as ReviewComment;
+    expect(root.syncedToGitHubAt).toBeDefined();
+  });
+
+  it('posts hunk-target threads as top-level comments with parsed anchor', async () => {
+    const now = '2026-02-19T13:40:00Z';
+    const session = readReviewSession(workspacePath, WORKSPACE_NAME, BASE_BRANCH);
+    session.threads.push({
+      id: 'hunk-thread',
+      target: {
+        kind: 'hunk',
+        file: 'src/hunk-note.ts',
+        hunkHeader: '@@ -5,2 +8,3 @@ function block',
+      },
+      decision: 'rejected',
+      resolved: false,
+      comments: [
+        {
+          id: 'hunk-root',
+          threadId: 'hunk-thread',
+          body: 'Hunk-level note',
+          author: 'local',
+          createdAt: now,
+        },
+      ],
+      createdAt: now,
+      updatedAt: now,
+    });
+    writeReviewSession(workspacePath, WORKSPACE_NAME, session);
+
+    await pushGitHubReview(workspacePath, WORKSPACE_NAME, BASE_BRANCH, PR_NUMBER);
+
+    const payloads = readPayloadLog(payloadLog);
+    const topCommentPayload = payloads.find((entry) => entry.kind === 'top_comment');
+
+    expect(topCommentPayload).toBeDefined();
+    expect(topCommentPayload?.payload.path).toBe('src/hunk-note.ts');
+    expect(topCommentPayload?.payload.line).toBe(8);
+    expect(topCommentPayload?.payload.side).toBe('RIGHT');
+    expect(topCommentPayload?.payload.subject_type).toBeUndefined();
+    expect(topCommentPayload?.payload.body).toContain('❌ **Rejected**');
   });
 
   it('persists posted replies if review submission later fails', async () => {

--- a/src/core/__tests__/github-review.test.ts
+++ b/src/core/__tests__/github-review.test.ts
@@ -310,6 +310,33 @@ describe('github-review sync behavior', () => {
     expect(result.threads).toHaveLength(2);
   });
 
+  it('imports outdated comments without line metadata as file-level targets', async () => {
+    setImportComments(importFile, [
+      {
+        id: 450,
+        body: 'Outdated comment',
+        path: 'src/outdated.ts',
+        line: null,
+        original_line: null,
+        side: 'RIGHT',
+        start_line: null,
+        original_start_line: null,
+        diff_hunk: '@@ -20,5 +20,0 @@ removed block',
+        user: { login: 'octocat' },
+        created_at: '2026-02-19T15:10:00Z',
+        pull_request_review_id: 31,
+      },
+    ]);
+
+    const result = await importGitHubReview(workspacePath, WORKSPACE_NAME, BASE_BRANCH, PR_NUMBER);
+    expect(result.imported).toBe(1);
+    expect(result.threads).toHaveLength(1);
+    expect(result.threads[0]?.target).toEqual({
+      kind: 'file',
+      file: 'src/outdated.ts',
+    });
+  });
+
   it('pushes only unsynced local comments and avoids replay on repeat push', async () => {
     setImportComments(importFile, [
       {

--- a/src/core/__tests__/github-review.test.ts
+++ b/src/core/__tests__/github-review.test.ts
@@ -567,6 +567,7 @@ describe('github-review sync behavior', () => {
     expect(topCommentPayload?.payload.path).toBe('src/file-note.ts');
     expect(topCommentPayload?.payload.subject_type).toBe('file');
     expect(topCommentPayload?.payload.commit_id).toBe('1111111111111111111111111111111111111111');
+    expect(topCommentPayload?.payload.body).toContain('File-level note');
     expect(reviewPayload).toBeUndefined();
 
     const afterPush = readReviewSession(workspacePath, WORKSPACE_NAME, BASE_BRANCH);
@@ -606,6 +607,7 @@ describe('github-review sync behavior', () => {
 
     const payloads = readPayloadLog(payloadLog);
     const topCommentPayload = payloads.find((entry) => entry.kind === 'top_comment');
+    const reviewPayload = payloads.find((entry) => entry.kind === 'review');
 
     expect(topCommentPayload).toBeDefined();
     expect(topCommentPayload?.payload.path).toBe('src/hunk-note.ts');
@@ -613,6 +615,10 @@ describe('github-review sync behavior', () => {
     expect(topCommentPayload?.payload.side).toBe('RIGHT');
     expect(topCommentPayload?.payload.subject_type).toBeUndefined();
     expect(topCommentPayload?.payload.body).toContain('❌ **Rejected**');
+    expect(reviewPayload).toBeDefined();
+    expect(reviewPayload?.payload.event).toBe('REQUEST_CHANGES');
+    expect(Array.isArray(reviewPayload?.payload.comments)).toBe(true);
+    expect(reviewPayload?.payload.comments).toHaveLength(0);
   });
 
   it('persists posted replies if review submission later fails', async () => {

--- a/src/core/__tests__/github-review.test.ts
+++ b/src/core/__tests__/github-review.test.ts
@@ -59,7 +59,7 @@ import { appendFileSync, existsSync, readFileSync, writeFileSync } from 'fs';
 const args = process.argv.slice(2);
 const callLog = process.env.GH_STUB_CALL_LOG;
 if (callLog) {
-  appendFileSync(callLog, JSON.stringify({ args }) + '\n', 'utf-8');
+  appendFileSync(callLog, JSON.stringify({ args, cwd: process.cwd() }) + '\n', 'utf-8');
 }
 
 function readFlag(name) {
@@ -157,6 +157,16 @@ function readPayloadLog(payloadLog: string): Array<{ kind: string; endpoint: str
   const raw = readFileSync(payloadLog, 'utf-8').trim();
   if (!raw) return [];
   return raw.split('\n').filter(Boolean).map((line) => JSON.parse(line));
+}
+
+function readCallLog(callLog: string): Array<{ args: string[]; cwd?: string }> {
+  if (!existsSync(callLog)) return [];
+  const raw = readFileSync(callLog, 'utf-8').trim();
+  if (!raw) return [];
+  return raw
+    .split('\n')
+    .filter(Boolean)
+    .map((line) => JSON.parse(line) as { args: string[]; cwd?: string });
 }
 
 describe('github-review sync behavior', () => {
@@ -308,6 +318,23 @@ describe('github-review sync behavior', () => {
     const result = await importGitHubReview(workspacePath, WORKSPACE_NAME, BASE_BRANCH, PR_NUMBER);
     expect(result.imported).toBe(2);
     expect(result.threads).toHaveLength(2);
+  });
+
+  it('fetches PR comments with workspace cwd context', async () => {
+    setImportComments(importFile, []);
+
+    await importGitHubReview(workspacePath, WORKSPACE_NAME, BASE_BRANCH, PR_NUMBER);
+
+    const calls = readCallLog(callLog);
+    const commentsApiCall = calls.find(
+      (entry) =>
+        entry.args[0] === 'api' &&
+        entry.args[1] === `repos/${OWNER}/${REPO}/pulls/${PR_NUMBER}/comments` &&
+        !entry.args.includes('--method')
+    );
+
+    expect(commentsApiCall).toBeDefined();
+    expect(commentsApiCall?.cwd?.endsWith(workspacePath)).toBe(true);
   });
 
   it('imports outdated comments without line metadata as file-level targets', async () => {

--- a/src/core/__tests__/github-review.test.ts
+++ b/src/core/__tests__/github-review.test.ts
@@ -19,6 +19,7 @@ type EnvSnapshot = {
   GH_STUB_PAYLOAD_LOG?: string;
   GH_STUB_REPLY_COUNTER_FILE?: string;
   GH_STUB_REVIEW_COUNTER_FILE?: string;
+  GH_STUB_REVIEW_COMMENTS_FILE?: string;
   GH_STUB_FAIL_REVIEW?: string;
 };
 
@@ -30,6 +31,7 @@ function captureEnv(): EnvSnapshot {
     GH_STUB_PAYLOAD_LOG: process.env.GH_STUB_PAYLOAD_LOG,
     GH_STUB_REPLY_COUNTER_FILE: process.env.GH_STUB_REPLY_COUNTER_FILE,
     GH_STUB_REVIEW_COUNTER_FILE: process.env.GH_STUB_REVIEW_COUNTER_FILE,
+    GH_STUB_REVIEW_COMMENTS_FILE: process.env.GH_STUB_REVIEW_COMMENTS_FILE,
     GH_STUB_FAIL_REVIEW: process.env.GH_STUB_FAIL_REVIEW,
   };
 }
@@ -52,6 +54,9 @@ function restoreEnv(env: EnvSnapshot): void {
 
   if (env.GH_STUB_REVIEW_COUNTER_FILE === undefined) delete process.env.GH_STUB_REVIEW_COUNTER_FILE;
   else process.env.GH_STUB_REVIEW_COUNTER_FILE = env.GH_STUB_REVIEW_COUNTER_FILE;
+
+  if (env.GH_STUB_REVIEW_COMMENTS_FILE === undefined) delete process.env.GH_STUB_REVIEW_COMMENTS_FILE;
+  else process.env.GH_STUB_REVIEW_COMMENTS_FILE = env.GH_STUB_REVIEW_COMMENTS_FILE;
 
   if (env.GH_STUB_FAIL_REVIEW === undefined) delete process.env.GH_STUB_FAIL_REVIEW;
   else process.env.GH_STUB_FAIL_REVIEW = env.GH_STUB_FAIL_REVIEW;
@@ -124,6 +129,20 @@ if (method === 'GET' && endpoint === 'repos/${OWNER}/${REPO}/pulls/${PR_NUMBER}/
   process.exit(0);
 }
 
+const reviewCommentsMatch = endpoint.match(/^repos\/${OWNER}\/${REPO}\/pulls\/${PR_NUMBER}\/reviews\/(\d+)\/comments$/);
+if (method === 'GET' && reviewCommentsMatch) {
+  const reviewId = reviewCommentsMatch[1];
+  const reviewCommentsFile = process.env.GH_STUB_REVIEW_COMMENTS_FILE;
+  if (reviewCommentsFile && existsSync(reviewCommentsFile)) {
+    const stored = JSON.parse(readFileSync(reviewCommentsFile, 'utf-8'));
+    const comments = Array.isArray(stored?.[reviewId]) ? stored[reviewId] : [];
+    process.stdout.write(JSON.stringify([comments]));
+  } else {
+    process.stdout.write('[]');
+  }
+  process.exit(0);
+}
+
 if (method === 'POST' && endpoint === 'repos/${OWNER}/${REPO}/pulls/${PR_NUMBER}/comments') {
   const payload = readInputPayload() ?? {};
   if (payloadLog) {
@@ -147,6 +166,34 @@ if (method === 'POST' && endpoint === 'repos/${OWNER}/${REPO}/pulls/${PR_NUMBER}
   }
   const counterFile = process.env.GH_STUB_REVIEW_COUNTER_FILE;
   const id = counterFile ? nextCounter(counterFile, 9000) : 9001;
+
+  const reviewCommentsFile = process.env.GH_STUB_REVIEW_COMMENTS_FILE;
+  if (reviewCommentsFile) {
+    let stored = {};
+    if (existsSync(reviewCommentsFile)) {
+      stored = JSON.parse(readFileSync(reviewCommentsFile, 'utf-8'));
+    }
+    const comments = Array.isArray(payload.comments) ? payload.comments : [];
+    const mapped = comments.map((comment, index) => ({
+      id: 8001 + index,
+      body: comment.body ?? '',
+      path: comment.path,
+      line: comment.line ?? null,
+      original_line: comment.line ?? null,
+      side: comment.side ?? 'RIGHT',
+      start_line: comment.start_line ?? null,
+      original_start_line: comment.start_line ?? null,
+      start_side: comment.start_side ?? null,
+      diff_hunk: '',
+      user: { login: 'reviewer' },
+      created_at: '2026-02-19T00:00:00Z',
+      in_reply_to_id: null,
+      pull_request_review_id: id,
+    }));
+    stored[String(id)] = mapped;
+    writeFileSync(reviewCommentsFile, JSON.stringify(stored), 'utf-8');
+  }
+
   process.stdout.write(JSON.stringify({ id, html_url: 'https://example.invalid/review/' + id }));
   process.exit(0);
 }
@@ -193,6 +240,7 @@ describe('github-review sync behavior', () => {
   let payloadLog: string;
   let replyCounter: string;
   let reviewCounter: string;
+  let reviewCommentsFile: string;
 
   beforeEach(() => {
     envSnapshot = captureEnv();
@@ -208,6 +256,7 @@ describe('github-review sync behavior', () => {
     payloadLog = join(tempRoot, 'gh-payloads.log');
     replyCounter = join(tempRoot, 'reply-counter.txt');
     reviewCounter = join(tempRoot, 'review-counter.txt');
+    reviewCommentsFile = join(tempRoot, 'gh-review-comments.json');
 
     setImportComments(importFile, []);
     writeFileSync(callLog, '', 'utf-8');
@@ -222,6 +271,7 @@ describe('github-review sync behavior', () => {
     process.env.GH_STUB_PAYLOAD_LOG = payloadLog;
     process.env.GH_STUB_REPLY_COUNTER_FILE = replyCounter;
     process.env.GH_STUB_REVIEW_COUNTER_FILE = reviewCounter;
+    process.env.GH_STUB_REVIEW_COMMENTS_FILE = reviewCommentsFile;
   });
 
   afterEach(() => {
@@ -464,7 +514,7 @@ describe('github-review sync behavior', () => {
     const pushedLocalLineRoot = afterFirstPush.threads
       .flatMap((thread) => thread.comments)
       .find((comment) => comment.id === 'local-line-root') as ReviewComment;
-    expect(pushedLocalLineRoot.githubId).toBeUndefined();
+    expect(pushedLocalLineRoot.githubId).toBeDefined();
     expect(pushedLocalLineRoot.syncedToGitHubAt).toBeDefined();
 
     writeFileSync(payloadLog, '', 'utf-8');
@@ -509,7 +559,7 @@ describe('github-review sync behavior', () => {
       .flatMap((thread) => thread.comments)
       .find((comment) => comment.id === 'editable-local-root') as ReviewComment;
     expect(firstComment.syncedToGitHubAt).toBeDefined();
-    expect(firstComment.githubId).toBeUndefined();
+    expect(firstComment.githubId).toBeDefined();
 
     updateComment(
       workspacePath,
@@ -574,7 +624,28 @@ describe('github-review sync behavior', () => {
     const root = afterPush.threads
       .flatMap((thread) => thread.comments)
       .find((comment) => comment.id === 'file-root') as ReviewComment;
+    expect(root.githubId).toBeDefined();
     expect(root.syncedToGitHubAt).toBeDefined();
+
+    setImportComments(importFile, [
+      {
+        id: root.githubId,
+        body: 'File-level note',
+        path: 'src/file-note.ts',
+        line: null,
+        original_line: null,
+        side: 'RIGHT',
+        start_line: null,
+        original_start_line: null,
+        diff_hunk: '',
+        user: { login: 'octocat' },
+        created_at: '2026-02-19T13:31:00Z',
+        pull_request_review_id: 55,
+      },
+    ]);
+
+    const importedAgain = await importGitHubReview(workspacePath, WORKSPACE_NAME, BASE_BRANCH, PR_NUMBER);
+    expect(importedAgain.imported).toBe(0);
   });
 
   it('posts hunk-target threads as top-level comments with parsed anchor', async () => {
@@ -619,6 +690,13 @@ describe('github-review sync behavior', () => {
     expect(reviewPayload?.payload.event).toBe('REQUEST_CHANGES');
     expect(Array.isArray(reviewPayload?.payload.comments)).toBe(true);
     expect(reviewPayload?.payload.comments).toHaveLength(0);
+
+    const afterPush = readReviewSession(workspacePath, WORKSPACE_NAME, BASE_BRANCH);
+    const root = afterPush.threads
+      .flatMap((thread) => thread.comments)
+      .find((comment) => comment.id === 'hunk-root') as ReviewComment;
+    expect(root.githubId).toBeDefined();
+    expect(root.syncedToGitHubAt).toBeDefined();
   });
 
   it('persists posted replies if review submission later fails', async () => {

--- a/src/core/__tests__/github-review.test.ts
+++ b/src/core/__tests__/github-review.test.ts
@@ -3,7 +3,7 @@ import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, wr
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { importGitHubReview, pushGitHubReview } from '../github-review.js';
-import { readReviewSession, writeReviewSession } from '../review.js';
+import { readReviewSession, updateComment, writeReviewSession } from '../review.js';
 import type { ReviewComment, ReviewThread } from '../../types/review.js';
 
 const OWNER = 'acme';
@@ -402,6 +402,64 @@ describe('github-review sync behavior', () => {
     const secondPush = await pushGitHubReview(workspacePath, WORKSPACE_NAME, BASE_BRANCH, PR_NUMBER);
     expect(secondPush.url).toContain(`/pull/${PR_NUMBER}`);
 
+    const payloadsAfterSecondPush = readPayloadLog(payloadLog);
+    expect(payloadsAfterSecondPush).toHaveLength(0);
+  });
+
+  it('does not re-queue synced local comments after edit', async () => {
+    const now = '2026-02-19T13:00:00Z';
+    const session = readReviewSession(workspacePath, WORKSPACE_NAME, BASE_BRANCH);
+    session.threads.push({
+      id: 'editable-line-thread',
+      target: {
+        kind: 'line',
+        file: 'src/editable.ts',
+        startLine: 21,
+        endLine: 21,
+        side: 'RIGHT',
+      },
+      resolved: false,
+      comments: [
+        {
+          id: 'editable-local-root',
+          threadId: 'editable-line-thread',
+          body: 'Original local note',
+          author: 'local',
+          createdAt: now,
+        },
+      ],
+      createdAt: now,
+      updatedAt: now,
+    });
+    writeReviewSession(workspacePath, WORKSPACE_NAME, session);
+
+    await pushGitHubReview(workspacePath, WORKSPACE_NAME, BASE_BRANCH, PR_NUMBER);
+
+    const afterFirstPush = readReviewSession(workspacePath, WORKSPACE_NAME, BASE_BRANCH);
+    const firstComment = afterFirstPush.threads
+      .flatMap((thread) => thread.comments)
+      .find((comment) => comment.id === 'editable-local-root') as ReviewComment;
+    expect(firstComment.syncedToGitHubAt).toBeDefined();
+    expect(firstComment.githubId).toBeUndefined();
+
+    updateComment(
+      workspacePath,
+      WORKSPACE_NAME,
+      BASE_BRANCH,
+      'editable-line-thread',
+      'editable-local-root',
+      'Edited local note'
+    );
+
+    const afterEdit = readReviewSession(workspacePath, WORKSPACE_NAME, BASE_BRANCH);
+    const editedComment = afterEdit.threads
+      .flatMap((thread) => thread.comments)
+      .find((comment) => comment.id === 'editable-local-root') as ReviewComment;
+    expect(editedComment.body).toBe('Edited local note');
+    expect(editedComment.syncedToGitHubAt).toBeDefined();
+
+    writeFileSync(payloadLog, '', 'utf-8');
+    await pushGitHubReview(workspacePath, WORKSPACE_NAME, BASE_BRANCH, PR_NUMBER);
     const payloadsAfterSecondPush = readPayloadLog(payloadLog);
     expect(payloadsAfterSecondPush).toHaveLength(0);
   });

--- a/src/core/__tests__/github-review.test.ts
+++ b/src/core/__tests__/github-review.test.ts
@@ -611,7 +611,7 @@ describe('github-review sync behavior', () => {
 
     expect(topCommentPayload).toBeDefined();
     expect(topCommentPayload?.payload.path).toBe('src/hunk-note.ts');
-    expect(topCommentPayload?.payload.line).toBe(8);
+    expect(topCommentPayload?.payload.line).toBe(10);
     expect(topCommentPayload?.payload.side).toBe('RIGHT');
     expect(topCommentPayload?.payload.subject_type).toBeUndefined();
     expect(topCommentPayload?.payload.body).toContain('❌ **Rejected**');

--- a/src/core/__tests__/github-review.test.ts
+++ b/src/core/__tests__/github-review.test.ts
@@ -19,6 +19,7 @@ type EnvSnapshot = {
   GH_STUB_PAYLOAD_LOG?: string;
   GH_STUB_REPLY_COUNTER_FILE?: string;
   GH_STUB_REVIEW_COUNTER_FILE?: string;
+  GH_STUB_FAIL_REVIEW?: string;
 };
 
 function captureEnv(): EnvSnapshot {
@@ -29,6 +30,7 @@ function captureEnv(): EnvSnapshot {
     GH_STUB_PAYLOAD_LOG: process.env.GH_STUB_PAYLOAD_LOG,
     GH_STUB_REPLY_COUNTER_FILE: process.env.GH_STUB_REPLY_COUNTER_FILE,
     GH_STUB_REVIEW_COUNTER_FILE: process.env.GH_STUB_REVIEW_COUNTER_FILE,
+    GH_STUB_FAIL_REVIEW: process.env.GH_STUB_FAIL_REVIEW,
   };
 }
 
@@ -50,6 +52,9 @@ function restoreEnv(env: EnvSnapshot): void {
 
   if (env.GH_STUB_REVIEW_COUNTER_FILE === undefined) delete process.env.GH_STUB_REVIEW_COUNTER_FILE;
   else process.env.GH_STUB_REVIEW_COUNTER_FILE = env.GH_STUB_REVIEW_COUNTER_FILE;
+
+  if (env.GH_STUB_FAIL_REVIEW === undefined) delete process.env.GH_STUB_FAIL_REVIEW;
+  else process.env.GH_STUB_FAIL_REVIEW = env.GH_STUB_FAIL_REVIEW;
 }
 
 function writeGhStub(binPath: string): void {
@@ -126,6 +131,10 @@ if (method === 'POST' && endpoint === 'repos/${OWNER}/${REPO}/pulls/${PR_NUMBER}
 }
 
 if (method === 'POST' && endpoint === 'repos/${OWNER}/${REPO}/pulls/${PR_NUMBER}/reviews') {
+  if (process.env.GH_STUB_FAIL_REVIEW === '1') {
+    process.stderr.write('Simulated review submission failure\n');
+    process.exit(1);
+  }
   const payload = readInputPayload() ?? {};
   if (payloadLog) {
     appendFileSync(payloadLog, JSON.stringify({ kind: 'review', endpoint, payload }) + '\n', 'utf-8');
@@ -516,5 +525,85 @@ describe('github-review sync behavior', () => {
     await pushGitHubReview(workspacePath, WORKSPACE_NAME, BASE_BRANCH, PR_NUMBER);
     const payloadsAfterSecondPush = readPayloadLog(payloadLog);
     expect(payloadsAfterSecondPush).toHaveLength(0);
+  });
+
+  it('persists posted replies if review submission later fails', async () => {
+    setImportComments(importFile, [
+      {
+        id: 301,
+        body: 'Imported root comment',
+        path: 'src/main.ts',
+        line: 8,
+        original_line: 8,
+        side: 'RIGHT',
+        start_line: 8,
+        original_start_line: 8,
+        diff_hunk: '@@ -6,2 +6,3 @@ context',
+        user: { login: 'octocat' },
+        created_at: '2026-02-19T12:00:00Z',
+        pull_request_review_id: 20,
+      },
+    ]);
+
+    await importGitHubReview(workspacePath, WORKSPACE_NAME, BASE_BRANCH, PR_NUMBER);
+
+    const session = readReviewSession(workspacePath, WORKSPACE_NAME, BASE_BRANCH);
+    const importedThread = session.threads[0] as ReviewThread;
+    importedThread.comments.push({
+      id: 'local-reply-failure',
+      threadId: importedThread.id,
+      body: 'Persist this reply even if review submit fails',
+      author: 'local',
+      createdAt: '2026-02-19T12:30:00Z',
+    });
+
+    session.threads.push({
+      id: 'local-line-thread-failure',
+      target: {
+        kind: 'line',
+        file: 'src/failure.ts',
+        startLine: 10,
+        endLine: 10,
+        side: 'RIGHT',
+      },
+      resolved: false,
+      comments: [
+        {
+          id: 'local-line-root-failure',
+          threadId: 'local-line-thread-failure',
+          body: 'Force review submission path',
+          author: 'local',
+          createdAt: '2026-02-19T12:31:00Z',
+        },
+      ],
+      createdAt: '2026-02-19T12:31:00Z',
+      updatedAt: '2026-02-19T12:31:00Z',
+    });
+
+    writeReviewSession(workspacePath, WORKSPACE_NAME, session);
+
+    process.env.GH_STUB_FAIL_REVIEW = '1';
+    let failed = false;
+    try {
+      await pushGitHubReview(workspacePath, WORKSPACE_NAME, BASE_BRANCH, PR_NUMBER);
+    } catch {
+      failed = true;
+    }
+    expect(failed).toBe(true);
+
+    const persistedSession = readReviewSession(workspacePath, WORKSPACE_NAME, BASE_BRANCH);
+    const persistedReply = persistedSession.threads
+      .flatMap((thread) => thread.comments)
+      .find((comment) => comment.id === 'local-reply-failure') as ReviewComment;
+    expect(persistedReply.githubId).toBeDefined();
+    expect(persistedReply.syncedToGitHubAt).toBeDefined();
+
+    delete process.env.GH_STUB_FAIL_REVIEW;
+    writeFileSync(payloadLog, '', 'utf-8');
+
+    await pushGitHubReview(workspacePath, WORKSPACE_NAME, BASE_BRANCH, PR_NUMBER);
+    const payloads = readPayloadLog(payloadLog);
+    const replyPayloads = payloads.filter((entry) => entry.kind === 'reply');
+    expect(replyPayloads).toHaveLength(0);
   });
 });

--- a/src/core/git.ts
+++ b/src/core/git.ts
@@ -14,11 +14,36 @@ import type { ReviewChangedFile } from '../types/review.js';
 const execAsync = promisify(exec);
 
 const BASE_REF_CACHE_TTL_MS = 60_000;
+const BASE_REF_CACHE_MAX_ENTRIES = 256;
 const comparableBaseRefCache = new Map<string, { baseRef: string; cachedAt: number }>();
 const comparableBaseRefInflight = new Map<string, Promise<string>>();
 
 function comparableBaseRefKey(workspacePath: string, baseBranch: string): string {
   return `${workspacePath}::${baseBranch}`;
+}
+
+function pruneComparableBaseRefCache(now: number): void {
+  for (const [key, value] of comparableBaseRefCache.entries()) {
+    if (now - value.cachedAt >= BASE_REF_CACHE_TTL_MS) {
+      comparableBaseRefCache.delete(key);
+    }
+  }
+
+  const overflow = comparableBaseRefCache.size - BASE_REF_CACHE_MAX_ENTRIES;
+  if (overflow <= 0) {
+    return;
+  }
+
+  const sortedByAge = [...comparableBaseRefCache.entries()].sort(
+    (a, b) => a[1].cachedAt - b[1].cachedAt
+  );
+  for (let index = 0; index < overflow; index++) {
+    const entry = sortedByAge[index];
+    if (!entry) {
+      break;
+    }
+    comparableBaseRefCache.delete(entry[0]);
+  }
 }
 
 /**
@@ -530,9 +555,12 @@ async function resolveComparableBaseRef(
   workspacePath: string,
   baseBranch: string
 ): Promise<string> {
+  const now = Date.now();
+  pruneComparableBaseRefCache(now);
+
   const cacheKey = comparableBaseRefKey(workspacePath, baseBranch);
   const cached = comparableBaseRefCache.get(cacheKey);
-  if (cached && Date.now() - cached.cachedAt < BASE_REF_CACHE_TTL_MS) {
+  if (cached && now - cached.cachedAt < BASE_REF_CACHE_TTL_MS) {
     return cached.baseRef;
   }
 
@@ -564,6 +592,7 @@ async function resolveComparableBaseRef(
           baseRef: candidate,
           cachedAt: Date.now(),
         });
+        pruneComparableBaseRefCache(Date.now());
         return candidate;
       } catch {
         // Try next candidate

--- a/src/core/git.ts
+++ b/src/core/git.ts
@@ -677,7 +677,7 @@ function parseChangedFilesFromNameStatusZ(stdout: string): ReviewChangedFile[] {
     }
 
     const statusCode = statusToken[0];
-    if (statusCode === 'R') {
+    if (statusCode === 'R' || statusCode === 'C') {
       const prev = tokens[index++];
       const next = tokens[index++];
       if (!prev || !next) {
@@ -686,7 +686,7 @@ function parseChangedFilesFromNameStatusZ(stdout: string): ReviewChangedFile[] {
       files.push({
         filePath: next,
         prevFilePath: prev,
-        changeType: 'renamed',
+        changeType: statusCode === 'R' ? 'renamed' : 'copied',
       });
       continue;
     }

--- a/src/core/git.ts
+++ b/src/core/git.ts
@@ -13,6 +13,14 @@ import type { ReviewChangedFile } from '../types/review.js';
 
 const execAsync = promisify(exec);
 
+const BASE_REF_CACHE_TTL_MS = 60_000;
+const comparableBaseRefCache = new Map<string, { baseRef: string; cachedAt: number }>();
+const comparableBaseRefInflight = new Map<string, Promise<string>>();
+
+function comparableBaseRefKey(workspacePath: string, baseBranch: string): string {
+  return `${workspacePath}::${baseBranch}`;
+}
+
 /**
  * Get the default branch of a repository
  */
@@ -522,32 +530,57 @@ async function resolveComparableBaseRef(
   workspacePath: string,
   baseBranch: string
 ): Promise<string> {
-  // Best effort fetch. Keep short timeout to avoid hanging review requests.
-  try {
-    await execAsync(`git fetch origin ${escapeShellArg(baseBranch)} --quiet`, {
-      cwd: workspacePath,
-      timeout: 8000,
-    });
-  } catch {
-    logger.debug(`Could not fetch origin/${baseBranch}, using local refs`);
+  const cacheKey = comparableBaseRefKey(workspacePath, baseBranch);
+  const cached = comparableBaseRefCache.get(cacheKey);
+  if (cached && Date.now() - cached.cachedAt < BASE_REF_CACHE_TTL_MS) {
+    return cached.baseRef;
   }
 
-  const candidates = [`origin/${baseBranch}`, baseBranch];
-  for (const candidate of candidates) {
+  const inFlight = comparableBaseRefInflight.get(cacheKey);
+  if (inFlight) {
+    return inFlight;
+  }
+
+  const resolvePromise = (async () => {
+    // Best effort fetch. Keep short timeout to avoid hanging review requests.
     try {
-      await execAsync(`git rev-parse --verify ${escapeShellArg(candidate)}`, {
+      await execAsync(`git fetch origin ${escapeShellArg(baseBranch)} --quiet`, {
         cwd: workspacePath,
-        timeout: 5000,
+        timeout: 8000,
       });
-      return candidate;
     } catch {
-      // Try next candidate
+      logger.debug(`Could not fetch origin/${baseBranch}, using local refs`);
     }
-  }
 
-  throw new Error(
-    `Cannot resolve base ref for "${baseBranch}". Fetch the branch or update project base branch config.`
-  );
+    const candidates = [`origin/${baseBranch}`, baseBranch];
+    for (const candidate of candidates) {
+      try {
+        await execAsync(`git rev-parse --verify ${escapeShellArg(candidate)}`, {
+          cwd: workspacePath,
+          timeout: 5000,
+        });
+
+        comparableBaseRefCache.set(cacheKey, {
+          baseRef: candidate,
+          cachedAt: Date.now(),
+        });
+        return candidate;
+      } catch {
+        // Try next candidate
+      }
+    }
+
+    throw new Error(
+      `Cannot resolve base ref for "${baseBranch}". Fetch the branch or update project base branch config.`
+    );
+  })();
+
+  comparableBaseRefInflight.set(cacheKey, resolvePromise);
+  try {
+    return await resolvePromise;
+  } finally {
+    comparableBaseRefInflight.delete(cacheKey);
+  }
 }
 
 async function resolveMergeBaseCommit(

--- a/src/core/git.ts
+++ b/src/core/git.ts
@@ -9,6 +9,7 @@ import { SpacesError } from '../types/errors.js';
 import { logger } from '../utils/logger.js';
 import { escapeShellArg } from '../utils/shell-escape.js';
 import type { WorktreeInfo } from '../types/workspace.js';
+import type { ReviewChangedFile } from '../types/review.js';
 
 const execAsync = promisify(exec);
 
@@ -329,18 +330,9 @@ export async function getWorkspaceDiff(
     });
     const headBranch = headOutput.trim();
 
-    // Fetch to ensure we have the latest base branch ref
-    try {
-      await execAsync(`git fetch origin ${escapeShellArg(baseBranch)} --quiet`, {
-        cwd: workspacePath,
-      });
-    } catch {
-      // Non-fatal — work with local refs
-      logger.debug(`Could not fetch origin/${baseBranch}, using local ref`);
-    }
+    const mergeBase = await resolveComparableBaseRef(workspacePath, baseBranch);
 
-    // Three-dot diff: changes on HEAD that aren't on origin/baseBranch
-    const mergeBase = `origin/${baseBranch}`;
+    // Three-dot diff: changes on HEAD that are not in the selected base ref
     const { stdout: diffOutput } = await execAsync(
       `git diff ${escapeShellArg(mergeBase)}...HEAD`,
       { cwd: workspacePath, maxBuffer: 50 * 1024 * 1024 } // 50MB max
@@ -358,6 +350,330 @@ export async function getWorkspaceDiff(
       2
     );
   }
+}
+
+/**
+ * List changed files in a workspace branch vs base branch.
+ */
+export async function getWorkspaceChangedFiles(
+  workspacePath: string,
+  baseBranch: string
+): Promise<{ files: ReviewChangedFile[]; baseBranch: string; headBranch: string }> {
+  try {
+    const { stdout: headOutput } = await execAsync('git rev-parse --abbrev-ref HEAD', {
+      cwd: workspacePath,
+    });
+    const headBranch = headOutput.trim();
+
+    const baseRef = await resolveComparableBaseRef(workspacePath, baseBranch);
+    const { stdout } = await execAsync(
+      `git diff --name-status -z --find-renames -M ${escapeShellArg(baseRef)}...HEAD`,
+      { cwd: workspacePath, maxBuffer: 10 * 1024 * 1024 }
+    );
+
+    return {
+      files: parseChangedFilesFromNameStatusZ(stdout),
+      baseBranch,
+      headBranch,
+    };
+  } catch (error) {
+    throw new SpacesError(
+      `Failed to list changed files: ${error instanceof Error ? error.message : 'Unknown error'}`,
+      'SYSTEM_ERROR',
+      2
+    );
+  }
+}
+
+/**
+ * Get diff for a single file path in workspace vs base branch.
+ */
+export async function getWorkspaceFileDiff(
+  workspacePath: string,
+  baseBranch: string,
+  filePath: string,
+  prevFilePath?: string
+): Promise<{ diff: string; baseBranch: string; headBranch: string }> {
+  try {
+    const { stdout: headOutput } = await execAsync('git rev-parse --abbrev-ref HEAD', {
+      cwd: workspacePath,
+    });
+    const headBranch = headOutput.trim();
+
+    const baseRef = await resolveComparableBaseRef(workspacePath, baseBranch);
+    const pathSpec = prevFilePath
+      ? `${escapeShellArg(prevFilePath)} ${escapeShellArg(filePath)}`
+      : escapeShellArg(filePath);
+
+    const { stdout } = await execAsync(
+      `git diff --patch --no-color --find-renames -M ${escapeShellArg(baseRef)}...HEAD -- ${pathSpec}`,
+      { cwd: workspacePath, maxBuffer: 20 * 1024 * 1024 }
+    );
+
+    return {
+      diff: stdout,
+      baseBranch,
+      headBranch,
+    };
+  } catch (error) {
+    throw new SpacesError(
+      `Failed to get file diff: ${error instanceof Error ? error.message : 'Unknown error'}`,
+      'SYSTEM_ERROR',
+      2
+    );
+  }
+}
+
+/**
+ * Read a file's old/new versions for the workspace diff base.
+ *
+ * Uses merge-base(<base-ref>, HEAD) for the old side so content aligns with
+ * three-dot diff semantics. For renames, pass prevFilePath for the old side.
+ */
+export async function getWorkspaceFileVersions(
+  workspacePath: string,
+  baseBranch: string,
+  filePath: string,
+  prevFilePath?: string
+): Promise<{ oldContents: string | null; newContents: string | null }> {
+  try {
+    const baseRef = await resolveComparableBaseRef(workspacePath, baseBranch);
+    const mergeBaseCommit = await resolveMergeBaseCommit(workspacePath, baseRef);
+
+    const oldPath = prevFilePath ?? filePath;
+    const [oldContents, newContents] = await Promise.all([
+      readFileAtRevision(workspacePath, mergeBaseCommit, oldPath),
+      readFileAtRevision(workspacePath, 'HEAD', filePath),
+    ]);
+
+    return { oldContents, newContents };
+  } catch (error) {
+    throw new SpacesError(
+      `Failed to read workspace file versions: ${error instanceof Error ? error.message : 'Unknown error'}`,
+      'SYSTEM_ERROR',
+      2
+    );
+  }
+}
+
+/**
+ * Read a file context range (or the full file when range omitted) on both
+ * old/base and new/head sides for on-demand diff expansion.
+ */
+export async function getWorkspaceFileContextRange(
+  workspacePath: string,
+  baseBranch: string,
+  filePath: string,
+  prevFilePath?: string,
+  range?: {
+    oldStart?: number;
+    oldEnd?: number;
+    newStart?: number;
+    newEnd?: number;
+  }
+): Promise<{
+  oldStart: number;
+  oldLines: string[];
+  oldTotal: number;
+  newStart: number;
+  newLines: string[];
+  newTotal: number;
+}> {
+  try {
+    const baseRef = await resolveComparableBaseRef(workspacePath, baseBranch);
+    const mergeBaseCommit = await resolveMergeBaseCommit(workspacePath, baseRef);
+
+    const oldPath = prevFilePath ?? filePath;
+    const [oldContents, newContents] = await Promise.all([
+      readFileAtRevision(workspacePath, mergeBaseCommit, oldPath),
+      readFileAtRevision(workspacePath, 'HEAD', filePath),
+    ]);
+
+    const oldAllLines = splitFileIntoLines(oldContents ?? '');
+    const newAllLines = splitFileIntoLines(newContents ?? '');
+
+    const oldTotal = oldAllLines.length;
+    const newTotal = newAllLines.length;
+
+    const [oldStart, oldEnd] = normalizeRange(oldTotal, range?.oldStart, range?.oldEnd);
+    const [newStart, newEnd] = normalizeRange(newTotal, range?.newStart, range?.newEnd);
+
+    const oldLines = oldTotal === 0 ? [] : oldAllLines.slice(oldStart - 1, oldEnd);
+    const newLines = newTotal === 0 ? [] : newAllLines.slice(newStart - 1, newEnd);
+
+    return {
+      oldStart,
+      oldLines,
+      oldTotal,
+      newStart,
+      newLines,
+      newTotal,
+    };
+  } catch (error) {
+    throw new SpacesError(
+      `Failed to read file context range: ${error instanceof Error ? error.message : 'Unknown error'}`,
+      'SYSTEM_ERROR',
+      2
+    );
+  }
+}
+
+async function resolveComparableBaseRef(
+  workspacePath: string,
+  baseBranch: string
+): Promise<string> {
+  // Best effort fetch. Keep short timeout to avoid hanging review requests.
+  try {
+    await execAsync(`git fetch origin ${escapeShellArg(baseBranch)} --quiet`, {
+      cwd: workspacePath,
+      timeout: 8000,
+    });
+  } catch {
+    logger.debug(`Could not fetch origin/${baseBranch}, using local refs`);
+  }
+
+  const candidates = [`origin/${baseBranch}`, baseBranch];
+  for (const candidate of candidates) {
+    try {
+      await execAsync(`git rev-parse --verify ${escapeShellArg(candidate)}`, {
+        cwd: workspacePath,
+        timeout: 5000,
+      });
+      return candidate;
+    } catch {
+      // Try next candidate
+    }
+  }
+
+  throw new Error(
+    `Cannot resolve base ref for "${baseBranch}". Fetch the branch or update project base branch config.`
+  );
+}
+
+async function resolveMergeBaseCommit(
+  workspacePath: string,
+  baseRef: string
+): Promise<string> {
+  const { stdout } = await execAsync(
+    `git merge-base ${escapeShellArg(baseRef)} HEAD`,
+    { cwd: workspacePath, timeout: 5000 }
+  );
+
+  const mergeBaseCommit = stdout.trim();
+  if (!mergeBaseCommit) {
+    throw new Error(`Could not determine merge base for ${baseRef} and HEAD`);
+  }
+
+  return mergeBaseCommit;
+}
+
+async function readFileAtRevision(
+  workspacePath: string,
+  revision: string,
+  filePath: string
+): Promise<string | null> {
+  const spec = `${revision}:${filePath}`;
+
+  try {
+    const { stdout } = await execAsync(`git show ${escapeShellArg(spec)}`, {
+      cwd: workspacePath,
+      maxBuffer: 20 * 1024 * 1024,
+    });
+    return stdout;
+  } catch (error) {
+    const err = error as { message?: string; stderr?: string };
+    const message = `${err.message ?? ''}\n${err.stderr ?? ''}`;
+
+    // Missing file at ref is expected for new/deleted/renamed files.
+    if (
+      /exists on disk, but not in/i.test(message) ||
+      /path .* does not exist in/i.test(message) ||
+      /path .* not in/i.test(message) ||
+      /invalid object name/i.test(message)
+    ) {
+      return null;
+    }
+
+    throw error;
+  }
+}
+
+function normalizeRange(total: number, start?: number, end?: number): [number, number] {
+  if (total <= 0) {
+    return [1, 0];
+  }
+
+  const normalizedStart =
+    typeof start === 'number' && Number.isFinite(start) ? clamp(Math.floor(start), 1, total) : 1;
+  const normalizedEnd =
+    typeof end === 'number' && Number.isFinite(end)
+      ? clamp(Math.floor(end), normalizedStart, total)
+      : total;
+
+  return [normalizedStart, normalizedEnd];
+}
+
+function clamp(value: number, min: number, max: number): number {
+  if (value < min) return min;
+  if (value > max) return max;
+  return value;
+}
+
+function splitFileIntoLines(contents: string): string[] {
+  if (contents.length === 0) {
+    return [];
+  }
+
+  const lines = contents.match(/[^\n]*\n|[^\n]+$/g);
+  return lines ?? [];
+}
+
+function parseChangedFilesFromNameStatusZ(stdout: string): ReviewChangedFile[] {
+  if (!stdout) {
+    return [];
+  }
+
+  const tokens = stdout.split('\0').filter((token) => token.length > 0);
+  const files: ReviewChangedFile[] = [];
+
+  let index = 0;
+  while (index < tokens.length) {
+    const statusToken = tokens[index++];
+    if (!statusToken) {
+      continue;
+    }
+
+    const statusCode = statusToken[0];
+    if (statusCode === 'R') {
+      const prev = tokens[index++];
+      const next = tokens[index++];
+      if (!prev || !next) {
+        continue;
+      }
+      files.push({
+        filePath: next,
+        prevFilePath: prev,
+        changeType: 'renamed',
+      });
+      continue;
+    }
+
+    const path = tokens[index++];
+    if (!path) {
+      continue;
+    }
+
+    const changeType: ReviewChangedFile['changeType'] =
+      statusCode === 'A'
+        ? 'new'
+        : statusCode === 'D'
+          ? 'deleted'
+          : 'modified';
+
+    files.push({ filePath: path, changeType });
+  }
+
+  return files;
 }
 
 /**

--- a/src/core/git.ts
+++ b/src/core/git.ts
@@ -309,6 +309,58 @@ export async function deleteLocalBranch(
 }
 
 /**
+ * Get the unified diff between a workspace branch and its base branch.
+ *
+ * Uses three-dot diff (`base...HEAD`) so we only see changes introduced by
+ * the workspace branch, not diverging changes on the base since the fork.
+ *
+ * @param workspacePath  Path to the git worktree
+ * @param baseBranch     The branch to diff against (e.g. 'main')
+ * @returns Unified diff string (empty string if no changes)
+ */
+export async function getWorkspaceDiff(
+  workspacePath: string,
+  baseBranch: string
+): Promise<{ diff: string; baseBranch: string; headBranch: string }> {
+  try {
+    // Get the current HEAD branch name
+    const { stdout: headOutput } = await execAsync('git rev-parse --abbrev-ref HEAD', {
+      cwd: workspacePath,
+    });
+    const headBranch = headOutput.trim();
+
+    // Fetch to ensure we have the latest base branch ref
+    try {
+      await execAsync(`git fetch origin ${escapeShellArg(baseBranch)} --quiet`, {
+        cwd: workspacePath,
+      });
+    } catch {
+      // Non-fatal — work with local refs
+      logger.debug(`Could not fetch origin/${baseBranch}, using local ref`);
+    }
+
+    // Three-dot diff: changes on HEAD that aren't on origin/baseBranch
+    const mergeBase = `origin/${baseBranch}`;
+    const { stdout: diffOutput } = await execAsync(
+      `git diff ${escapeShellArg(mergeBase)}...HEAD`,
+      { cwd: workspacePath, maxBuffer: 50 * 1024 * 1024 } // 50MB max
+    );
+
+    return {
+      diff: diffOutput,
+      baseBranch,
+      headBranch,
+    };
+  } catch (error) {
+    throw new SpacesError(
+      `Failed to get workspace diff: ${error instanceof Error ? error.message : 'Unknown error'}`,
+      'SYSTEM_ERROR',
+      2
+    );
+  }
+}
+
+/**
  * List all worktrees in a repository
  */
 export async function listWorktrees(repoPath: string): Promise<string[]> {

--- a/src/core/github-review.ts
+++ b/src/core/github-review.ts
@@ -221,6 +221,7 @@ export async function pushGitHubReview(
   const reviewCommentIdsByThreadId = new Map<string, string[]>();
   const workspaceNoteBodies: string[] = [];
   const workspaceNoteIdsByThreadId = new Map<string, string[]>();
+  let pushedPendingHunkTopLevel = false;
   let pullHeadSha: string | null = null;
 
   const resolvePullHeadSha = async (): Promise<string> => {
@@ -292,6 +293,9 @@ export async function pushGitHubReview(
         if (posted.html_url) {
           url = posted.html_url;
         }
+        if (thread.target.kind === 'hunk') {
+          pushedPendingHunkTopLevel = true;
+        }
         changed = true;
       }
       continue;
@@ -313,7 +317,12 @@ export async function pushGitHubReview(
     bodyParts.push('**General notes:**\n\n' + workspaceNotes);
   }
 
-  if (reviewComments.length > 0 || bodyParts.length > 0) {
+  const shouldSubmitFormalReview =
+    reviewComments.length > 0 ||
+    bodyParts.length > 0 ||
+    (event !== 'COMMENT' && pushedPendingHunkTopLevel);
+
+  if (shouldSubmitFormalReview) {
     const reviewBody = bodyParts.join('\n\n') || 'Review submitted via gssh.';
 
     const reviewData = await submitPullReview(

--- a/src/core/github-review.ts
+++ b/src/core/github-review.ts
@@ -205,6 +205,8 @@ export async function pushGitHubReview(
 
   const session = readReviewSession(workspacePath, workspaceName, baseBranch);
   const unresolved = session.threads.filter(t => !t.resolved);
+  const syncedAt = new Date().toISOString();
+  let changed = false;
 
   // Compute overall review action
   const hunkThreads = unresolved.filter(t => t.target.kind === 'hunk');
@@ -219,52 +221,95 @@ export async function pushGitHubReview(
       ? 'APPROVE'
       : 'COMMENT';
 
-  // Build review comments (only threads that can be mapped to a file+line)
-  const reviewComments = unresolved
-    .filter(t => t.target.kind !== 'workspace')
-    .map(t => buildGitHubComment(t))
-    .filter(Boolean);
+  const reviewComments: GitHubDraftReviewComment[] = [];
+  const reviewCommentIdsByThreadId = new Map<string, string[]>();
+  const workspaceNoteBodies: string[] = [];
+  const workspaceNoteIdsByThreadId = new Map<string, string[]>();
 
-  // Collect workspace-level threads as PR body additions
-  const workspaceNotes = unresolved
-    .filter(t => t.target.kind === 'workspace')
-    .map(t => t.comments[0]?.body ?? '')
-    .filter(Boolean)
-    .join('\n\n');
+  for (const thread of unresolved) {
+    const pendingLocalComments = thread.comments.filter(isPendingLocalComment);
+    if (pendingLocalComments.length === 0) {
+      continue;
+    }
+
+    const rootGithubCommentId = getRootGithubCommentId(thread);
+    if (rootGithubCommentId !== null) {
+      for (const comment of pendingLocalComments) {
+        const posted = await postPRReply(
+          owner,
+          repo,
+          prNumber,
+          rootGithubCommentId,
+          comment.body,
+          workspacePath
+        );
+        comment.githubId = posted.id;
+        comment.syncedToGitHubAt = syncedAt;
+        changed = true;
+      }
+      thread.updatedAt = syncedAt;
+      continue;
+    }
+
+    const localBodies = pendingLocalComments.map((comment) => comment.body);
+    if (thread.target.kind === 'workspace') {
+      workspaceNoteBodies.push(localBodies.join('\n\n---\n\n'));
+      workspaceNoteIdsByThreadId.set(thread.id, pendingLocalComments.map((comment) => comment.id));
+      continue;
+    }
+
+    const reviewComment = buildGitHubComment(thread, localBodies);
+    if (reviewComment) {
+      reviewComments.push(reviewComment);
+      reviewCommentIdsByThreadId.set(thread.id, pendingLocalComments.map((comment) => comment.id));
+    }
+  }
+
+  const workspaceNotes = workspaceNoteBodies.join('\n\n');
 
   const bodyParts: string[] = [];
   if (workspaceNotes) {
     bodyParts.push('**General notes:**\n\n' + workspaceNotes);
   }
 
-  const reviewBody = bodyParts.join('\n\n') || 'Review submitted via gssh.';
+  let url = `https://github.com/${owner}/${repo}/pull/${prNumber}`;
+  if (reviewComments.length > 0 || bodyParts.length > 0) {
+    const reviewBody = bodyParts.join('\n\n') || 'Review submitted via gssh.';
 
-  // Submit via `gh api`
-  const payload = {
-    body: reviewBody,
-    event,
-    comments: reviewComments,
-  };
-
-  // Write payload to temp file for `gh api --input`
-  const tmpFile = join(tmpdir(), `gssh-review-${Date.now()}.json`);
-  let rawStdout = '';
-  try {
-    writeFileSync(tmpFile, JSON.stringify(payload), 'utf-8');
-    const reviewsEndpoint = `repos/${owner}/${repo}/pulls/${prNumber}/reviews`;
-    const result = await execAsync(
-      `gh api ${escapeShellArg(reviewsEndpoint)} --method POST --input ${escapeShellArg(tmpFile)}`,
-      { cwd: workspacePath }
+    const reviewData = await submitPullReview(
+      owner,
+      repo,
+      prNumber,
+      {
+        body: reviewBody,
+        event,
+        comments: reviewComments,
+      },
+      workspacePath
     );
-    rawStdout = result.stdout;
-  } finally {
-    try { unlinkSync(tmpFile); } catch { /* ignore */ }
+
+    url =
+      reviewData.html_url ??
+      `https://github.com/${owner}/${repo}/pull/${prNumber}#pullrequestreview-${reviewData.id}`;
+
+    for (const thread of unresolved) {
+      const reviewCommentIds = reviewCommentIdsByThreadId.get(thread.id) ?? [];
+      const workspaceNoteIds = workspaceNoteIdsByThreadId.get(thread.id) ?? [];
+      const syncedIds = new Set([...reviewCommentIds, ...workspaceNoteIds]);
+      if (syncedIds.size === 0) {
+        continue;
+      }
+
+      markThreadCommentsSynced(thread, syncedIds, syncedAt);
+      thread.updatedAt = syncedAt;
+      changed = true;
+    }
   }
 
-  const reviewData = JSON.parse(rawStdout) as { id: number; html_url?: string };
-  const url =
-    reviewData.html_url ??
-    `https://github.com/${owner}/${repo}/pull/${prNumber}#pullrequestreview-${reviewData.id}`;
+  if (changed) {
+    session.prNumber = prNumber;
+    writeReviewSession(workspacePath, workspaceName, session);
+  }
 
   return { prNumber, url };
 }
@@ -280,9 +325,23 @@ async function fetchPRComments(
 ): Promise<GitHubPRComment[]> {
   const commentsEndpoint = `repos/${owner}/${repo}/pulls/${prNumber}/comments`;
   const { stdout } = await execAsync(
-    `gh api ${escapeShellArg(commentsEndpoint)} --paginate`
+    `gh api ${escapeShellArg(commentsEndpoint)} --paginate --slurp`
   );
-  return JSON.parse(stdout) as GitHubPRComment[];
+  const parsed = JSON.parse(stdout) as unknown;
+
+  if (!Array.isArray(parsed)) {
+    return [];
+  }
+
+  if (parsed.length === 0) {
+    return [];
+  }
+
+  if (Array.isArray(parsed[0])) {
+    return (parsed as GitHubPRComment[][]).flat();
+  }
+
+  return parsed as GitHubPRComment[];
 }
 
 async function getRepoOwner(cwd: string): Promise<string> {
@@ -327,17 +386,23 @@ function buildTarget(comment: GitHubPRComment): ThreadTarget {
 
 /** Build a GitHub PR review comment from a local thread */
 function buildGitHubComment(
-  thread: ReviewThread
-): { path: string; line: number; side: string; body: string } | null {
-  const body = thread.comments.map(c => c.body).join('\n\n---\n\n');
+  thread: ReviewThread,
+  bodies: string[]
+): GitHubDraftReviewComment | null {
+  const body = bodies.join('\n\n---\n\n');
 
   if (thread.target.kind === 'line') {
-    return {
+    const payload: GitHubDraftReviewComment = {
       path: thread.target.file,
       line: thread.target.endLine,
       side: thread.target.side,
       body,
     };
+    if (thread.target.startLine !== thread.target.endLine) {
+      payload.start_line = thread.target.startLine;
+      payload.start_side = thread.target.side;
+    }
+    return payload;
   }
 
   if (thread.target.kind === 'hunk') {
@@ -368,4 +433,85 @@ function buildGitHubComment(
 
   // workspace-level threads go in the review body — handled separately
   return null;
+}
+
+function isPendingLocalComment(comment: ReviewComment): boolean {
+  return (
+    comment.author === 'local' &&
+    comment.githubId === undefined &&
+    !comment.syncedToGitHubAt
+  );
+}
+
+function getRootGithubCommentId(thread: ReviewThread): number | null {
+  const rootComment = thread.comments[0];
+  return rootComment?.githubId ?? null;
+}
+
+function markThreadCommentsSynced(
+  thread: ReviewThread,
+  commentIds: Set<string>,
+  syncedAt: string
+): void {
+  for (const comment of thread.comments) {
+    if (commentIds.has(comment.id)) {
+      comment.syncedToGitHubAt = syncedAt;
+    }
+  }
+}
+
+async function postPRReply(
+  owner: string,
+  repo: string,
+  prNumber: number,
+  inReplyTo: number,
+  body: string,
+  cwd: string
+): Promise<{ id: number; html_url?: string }> {
+  const endpoint = `repos/${owner}/${repo}/pulls/${prNumber}/comments`;
+  const payload = {
+    body,
+    in_reply_to: inReplyTo,
+  };
+  const response = await postGitHubApi(endpoint, payload, cwd);
+  return JSON.parse(response) as { id: number; html_url?: string };
+}
+
+async function submitPullReview(
+  owner: string,
+  repo: string,
+  prNumber: number,
+  payload: {
+    body: string;
+    event: 'APPROVE' | 'REQUEST_CHANGES' | 'COMMENT';
+    comments: GitHubDraftReviewComment[];
+  },
+  cwd: string
+): Promise<{ id: number; html_url?: string }> {
+  const endpoint = `repos/${owner}/${repo}/pulls/${prNumber}/reviews`;
+  const response = await postGitHubApi(endpoint, payload, cwd);
+  return JSON.parse(response) as { id: number; html_url?: string };
+}
+
+interface GitHubDraftReviewComment {
+  path: string;
+  line: number;
+  side: 'LEFT' | 'RIGHT' | string;
+  body: string;
+  start_line?: number;
+  start_side?: 'LEFT' | 'RIGHT' | string;
+}
+
+async function postGitHubApi(endpoint: string, payload: object, cwd: string): Promise<string> {
+  const tmpFile = join(tmpdir(), `gssh-review-${Date.now()}-${Math.random().toString(36).slice(2)}.json`);
+  try {
+    writeFileSync(tmpFile, JSON.stringify(payload), 'utf-8');
+    const { stdout } = await execAsync(
+      `gh api ${escapeShellArg(endpoint)} --method POST --input ${escapeShellArg(tmpFile)}`,
+      { cwd }
+    );
+    return stdout;
+  } finally {
+    try { unlinkSync(tmpFile); } catch { /* ignore */ }
+  }
 }

--- a/src/core/github-review.ts
+++ b/src/core/github-review.ts
@@ -240,9 +240,11 @@ export async function pushGitHubReview(
         );
         comment.githubId = posted.id;
         comment.syncedToGitHubAt = syncedAt;
+        thread.updatedAt = syncedAt;
+        session.prNumber = prNumber;
+        writeReviewSession(workspacePath, workspaceName, session);
         changed = true;
       }
-      thread.updatedAt = syncedAt;
       continue;
     }
 

--- a/src/core/github-review.ts
+++ b/src/core/github-review.ts
@@ -354,12 +354,13 @@ async function getRepoName(cwd: string): Promise<string> {
 
 /** Build a ThreadTarget from a GitHub PR comment */
 function buildTarget(comment: GitHubPRComment): ThreadTarget {
-  const line = comment.line ?? comment.original_line ?? 1;
-  const startLine = comment.start_line ?? comment.original_start_line ?? line;
+  const line = comment.line ?? comment.original_line;
 
   // Extract hunk header from diff_hunk
   const hunkHeaderMatch = comment.diff_hunk.match(/^(@@ [^@]+ @@[^\n]*)/m);
-  if (hunkHeaderMatch) {
+  if (hunkHeaderMatch && line !== null) {
+    const startLine = comment.start_line ?? comment.original_start_line ?? line;
+
     // We prefer line-level targeting so the annotation is precise
     return {
       kind: 'line',

--- a/src/core/github-review.ts
+++ b/src/core/github-review.ts
@@ -557,11 +557,11 @@ function parseHunkAnchor(hunkHeader: string): HunkAnchor | null {
   }
 
   if (newCount > 0) {
-    return { line: newStart, side: 'RIGHT' };
+    return { line: newStart + newCount - 1, side: 'RIGHT' };
   }
 
   if (oldCount > 0) {
-    return { line: oldStart, side: 'LEFT' };
+    return { line: oldStart + oldCount - 1, side: 'LEFT' };
   }
 
   return null;

--- a/src/core/github-review.ts
+++ b/src/core/github-review.ts
@@ -202,6 +202,7 @@ export async function pushGitHubReview(
   const unresolved = session.threads.filter(t => !t.resolved);
   const syncedAt = new Date().toISOString();
   let changed = false;
+  let url = `https://github.com/${owner}/${repo}/pull/${prNumber}`;
 
   // Compute overall review action
   const hunkThreads = unresolved.filter(t => t.target.kind === 'hunk');
@@ -220,6 +221,15 @@ export async function pushGitHubReview(
   const reviewCommentIdsByThreadId = new Map<string, string[]>();
   const workspaceNoteBodies: string[] = [];
   const workspaceNoteIdsByThreadId = new Map<string, string[]>();
+  let pullHeadSha: string | null = null;
+
+  const resolvePullHeadSha = async (): Promise<string> => {
+    if (pullHeadSha !== null) {
+      return pullHeadSha;
+    }
+    pullHeadSha = await getPullHeadSha(owner, repo, prNumber, workspacePath);
+    return pullHeadSha;
+  };
 
   for (const thread of unresolved) {
     const pendingLocalComments = thread.comments.filter(isPendingLocalComment);
@@ -255,6 +265,38 @@ export async function pushGitHubReview(
       continue;
     }
 
+    if (thread.target.kind === 'file' || thread.target.kind === 'hunk') {
+      const topLevelComment = buildGitHubTopLevelComment(
+        thread,
+        localBodies,
+        await resolvePullHeadSha()
+      );
+
+      if (topLevelComment) {
+        const posted = await postPRTopLevelComment(
+          owner,
+          repo,
+          prNumber,
+          topLevelComment,
+          workspacePath
+        );
+
+        markThreadCommentsSynced(
+          thread,
+          new Set(pendingLocalComments.map((comment) => comment.id)),
+          syncedAt
+        );
+        thread.updatedAt = syncedAt;
+        session.prNumber = prNumber;
+        writeReviewSession(workspacePath, workspaceName, session);
+        if (posted.html_url) {
+          url = posted.html_url;
+        }
+        changed = true;
+      }
+      continue;
+    }
+
     const reviewComment = buildGitHubComment(thread, localBodies);
     if (reviewComment) {
       reviewComments.push(reviewComment);
@@ -269,7 +311,6 @@ export async function pushGitHubReview(
     bodyParts.push('**General notes:**\n\n' + workspaceNotes);
   }
 
-  let url = `https://github.com/${owner}/${repo}/pull/${prNumber}`;
   if (reviewComments.length > 0 || bodyParts.length > 0) {
     const reviewBody = bodyParts.join('\n\n') || 'Review submitted via gssh.';
 
@@ -500,6 +541,133 @@ interface GitHubDraftReviewComment {
   body: string;
   start_line?: number;
   start_side?: 'LEFT' | 'RIGHT' | string;
+}
+
+interface GitHubTopLevelPRComment {
+  body: string;
+  commit_id: string;
+  path: string;
+  subject_type?: 'file';
+  line?: number;
+  side?: 'LEFT' | 'RIGHT';
+}
+
+interface HunkAnchor {
+  line: number;
+  side: 'LEFT' | 'RIGHT';
+}
+
+function parseHunkAnchor(hunkHeader: string): HunkAnchor | null {
+  const match = hunkHeader.match(/^@@\s*-(\d+)(?:,(\d+))?\s+\+(\d+)(?:,(\d+))?\s*@@/);
+  if (!match) {
+    return null;
+  }
+
+  const oldStart = parseInt(match[1] ?? '', 10);
+  const oldCount = parseInt(match[2] ?? '1', 10);
+  const newStart = parseInt(match[3] ?? '', 10);
+  const newCount = parseInt(match[4] ?? '1', 10);
+
+  if (Number.isNaN(oldStart) || Number.isNaN(oldCount) || Number.isNaN(newStart) || Number.isNaN(newCount)) {
+    return null;
+  }
+
+  if (newCount > 0) {
+    return { line: newStart, side: 'RIGHT' };
+  }
+
+  if (oldCount > 0) {
+    return { line: oldStart, side: 'LEFT' };
+  }
+
+  return null;
+}
+
+function buildGitHubTopLevelComment(
+  thread: ReviewThread,
+  bodies: string[],
+  commitSha: string
+): GitHubTopLevelPRComment | null {
+  const body = bodies.join('\n\n---\n\n');
+
+  if (thread.target.kind === 'file') {
+    return {
+      path: thread.target.file,
+      commit_id: commitSha,
+      subject_type: 'file',
+      body,
+    };
+  }
+
+  if (thread.target.kind === 'hunk') {
+    const decisionPrefix =
+      thread.decision === 'approved'
+        ? '✅ **Approved**\n\n'
+        : thread.decision === 'rejected'
+          ? '❌ **Rejected**\n\n'
+          : '';
+    const finalBody = decisionPrefix + body;
+    const anchor = parseHunkAnchor(thread.target.hunkHeader);
+
+    if (!anchor) {
+      return {
+        path: thread.target.file,
+        commit_id: commitSha,
+        subject_type: 'file',
+        body: finalBody,
+      };
+    }
+
+    return {
+      path: thread.target.file,
+      commit_id: commitSha,
+      line: anchor.line,
+      side: anchor.side,
+      body: finalBody,
+    };
+  }
+
+  return null;
+}
+
+async function getPullHeadSha(
+  owner: string,
+  repo: string,
+  prNumber: number,
+  cwd: string
+): Promise<string> {
+  const endpoint = `repos/${owner}/${repo}/pulls/${prNumber}`;
+  const { stdout } = await execAsync(
+    `gh api ${escapeShellArg(endpoint)} --jq '.head.sha'`,
+    { cwd }
+  );
+  const trimmed = stdout.trim();
+  if (!trimmed) {
+    throw new Error(`Could not resolve head SHA for PR #${prNumber}`);
+  }
+
+  if (trimmed.startsWith('{')) {
+    const parsed = JSON.parse(trimmed) as { head?: { sha?: string } };
+    const sha = parsed.head?.sha?.trim();
+    if (sha) {
+      return sha;
+    }
+    throw new Error(`Could not resolve head SHA for PR #${prNumber}`);
+  }
+
+  return trimmed;
+}
+
+async function postPRTopLevelComment(
+  owner: string,
+  repo: string,
+  prNumber: number,
+  payload: GitHubTopLevelPRComment,
+  cwd: string
+): Promise<{ id: number; html_url?: string }> {
+  const endpoint = `repos/${owner}/${repo}/pulls/${prNumber}/comments`;
+  const response = await postGitHubApi(endpoint, payload, cwd);
+  return JSON.parse(response) as { id: number; html_url?: string };
 }
 
 async function postGitHubApi(endpoint: string, payload: object, cwd: string): Promise<string> {

--- a/src/core/github-review.ts
+++ b/src/core/github-review.ts
@@ -1,0 +1,338 @@
+/**
+ * GitHub PR review integration
+ *
+ * Import PR review comments from GitHub into the local ReviewThread format,
+ * and push local threads back to GitHub as a PR review.
+ *
+ * Uses the `gh` CLI for all GitHub API calls (inherits existing auth).
+ */
+
+import { exec } from 'child_process';
+import { promisify } from 'util';
+import { writeFileSync, unlinkSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import type { ReviewThread, ReviewComment, ThreadTarget } from '../types/review.js';
+import { readReviewSession, writeReviewSession } from './review.js';
+
+const execAsync = promisify(exec);
+
+// ============================================================================
+// GitHub API Types (raw shapes returned by `gh api`)
+// ============================================================================
+
+interface GitHubPRComment {
+  id: number;
+  body: string;
+  path: string;
+  line: number | null;
+  original_line: number | null;
+  side: 'LEFT' | 'RIGHT';
+  start_line: number | null;
+  original_start_line: number | null;
+  diff_hunk: string;
+  user: { login: string };
+  created_at: string;
+  in_reply_to_id?: number;
+  pull_request_review_id: number;
+}
+
+interface GitHubReview {
+  id: number;
+  body: string;
+  state: 'APPROVED' | 'CHANGES_REQUESTED' | 'COMMENTED' | 'DISMISSED' | 'PENDING';
+  user: { login: string };
+  submitted_at: string;
+}
+
+// ============================================================================
+// Import from GitHub
+// ============================================================================
+
+/**
+ * Import PR review comments from GitHub into local threads.
+ * Deduplicates by githubId — existing threads are not overwritten.
+ *
+ * @returns Number of newly imported threads
+ */
+export async function importGitHubReview(
+  workspacePath: string,
+  workspaceName: string,
+  baseBranch: string,
+  prNumber: number
+): Promise<{ imported: number; threads: ReviewThread[] }> {
+  const owner = await getRepoOwner(workspacePath);
+  const repo = await getRepoName(workspacePath);
+
+  // Fetch all review comments from the PR
+  const comments = await fetchPRComments(owner, repo, prNumber);
+
+  const session = readReviewSession(workspacePath, workspaceName, baseBranch);
+
+  // Build a set of existing github IDs to avoid duplication
+  const existingGithubIds = new Set<number>();
+  for (const thread of session.threads) {
+    for (const comment of thread.comments) {
+      if (comment.githubId !== undefined) {
+        existingGithubIds.add(comment.githubId);
+      }
+    }
+  }
+
+  // Group comments into threads (root comments + replies)
+  const roots = comments.filter(c => !c.in_reply_to_id);
+  const replies = comments.filter(c => c.in_reply_to_id !== undefined);
+
+  // Map: root comment id → reply list
+  const replyMap = new Map<number, GitHubPRComment[]>();
+  for (const reply of replies) {
+    const rootId = reply.in_reply_to_id!;
+    const list = replyMap.get(rootId) ?? [];
+    list.push(reply);
+    replyMap.set(rootId, list);
+  }
+
+  let imported = 0;
+
+  for (const root of roots) {
+    // Skip if already imported
+    if (existingGithubIds.has(root.id)) continue;
+
+    const now = new Date().toISOString();
+    const threadId = generateId();
+
+    const rootComment: ReviewComment = {
+      id: generateId(),
+      threadId,
+      body: root.body,
+      author: root.user.login,
+      createdAt: root.created_at,
+      githubId: root.id,
+    };
+
+    const replyComments: ReviewComment[] = (replyMap.get(root.id) ?? [])
+      .filter(r => !existingGithubIds.has(r.id))
+      .map(r => ({
+        id: generateId(),
+        threadId,
+        body: r.body,
+        author: r.user.login,
+        createdAt: r.created_at,
+        githubId: r.id,
+      }));
+
+    const target: ThreadTarget = buildTarget(root);
+
+    const thread: ReviewThread = {
+      id: threadId,
+      target,
+      resolved: false,
+      comments: [rootComment, ...replyComments],
+      createdAt: root.created_at,
+      updatedAt: now,
+    };
+
+    session.threads.push(thread);
+    imported++;
+  }
+
+  session.prNumber = prNumber;
+  writeReviewSession(workspacePath, workspaceName, session);
+
+  return { imported, threads: session.threads };
+}
+
+// ============================================================================
+// Push to GitHub
+// ============================================================================
+
+/**
+ * Push all unresolved threads to GitHub as a PR review.
+ *
+ * Derives the overall action from hunk decisions:
+ *  - Any rejected hunk → REQUEST_CHANGES
+ *  - All hunks approved, none rejected → APPROVE
+ *  - Otherwise → COMMENT
+ *
+ * @returns The PR number and URL of the submitted review
+ */
+export async function pushGitHubReview(
+  workspacePath: string,
+  workspaceName: string,
+  baseBranch: string,
+  prNumber: number
+): Promise<{ prNumber: number; url: string }> {
+  const owner = await getRepoOwner(workspacePath);
+  const repo = await getRepoName(workspacePath);
+
+  const session = readReviewSession(workspacePath, workspaceName, baseBranch);
+  const unresolved = session.threads.filter(t => !t.resolved);
+
+  // Compute overall review action
+  const hunkThreads = unresolved.filter(t => t.target.kind === 'hunk');
+  const hasRejection = hunkThreads.some(t => t.decision === 'rejected');
+  const allApproved =
+    hunkThreads.length > 0 &&
+    hunkThreads.every(t => t.decision === 'approved');
+
+  const event: 'APPROVE' | 'REQUEST_CHANGES' | 'COMMENT' = hasRejection
+    ? 'REQUEST_CHANGES'
+    : allApproved
+      ? 'APPROVE'
+      : 'COMMENT';
+
+  // Build review comments (only threads that can be mapped to a file+line)
+  const reviewComments = unresolved
+    .filter(t => t.target.kind !== 'workspace')
+    .map(t => buildGitHubComment(t))
+    .filter(Boolean);
+
+  // Collect workspace-level threads as PR body additions
+  const workspaceNotes = unresolved
+    .filter(t => t.target.kind === 'workspace')
+    .map(t => t.comments[0]?.body ?? '')
+    .filter(Boolean)
+    .join('\n\n');
+
+  const bodyParts: string[] = [];
+  if (workspaceNotes) {
+    bodyParts.push('**General notes:**\n\n' + workspaceNotes);
+  }
+
+  const reviewBody = bodyParts.join('\n\n') || 'Review submitted via gssh.';
+
+  // Submit via `gh api`
+  const payload = {
+    body: reviewBody,
+    event,
+    comments: reviewComments,
+  };
+
+  // Write payload to temp file for `gh api --input`
+  const tmpFile = join(tmpdir(), `gssh-review-${Date.now()}.json`);
+  let rawStdout = '';
+  try {
+    writeFileSync(tmpFile, JSON.stringify(payload), 'utf-8');
+    const result = await execAsync(
+      `gh api repos/${owner}/${repo}/pulls/${prNumber}/reviews --method POST --input ${JSON.stringify(tmpFile)}`,
+      { cwd: workspacePath }
+    );
+    rawStdout = result.stdout;
+  } finally {
+    try { unlinkSync(tmpFile); } catch { /* ignore */ }
+  }
+
+  const reviewData = JSON.parse(rawStdout) as { id: number; html_url?: string };
+  const url =
+    reviewData.html_url ??
+    `https://github.com/${owner}/${repo}/pull/${prNumber}#pullrequestreview-${reviewData.id}`;
+
+  return { prNumber, url };
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+async function fetchPRComments(
+  owner: string,
+  repo: string,
+  prNumber: number
+): Promise<GitHubPRComment[]> {
+  const { stdout } = await execAsync(
+    `gh api repos/${owner}/${repo}/pulls/${prNumber}/comments --paginate`
+  );
+  return JSON.parse(stdout) as GitHubPRComment[];
+}
+
+async function getRepoOwner(cwd: string): Promise<string> {
+  const { stdout } = await execAsync(
+    "gh repo view --json owner --jq '.owner.login'",
+    { cwd }
+  );
+  return stdout.trim();
+}
+
+async function getRepoName(cwd: string): Promise<string> {
+  const { stdout } = await execAsync(
+    "gh repo view --json name --jq '.name'",
+    { cwd }
+  );
+  return stdout.trim();
+}
+
+/** Build a ThreadTarget from a GitHub PR comment */
+function buildTarget(comment: GitHubPRComment): ThreadTarget {
+  const line = comment.line ?? comment.original_line ?? 1;
+  const startLine = comment.start_line ?? comment.original_start_line ?? line;
+
+  // Extract hunk header from diff_hunk
+  const hunkHeaderMatch = comment.diff_hunk.match(/^(@@ [^@]+ @@[^\n]*)/m);
+  if (hunkHeaderMatch) {
+    // We prefer line-level targeting so the annotation is precise
+    return {
+      kind: 'line',
+      file: comment.path,
+      startLine,
+      endLine: line,
+      side: comment.side ?? 'RIGHT',
+    };
+  }
+
+  return {
+    kind: 'file',
+    file: comment.path,
+  };
+}
+
+/** Build a GitHub PR review comment from a local thread */
+function buildGitHubComment(
+  thread: ReviewThread
+): { path: string; line: number; side: string; body: string } | null {
+  const body = thread.comments.map(c => c.body).join('\n\n---\n\n');
+
+  if (thread.target.kind === 'line') {
+    return {
+      path: thread.target.file,
+      line: thread.target.endLine,
+      side: thread.target.side,
+      body,
+    };
+  }
+
+  if (thread.target.kind === 'hunk') {
+    // For hunk-level threads, we can only submit as a file comment at line 1
+    // GitHub doesn't have a hunk-level comment concept natively
+    const decisionPrefix =
+      thread.decision === 'approved'
+        ? '✅ **Approved**\n\n'
+        : thread.decision === 'rejected'
+          ? '❌ **Rejected**\n\n'
+          : '';
+    return {
+      path: thread.target.file,
+      line: 1,
+      side: 'RIGHT',
+      body: decisionPrefix + body,
+    };
+  }
+
+  if (thread.target.kind === 'file') {
+    return {
+      path: thread.target.file,
+      line: 1,
+      side: 'RIGHT',
+      body,
+    };
+  }
+
+  // workspace-level threads go in the review body — handled separately
+  return null;
+}
+
+function generateId(): string {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
+}

--- a/src/core/github-review.ts
+++ b/src/core/github-review.ts
@@ -297,11 +297,13 @@ export async function pushGitHubReview(
       continue;
     }
 
-    const reviewComment = buildGitHubComment(thread, localBodies);
-    if (reviewComment) {
-      reviewComments.push(reviewComment);
-      reviewCommentIdsByThreadId.set(thread.id, pendingLocalComments.map((comment) => comment.id));
+    if (thread.target.kind !== 'line') {
+      continue;
     }
+
+    const reviewComment = buildGitHubLineComment(thread, localBodies);
+    reviewComments.push(reviewComment);
+    reviewCommentIdsByThreadId.set(thread.id, pendingLocalComments.map((comment) => comment.id));
   }
 
   const workspaceNotes = workspaceNoteBodies.join('\n\n');
@@ -425,55 +427,28 @@ function buildTarget(comment: GitHubPRComment): ThreadTarget {
   };
 }
 
-/** Build a GitHub PR review comment from a local thread */
-function buildGitHubComment(
+/** Build a line-anchored GitHub PR review comment from a local line thread */
+function buildGitHubLineComment(
   thread: ReviewThread,
   bodies: string[]
-): GitHubDraftReviewComment | null {
+): GitHubDraftReviewComment {
+  if (thread.target.kind !== 'line') {
+    throw new Error(`Expected line target thread, got: ${thread.target.kind}`);
+  }
+
   const body = bodies.join('\n\n---\n\n');
 
-  if (thread.target.kind === 'line') {
-    const payload: GitHubDraftReviewComment = {
-      path: thread.target.file,
-      line: thread.target.endLine,
-      side: thread.target.side,
-      body,
-    };
-    if (thread.target.startLine !== thread.target.endLine) {
-      payload.start_line = thread.target.startLine;
-      payload.start_side = thread.target.side;
-    }
-    return payload;
+  const payload: GitHubDraftReviewComment = {
+    path: thread.target.file,
+    line: thread.target.endLine,
+    side: thread.target.side,
+    body,
+  };
+  if (thread.target.startLine !== thread.target.endLine) {
+    payload.start_line = thread.target.startLine;
+    payload.start_side = thread.target.side;
   }
-
-  if (thread.target.kind === 'hunk') {
-    // For hunk-level threads, we can only submit as a file comment at line 1
-    // GitHub doesn't have a hunk-level comment concept natively
-    const decisionPrefix =
-      thread.decision === 'approved'
-        ? '✅ **Approved**\n\n'
-        : thread.decision === 'rejected'
-          ? '❌ **Rejected**\n\n'
-          : '';
-    return {
-      path: thread.target.file,
-      line: 1,
-      side: 'RIGHT',
-      body: decisionPrefix + body,
-    };
-  }
-
-  if (thread.target.kind === 'file') {
-    return {
-      path: thread.target.file,
-      line: 1,
-      side: 'RIGHT',
-      body,
-    };
-  }
-
-  // workspace-level threads go in the review body — handled separately
-  return null;
+  return payload;
 }
 
 function isPendingLocalComment(comment: ReviewComment): boolean {

--- a/src/core/github-review.ts
+++ b/src/core/github-review.ts
@@ -14,6 +14,8 @@ import { join } from 'path';
 import { tmpdir } from 'os';
 import type { ReviewThread, ReviewComment, ThreadTarget } from '../types/review.js';
 import { readReviewSession, writeReviewSession } from './review.js';
+import { escapeShellArg } from '../utils/shell-escape.js';
+import { generateId } from '../utils/id.js';
 
 const execAsync = promisify(exec);
 
@@ -249,8 +251,9 @@ export async function pushGitHubReview(
   let rawStdout = '';
   try {
     writeFileSync(tmpFile, JSON.stringify(payload), 'utf-8');
+    const reviewsEndpoint = `repos/${owner}/${repo}/pulls/${prNumber}/reviews`;
     const result = await execAsync(
-      `gh api repos/${owner}/${repo}/pulls/${prNumber}/reviews --method POST --input ${JSON.stringify(tmpFile)}`,
+      `gh api ${escapeShellArg(reviewsEndpoint)} --method POST --input ${escapeShellArg(tmpFile)}`,
       { cwd: workspacePath }
     );
     rawStdout = result.stdout;
@@ -275,8 +278,9 @@ async function fetchPRComments(
   repo: string,
   prNumber: number
 ): Promise<GitHubPRComment[]> {
+  const commentsEndpoint = `repos/${owner}/${repo}/pulls/${prNumber}/comments`;
   const { stdout } = await execAsync(
-    `gh api repos/${owner}/${repo}/pulls/${prNumber}/comments --paginate`
+    `gh api ${escapeShellArg(commentsEndpoint)} --paginate`
   );
   return JSON.parse(stdout) as GitHubPRComment[];
 }
@@ -364,11 +368,4 @@ function buildGitHubComment(
 
   // workspace-level threads go in the review body — handled separately
   return null;
-}
-
-function generateId(): string {
-  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
-    return crypto.randomUUID();
-  }
-  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
 }

--- a/src/core/github-review.ts
+++ b/src/core/github-review.ts
@@ -16,6 +16,7 @@ import type { ReviewThread, ReviewComment, ThreadTarget } from '../types/review.
 import { readReviewSession, writeReviewSession } from './review.js';
 import { escapeShellArg } from '../utils/shell-escape.js';
 import { generateId } from '../utils/id.js';
+import { logger } from '../utils/logger.js';
 
 const execAsync = promisify(exec);
 
@@ -32,6 +33,7 @@ interface GitHubPRComment {
   side: 'LEFT' | 'RIGHT';
   start_line: number | null;
   original_start_line: number | null;
+  start_side?: 'LEFT' | 'RIGHT' | null;
   diff_hunk: string;
   user: { login: string };
   created_at: string;
@@ -219,6 +221,7 @@ export async function pushGitHubReview(
 
   const reviewComments: GitHubDraftReviewComment[] = [];
   const reviewCommentIdsByThreadId = new Map<string, string[]>();
+  const reviewCommentDraftByThreadId = new Map<string, GitHubDraftReviewComment>();
   const workspaceNoteBodies: string[] = [];
   const workspaceNoteIdsByThreadId = new Map<string, string[]>();
   let pushedPendingHunkTopLevel = false;
@@ -285,7 +288,8 @@ export async function pushGitHubReview(
         markThreadCommentsSynced(
           thread,
           new Set(pendingLocalComments.map((comment) => comment.id)),
-          syncedAt
+          syncedAt,
+          posted.id
         );
         thread.updatedAt = syncedAt;
         session.prNumber = prNumber;
@@ -308,6 +312,7 @@ export async function pushGitHubReview(
     const reviewComment = buildGitHubLineComment(thread, localBodies);
     reviewComments.push(reviewComment);
     reviewCommentIdsByThreadId.set(thread.id, pendingLocalComments.map((comment) => comment.id));
+    reviewCommentDraftByThreadId.set(thread.id, reviewComment);
   }
 
   const workspaceNotes = workspaceNoteBodies.join('\n\n');
@@ -341,6 +346,28 @@ export async function pushGitHubReview(
       reviewData.html_url ??
       `https://github.com/${owner}/${repo}/pull/${prNumber}#pullrequestreview-${reviewData.id}`;
 
+    const reviewCommentGithubIdsByKey = new Map<string, number[]>();
+    if (reviewComments.length > 0) {
+      try {
+        const postedReviewComments = await fetchReviewCommentsForReview(
+          owner,
+          repo,
+          prNumber,
+          reviewData.id,
+          workspacePath
+        );
+        for (const comment of postedReviewComments) {
+          const key = buildReviewCommentMatchKey(comment);
+          const ids = reviewCommentGithubIdsByKey.get(key) ?? [];
+          ids.push(comment.id);
+          reviewCommentGithubIdsByKey.set(key, ids);
+        }
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        logger.warning(`Could not map GitHub review comment IDs: ${message}`);
+      }
+    }
+
     for (const thread of unresolved) {
       const reviewCommentIds = reviewCommentIdsByThreadId.get(thread.id) ?? [];
       const workspaceNoteIds = workspaceNoteIdsByThreadId.get(thread.id) ?? [];
@@ -349,7 +376,22 @@ export async function pushGitHubReview(
         continue;
       }
 
-      markThreadCommentsSynced(thread, syncedIds, syncedAt);
+      let githubId: number | undefined;
+      if (reviewCommentIds.length > 0) {
+        const draft = reviewCommentDraftByThreadId.get(thread.id);
+        if (draft) {
+          const key = buildReviewCommentMatchKey(draft);
+          const ids = reviewCommentGithubIdsByKey.get(key);
+          if (ids && ids.length > 0) {
+            githubId = ids.shift();
+            if (ids.length === 0) {
+              reviewCommentGithubIdsByKey.delete(key);
+            }
+          }
+        }
+      }
+
+      markThreadCommentsSynced(thread, syncedIds, syncedAt, githubId);
       thread.updatedAt = syncedAt;
       changed = true;
     }
@@ -476,11 +518,17 @@ function getRootGithubCommentId(thread: ReviewThread): number | null {
 function markThreadCommentsSynced(
   thread: ReviewThread,
   commentIds: Set<string>,
-  syncedAt: string
+  syncedAt: string,
+  githubId?: number
 ): void {
+  let githubIdAssigned = false;
   for (const comment of thread.comments) {
     if (commentIds.has(comment.id)) {
       comment.syncedToGitHubAt = syncedAt;
+      if (!githubIdAssigned && githubId !== undefined && comment.githubId === undefined) {
+        comment.githubId = githubId;
+        githubIdAssigned = true;
+      }
     }
   }
 }
@@ -516,6 +564,50 @@ async function submitPullReview(
   const endpoint = `repos/${owner}/${repo}/pulls/${prNumber}/reviews`;
   const response = await postGitHubApi(endpoint, payload, cwd);
   return JSON.parse(response) as { id: number; html_url?: string };
+}
+
+async function fetchReviewCommentsForReview(
+  owner: string,
+  repo: string,
+  prNumber: number,
+  reviewId: number,
+  cwd: string
+): Promise<GitHubPRComment[]> {
+  const endpoint = `repos/${owner}/${repo}/pulls/${prNumber}/reviews/${reviewId}/comments`;
+  const { stdout } = await execAsync(
+    `gh api ${escapeShellArg(endpoint)} --paginate --slurp`,
+    { cwd }
+  );
+
+  const parsed = JSON.parse(stdout) as unknown;
+  if (!Array.isArray(parsed)) {
+    return [];
+  }
+  if (parsed.length === 0) {
+    return [];
+  }
+  if (Array.isArray(parsed[0])) {
+    return (parsed as GitHubPRComment[][]).flat();
+  }
+  return parsed as GitHubPRComment[];
+}
+
+function buildReviewCommentMatchKey(comment: {
+  path: string;
+  line: number | null;
+  side?: string | null;
+  start_line?: number | null;
+  start_side?: string | null;
+  body: string;
+}): string {
+  return [
+    comment.path,
+    String(comment.line ?? ''),
+    String(comment.side ?? ''),
+    String(comment.start_line ?? ''),
+    String(comment.start_side ?? ''),
+    comment.body,
+  ].join('|');
 }
 
 interface GitHubDraftReviewComment {

--- a/src/core/github-review.ts
+++ b/src/core/github-review.ts
@@ -71,11 +71,19 @@ export async function importGitHubReview(
 
   // Build a set of existing github IDs to avoid duplication
   const existingGithubIds = new Set<number>();
+  const threadByRootGithubId = new Map<number, ReviewThread>();
   for (const thread of session.threads) {
+    let rootGithubId: number | null = null;
     for (const comment of thread.comments) {
       if (comment.githubId !== undefined) {
         existingGithubIds.add(comment.githubId);
+        if (rootGithubId === null) {
+          rootGithubId = comment.githubId;
+        }
       }
+    }
+    if (rootGithubId !== null) {
+      threadByRootGithubId.set(rootGithubId, thread);
     }
   }
 
@@ -95,8 +103,35 @@ export async function importGitHubReview(
   let imported = 0;
 
   for (const root of roots) {
-    // Skip if already imported
-    if (existingGithubIds.has(root.id)) continue;
+    const freshReplies: ReviewComment[] = (replyMap.get(root.id) ?? [])
+      .filter(r => !existingGithubIds.has(r.id))
+      .map(r => ({
+        id: generateId(),
+        threadId: '',
+        body: r.body,
+        author: r.user.login,
+        createdAt: r.created_at,
+        githubId: r.id,
+      }));
+
+    const existingThread = threadByRootGithubId.get(root.id);
+    if (existingThread) {
+      if (freshReplies.length > 0) {
+        for (const reply of freshReplies) {
+          existingThread.comments.push({
+            ...reply,
+            threadId: existingThread.id,
+          });
+          if (reply.githubId !== undefined) {
+            existingGithubIds.add(reply.githubId);
+          }
+        }
+
+        const newestReply = freshReplies[freshReplies.length - 1];
+        existingThread.updatedAt = newestReply?.createdAt ?? new Date().toISOString();
+      }
+      continue;
+    }
 
     const now = new Date().toISOString();
     const threadId = generateId();
@@ -110,16 +145,10 @@ export async function importGitHubReview(
       githubId: root.id,
     };
 
-    const replyComments: ReviewComment[] = (replyMap.get(root.id) ?? [])
-      .filter(r => !existingGithubIds.has(r.id))
-      .map(r => ({
-        id: generateId(),
-        threadId,
-        body: r.body,
-        author: r.user.login,
-        createdAt: r.created_at,
-        githubId: r.id,
-      }));
+    const replyComments: ReviewComment[] = freshReplies.map((reply) => ({
+      ...reply,
+      threadId,
+    }));
 
     const target: ThreadTarget = buildTarget(root);
 
@@ -133,6 +162,13 @@ export async function importGitHubReview(
     };
 
     session.threads.push(thread);
+    threadByRootGithubId.set(root.id, thread);
+    existingGithubIds.add(root.id);
+    for (const reply of replyComments) {
+      if (reply.githubId !== undefined) {
+        existingGithubIds.add(reply.githubId);
+      }
+    }
     imported++;
   }
 

--- a/src/core/github-review.ts
+++ b/src/core/github-review.ts
@@ -35,7 +35,7 @@ interface GitHubPRComment {
   diff_hunk: string;
   user: { login: string };
   created_at: string;
-  in_reply_to_id?: number;
+  in_reply_to_id?: number | null;
   pull_request_review_id: number;
 }
 
@@ -82,13 +82,16 @@ export async function importGitHubReview(
   }
 
   // Group comments into threads (root comments + replies)
-  const roots = comments.filter(c => !c.in_reply_to_id);
-  const replies = comments.filter(c => c.in_reply_to_id !== undefined);
+  const roots = comments.filter(c => c.in_reply_to_id == null);
+  const replies = comments.filter(c => c.in_reply_to_id != null);
 
   // Map: root comment id → reply list
   const replyMap = new Map<number, GitHubPRComment[]>();
   for (const reply of replies) {
-    const rootId = reply.in_reply_to_id!;
+    const rootId = reply.in_reply_to_id;
+    if (rootId == null) {
+      continue;
+    }
     const list = replyMap.get(rootId) ?? [];
     list.push(reply);
     replyMap.set(rootId, list);

--- a/src/core/github-review.ts
+++ b/src/core/github-review.ts
@@ -39,14 +39,6 @@ interface GitHubPRComment {
   pull_request_review_id: number;
 }
 
-interface GitHubReview {
-  id: number;
-  body: string;
-  state: 'APPROVED' | 'CHANGES_REQUESTED' | 'COMMENTED' | 'DISMISSED' | 'PENDING';
-  user: { login: string };
-  submitted_at: string;
-}
-
 // ============================================================================
 // Import from GitHub
 // ============================================================================

--- a/src/core/github-review.ts
+++ b/src/core/github-review.ts
@@ -59,7 +59,7 @@ export async function importGitHubReview(
   const repo = await getRepoName(workspacePath);
 
   // Fetch all review comments from the PR
-  const comments = await fetchPRComments(owner, repo, prNumber);
+  const comments = await fetchPRComments(owner, repo, prNumber, workspacePath);
 
   const session = readReviewSession(workspacePath, workspaceName, baseBranch);
 
@@ -316,11 +316,13 @@ export async function pushGitHubReview(
 async function fetchPRComments(
   owner: string,
   repo: string,
-  prNumber: number
+  prNumber: number,
+  cwd: string
 ): Promise<GitHubPRComment[]> {
   const commentsEndpoint = `repos/${owner}/${repo}/pulls/${prNumber}/comments`;
   const { stdout } = await execAsync(
-    `gh api ${escapeShellArg(commentsEndpoint)} --paginate --slurp`
+    `gh api ${escapeShellArg(commentsEndpoint)} --paginate --slurp`,
+    { cwd }
   );
   const parsed = JSON.parse(stdout) as unknown;
 

--- a/src/core/review-executor.ts
+++ b/src/core/review-executor.ts
@@ -29,6 +29,17 @@ import type { ReviewOperation, ReviewResult } from '../types/review.js';
 
 type ScanWorkspacesFn = typeof scanWorkspaces;
 
+function toCanonicalWorkspaceId(workspace: { projectName: string; id: string }): string {
+  return `${workspace.projectName}:${workspace.id}`;
+}
+
+function matchesWorkspaceId(
+  workspace: { projectName: string; id: string },
+  workspaceId: string
+): boolean {
+  return workspace.id === workspaceId || toCanonicalWorkspaceId(workspace) === workspaceId;
+}
+
 async function resolveWorkspaceByName(
   projectName: string,
   workspaceName: string,
@@ -36,7 +47,7 @@ async function resolveWorkspaceByName(
 ): Promise<{ id: string; path: string; baseBranch: string }> {
   const workspaces = await scan();
   const workspace = workspaces.find(
-    (w) => w.projectName === projectName && w.id === workspaceName
+    (w) => w.projectName === projectName && matchesWorkspaceId(w, workspaceName)
   );
 
   if (!workspace) {
@@ -71,7 +82,7 @@ export async function executeLocalReviewOperation(
         operation.workspaceName,
         scan
       );
-      const threads = getThreads(workspace.path, operation.workspaceName, workspace.baseBranch);
+      const threads = getThreads(workspace.path, workspace.id, workspace.baseBranch);
       return { op: 'threads', threads };
     }
 
@@ -83,7 +94,7 @@ export async function executeLocalReviewOperation(
       );
       const thread = await createThread(
         workspace.path,
-        operation.workspaceName,
+        workspace.id,
         workspace.baseBranch,
         operation.target,
         operation.body,
@@ -100,7 +111,7 @@ export async function executeLocalReviewOperation(
       );
       const thread = addReply(
         workspace.path,
-        operation.workspaceName,
+        workspace.id,
         workspace.baseBranch,
         operation.threadId,
         operation.body
@@ -116,7 +127,7 @@ export async function executeLocalReviewOperation(
       );
       const thread = updateThread(
         workspace.path,
-        operation.workspaceName,
+        workspace.id,
         workspace.baseBranch,
         operation.threadId,
         { resolved: operation.resolved, decision: operation.decision }
@@ -132,7 +143,7 @@ export async function executeLocalReviewOperation(
       );
       const thread = updateComment(
         workspace.path,
-        operation.workspaceName,
+        workspace.id,
         workspace.baseBranch,
         operation.threadId,
         operation.commentId,
@@ -149,7 +160,7 @@ export async function executeLocalReviewOperation(
       );
       const thread = deleteComment(
         workspace.path,
-        operation.workspaceName,
+        workspace.id,
         workspace.baseBranch,
         operation.threadId,
         operation.commentId
@@ -287,7 +298,7 @@ export async function executeLocalReviewOperation(
       }
       const { imported, threads } = await importGitHubReview(
         workspace.path,
-        operation.workspaceName,
+        workspace.id,
         workspace.baseBranch,
         prNumber
       );
@@ -309,7 +320,7 @@ export async function executeLocalReviewOperation(
       }
       const { url } = await pushGitHubReview(
         workspace.path,
-        operation.workspaceName,
+        workspace.id,
         workspace.baseBranch,
         prNumber
       );

--- a/src/core/review-executor.ts
+++ b/src/core/review-executor.ts
@@ -15,7 +15,13 @@ import {
   deleteComment,
   detectPRNumber,
 } from './review.js';
-import { getWorkspaceDiff } from './git.js';
+import {
+  getWorkspaceChangedFiles,
+  getWorkspaceDiff,
+  getWorkspaceFileContextRange,
+  getWorkspaceFileDiff,
+  getWorkspaceFileVersions,
+} from './git.js';
 import { importGitHubReview, pushGitHubReview } from './github-review.js';
 import { readProjectConfig } from './config.js';
 import { scanWorkspaces } from '../lib/remote-session/workspace-scanner.js';
@@ -174,6 +180,94 @@ export async function executeLocalReviewOperation(
         diff: diffResult.diff,
         baseBranch: diffResult.baseBranch,
         headBranch: diffResult.headBranch,
+      };
+    }
+
+    case 'get_changed_files': {
+      const workspace = await resolveWorkspaceByName(
+        operation.projectName,
+        operation.workspaceName,
+        scan
+      );
+      const changed = await getWorkspaceChangedFiles(workspace.path, workspace.baseBranch);
+      return {
+        op: 'changed_files',
+        files: changed.files,
+        baseBranch: changed.baseBranch,
+        headBranch: changed.headBranch,
+      };
+    }
+
+    case 'get_file_diff': {
+      const workspace = await resolveWorkspaceByName(
+        operation.projectName,
+        operation.workspaceName,
+        scan
+      );
+      const result = await getWorkspaceFileDiff(
+        workspace.path,
+        workspace.baseBranch,
+        operation.filePath,
+        operation.prevFilePath
+      );
+      return {
+        op: 'file_diff',
+        filePath: operation.filePath,
+        prevFilePath: operation.prevFilePath,
+        diff: result.diff,
+      };
+    }
+
+    case 'get_file_versions': {
+      const workspace = await resolveWorkspaceByName(
+        operation.projectName,
+        operation.workspaceName,
+        scan
+      );
+      const { oldContents, newContents } = await getWorkspaceFileVersions(
+        workspace.path,
+        workspace.baseBranch,
+        operation.filePath,
+        operation.prevFilePath
+      );
+      return {
+        op: 'file_versions',
+        filePath: operation.filePath,
+        prevFilePath: operation.prevFilePath,
+        oldContents,
+        newContents,
+      };
+    }
+
+    case 'get_file_context_range': {
+      const workspace = await resolveWorkspaceByName(
+        operation.projectName,
+        operation.workspaceName,
+        scan
+      );
+      const result = await getWorkspaceFileContextRange(
+        workspace.path,
+        workspace.baseBranch,
+        operation.filePath,
+        operation.prevFilePath,
+        {
+          oldStart: operation.oldStart,
+          oldEnd: operation.oldEnd,
+          newStart: operation.newStart,
+          newEnd: operation.newEnd,
+        }
+      );
+
+      return {
+        op: 'file_context_range',
+        filePath: operation.filePath,
+        prevFilePath: operation.prevFilePath,
+        oldStart: result.oldStart,
+        oldLines: result.oldLines,
+        oldTotal: result.oldTotal,
+        newStart: result.newStart,
+        newLines: result.newLines,
+        newTotal: result.newTotal,
       };
     }
 

--- a/src/core/review-executor.ts
+++ b/src/core/review-executor.ts
@@ -155,6 +155,7 @@ export async function executeLocalReviewOperation(
         operation.commentId
       );
       // deleteComment may return null if the thread was itself removed
+      const now = new Date().toISOString();
       return {
         op: 'comment_deleted',
         thread: thread ?? {
@@ -162,8 +163,8 @@ export async function executeLocalReviewOperation(
           target: { kind: 'workspace' as const },
           resolved: true,
           comments: [],
-          createdAt: '',
-          updatedAt: '',
+          createdAt: now,
+          updatedAt: now,
         },
       };
     }

--- a/src/core/review-executor.ts
+++ b/src/core/review-executor.ts
@@ -1,0 +1,229 @@
+/**
+ * Local review operation executor.
+ *
+ * Shared by LocalSessionBackend (direct filesystem access) and
+ * RemoteSessionHandler (over encrypted WebSocket). Implements all
+ * ReviewOperation variants using the core review and git modules.
+ */
+
+import {
+  getThreads,
+  createThread,
+  addReply,
+  updateThread,
+  updateComment,
+  deleteComment,
+  detectPRNumber,
+} from './review.js';
+import { getWorkspaceDiff } from './git.js';
+import { importGitHubReview, pushGitHubReview } from './github-review.js';
+import { readProjectConfig } from './config.js';
+import { scanWorkspaces } from '../lib/remote-session/workspace-scanner.js';
+import type { ReviewOperation, ReviewResult } from '../types/review.js';
+
+type ScanWorkspacesFn = typeof scanWorkspaces;
+
+async function resolveWorkspaceByName(
+  projectName: string,
+  workspaceName: string,
+  scan: ScanWorkspacesFn
+): Promise<{ id: string; path: string; baseBranch: string }> {
+  const workspaces = await scan();
+  const workspace = workspaces.find(
+    (w) => w.projectName === projectName && w.id === workspaceName
+  );
+
+  if (!workspace) {
+    throw new Error(`Workspace not found: ${projectName}:${workspaceName}`);
+  }
+
+  let baseBranch = 'main';
+  try {
+    const projectConfig = readProjectConfig(projectName);
+    baseBranch = projectConfig.baseBranch ?? 'main';
+  } catch {
+    // Fall back to 'main'
+  }
+
+  return { id: workspace.id, path: workspace.path, baseBranch };
+}
+
+/**
+ * Execute a ReviewOperation with direct filesystem access.
+ *
+ * @param operation - The operation to execute
+ * @param scan - scanWorkspaces implementation (injectable for testing)
+ */
+export async function executeLocalReviewOperation(
+  operation: ReviewOperation,
+  scan: ScanWorkspacesFn = scanWorkspaces
+): Promise<ReviewResult> {
+  switch (operation.op) {
+    case 'get_threads': {
+      const workspace = await resolveWorkspaceByName(
+        operation.projectName,
+        operation.workspaceName,
+        scan
+      );
+      const threads = getThreads(workspace.path, operation.workspaceName, workspace.baseBranch);
+      return { op: 'threads', threads };
+    }
+
+    case 'create_thread': {
+      const workspace = await resolveWorkspaceByName(
+        operation.projectName,
+        operation.workspaceName,
+        scan
+      );
+      const thread = await createThread(
+        workspace.path,
+        operation.workspaceName,
+        workspace.baseBranch,
+        operation.target,
+        operation.body,
+        operation.decision
+      );
+      return { op: 'thread_created', thread };
+    }
+
+    case 'add_reply': {
+      const workspace = await resolveWorkspaceByName(
+        operation.projectName,
+        operation.workspaceName,
+        scan
+      );
+      const thread = addReply(
+        workspace.path,
+        operation.workspaceName,
+        workspace.baseBranch,
+        operation.threadId,
+        operation.body
+      );
+      return { op: 'comment_added', thread };
+    }
+
+    case 'update_thread': {
+      const workspace = await resolveWorkspaceByName(
+        operation.projectName,
+        operation.workspaceName,
+        scan
+      );
+      const thread = updateThread(
+        workspace.path,
+        operation.workspaceName,
+        workspace.baseBranch,
+        operation.threadId,
+        { resolved: operation.resolved, decision: operation.decision }
+      );
+      return { op: 'thread_updated', thread };
+    }
+
+    case 'update_comment': {
+      const workspace = await resolveWorkspaceByName(
+        operation.projectName,
+        operation.workspaceName,
+        scan
+      );
+      const thread = updateComment(
+        workspace.path,
+        operation.workspaceName,
+        workspace.baseBranch,
+        operation.threadId,
+        operation.commentId,
+        operation.body
+      );
+      return { op: 'comment_updated', thread };
+    }
+
+    case 'delete_comment': {
+      const workspace = await resolveWorkspaceByName(
+        operation.projectName,
+        operation.workspaceName,
+        scan
+      );
+      const thread = deleteComment(
+        workspace.path,
+        operation.workspaceName,
+        workspace.baseBranch,
+        operation.threadId,
+        operation.commentId
+      );
+      // deleteComment may return null if the thread was itself removed
+      return {
+        op: 'comment_deleted',
+        thread: thread ?? {
+          id: operation.threadId,
+          target: { kind: 'workspace' as const },
+          resolved: true,
+          comments: [],
+          createdAt: '',
+          updatedAt: '',
+        },
+      };
+    }
+
+    case 'get_diff': {
+      const workspace = await resolveWorkspaceByName(
+        operation.projectName,
+        operation.workspaceName,
+        scan
+      );
+      const diffResult = await getWorkspaceDiff(workspace.path, workspace.baseBranch);
+      return {
+        op: 'diff',
+        diff: diffResult.diff,
+        baseBranch: diffResult.baseBranch,
+        headBranch: diffResult.headBranch,
+      };
+    }
+
+    case 'import_github': {
+      const workspace = await resolveWorkspaceByName(
+        operation.projectName,
+        operation.workspaceName,
+        scan
+      );
+      const prNumber =
+        operation.prNumber ?? (await detectPRNumber(workspace.path)) ?? null;
+      if (!prNumber) {
+        throw new Error(
+          'Could not determine PR number. Pass prNumber explicitly or ensure the branch has an open PR.'
+        );
+      }
+      const { imported, threads } = await importGitHubReview(
+        workspace.path,
+        operation.workspaceName,
+        workspace.baseBranch,
+        prNumber
+      );
+      return { op: 'github_imported', imported, threads };
+    }
+
+    case 'push_github': {
+      const workspace = await resolveWorkspaceByName(
+        operation.projectName,
+        operation.workspaceName,
+        scan
+      );
+      const prNumber =
+        operation.prNumber ?? (await detectPRNumber(workspace.path)) ?? null;
+      if (!prNumber) {
+        throw new Error(
+          'Could not determine PR number. Pass prNumber explicitly or ensure the branch has an open PR.'
+        );
+      }
+      const { url } = await pushGitHubReview(
+        workspace.path,
+        operation.workspaceName,
+        workspace.baseBranch,
+        prNumber
+      );
+      return { op: 'github_pushed', prNumber, url };
+    }
+
+    default: {
+      const unknown = operation as { op: string };
+      throw new Error(`Unknown review operation: ${unknown.op}`);
+    }
+  }
+}

--- a/src/core/review-executor.ts
+++ b/src/core/review-executor.ts
@@ -155,18 +155,9 @@ export async function executeLocalReviewOperation(
         operation.threadId,
         operation.commentId
       );
-      // deleteComment may return null if the thread was itself removed
-      const now = new Date().toISOString();
       return {
         op: 'comment_deleted',
-        thread: thread ?? {
-          id: operation.threadId,
-          target: { kind: 'workspace' as const },
-          resolved: true,
-          comments: [],
-          createdAt: now,
-          updatedAt: now,
-        },
+        thread,
       };
     }
 

--- a/src/core/review-executor.ts
+++ b/src/core/review-executor.ts
@@ -26,19 +26,9 @@ import { importGitHubReview, pushGitHubReview } from './github-review.js';
 import { readProjectConfig } from './config.js';
 import { scanWorkspaces } from '../lib/remote-session/workspace-scanner.js';
 import type { ReviewOperation, ReviewResult } from '../types/review.js';
+import { matchesWorkspaceId } from '../utils/workspace-id.js';
 
 type ScanWorkspacesFn = typeof scanWorkspaces;
-
-function toCanonicalWorkspaceId(workspace: { projectName: string; id: string }): string {
-  return `${workspace.projectName}:${workspace.id}`;
-}
-
-function matchesWorkspaceId(
-  workspace: { projectName: string; id: string },
-  workspaceId: string
-): boolean {
-  return workspace.id === workspaceId || toCanonicalWorkspaceId(workspace) === workspaceId;
-}
 
 async function resolveWorkspaceByName(
   projectName: string,

--- a/src/core/review.ts
+++ b/src/core/review.ts
@@ -154,6 +154,10 @@ export async function createThread(
   decision?: HunkDecision,
   author = 'local'
 ): Promise<ReviewThread> {
+  // Ensure .gitignore decision is handled before reading/writing session state so
+  // concurrent CRUD writes cannot be overwritten after an async gap.
+  await ensureGitignore(workspacePath, workspaceName);
+
   const session = readReviewSession(workspacePath, workspaceName, baseBranch);
   const now = new Date().toISOString();
 
@@ -179,9 +183,6 @@ export async function createThread(
   };
 
   session.threads.push(thread);
-
-  // First-time .gitignore prompt
-  await ensureGitignore(workspacePath, workspaceName);
 
   writeReviewSession(workspacePath, workspaceName, session);
   return thread;
@@ -285,7 +286,8 @@ export function updateComment(
 /**
  * Delete a specific comment from a thread.
  * If it's the only comment in the thread, the thread itself is deleted.
- * Returns the updated thread, or null if the thread was deleted.
+ * Returns the updated thread snapshot. If the last comment is deleted,
+ * the returned thread keeps its original target metadata and has comments: [].
  */
 export function deleteComment(
   workspacePath: string,
@@ -293,7 +295,7 @@ export function deleteComment(
   baseBranch: string,
   threadId: string,
   commentId: string
-): ReviewThread | null {
+): ReviewThread {
   const session = readReviewSession(workspacePath, workspaceName, baseBranch);
   const threadIndex = session.threads.findIndex(t => t.id === threadId);
 
@@ -309,15 +311,15 @@ export function deleteComment(
   }
 
   thread.comments.splice(commentIndex, 1);
+  thread.updatedAt = new Date().toISOString();
 
   // If no comments remain, delete the whole thread
   if (thread.comments.length === 0) {
     session.threads.splice(threadIndex, 1);
     writeReviewSession(workspacePath, workspaceName, session);
-    return null;
+    return thread;
   }
 
-  thread.updatedAt = new Date().toISOString();
   writeReviewSession(workspacePath, workspaceName, session);
   return thread;
 }

--- a/src/core/review.ts
+++ b/src/core/review.ts
@@ -20,6 +20,7 @@ import type {
 } from '../types/review.js';
 import { generateId } from '../utils/id.js';
 import { SpacesError } from '../types/errors.js';
+import { logger } from '../utils/logger.js';
 
 const execAsync = promisify(exec);
 
@@ -64,8 +65,29 @@ export function readReviewSession(
     const raw = readFileSync(notesPath, 'utf-8');
     const parsed = JSON.parse(raw) as ReviewSession;
     return parsed;
-  } catch {
-    return createEmptySession(workspaceName, baseBranch);
+  } catch (error) {
+    const code =
+      typeof error === 'object' && error !== null && 'code' in error
+        ? String((error as { code?: unknown }).code)
+        : undefined;
+
+    if (code === 'ENOENT') {
+      return createEmptySession(workspaceName, baseBranch);
+    }
+
+    const message = error instanceof Error ? error.message : String(error);
+
+    if (error instanceof SyntaxError) {
+      logger.error(`Failed to parse review notes at ${notesPath}: ${message}`);
+      throw new SpacesError(`Corrupted review notes at ${notesPath}: ${message}`, 'USER_ERROR', 1);
+    }
+
+    logger.error(`Failed to read review notes at ${notesPath}: ${message}`);
+    if (error instanceof Error) {
+      throw error;
+    }
+
+    throw new SpacesError(`Failed to read review notes at ${notesPath}: ${message}`, 'SYSTEM_ERROR', 2);
   }
 }
 

--- a/src/core/review.ts
+++ b/src/core/review.ts
@@ -32,14 +32,14 @@ const execAsync = promisify(exec);
  * Returns the directory where review notes are stored for this workspace.
  * Path: <workspacePath>/.gitspace/review/<workspaceName>/
  */
-export function getReviewDir(workspacePath: string, workspaceName: string): string {
+function getReviewDir(workspacePath: string, workspaceName: string): string {
   return join(workspacePath, '.gitspace', 'review', workspaceName);
 }
 
 /**
  * Returns the path to the notes.json file for this workspace.
  */
-export function getNotesPath(workspacePath: string, workspaceName: string): string {
+function getNotesPath(workspacePath: string, workspaceName: string): string {
   return join(getReviewDir(workspacePath, workspaceName), 'notes.json');
 }
 

--- a/src/core/review.ts
+++ b/src/core/review.ts
@@ -1,0 +1,440 @@
+/**
+ * Core review operations
+ *
+ * Manages ReviewThread storage in <workspace>/.gitspace/review/<workspaceName>/notes.json
+ * Threads are namespaced by workspace name so that workspaces branched from each
+ * other don't share the same thread store.
+ */
+
+import { existsSync, readFileSync, writeFileSync, mkdirSync, appendFileSync } from 'fs';
+import { join, dirname } from 'path';
+import { exec } from 'child_process';
+import { promisify } from 'util';
+import { confirm } from '@inquirer/prompts';
+import type {
+  ReviewSession,
+  ReviewThread,
+  ReviewComment,
+  ThreadTarget,
+  HunkDecision,
+} from '../types/review.js';
+
+const execAsync = promisify(exec);
+
+// ============================================================================
+// Path Helpers
+// ============================================================================
+
+/**
+ * Returns the directory where review notes are stored for this workspace.
+ * Path: <workspacePath>/.gitspace/review/<workspaceName>/
+ */
+export function getReviewDir(workspacePath: string, workspaceName: string): string {
+  return join(workspacePath, '.gitspace', 'review', workspaceName);
+}
+
+/**
+ * Returns the path to the notes.json file for this workspace.
+ */
+export function getNotesPath(workspacePath: string, workspaceName: string): string {
+  return join(getReviewDir(workspacePath, workspaceName), 'notes.json');
+}
+
+// ============================================================================
+// Session Read / Write
+// ============================================================================
+
+/**
+ * Read the review session from disk. Returns a fresh session if none exists.
+ */
+export function readReviewSession(
+  workspacePath: string,
+  workspaceName: string,
+  baseBranch: string
+): ReviewSession {
+  const notesPath = getNotesPath(workspacePath, workspaceName);
+
+  if (!existsSync(notesPath)) {
+    return createEmptySession(workspaceName, baseBranch);
+  }
+
+  try {
+    const raw = readFileSync(notesPath, 'utf-8');
+    const parsed = JSON.parse(raw) as ReviewSession;
+    return parsed;
+  } catch {
+    return createEmptySession(workspaceName, baseBranch);
+  }
+}
+
+/**
+ * Write the review session to disk, creating directories as needed.
+ */
+export function writeReviewSession(
+  workspacePath: string,
+  workspaceName: string,
+  session: ReviewSession
+): void {
+  const notesPath = getNotesPath(workspacePath, workspaceName);
+  const dir = dirname(notesPath);
+
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true });
+  }
+
+  const updated: ReviewSession = {
+    ...session,
+    updatedAt: new Date().toISOString(),
+  };
+
+  writeFileSync(notesPath, JSON.stringify(updated, null, 2), 'utf-8');
+}
+
+function createEmptySession(workspaceName: string, baseBranch: string): ReviewSession {
+  const now = new Date().toISOString();
+  return {
+    version: '1.0',
+    workspaceName,
+    baseBranch,
+    prNumber: null,
+    threads: [],
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+// ============================================================================
+// Thread CRUD
+// ============================================================================
+
+/**
+ * Get all threads for a workspace.
+ */
+export function getThreads(
+  workspacePath: string,
+  workspaceName: string,
+  baseBranch: string
+): ReviewThread[] {
+  return readReviewSession(workspacePath, workspaceName, baseBranch).threads;
+}
+
+/**
+ * Create a new thread with an initial comment.
+ */
+export async function createThread(
+  workspacePath: string,
+  workspaceName: string,
+  baseBranch: string,
+  target: ThreadTarget,
+  body: string,
+  decision?: HunkDecision,
+  author = 'local'
+): Promise<ReviewThread> {
+  const session = readReviewSession(workspacePath, workspaceName, baseBranch);
+  const now = new Date().toISOString();
+
+  const threadId = generateId();
+  const commentId = generateId();
+
+  const comment: ReviewComment = {
+    id: commentId,
+    threadId,
+    body,
+    author,
+    createdAt: now,
+  };
+
+  const thread: ReviewThread = {
+    id: threadId,
+    target,
+    decision: target.kind === 'hunk' ? (decision ?? 'pending') : undefined,
+    resolved: false,
+    comments: [comment],
+    createdAt: now,
+    updatedAt: now,
+  };
+
+  session.threads.push(thread);
+
+  // First-time .gitignore prompt
+  await ensureGitignore(workspacePath, workspaceName);
+
+  writeReviewSession(workspacePath, workspaceName, session);
+  return thread;
+}
+
+/**
+ * Add a reply to an existing thread.
+ */
+export function addReply(
+  workspacePath: string,
+  workspaceName: string,
+  baseBranch: string,
+  threadId: string,
+  body: string,
+  author = 'local'
+): ReviewThread {
+  const session = readReviewSession(workspacePath, workspaceName, baseBranch);
+  const thread = session.threads.find(t => t.id === threadId);
+
+  if (!thread) {
+    throw new Error(`Thread not found: ${threadId}`);
+  }
+
+  const now = new Date().toISOString();
+  const comment: ReviewComment = {
+    id: generateId(),
+    threadId,
+    body,
+    author,
+    createdAt: now,
+  };
+
+  thread.comments.push(comment);
+  thread.updatedAt = now;
+
+  writeReviewSession(workspacePath, workspaceName, session);
+  return thread;
+}
+
+/**
+ * Update a thread's resolved status or hunk decision.
+ */
+export function updateThread(
+  workspacePath: string,
+  workspaceName: string,
+  baseBranch: string,
+  threadId: string,
+  updates: { resolved?: boolean; decision?: HunkDecision }
+): ReviewThread {
+  const session = readReviewSession(workspacePath, workspaceName, baseBranch);
+  const thread = session.threads.find(t => t.id === threadId);
+
+  if (!thread) {
+    throw new Error(`Thread not found: ${threadId}`);
+  }
+
+  if (updates.resolved !== undefined) {
+    thread.resolved = updates.resolved;
+  }
+
+  if (updates.decision !== undefined && thread.target.kind === 'hunk') {
+    thread.decision = updates.decision;
+  }
+
+  thread.updatedAt = new Date().toISOString();
+
+  writeReviewSession(workspacePath, workspaceName, session);
+  return thread;
+}
+
+/**
+ * Update the body of a specific comment in a thread.
+ */
+export function updateComment(
+  workspacePath: string,
+  workspaceName: string,
+  baseBranch: string,
+  threadId: string,
+  commentId: string,
+  body: string
+): ReviewThread {
+  const session = readReviewSession(workspacePath, workspaceName, baseBranch);
+  const thread = session.threads.find(t => t.id === threadId);
+
+  if (!thread) {
+    throw new Error(`Thread not found: ${threadId}`);
+  }
+
+  const comment = thread.comments.find(c => c.id === commentId);
+  if (!comment) {
+    throw new Error(`Comment not found: ${commentId}`);
+  }
+
+  comment.body = body;
+  thread.updatedAt = new Date().toISOString();
+
+  writeReviewSession(workspacePath, workspaceName, session);
+  return thread;
+}
+
+/**
+ * Delete a specific comment from a thread.
+ * If it's the only comment in the thread, the thread itself is deleted.
+ * Returns the updated thread, or null if the thread was deleted.
+ */
+export function deleteComment(
+  workspacePath: string,
+  workspaceName: string,
+  baseBranch: string,
+  threadId: string,
+  commentId: string
+): ReviewThread | null {
+  const session = readReviewSession(workspacePath, workspaceName, baseBranch);
+  const threadIndex = session.threads.findIndex(t => t.id === threadId);
+
+  if (threadIndex === -1) {
+    throw new Error(`Thread not found: ${threadId}`);
+  }
+
+  const thread = session.threads[threadIndex];
+  const commentIndex = thread.comments.findIndex(c => c.id === commentId);
+
+  if (commentIndex === -1) {
+    throw new Error(`Comment not found: ${commentId}`);
+  }
+
+  thread.comments.splice(commentIndex, 1);
+
+  // If no comments remain, delete the whole thread
+  if (thread.comments.length === 0) {
+    session.threads.splice(threadIndex, 1);
+    writeReviewSession(workspacePath, workspaceName, session);
+    return null;
+  }
+
+  thread.updatedAt = new Date().toISOString();
+  writeReviewSession(workspacePath, workspaceName, session);
+  return thread;
+}
+
+// ============================================================================
+// PR Number Association
+// ============================================================================
+
+/**
+ * Associate a GitHub PR number with the workspace's review session.
+ */
+export function setPRNumber(
+  workspacePath: string,
+  workspaceName: string,
+  baseBranch: string,
+  prNumber: number | null
+): void {
+  const session = readReviewSession(workspacePath, workspaceName, baseBranch);
+  session.prNumber = prNumber;
+  writeReviewSession(workspacePath, workspaceName, session);
+}
+
+// ============================================================================
+// .gitignore Management
+// ============================================================================
+
+const GITIGNORE_ENTRY = '.gitspace/review/';
+const GITIGNORE_MARKER = '# gssh review — workspace review notes';
+
+/**
+ * Ensure that .gitspace/review/ is handled appropriately in .gitignore.
+ * On first note creation, prompts the user whether to gitignore or commit.
+ * Remembers the choice in a local marker file so it's not asked again.
+ */
+async function ensureGitignore(workspacePath: string, workspaceName: string): Promise<void> {
+  const reviewDir = getReviewDir(workspacePath, workspaceName);
+  const markerPath = join(reviewDir, '.gitignore-decided');
+
+  // Already decided — skip
+  if (existsSync(markerPath)) return;
+
+  const gitignorePath = join(workspacePath, '.gitignore');
+  const alreadyIgnored =
+    existsSync(gitignorePath) &&
+    readFileSync(gitignorePath, 'utf-8').includes(GITIGNORE_ENTRY);
+
+  if (alreadyIgnored) {
+    // Already ignored — write marker and return
+    mkdirSync(dirname(markerPath), { recursive: true });
+    writeFileSync(markerPath, 'gitignored\n', 'utf-8');
+    return;
+  }
+
+  let keepPrivate = true;
+
+  // Only prompt when running interactively (stdin is a TTY).
+  // When called from the serve daemon there is no TTY, so we silently
+  // default to keeping notes private.
+  const isTTY = Boolean(process.stdin.isTTY);
+  if (isTTY) {
+    try {
+      keepPrivate = await confirm({
+        message:
+          'Review notes found. Keep them private (add to .gitignore) or share with the team (commit alongside branch)?',
+        default: true,
+      });
+    } catch {
+      // Prompt cancelled or non-interactive — default to private
+      keepPrivate = true;
+    }
+  }
+
+  if (keepPrivate) {
+    appendFileSync(
+      gitignorePath,
+      `\n${GITIGNORE_MARKER}\n${GITIGNORE_ENTRY}\n`,
+      'utf-8'
+    );
+  }
+
+  mkdirSync(dirname(markerPath), { recursive: true });
+  writeFileSync(markerPath, keepPrivate ? 'gitignored\n' : 'committed\n', 'utf-8');
+}
+
+// ============================================================================
+// Workspace Detection
+// ============================================================================
+
+/**
+ * Detect the PR number associated with the current workspace branch
+ * by using `gh pr view`.
+ */
+export async function detectPRNumber(workspacePath: string): Promise<number | null> {
+  try {
+    const { stdout } = await execAsync('gh pr view --json number --jq .number', {
+      cwd: workspacePath,
+    });
+    const num = parseInt(stdout.trim(), 10);
+    return isNaN(num) ? null : num;
+  } catch {
+    return null;
+  }
+}
+
+// ============================================================================
+// Utility
+// ============================================================================
+
+function generateId(): string {
+  // Use crypto.randomUUID if available (Bun/modern Node), fallback to timestamp+random
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
+}
+
+/**
+ * LLM-friendly JSON summary of all threads in a workspace.
+ * Used by `gssh review notes` CLI command.
+ */
+export function buildNotesSummary(
+  threads: ReviewThread[],
+  workspaceName: string,
+  baseBranch: string
+): object {
+  const unresolved = threads.filter(t => !t.resolved);
+  return {
+    workspace: workspaceName,
+    baseBranch,
+    totalThreads: threads.length,
+    unresolvedThreads: unresolved.length,
+    threads: threads.map(t => ({
+      id: t.id,
+      target: t.target,
+      decision: t.decision,
+      resolved: t.resolved,
+      commentCount: t.comments.length,
+      firstComment: t.comments[0]?.body ?? '',
+      lastReply: t.comments.length > 1 ? t.comments[t.comments.length - 1]?.body : undefined,
+      createdAt: t.createdAt,
+      updatedAt: t.updatedAt,
+    })),
+  };
+}

--- a/src/core/review.ts
+++ b/src/core/review.ts
@@ -10,7 +10,6 @@ import { existsSync, readFileSync, writeFileSync, mkdirSync, appendFileSync } fr
 import { join, dirname } from 'path';
 import { exec } from 'child_process';
 import { promisify } from 'util';
-import { confirm } from '@inquirer/prompts';
 import type {
   ReviewSession,
   ReviewThread,
@@ -363,6 +362,7 @@ async function ensureGitignore(workspacePath: string, workspaceName: string): Pr
   const isTTY = Boolean(process.stdin.isTTY);
   if (isTTY) {
     try {
+      const { confirm } = await import('@inquirer/prompts');
       keepPrivate = await confirm({
         message:
           'Review notes found. Keep them private (add to .gitignore) or share with the team (commit alongside branch)?',

--- a/src/core/review.ts
+++ b/src/core/review.ts
@@ -19,6 +19,7 @@ import type {
   HunkDecision,
 } from '../types/review.js';
 import { generateId } from '../utils/id.js';
+import { SpacesError } from '../types/errors.js';
 
 const execAsync = promisify(exec);
 
@@ -179,7 +180,7 @@ export function addReply(
   const thread = session.threads.find(t => t.id === threadId);
 
   if (!thread) {
-    throw new Error(`Thread not found: ${threadId}`);
+    throw new SpacesError(`Thread not found: ${threadId}`, 'USER_ERROR', 1);
   }
 
   const now = new Date().toISOString();
@@ -212,7 +213,7 @@ export function updateThread(
   const thread = session.threads.find(t => t.id === threadId);
 
   if (!thread) {
-    throw new Error(`Thread not found: ${threadId}`);
+    throw new SpacesError(`Thread not found: ${threadId}`, 'USER_ERROR', 1);
   }
 
   if (updates.resolved !== undefined) {
@@ -244,12 +245,12 @@ export function updateComment(
   const thread = session.threads.find(t => t.id === threadId);
 
   if (!thread) {
-    throw new Error(`Thread not found: ${threadId}`);
+    throw new SpacesError(`Thread not found: ${threadId}`, 'USER_ERROR', 1);
   }
 
   const comment = thread.comments.find(c => c.id === commentId);
   if (!comment) {
-    throw new Error(`Comment not found: ${commentId}`);
+    throw new SpacesError(`Comment not found: ${commentId}`, 'USER_ERROR', 1);
   }
 
   comment.body = body;
@@ -278,14 +279,14 @@ export function deleteComment(
   const threadIndex = session.threads.findIndex(t => t.id === threadId);
 
   if (threadIndex === -1) {
-    throw new Error(`Thread not found: ${threadId}`);
+    throw new SpacesError(`Thread not found: ${threadId}`, 'USER_ERROR', 1);
   }
 
   const thread = session.threads[threadIndex];
   const commentIndex = thread.comments.findIndex(c => c.id === commentId);
 
   if (commentIndex === -1) {
-    throw new Error(`Comment not found: ${commentId}`);
+    throw new SpacesError(`Comment not found: ${commentId}`, 'USER_ERROR', 1);
   }
 
   thread.comments.splice(commentIndex, 1);

--- a/src/core/review.ts
+++ b/src/core/review.ts
@@ -276,9 +276,6 @@ export function updateComment(
   }
 
   comment.body = body;
-  if (comment.author === 'local' && comment.githubId === undefined) {
-    delete comment.syncedToGitHubAt;
-  }
   thread.updatedAt = new Date().toISOString();
 
   writeReviewSession(workspacePath, workspaceName, session);

--- a/src/core/review.ts
+++ b/src/core/review.ts
@@ -18,6 +18,7 @@ import type {
   ThreadTarget,
   HunkDecision,
 } from '../types/review.js';
+import { generateId } from '../utils/id.js';
 
 const execAsync = promisify(exec);
 
@@ -299,24 +300,6 @@ export function deleteComment(
 }
 
 // ============================================================================
-// PR Number Association
-// ============================================================================
-
-/**
- * Associate a GitHub PR number with the workspace's review session.
- */
-export function setPRNumber(
-  workspacePath: string,
-  workspaceName: string,
-  baseBranch: string,
-  prNumber: number | null
-): void {
-  const session = readReviewSession(workspacePath, workspaceName, baseBranch);
-  session.prNumber = prNumber;
-  writeReviewSession(workspacePath, workspaceName, session);
-}
-
-// ============================================================================
 // .gitignore Management
 // ============================================================================
 
@@ -396,16 +379,4 @@ export async function detectPRNumber(workspacePath: string): Promise<number | nu
   } catch {
     return null;
   }
-}
-
-// ============================================================================
-// Utility
-// ============================================================================
-
-function generateId(): string {
-  // Use crypto.randomUUID if available (Bun/modern Node), fallback to timestamp+random
-  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
-    return crypto.randomUUID();
-  }
-  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
 }

--- a/src/core/review.ts
+++ b/src/core/review.ts
@@ -253,6 +253,9 @@ export function updateComment(
   }
 
   comment.body = body;
+  if (comment.author === 'local' && comment.githubId === undefined) {
+    delete comment.syncedToGitHubAt;
+  }
   thread.updatedAt = new Date().toISOString();
 
   writeReviewSession(workspacePath, workspaceName, session);

--- a/src/core/review.ts
+++ b/src/core/review.ts
@@ -409,32 +409,3 @@ function generateId(): string {
   }
   return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
 }
-
-/**
- * LLM-friendly JSON summary of all threads in a workspace.
- * Used by `gssh review notes` CLI command.
- */
-export function buildNotesSummary(
-  threads: ReviewThread[],
-  workspaceName: string,
-  baseBranch: string
-): object {
-  const unresolved = threads.filter(t => !t.resolved);
-  return {
-    workspace: workspaceName,
-    baseBranch,
-    totalThreads: threads.length,
-    unresolvedThreads: unresolved.length,
-    threads: threads.map(t => ({
-      id: t.id,
-      target: t.target,
-      decision: t.decision,
-      resolved: t.resolved,
-      commentCount: t.comments.length,
-      firstComment: t.comments[0]?.body ?? '',
-      lastReply: t.comments.length > 1 ? t.comments[t.comments.length - 1]?.body : undefined,
-      createdAt: t.createdAt,
-      updatedAt: t.updatedAt,
-    })),
-  };
-}

--- a/src/core/shell.ts
+++ b/src/core/shell.ts
@@ -10,6 +10,7 @@ import {
 	createSession,
 	isNested,
 } from '../lib/tmux-lite/cli.js'
+import { buildWorkspaceSessionHooks } from '../session/workspace-shell-hooks.js'
 
 /**
  * Print a message to terminal using echo (same mechanism as scripts)
@@ -93,7 +94,9 @@ async function openTmuxLiteSession(
 		logger.debug(`Creating tmux-lite session: ${fullSessionName}`)
 
 		// Create new session
-		const session = await createSession(fullSessionName, workspacePath)
+		const session = await createSession(fullSessionName, workspacePath, {
+			hooks: buildWorkspaceSessionHooks(projectName, workspaceName),
+		})
 
 		// Spawn the CLI attach command as a subprocess with inherited stdio
 		// This works better with TUI suspension than direct attach() call

--- a/src/core/shell.ts
+++ b/src/core/shell.ts
@@ -37,12 +37,12 @@ export async function openWorkspaceShell(
 	noSetup: boolean = false,
 	sessionName?: string
 ): Promise<void> {
-	const workspaceName = workspacePath.split('/').pop() || 'workspace'
+	const workspaceId = workspacePath.split('/').pop() || 'workspace'
 
 	const prepareResult = await prepareWorkspaceForSession({
 		projectName,
 		workspacePath,
-		workspaceName,
+		workspaceName: workspaceId,
 		repository,
 		noSetup,
 		interactiveScripts: true,
@@ -58,14 +58,14 @@ export async function openWorkspaceShell(
 	printToTerminal('')
 
 	// Create or attach to tmux-lite session
-	await openTmuxLiteSession(workspacePath, projectName, workspaceName, sessionName)
+	await openTmuxLiteSession(workspacePath, projectName, workspaceId, sessionName)
 }
 
 /**
  * Build a full session name from components
  */
-function buildSessionName(projectName: string, workspaceName: string, sessionName: string): string {
-	return `${projectName}:${workspaceName}:${sessionName}`
+function buildSessionName(projectName: string, workspaceId: string, sessionName: string): string {
+	return `${projectName}:${workspaceId}:${sessionName}`
 }
 
 /**
@@ -76,7 +76,7 @@ function buildSessionName(projectName: string, workspaceName: string, sessionNam
 async function openTmuxLiteSession(
 	workspacePath: string,
 	projectName: string,
-	workspaceName: string,
+	workspaceId: string,
 	sessionName?: string
 ): Promise<void> {
 	// Check if we're already in a tmux-lite session
@@ -89,13 +89,13 @@ async function openTmuxLiteSession(
 		const suffix = sessionName && sessionName.trim().length > 0
 			? sessionName
 			: `${Date.now()}`
-		const fullSessionName = buildSessionName(projectName, workspaceName, suffix)
+		const fullSessionName = buildSessionName(projectName, workspaceId, suffix)
 
 		logger.debug(`Creating tmux-lite session: ${fullSessionName}`)
 
 		// Create new session
 		const session = await createSession(fullSessionName, workspacePath, {
-			hooks: buildWorkspaceSessionHooks(projectName, workspaceName),
+			hooks: buildWorkspaceSessionHooks(projectName, workspaceId),
 		})
 
 		// Spawn the CLI attach command as a subprocess with inherited stdio

--- a/src/hooks/__tests__/useLocalSession.tui.test.ts
+++ b/src/hooks/__tests__/useLocalSession.tui.test.ts
@@ -127,6 +127,10 @@ class FakeLocalBackend implements SessionBackend {
 
   async updateNotificationConfig(_config: NotificationConfig): Promise<void> {}
 
+  async sendReviewRequest(): Promise<never> {
+    throw new Error('not implemented')
+  }
+
   async writePtyData(data: Uint8Array): Promise<void> {
     this.writeCalls.push(new Uint8Array(data))
   }

--- a/src/hooks/useReview.web.ts
+++ b/src/hooks/useReview.web.ts
@@ -207,7 +207,7 @@ export function useReview({ sendReviewRequest, projectName, workspaceName }: Use
         setThreads(result.threads);
         return { imported: result.imported };
       }
-      return { imported: 0 };
+      throw new Error(`Unexpected response from import_github: ${result.op}`);
     });
   }, [run, sendReviewRequest, projectName, workspaceName]);
 

--- a/src/hooks/useReview.web.ts
+++ b/src/hooks/useReview.web.ts
@@ -55,11 +55,13 @@ export function useReview({ sendReviewRequest, projectName, workspaceName }: Use
   const [diff, setDiff] = useState<string | null>(null);
   const [baseBranch, setBaseBranch] = useState<string | null>(null);
   const [headBranch, setHeadBranch] = useState<string | null>(null);
-  const [loading, setLoading] = useState(false);
+  const [inFlightCount, setInFlightCount] = useState(0);
   const [error, setError] = useState<string | null>(null);
 
+  const loading = inFlightCount > 0;
+
   const run = useCallback(async <T>(fn: () => Promise<T>): Promise<T> => {
-    setLoading(true);
+    setInFlightCount((count) => count + 1);
     setError(null);
     try {
       return await fn();
@@ -68,7 +70,7 @@ export function useReview({ sendReviewRequest, projectName, workspaceName }: Use
       setError(message);
       throw err;
     } finally {
-      setLoading(false);
+      setInFlightCount((count) => (count > 0 ? count - 1 : 0));
     }
   }, []);
 

--- a/src/hooks/useReview.web.ts
+++ b/src/hooks/useReview.web.ts
@@ -1,0 +1,246 @@
+/** @jsxImportSource react */
+/**
+ * useReview — React hook for the review system.
+ *
+ * Calls terminal.sendReviewRequest() over the existing encrypted WebSocket
+ * channel and manages local state for threads, diff, and loading.
+ */
+
+import { useState, useCallback } from 'react';
+import type { ReviewThread, ThreadTarget, HunkDecision, ReviewOperation } from '../types/review.js';
+
+export interface UseReviewOptions {
+  sendReviewRequest: (operation: ReviewOperation) => Promise<import('../types/review.js').ReviewResult>;
+  projectName: string;
+  workspaceName: string;
+}
+
+export interface UseReviewReturn {
+  /** All review threads for this workspace */
+  threads: ReviewThread[];
+  /** The raw unified diff text */
+  diff: string | null;
+  /** Base branch (e.g. "main") */
+  baseBranch: string | null;
+  /** Current branch */
+  headBranch: string | null;
+  /** True while any operation is in flight */
+  loading: boolean;
+  /** Last error message, if any */
+  error: string | null;
+
+  /** Load threads from the machine */
+  loadThreads: () => Promise<void>;
+  /** Load the current diff from the machine */
+  loadDiff: () => Promise<void>;
+
+  /** Create a new thread */
+  createThread: (target: ThreadTarget, body: string, decision?: HunkDecision) => Promise<void>;
+  /** Add a reply to an existing thread */
+  addReply: (threadId: string, body: string) => Promise<void>;
+  /** Update thread properties (resolve/unresolve, change hunk decision) */
+  updateThread: (threadId: string, updates: { resolved?: boolean; decision?: HunkDecision }) => Promise<void>;
+  /** Update the body of a specific comment */
+  updateComment: (threadId: string, commentId: string, body: string) => Promise<void>;
+  /** Delete a comment */
+  deleteComment: (threadId: string, commentId: string) => Promise<void>;
+  /** Import GitHub PR review comments */
+  importGitHub: (prNumber?: number) => Promise<{ imported: number }>;
+  /** Push local review to GitHub as a formal PR review */
+  pushGitHub: (prNumber?: number) => Promise<{ prNumber: number; url: string }>;
+}
+
+export function useReview({ sendReviewRequest, projectName, workspaceName }: UseReviewOptions): UseReviewReturn {
+  const [threads, setThreads] = useState<ReviewThread[]>([]);
+  const [diff, setDiff] = useState<string | null>(null);
+  const [baseBranch, setBaseBranch] = useState<string | null>(null);
+  const [headBranch, setHeadBranch] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const run = useCallback(async <T>(fn: () => Promise<T>): Promise<T> => {
+    setLoading(true);
+    setError(null);
+    try {
+      return await fn();
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      setError(message);
+      throw err;
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  const loadThreads = useCallback(async () => {
+    await run(async () => {
+      const result = await sendReviewRequest({
+        op: 'get_threads',
+        projectName,
+        workspaceName,
+      });
+      if (result.op === 'threads') {
+        setThreads(result.threads);
+      }
+    });
+  }, [run, sendReviewRequest, projectName, workspaceName]);
+
+  const loadDiff = useCallback(async () => {
+    await run(async () => {
+      const result = await sendReviewRequest({
+        op: 'get_diff',
+        projectName,
+        workspaceName,
+      });
+      if (result.op === 'diff') {
+        setDiff(result.diff);
+        setBaseBranch(result.baseBranch);
+        setHeadBranch(result.headBranch);
+      }
+    });
+  }, [run, sendReviewRequest, projectName, workspaceName]);
+
+  const createThread = useCallback(async (
+    target: ThreadTarget,
+    body: string,
+    decision?: HunkDecision
+  ) => {
+    await run(async () => {
+      const result = await sendReviewRequest({
+        op: 'create_thread',
+        projectName,
+        workspaceName,
+        target,
+        body,
+        decision,
+      });
+      if (result.op === 'thread_created') {
+        setThreads((prev) => [...prev, result.thread]);
+      }
+    });
+  }, [run, sendReviewRequest, projectName, workspaceName]);
+
+  const addReply = useCallback(async (threadId: string, body: string) => {
+    await run(async () => {
+      const result = await sendReviewRequest({
+        op: 'add_reply',
+        projectName,
+        workspaceName,
+        threadId,
+        body,
+      });
+      if (result.op === 'comment_added') {
+        setThreads((prev) => prev.map((t) => t.id === threadId ? result.thread : t));
+      }
+    });
+  }, [run, sendReviewRequest, projectName, workspaceName]);
+
+  const updateThread = useCallback(async (
+    threadId: string,
+    updates: { resolved?: boolean; decision?: HunkDecision }
+  ) => {
+    await run(async () => {
+      const result = await sendReviewRequest({
+        op: 'update_thread',
+        projectName,
+        workspaceName,
+        threadId,
+        ...updates,
+      });
+      if (result.op === 'thread_updated') {
+        setThreads((prev) => prev.map((t) => t.id === threadId ? result.thread : t));
+      }
+    });
+  }, [run, sendReviewRequest, projectName, workspaceName]);
+
+  const updateComment = useCallback(async (
+    threadId: string,
+    commentId: string,
+    body: string
+  ) => {
+    await run(async () => {
+      const result = await sendReviewRequest({
+        op: 'update_comment',
+        projectName,
+        workspaceName,
+        threadId,
+        commentId,
+        body,
+      });
+      if (result.op === 'comment_updated') {
+        setThreads((prev) => prev.map((t) => t.id === threadId ? result.thread : t));
+      }
+    });
+  }, [run, sendReviewRequest, projectName, workspaceName]);
+
+  const deleteComment = useCallback(async (threadId: string, commentId: string) => {
+    await run(async () => {
+      const result = await sendReviewRequest({
+        op: 'delete_comment',
+        projectName,
+        workspaceName,
+        threadId,
+        commentId,
+      });
+      if (result.op === 'comment_deleted') {
+        // When the last comment is deleted, the server removes the whole thread
+        // and returns a stub with comments: []. Filter it out rather than keeping
+        // a zombie thread in state.
+        if (result.thread.comments.length === 0) {
+          setThreads((prev) => prev.filter((t) => t.id !== threadId));
+        } else {
+          setThreads((prev) => prev.map((t) => t.id === threadId ? result.thread : t));
+        }
+      }
+    });
+  }, [run, sendReviewRequest, projectName, workspaceName]);
+
+  const importGitHub = useCallback(async (prNumber?: number): Promise<{ imported: number }> => {
+    return run(async () => {
+      const result = await sendReviewRequest({
+        op: 'import_github',
+        projectName,
+        workspaceName,
+        prNumber,
+      });
+      if (result.op === 'github_imported') {
+        setThreads(result.threads);
+        return { imported: result.imported };
+      }
+      return { imported: 0 };
+    });
+  }, [run, sendReviewRequest, projectName, workspaceName]);
+
+  const pushGitHub = useCallback(async (prNumber?: number): Promise<{ prNumber: number; url: string }> => {
+    return run(async () => {
+      const result = await sendReviewRequest({
+        op: 'push_github',
+        projectName,
+        workspaceName,
+        prNumber,
+      });
+      if (result.op === 'github_pushed') {
+        return { prNumber: result.prNumber, url: result.url };
+      }
+      throw new Error('Unexpected response from push_github');
+    });
+  }, [run, sendReviewRequest, projectName, workspaceName]);
+
+  return {
+    threads,
+    diff,
+    baseBranch,
+    headBranch,
+    loading,
+    error,
+    loadThreads,
+    loadDiff,
+    createThread,
+    addReply,
+    updateThread,
+    updateComment,
+    deleteComment,
+    importGitHub,
+    pushGitHub,
+  };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -971,6 +971,8 @@ registerReviewSubcommands(reviewCommand)
 // Intended to be used from `space` shell function injected into workspace sessions.
 const spaceCommand = program
 	.command('space', { hidden: true })
+	.option('--workspace <name>', 'Workspace name')
+	.option('--project <name>', 'Project name')
 	.description('Workspace-scoped commands')
 
 spaceCommand

--- a/src/index.ts
+++ b/src/index.ts
@@ -59,7 +59,17 @@ import { configNotifications, linearSetup, linearShow, linearClear } from './com
 import { migrateCleanupLegacy } from './commands/migrate.js'
 import { notificationsInstall, notificationsUninstall, notificationsHook, notificationsStatus } from './commands/notifications.js'
 import { bundleRefresh, bundleStatus } from './commands/bundle.js'
-import { openReview, showReviewNotes, importReview, pushReview } from './commands/review.js'
+import {
+	openReview,
+	showReviewNotes,
+	importReview,
+	pushReview,
+	listReviewHunks,
+	addHunkReview,
+	addFileReview,
+	addLineReview,
+	showSpaceContext,
+} from './commands/review.js'
 
 const program = new Command()
 
@@ -899,6 +909,216 @@ reviewCommand
 		}
 	})
 
+reviewCommand
+	.command('hunks <file>')
+	.description('List hunks in a changed file (AI-friendly target IDs)')
+	.option('--workspace <name>', 'Workspace name')
+	.option('--project <name>', 'Project name')
+	.option('--format <format>', 'Output format: json (default) or text')
+	.action(async (file, options) => {
+		await checkFirstTimeSetup()
+		try {
+			await listReviewHunks(file, options)
+		} catch (error) {
+			handleError(error)
+		}
+	})
+
+reviewCommand
+	.command('add-hunk <file>')
+	.description('Add or update hunk review by hunk index')
+	.option('--workspace <name>', 'Workspace name')
+	.option('--project <name>', 'Project name')
+	.requiredOption('--index <number>', '1-based hunk index', (v) => parseInt(v, 10))
+	.option('--body <text>', 'Optional comment body')
+	.option('--approve', 'Set hunk decision to approved')
+	.option('--reject', 'Set hunk decision to rejected')
+	.option('--pending', 'Set hunk decision to pending')
+	.option('--json', 'Output structured JSON')
+	.action(async (file, options) => {
+		await checkFirstTimeSetup()
+		try {
+			await addHunkReview(file, options)
+		} catch (error) {
+			handleError(error)
+		}
+	})
+
+reviewCommand
+	.command('add-file <file>')
+	.description('Add a file-level review thread')
+	.option('--workspace <name>', 'Workspace name')
+	.option('--project <name>', 'Project name')
+	.requiredOption('--body <text>', 'Comment body')
+	.option('--json', 'Output structured JSON')
+	.action(async (file, options) => {
+		await checkFirstTimeSetup()
+		try {
+			await addFileReview(file, options)
+		} catch (error) {
+			handleError(error)
+		}
+	})
+
+reviewCommand
+	.command('add-line <file>')
+	.description('Add a line-range review thread')
+	.option('--workspace <name>', 'Workspace name')
+	.option('--project <name>', 'Project name')
+	.requiredOption('--start <number>', '1-based start line', (v) => parseInt(v, 10))
+	.option('--end <number>', '1-based end line (defaults to start)', (v) => parseInt(v, 10))
+	.option('--side <side>', 'LEFT or RIGHT side of diff (default: RIGHT)')
+	.requiredOption('--body <text>', 'Comment body')
+	.option('--json', 'Output structured JSON')
+	.action(async (file, options) => {
+		await checkFirstTimeSetup()
+		try {
+			await addLineReview(file, options)
+		} catch (error) {
+			handleError(error)
+		}
+	})
+
+// Hidden workspace-scoped command surface.
+// Intended to be used from `space` shell function injected into workspace sessions.
+const spaceCommand = program
+	.command('space', { hidden: true })
+	.description('Workspace-scoped commands')
+
+spaceCommand
+	.command('context')
+	.description('Show resolved workspace context')
+	.option('--workspace <name>', 'Workspace name')
+	.option('--project <name>', 'Project name')
+	.option('--json', 'Output structured JSON')
+	.action(async (options) => {
+		await checkFirstTimeSetup()
+		try {
+			await showSpaceContext(options)
+		} catch (error) {
+			handleError(error)
+		}
+	})
+
+const spaceReviewCommand = spaceCommand
+	.command('review')
+	.description('Workspace review commands')
+
+spaceReviewCommand
+	.command('notes')
+	.description('Print review threads as structured JSON (LLM-friendly)')
+	.option('--workspace <name>', 'Workspace name')
+	.option('--project <name>', 'Project name')
+	.option('--format <format>', 'Output format: json (default) or text')
+	.action(async (options) => {
+		await checkFirstTimeSetup()
+		try {
+			await showReviewNotes(options)
+		} catch (error) {
+			handleError(error)
+		}
+	})
+
+spaceReviewCommand
+	.command('import')
+	.description('Import GitHub PR review comments as local threads')
+	.option('--workspace <name>', 'Workspace name')
+	.option('--project <name>', 'Project name')
+	.option('--pr <number>', 'PR number to import from', (v) => parseInt(v, 10))
+	.action(async (options) => {
+		await checkFirstTimeSetup()
+		try {
+			await importReview(options)
+		} catch (error) {
+			handleError(error)
+		}
+	})
+
+spaceReviewCommand
+	.command('push')
+	.description('Push local review decisions to GitHub as a formal PR review')
+	.option('--workspace <name>', 'Workspace name')
+	.option('--project <name>', 'Project name')
+	.option('--pr <number>', 'PR number to submit review on', (v) => parseInt(v, 10))
+	.action(async (options) => {
+		await checkFirstTimeSetup()
+		try {
+			await pushReview(options)
+		} catch (error) {
+			handleError(error)
+		}
+	})
+
+spaceReviewCommand
+	.command('hunks <file>')
+	.description('List hunks in a changed file (AI-friendly target IDs)')
+	.option('--workspace <name>', 'Workspace name')
+	.option('--project <name>', 'Project name')
+	.option('--format <format>', 'Output format: json (default) or text')
+	.action(async (file, options) => {
+		await checkFirstTimeSetup()
+		try {
+			await listReviewHunks(file, options)
+		} catch (error) {
+			handleError(error)
+		}
+	})
+
+spaceReviewCommand
+	.command('add-hunk <file>')
+	.description('Add or update hunk review by hunk index')
+	.option('--workspace <name>', 'Workspace name')
+	.option('--project <name>', 'Project name')
+	.requiredOption('--index <number>', '1-based hunk index', (v) => parseInt(v, 10))
+	.option('--body <text>', 'Optional comment body')
+	.option('--approve', 'Set hunk decision to approved')
+	.option('--reject', 'Set hunk decision to rejected')
+	.option('--pending', 'Set hunk decision to pending')
+	.option('--json', 'Output structured JSON')
+	.action(async (file, options) => {
+		await checkFirstTimeSetup()
+		try {
+			await addHunkReview(file, options)
+		} catch (error) {
+			handleError(error)
+		}
+	})
+
+spaceReviewCommand
+	.command('add-file <file>')
+	.description('Add a file-level review thread')
+	.option('--workspace <name>', 'Workspace name')
+	.option('--project <name>', 'Project name')
+	.requiredOption('--body <text>', 'Comment body')
+	.option('--json', 'Output structured JSON')
+	.action(async (file, options) => {
+		await checkFirstTimeSetup()
+		try {
+			await addFileReview(file, options)
+		} catch (error) {
+			handleError(error)
+		}
+	})
+
+spaceReviewCommand
+	.command('add-line <file>')
+	.description('Add a line-range review thread')
+	.option('--workspace <name>', 'Workspace name')
+	.option('--project <name>', 'Project name')
+	.requiredOption('--start <number>', '1-based start line', (v) => parseInt(v, 10))
+	.option('--end <number>', '1-based end line (defaults to start)', (v) => parseInt(v, 10))
+	.option('--side <side>', 'LEFT or RIGHT side of diff (default: RIGHT)')
+	.requiredOption('--body <text>', 'Comment body')
+	.option('--json', 'Output structured JSON')
+	.action(async (file, options) => {
+		await checkFirstTimeSetup()
+		try {
+			await addLineReview(file, options)
+		} catch (error) {
+			handleError(error)
+		}
+	})
+
 // ============================================================================
 // Auth Commands (gitspace.sh)
 // ============================================================================
@@ -1057,9 +1277,49 @@ process.on('unhandledRejection', (reason) => {
 	process.exit(1)
 })
 
+function isWorkspaceScopedSession(): boolean {
+	return process.env.GSSH_SESSION_MODE === 'workspace'
+}
+
+function isAllowedWorkspaceSessionCommand(args: string[]): boolean {
+	if (args.length === 0) {
+		return false
+	}
+
+	const first = args[0]
+	if (!first) {
+		return false
+	}
+
+	if (first === 'space') {
+		return true
+	}
+
+	if (first === '--help' || first === '-h' || first === '--version' || first === '-V') {
+		return true
+	}
+
+	if (first === 'help') {
+		return true
+	}
+
+	return false
+}
+
 // Parse command line arguments
 // Check for global relay options (TUI mode with relay)
 const args = process.argv.slice(2)
+
+if (isWorkspaceScopedSession() && !isAllowedWorkspaceSessionCommand(args)) {
+	if (args[0] === 'tmux') {
+		logger.error('tmux commands are disabled inside workspace sessions.')
+	} else {
+		logger.error('This command is disabled inside a workspace session.')
+	}
+	logger.log('Use `space ...` for workspace-scoped operations.')
+	process.exit(1)
+}
+
 let relayUrlFromArgs: string | undefined
 let ignoreKeychainAndSkipSecrets = false
 let hasOnlyTuiOptions = true

--- a/src/index.ts
+++ b/src/index.ts
@@ -969,10 +969,10 @@ registerReviewSubcommands(reviewCommand)
 
 // Hidden workspace-scoped command surface.
 // Intended to be used from `space` shell function injected into workspace sessions.
+// Scope flags intentionally live on leaf subcommands so Commander passes them
+// to each handler's `options` object.
 const spaceCommand = program
 	.command('space', { hidden: true })
-	.option('--workspace <name>', 'Workspace name')
-	.option('--project <name>', 'Project name')
 	.description('Workspace-scoped commands')
 
 spaceCommand

--- a/src/index.ts
+++ b/src/index.ts
@@ -59,6 +59,7 @@ import { configNotifications, linearSetup, linearShow, linearClear } from './com
 import { migrateCleanupLegacy } from './commands/migrate.js'
 import { notificationsInstall, notificationsUninstall, notificationsHook, notificationsStatus } from './commands/notifications.js'
 import { bundleRefresh, bundleStatus } from './commands/bundle.js'
+import { openReview, showReviewNotes, importReview, pushReview } from './commands/review.js'
 
 const program = new Command()
 
@@ -829,6 +830,70 @@ bundleCommand
 		await checkFirstTimeSetup()
 		try {
 			await bundleStatus(options)
+		} catch (error) {
+			handleError(error)
+		}
+	})
+
+// ============================================================================
+// Review Commands
+// ============================================================================
+
+const reviewCommand = program
+	.command('review')
+	.description('Open or interact with the diff review system')
+	.option('--workspace <name>', 'Workspace name')
+	.option('--project <name>', 'Project name')
+	.option('--port <number>', 'Port of the serve daemon (default: 4480)', (v) => parseInt(v, 10))
+	.action(async (options) => {
+		await checkFirstTimeSetup()
+		try {
+			await openReview(options)
+		} catch (error) {
+			handleError(error)
+		}
+	})
+
+reviewCommand
+	.command('notes')
+	.description('Print review threads as structured JSON (LLM-friendly)')
+	.option('--workspace <name>', 'Workspace name')
+	.option('--project <name>', 'Project name')
+	.option('--format <format>', 'Output format: json (default) or text')
+	.action(async (options) => {
+		await checkFirstTimeSetup()
+		try {
+			await showReviewNotes(options)
+		} catch (error) {
+			handleError(error)
+		}
+	})
+
+reviewCommand
+	.command('import')
+	.description('Import GitHub PR review comments as local threads')
+	.option('--workspace <name>', 'Workspace name')
+	.option('--project <name>', 'Project name')
+	.option('--pr <number>', 'PR number to import from', (v) => parseInt(v, 10))
+	.action(async (options) => {
+		await checkFirstTimeSetup()
+		try {
+			await importReview(options)
+		} catch (error) {
+			handleError(error)
+		}
+	})
+
+reviewCommand
+	.command('push')
+	.description('Push local review decisions to GitHub as a formal PR review')
+	.option('--workspace <name>', 'Workspace name')
+	.option('--project <name>', 'Project name')
+	.option('--pr <number>', 'PR number to submit review on', (v) => parseInt(v, 10))
+	.action(async (options) => {
+		await checkFirstTimeSetup()
+		try {
+			await pushReview(options)
 		} catch (error) {
 			handleError(error)
 		}

--- a/src/index.ts
+++ b/src/index.ts
@@ -849,6 +849,107 @@ bundleCommand
 // Review Commands
 // ============================================================================
 
+function withReviewSetup<T extends unknown[]>(
+	handler: (...args: T) => Promise<void>
+): (...args: T) => Promise<void> {
+	return async (...args: T): Promise<void> => {
+		await checkFirstTimeSetup()
+		try {
+			await handler(...args)
+		} catch (error) {
+			handleError(error)
+		}
+	}
+}
+
+function addReviewScopeOptions(command: Command): Command {
+	return command
+		.option('--workspace <name>', 'Workspace name')
+		.option('--project <name>', 'Project name')
+}
+
+function registerReviewSubcommands(command: Command): void {
+	addReviewScopeOptions(
+		command
+			.command('notes')
+			.description('Print review threads as structured JSON (LLM-friendly)')
+	)
+		.option('--format <format>', 'Output format: json (default) or text')
+		.action(withReviewSetup(async (options) => {
+			await showReviewNotes(options)
+		}))
+
+	addReviewScopeOptions(
+		command
+			.command('import')
+			.description('Import GitHub PR review comments as local threads')
+	)
+		.option('--pr <number>', 'PR number to import from', (v) => parseInt(v, 10))
+		.action(withReviewSetup(async (options) => {
+			await importReview(options)
+		}))
+
+	addReviewScopeOptions(
+		command
+			.command('push')
+			.description('Push local review decisions to GitHub as a formal PR review')
+	)
+		.option('--pr <number>', 'PR number to submit review on', (v) => parseInt(v, 10))
+		.action(withReviewSetup(async (options) => {
+			await pushReview(options)
+		}))
+
+	addReviewScopeOptions(
+		command
+			.command('hunks <file>')
+			.description('List hunks in a changed file (AI-friendly target IDs)')
+	)
+		.option('--format <format>', 'Output format: json (default) or text')
+		.action(withReviewSetup(async (file, options) => {
+			await listReviewHunks(file, options)
+		}))
+
+	addReviewScopeOptions(
+		command
+			.command('add-hunk <file>')
+			.description('Add or update hunk review by hunk index')
+	)
+		.requiredOption('--index <number>', '1-based hunk index', (v) => parseInt(v, 10))
+		.option('--body <text>', 'Optional comment body')
+		.option('--approve', 'Set hunk decision to approved')
+		.option('--reject', 'Set hunk decision to rejected')
+		.option('--pending', 'Set hunk decision to pending')
+		.option('--json', 'Output structured JSON')
+		.action(withReviewSetup(async (file, options) => {
+			await addHunkReview(file, options)
+		}))
+
+	addReviewScopeOptions(
+		command
+			.command('add-file <file>')
+			.description('Add a file-level review thread')
+	)
+		.requiredOption('--body <text>', 'Comment body')
+		.option('--json', 'Output structured JSON')
+		.action(withReviewSetup(async (file, options) => {
+			await addFileReview(file, options)
+		}))
+
+	addReviewScopeOptions(
+		command
+			.command('add-line <file>')
+			.description('Add a line-range review thread')
+	)
+		.requiredOption('--start <number>', '1-based start line', (v) => parseInt(v, 10))
+		.option('--end <number>', '1-based end line (defaults to start)', (v) => parseInt(v, 10))
+		.option('--side <side>', 'LEFT or RIGHT side of diff (default: RIGHT)')
+		.requiredOption('--body <text>', 'Comment body')
+		.option('--json', 'Output structured JSON')
+		.action(withReviewSetup(async (file, options) => {
+			await addLineReview(file, options)
+		}))
+}
+
 const reviewCommand = program
 	.command('review')
 	.description('Open or interact with the diff review system')
@@ -864,120 +965,7 @@ const reviewCommand = program
 		}
 	})
 
-reviewCommand
-	.command('notes')
-	.description('Print review threads as structured JSON (LLM-friendly)')
-	.option('--workspace <name>', 'Workspace name')
-	.option('--project <name>', 'Project name')
-	.option('--format <format>', 'Output format: json (default) or text')
-	.action(async (options) => {
-		await checkFirstTimeSetup()
-		try {
-			await showReviewNotes(options)
-		} catch (error) {
-			handleError(error)
-		}
-	})
-
-reviewCommand
-	.command('import')
-	.description('Import GitHub PR review comments as local threads')
-	.option('--workspace <name>', 'Workspace name')
-	.option('--project <name>', 'Project name')
-	.option('--pr <number>', 'PR number to import from', (v) => parseInt(v, 10))
-	.action(async (options) => {
-		await checkFirstTimeSetup()
-		try {
-			await importReview(options)
-		} catch (error) {
-			handleError(error)
-		}
-	})
-
-reviewCommand
-	.command('push')
-	.description('Push local review decisions to GitHub as a formal PR review')
-	.option('--workspace <name>', 'Workspace name')
-	.option('--project <name>', 'Project name')
-	.option('--pr <number>', 'PR number to submit review on', (v) => parseInt(v, 10))
-	.action(async (options) => {
-		await checkFirstTimeSetup()
-		try {
-			await pushReview(options)
-		} catch (error) {
-			handleError(error)
-		}
-	})
-
-reviewCommand
-	.command('hunks <file>')
-	.description('List hunks in a changed file (AI-friendly target IDs)')
-	.option('--workspace <name>', 'Workspace name')
-	.option('--project <name>', 'Project name')
-	.option('--format <format>', 'Output format: json (default) or text')
-	.action(async (file, options) => {
-		await checkFirstTimeSetup()
-		try {
-			await listReviewHunks(file, options)
-		} catch (error) {
-			handleError(error)
-		}
-	})
-
-reviewCommand
-	.command('add-hunk <file>')
-	.description('Add or update hunk review by hunk index')
-	.option('--workspace <name>', 'Workspace name')
-	.option('--project <name>', 'Project name')
-	.requiredOption('--index <number>', '1-based hunk index', (v) => parseInt(v, 10))
-	.option('--body <text>', 'Optional comment body')
-	.option('--approve', 'Set hunk decision to approved')
-	.option('--reject', 'Set hunk decision to rejected')
-	.option('--pending', 'Set hunk decision to pending')
-	.option('--json', 'Output structured JSON')
-	.action(async (file, options) => {
-		await checkFirstTimeSetup()
-		try {
-			await addHunkReview(file, options)
-		} catch (error) {
-			handleError(error)
-		}
-	})
-
-reviewCommand
-	.command('add-file <file>')
-	.description('Add a file-level review thread')
-	.option('--workspace <name>', 'Workspace name')
-	.option('--project <name>', 'Project name')
-	.requiredOption('--body <text>', 'Comment body')
-	.option('--json', 'Output structured JSON')
-	.action(async (file, options) => {
-		await checkFirstTimeSetup()
-		try {
-			await addFileReview(file, options)
-		} catch (error) {
-			handleError(error)
-		}
-	})
-
-reviewCommand
-	.command('add-line <file>')
-	.description('Add a line-range review thread')
-	.option('--workspace <name>', 'Workspace name')
-	.option('--project <name>', 'Project name')
-	.requiredOption('--start <number>', '1-based start line', (v) => parseInt(v, 10))
-	.option('--end <number>', '1-based end line (defaults to start)', (v) => parseInt(v, 10))
-	.option('--side <side>', 'LEFT or RIGHT side of diff (default: RIGHT)')
-	.requiredOption('--body <text>', 'Comment body')
-	.option('--json', 'Output structured JSON')
-	.action(async (file, options) => {
-		await checkFirstTimeSetup()
-		try {
-			await addLineReview(file, options)
-		} catch (error) {
-			handleError(error)
-		}
-	})
+registerReviewSubcommands(reviewCommand)
 
 // Hidden workspace-scoped command surface.
 // Intended to be used from `space` shell function injected into workspace sessions.
@@ -1004,120 +992,7 @@ const spaceReviewCommand = spaceCommand
 	.command('review')
 	.description('Workspace review commands')
 
-spaceReviewCommand
-	.command('notes')
-	.description('Print review threads as structured JSON (LLM-friendly)')
-	.option('--workspace <name>', 'Workspace name')
-	.option('--project <name>', 'Project name')
-	.option('--format <format>', 'Output format: json (default) or text')
-	.action(async (options) => {
-		await checkFirstTimeSetup()
-		try {
-			await showReviewNotes(options)
-		} catch (error) {
-			handleError(error)
-		}
-	})
-
-spaceReviewCommand
-	.command('import')
-	.description('Import GitHub PR review comments as local threads')
-	.option('--workspace <name>', 'Workspace name')
-	.option('--project <name>', 'Project name')
-	.option('--pr <number>', 'PR number to import from', (v) => parseInt(v, 10))
-	.action(async (options) => {
-		await checkFirstTimeSetup()
-		try {
-			await importReview(options)
-		} catch (error) {
-			handleError(error)
-		}
-	})
-
-spaceReviewCommand
-	.command('push')
-	.description('Push local review decisions to GitHub as a formal PR review')
-	.option('--workspace <name>', 'Workspace name')
-	.option('--project <name>', 'Project name')
-	.option('--pr <number>', 'PR number to submit review on', (v) => parseInt(v, 10))
-	.action(async (options) => {
-		await checkFirstTimeSetup()
-		try {
-			await pushReview(options)
-		} catch (error) {
-			handleError(error)
-		}
-	})
-
-spaceReviewCommand
-	.command('hunks <file>')
-	.description('List hunks in a changed file (AI-friendly target IDs)')
-	.option('--workspace <name>', 'Workspace name')
-	.option('--project <name>', 'Project name')
-	.option('--format <format>', 'Output format: json (default) or text')
-	.action(async (file, options) => {
-		await checkFirstTimeSetup()
-		try {
-			await listReviewHunks(file, options)
-		} catch (error) {
-			handleError(error)
-		}
-	})
-
-spaceReviewCommand
-	.command('add-hunk <file>')
-	.description('Add or update hunk review by hunk index')
-	.option('--workspace <name>', 'Workspace name')
-	.option('--project <name>', 'Project name')
-	.requiredOption('--index <number>', '1-based hunk index', (v) => parseInt(v, 10))
-	.option('--body <text>', 'Optional comment body')
-	.option('--approve', 'Set hunk decision to approved')
-	.option('--reject', 'Set hunk decision to rejected')
-	.option('--pending', 'Set hunk decision to pending')
-	.option('--json', 'Output structured JSON')
-	.action(async (file, options) => {
-		await checkFirstTimeSetup()
-		try {
-			await addHunkReview(file, options)
-		} catch (error) {
-			handleError(error)
-		}
-	})
-
-spaceReviewCommand
-	.command('add-file <file>')
-	.description('Add a file-level review thread')
-	.option('--workspace <name>', 'Workspace name')
-	.option('--project <name>', 'Project name')
-	.requiredOption('--body <text>', 'Comment body')
-	.option('--json', 'Output structured JSON')
-	.action(async (file, options) => {
-		await checkFirstTimeSetup()
-		try {
-			await addFileReview(file, options)
-		} catch (error) {
-			handleError(error)
-		}
-	})
-
-spaceReviewCommand
-	.command('add-line <file>')
-	.description('Add a line-range review thread')
-	.option('--workspace <name>', 'Workspace name')
-	.option('--project <name>', 'Project name')
-	.requiredOption('--start <number>', '1-based start line', (v) => parseInt(v, 10))
-	.option('--end <number>', '1-based end line (defaults to start)', (v) => parseInt(v, 10))
-	.option('--side <side>', 'LEFT or RIGHT side of diff (default: RIGHT)')
-	.requiredOption('--body <text>', 'Comment body')
-	.option('--json', 'Output structured JSON')
-	.action(async (file, options) => {
-		await checkFirstTimeSetup()
-		try {
-			await addLineReview(file, options)
-		} catch (error) {
-			handleError(error)
-		}
-	})
+registerReviewSubcommands(spaceReviewCommand)
 
 // ============================================================================
 // Auth Commands (gitspace.sh)
@@ -1311,7 +1186,9 @@ function isAllowedWorkspaceSessionCommand(args: string[]): boolean {
 const args = process.argv.slice(2)
 
 if (isWorkspaceScopedSession() && !isAllowedWorkspaceSessionCommand(args)) {
-	if (args[0] === 'tmux') {
+	if (args.length === 0) {
+		logger.error('Bare `gssh` is disabled inside a workspace session.')
+	} else if (args[0] === 'tmux') {
 		logger.error('tmux commands are disabled inside workspace sessions.')
 	} else {
 		logger.error('This command is disabled inside a workspace session.')

--- a/src/lib/remote-session/protocol.ts
+++ b/src/lib/remote-session/protocol.ts
@@ -17,6 +17,7 @@
 
 // Re-export InboxItem from tmux-lite protocol
 export type { InboxItem } from "../tmux-lite/protocol.js";
+export type { ReviewOperation, ReviewResult } from "../../types/review.js";
 export type {
   BundleRefreshPlan,
   BundleRefreshSubmission,
@@ -112,6 +113,17 @@ export interface ApplyBundleRefreshRequest {
   projectName: string;
   workspaceId: string;
   submission: import("../../types/bundle-refresh.js").BundleRefreshSubmission;
+}
+
+/**
+ * Review operation request — wraps all review sub-operations in a single
+ * message type, matched to its response by requestId.
+ */
+export interface ReviewRequest {
+  type: "review_request";
+  /** Unique ID for correlating request → response */
+  requestId: string;
+  operation: import("../../types/review.js").ReviewOperation;
 }
 
 // ============================================================================
@@ -267,6 +279,15 @@ export interface BundleRefreshAppliedResponse {
   workspaceId: string;
 }
 
+/** Review operation response — carries either a result or an error */
+export interface ReviewResponse {
+  type: "review_response";
+  /** Matches the requestId from the ReviewRequest */
+  requestId: string;
+  result?: import("../../types/review.js").ReviewResult;
+  error?: { code: string; message: string };
+}
+
 // ============================================================================
 // Union Types
 // ============================================================================
@@ -285,7 +306,8 @@ export type ClientToMachineMessage =
   | GetNotificationConfigRequest
   | UpdateNotificationConfigRequest
   | GetBundleRefreshPlanRequest
-  | ApplyBundleRefreshRequest;
+  | ApplyBundleRefreshRequest
+  | ReviewRequest;
 
 /** All messages from machine to client (browsing mode) */
 export type MachineToClientMessage =
@@ -305,7 +327,8 @@ export type MachineToClientMessage =
   | NotificationConfigUpdatedResponse
   | ScriptOutputResponse
   | BundleRefreshPlanResponse
-  | BundleRefreshAppliedResponse;
+  | BundleRefreshAppliedResponse
+  | ReviewResponse;
 
 /** All remote session messages */
 export type RemoteSessionMessage =

--- a/src/lib/remote-session/session-handler.ts
+++ b/src/lib/remote-session/session-handler.ts
@@ -44,6 +44,7 @@ import {
   applyBundleRefreshSubmission,
 } from '../../core/bundle-refresh.js';
 import { buildSessionName } from '../../session/session-name.js';
+import { buildWorkspaceSessionHooks } from '../../session/workspace-shell-hooks.js';
 
 import { logger } from "../../utils/logger.js";
 
@@ -499,7 +500,9 @@ export class RemoteSessionHandler {
         });
         console.log(`[remote-session] Selected session name: ${sessionName}`);
 
-        targetSession = await createSession(sessionName, workspace.path);
+        targetSession = await createSession(sessionName, workspace.path, {
+          hooks: buildWorkspaceSessionHooks(workspace.projectName, workspace.id),
+        });
         console.log(`[remote-session] Created session: ${targetSession.name} (id: ${targetSession.id})`)
       } else if (msg.sessionId) {
         // Security: Check if client can attach to this session

--- a/src/lib/remote-session/session-handler.ts
+++ b/src/lib/remote-session/session-handler.ts
@@ -34,6 +34,10 @@ import { listProjectSummaries } from "../../core/project-catalog";
 // Import workspace operations
 import { deleteWorkspaceCore } from "../../core/workspace";
 import { prepareWorkspaceForSession } from "../../core/workspace-lifecycle";
+
+// Import review operations
+import { executeLocalReviewOperation } from "../../core/review-executor.js";
+import type { ReviewOperation, ReviewResult } from "../../types/review.js";
 import { getNotificationConfig, updateNotificationConfig } from "../../core/config";
 import {
   getBundleRefreshPlan,
@@ -276,6 +280,15 @@ export class RemoteSessionHandler {
           msg.projectName,
           msg.workspaceId,
           msg.submission,
+          sendResponse
+        );
+        break;
+
+      case 'review_request':
+        await this.handleReviewRequest(
+          session,
+          msg.requestId,
+          msg.operation,
           sendResponse
         );
         break;
@@ -822,6 +835,46 @@ export class RemoteSessionHandler {
       const message = error instanceof Error ? error.message : 'Failed to apply bundle refresh';
       await this.sendError(session, sendResponse, 'BUNDLE_REFRESH_APPLY_FAILED', message);
     }
+  }
+
+  // ============================================================================
+  // Review Request Handling
+  // ============================================================================
+
+  /**
+   * Handle a review_request message by dispatching to the appropriate
+   * review operation and responding with a review_response.
+   */
+  private async handleReviewRequest(
+    session: RemoteClientSession,
+    requestId: string,
+    operation: ReviewOperation,
+    sendResponse: (data: Uint8Array) => void
+  ): Promise<void> {
+    try {
+      const result = await this.executeReviewOperation(operation);
+      await this.sendMessage(session, sendResponse, {
+        type: 'review_response',
+        requestId,
+        result,
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      await this.sendMessage(session, sendResponse, {
+        type: 'review_response',
+        requestId,
+        error: { code: 'REVIEW_ERROR', message },
+      });
+    }
+  }
+
+  /**
+   * Delegate to the shared executeLocalReviewOperation from review-executor.ts.
+   * This is the single authoritative implementation used by both the remote
+   * session handler and the local session backend.
+   */
+  private async executeReviewOperation(operation: ReviewOperation): Promise<ReviewResult> {
+    return executeLocalReviewOperation(operation, scanWorkspaces);
   }
 
   private async resolveWorkspace(

--- a/src/lib/remote-session/session-handler.ts
+++ b/src/lib/remote-session/session-handler.ts
@@ -93,6 +93,20 @@ function canAttachSession(
   return false;
 }
 
+const MUTATING_REVIEW_OPERATIONS = new Set<ReviewOperation['op']>([
+  'create_thread',
+  'add_reply',
+  'update_thread',
+  'update_comment',
+  'delete_comment',
+  'import_github',
+  'push_github',
+]);
+
+function isMutatingReviewOperation(operation: ReviewOperation): boolean {
+  return MUTATING_REVIEW_OPERATIONS.has(operation.op);
+}
+
 function toCanonicalWorkspaceId(workspace: { projectName: string; id: string }): string {
   return `${workspace.projectName}:${workspace.id}`;
 }
@@ -854,6 +868,18 @@ export class RemoteSessionHandler {
     operation: ReviewOperation,
     sendResponse: (data: Uint8Array) => void
   ): Promise<void> {
+    if (isMutatingReviewOperation(operation) && !canManage(session.accessType)) {
+      await this.sendMessage(session, sendResponse, {
+        type: 'review_response',
+        requestId,
+        error: {
+          code: 'PERMISSION_DENIED',
+          message: 'Requires full access to perform this review operation',
+        },
+      });
+      return;
+    }
+
     try {
       const result = await this.executeReviewOperation(operation);
       await this.sendMessage(session, sendResponse, {

--- a/src/lib/remote-session/session-handler.ts
+++ b/src/lib/remote-session/session-handler.ts
@@ -45,6 +45,7 @@ import {
 } from '../../core/bundle-refresh.js';
 import { buildSessionName } from '../../session/session-name.js';
 import { buildWorkspaceSessionHooks } from '../../session/workspace-shell-hooks.js';
+import { matchesWorkspaceId, toCanonicalWorkspaceId } from '../../utils/workspace-id.js';
 
 import { logger } from "../../utils/logger.js";
 
@@ -105,17 +106,6 @@ const MUTATING_REVIEW_OPERATIONS = new Set<ReviewOperation['op']>([
 
 function isMutatingReviewOperation(operation: ReviewOperation): boolean {
   return MUTATING_REVIEW_OPERATIONS.has(operation.op);
-}
-
-function toCanonicalWorkspaceId(workspace: { projectName: string; id: string }): string {
-  return `${workspace.projectName}:${workspace.id}`;
-}
-
-function matchesWorkspaceId(
-  workspace: { projectName: string; id: string },
-  workspaceId: string
-): boolean {
-  return workspace.id === workspaceId || toCanonicalWorkspaceId(workspace) === workspaceId;
 }
 
 /**

--- a/src/lib/tmux-lite/cli.ts
+++ b/src/lib/tmux-lite/cli.ts
@@ -26,6 +26,7 @@ import {
   type Session,
   type SessionEvent,
   type InboxItem,
+  type SessionCreateHooks,
   encodeRouterMessage,
   decodeRouterMessages,
   encodeControl,
@@ -280,9 +281,13 @@ export async function listSessions(): Promise<Session[]> {
   throw new Error("Unexpected response");
 }
 
-export async function createSession(name: string, cwd: string): Promise<Session> {
+export async function createSession(
+  name: string,
+  cwd: string,
+  options?: { hooks?: SessionCreateHooks }
+): Promise<Session> {
   await ensureServer();
-  const res = await send({ type: "new", name, cwd });
+  const res = await send({ type: "new", name, cwd, hooks: options?.hooks });
   if (res.type === "session") return res.session;
   if (res.type === "error") throw new Error(res.message);
   throw new Error("Unexpected response");

--- a/src/lib/tmux-lite/protocol.ts
+++ b/src/lib/tmux-lite/protocol.ts
@@ -82,9 +82,25 @@ export function decodeRouterMessages(buffer: Buffer): {
 }
 
 // Router commands
+export interface SessionCreateHooks {
+  /** Environment variables injected into spawned shell process */
+  env?: Record<string, string>;
+  /** Optional shell init snippets (run once after shell starts) */
+  shellInit?: {
+    /** Runs for all shells */
+    all?: string;
+    /** Runs for bash shells */
+    bash?: string;
+    /** Runs for zsh shells */
+    zsh?: string;
+    /** Runs for sh shells */
+    sh?: string;
+  };
+}
+
 export type Command =
   | { type: "list" }
-  | { type: "new"; name?: string; cwd: string }
+  | { type: "new"; name?: string; cwd: string; hooks?: SessionCreateHooks }
   | { type: "attach"; id: string; force?: boolean }
   | { type: "kill"; id: string }
   | { type: "kill-server" }

--- a/src/lib/tmux-lite/server.ts
+++ b/src/lib/tmux-lite/server.ts
@@ -24,6 +24,7 @@ import {
   type Session,
   type SessionCtrl,
   type InboxItem,
+  type SessionCreateHooks,
   encodeRouterMessage,
   decodeRouterMessages,
   encodePTY,
@@ -1010,7 +1011,11 @@ function createSessionSocketHandlers(
 /**
  * Builds the shell environment with integration hooks.
  */
-function buildShellEnvironment(id: string, shell: string): Record<string, string> {
+function buildShellEnvironment(
+  id: string,
+  shell: string,
+  hooks?: SessionCreateHooks
+): Record<string, string> {
   // Shell integration: report non-zero exit codes via OSC 777
   // This creates inbox notifications for failed commands
   const exitReporter = '__tl_report() { local e=$?; [[ $e -ne 0 ]] && printf "\\033]777;exit:%d\\007" "$e"; return $e; }';
@@ -1018,6 +1023,7 @@ function buildShellEnvironment(id: string, shell: string): Record<string, string
   const shellEnv: Record<string, string> = {
     ...process.env as Record<string, string>,
     TMUX_LITE: id,
+    ...(hooks?.env ?? {}),
   };
 
   // Add PROMPT_COMMAND for bash
@@ -1029,11 +1035,37 @@ function buildShellEnvironment(id: string, shell: string): Record<string, string
   return shellEnv;
 }
 
+function getShellInitScript(shell: string, hooks?: SessionCreateHooks): string | null {
+  const shellInit = hooks?.shellInit;
+  if (!shellInit) return null;
+
+  const shellName = shell.split('/').pop() ?? '';
+  const scriptParts: string[] = [];
+
+  if (shellInit.all) {
+    scriptParts.push(shellInit.all);
+  }
+
+  if (shellName.endsWith('bash') && shellInit.bash) {
+    scriptParts.push(shellInit.bash);
+  } else if (shellName.endsWith('zsh') && shellInit.zsh) {
+    scriptParts.push(shellInit.zsh);
+  } else if ((shellName.endsWith('sh') || shellName === 'sh') && shellInit.sh) {
+    scriptParts.push(shellInit.sh);
+  }
+
+  if (scriptParts.length === 0) {
+    return null;
+  }
+
+  return `${scriptParts.join('\n')}\n`;
+}
+
 // ============================================================================
 // Main Session Creation
 // ============================================================================
 
-function createSession(name: string | undefined, cwd: string): Session {
+function createSession(name: string | undefined, cwd: string, hooks?: SessionCreateHooks): Session {
   const id = genId();
   const sessionName = name || `session-${id}`;
   const socketPath = getSessionSocketPath(id);
@@ -1101,13 +1133,23 @@ function createSession(name: string | undefined, cwd: string): Session {
 
   // Spawn shell process
   const shell = process.env.SHELL || "/bin/bash";
-  const shellEnv = buildShellEnvironment(id, shell);
+  const shellEnv = buildShellEnvironment(id, shell, hooks);
 
   const proc = Bun.spawn([shell], {
     terminal: ptyTerminal,
     cwd,
     env: shellEnv,
   });
+
+  const shellInitScript = getShellInitScript(shell, hooks);
+  if (shellInitScript) {
+    try {
+      ptyTerminal.write(shellInitScript);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      console.warn(`[${sessionName}] failed to apply shell init hook: ${message}`);
+    }
+  }
 
   // Handle process exit
   proc.exited.then(handleProcessExit(id, sessionName, xterm, socketPath, disposeDsr, getProcessTitle));
@@ -1205,7 +1247,7 @@ Bun.listen({
 
           case "new":
             try {
-              const session = createSession(cmd.name, cmd.cwd);
+              const session = createSession(cmd.name, cmd.cwd, cmd.hooks);
               res = { type: "session", session };
             } catch (e) {
               const errMsg = e instanceof Error ? e.message : String(e);

--- a/src/lib/tmux-lite/server.ts
+++ b/src/lib/tmux-lite/server.ts
@@ -1026,8 +1026,10 @@ function buildShellEnvironment(
     ...(hooks?.env ?? {}),
   };
 
-  // Add PROMPT_COMMAND for bash
-  if (shell.endsWith('/bash') || shell.endsWith('/sh')) {
+  const shellName = shell.split('/').pop() ?? '';
+
+  // Add PROMPT_COMMAND only for bash-compatible shells.
+  if (shellName === 'bash' || shellName === 'rbash') {
     const existingPrompt = process.env.PROMPT_COMMAND || '';
     shellEnv.PROMPT_COMMAND = `${exitReporter}; __tl_report${existingPrompt ? '; ' + existingPrompt : ''}`;
   }
@@ -1046,11 +1048,15 @@ function getShellInitScript(shell: string, hooks?: SessionCreateHooks): string |
     scriptParts.push(shellInit.all);
   }
 
-  if (shellName.endsWith('bash') && shellInit.bash) {
+  const isBashShell = shellName === 'bash' || shellName === 'rbash';
+  const isZshShell = shellName === 'zsh';
+  const isShShell = shellName === 'sh' || shellName === 'dash';
+
+  if (isBashShell && shellInit.bash) {
     scriptParts.push(shellInit.bash);
-  } else if (shellName.endsWith('zsh') && shellInit.zsh) {
+  } else if (isZshShell && shellInit.zsh) {
     scriptParts.push(shellInit.zsh);
-  } else if ((shellName.endsWith('sh') || shellName === 'sh') && shellInit.sh) {
+  } else if (isShShell && shellInit.sh) {
     scriptParts.push(shellInit.sh);
   }
 

--- a/src/pages/ReviewPage.web.tsx
+++ b/src/pages/ReviewPage.web.tsx
@@ -42,6 +42,19 @@ export function ReviewPage({
   onBack,
 }: ReviewPageProps) {
   const review = useReview({ sendReviewRequest, projectName, workspaceName });
+  const {
+    threads,
+    loading: reviewLoading,
+    error: reviewError,
+    loadThreads,
+    createThread,
+    updateThread,
+    addReply,
+    updateComment,
+    deleteComment,
+    importGitHub,
+    pushGitHub,
+  } = review;
 
   const [files, setFiles] = useState<ReviewChangedFile[]>([]);
   const [baseBranch, setBaseBranch] = useState<string | null>(null);
@@ -63,7 +76,7 @@ export function ReviewPage({
   const [actionError, setActionError] = useState<string | null>(null);
   const [actionSuccess, setActionSuccess] = useState<string | null>(null);
 
-  const status = computeWorkspaceStatus(review.threads);
+  const status = computeWorkspaceStatus(threads);
   const statusInfo = STATUS_LABELS[status];
 
   const loadChangedFiles = useCallback(async () => {
@@ -92,22 +105,22 @@ export function ReviewPage({
   }, [sendReviewRequest, projectName, workspaceName]);
 
   useEffect(() => {
-    void review.loadThreads();
+    void loadThreads();
     void loadChangedFiles();
-  }, [projectName, workspaceName, loadChangedFiles, review.loadThreads]);
+  }, [projectName, workspaceName, loadChangedFiles, loadThreads]);
 
   const handleRefresh = useCallback(() => {
-    void review.loadThreads();
+    void loadThreads();
     void loadChangedFiles();
-  }, [review, loadChangedFiles]);
+  }, [loadThreads, loadChangedFiles]);
 
   const handleCreateThread = useCallback(async (target: ThreadTarget, body: string, decision?: HunkDecision) => {
-    await review.createThread(target, body, decision);
-  }, [review]);
+    await createThread(target, body, decision);
+  }, [createThread]);
 
   const handleUpdateThread = useCallback(async (threadId: string, updates: { decision?: HunkDecision }) => {
-    await review.updateThread(threadId, updates);
-  }, [review]);
+    await updateThread(threadId, updates);
+  }, [updateThread]);
 
   const handleGetFileDiff = useCallback(async (filePath: string, prevFilePath?: string) => {
     const result = await sendReviewRequest({
@@ -154,7 +167,7 @@ export function ReviewPage({
     setActionError(null);
     setActionSuccess(null);
     try {
-      const { imported } = await review.importGitHub();
+      const { imported } = await importGitHub();
       setActionSuccess(`Imported ${imported} comment(s) from GitHub.`);
       setTimeout(() => setActionSuccess(null), 4000);
     } catch (error) {
@@ -163,14 +176,14 @@ export function ReviewPage({
     } finally {
       setImporting(false);
     }
-  }, [review]);
+  }, [importGitHub]);
 
   const handlePush = useCallback(async () => {
     setPushing(true);
     setActionError(null);
     setActionSuccess(null);
     try {
-      const { url } = await review.pushGitHub();
+      const { url } = await pushGitHub();
       setActionSuccess(`Review submitted: ${url}`);
       setTimeout(() => setActionSuccess(null), 6000);
     } catch (error) {
@@ -179,7 +192,7 @@ export function ReviewPage({
     } finally {
       setPushing(false);
     }
-  }, [review]);
+  }, [pushGitHub]);
 
   const openThread = useCallback((threadId: string) => {
     setSelectedThreadId(threadId);
@@ -315,7 +328,7 @@ export function ReviewPage({
 
         <button
           onClick={handleRefresh}
-          disabled={filesLoading || review.loading}
+          disabled={filesLoading || reviewLoading}
           style={{
             fontSize: '12px',
             padding: '5px 10px',
@@ -326,7 +339,7 @@ export function ReviewPage({
             cursor: 'pointer',
           }}
         >
-          {filesLoading || review.loading ? '...' : '↺ Refresh'}
+          {filesLoading || reviewLoading ? '...' : '↺ Refresh'}
         </button>
 
         <button
@@ -347,7 +360,7 @@ export function ReviewPage({
 
         <button
           onClick={() => void handlePush()}
-          disabled={pushing || review.threads.length === 0}
+          disabled={pushing || threads.length === 0}
           style={{
             fontSize: '12px',
             padding: '5px 10px',
@@ -355,7 +368,7 @@ export function ReviewPage({
             color: pushing ? '#8b949e' : '#0d1117',
             border: '1px solid #30363d',
             borderRadius: '6px',
-            cursor: review.threads.length === 0 ? 'not-allowed' : 'pointer',
+            cursor: threads.length === 0 ? 'not-allowed' : 'pointer',
             fontWeight: 600,
           }}
         >
@@ -375,7 +388,7 @@ export function ReviewPage({
           }}
         >
           {panelCollapsed ? '≡ Threads' : '≡ Hide'}
-          {review.threads.filter((thread) => !thread.resolved).length > 0 && (
+          {threads.filter((thread) => !thread.resolved).length > 0 && (
             <span style={{
               marginLeft: '6px',
               fontSize: '10px',
@@ -385,13 +398,13 @@ export function ReviewPage({
               borderRadius: '8px',
               fontWeight: 700,
             }}>
-              {review.threads.filter((thread) => !thread.resolved).length}
+              {threads.filter((thread) => !thread.resolved).length}
             </span>
           )}
         </button>
       </div>
 
-      {(review.error || filesError) && (
+      {(reviewError || filesError) && (
         <div style={{
           padding: '8px 16px',
           background: '#f8514922',
@@ -399,7 +412,7 @@ export function ReviewPage({
           color: '#f85149',
           fontSize: '12px',
         }}>
-          Error: {filesError?.message ?? review.error}
+          Error: {filesError?.message ?? reviewError}
         </div>
       )}
 
@@ -435,7 +448,7 @@ export function ReviewPage({
           <div style={{ flex: panelCollapsed ? '1 1 100%' : '1 1 auto', overflow: 'hidden' }}>
             <DiffViewer
               files={files}
-              threads={review.threads}
+              threads={threads}
               onCreateThread={handleCreateThread}
               onUpdateThread={handleUpdateThread}
               onRequestFileDiff={handleGetFileDiff}
@@ -467,18 +480,18 @@ export function ReviewPage({
 
               <div style={{ flex: 1, overflow: 'hidden', borderLeft: '1px solid #30363d' }}>
               <ThreadPanel
-                threads={review.threads}
+                threads={threads}
                 currentFilePath={currentFilePath}
                 hunkFocus={currentHunkFocus}
                 filterMode={threadFilter}
                 onFilterModeChange={setThreadFilter}
                 selectedThreadId={selectedThreadId}
                 hoveredThreadId={hoveredThreadId}
-                onResolveThread={(threadId, resolved) => review.updateThread(threadId, { resolved })}
-                onAddReply={review.addReply}
-                onUpdateComment={review.updateComment}
-                onDeleteComment={review.deleteComment}
-                onUpdateDecision={(threadId, decision) => review.updateThread(threadId, { decision })}
+                onResolveThread={(threadId, resolved) => updateThread(threadId, { resolved })}
+                onAddReply={addReply}
+                onUpdateComment={updateComment}
+                onDeleteComment={deleteComment}
+                onUpdateDecision={(threadId, decision) => updateThread(threadId, { decision })}
                 onOpenThreadTarget={openThread}
                 onClose={() => setPanelCollapsed(true)}
               />

--- a/src/pages/ReviewPage.web.tsx
+++ b/src/pages/ReviewPage.web.tsx
@@ -15,6 +15,7 @@ import type {
   ReviewResult,
   ThreadTarget,
 } from '../types/review.js';
+import { SpacesError } from '../types/errors.js';
 
 export interface ReviewPageProps {
   projectName: string;
@@ -31,6 +32,16 @@ const STATUS_LABELS = {
   changes_required: { label: 'Changes required', color: '#f85149' },
 };
 
+function toSpacesError(error: unknown, fallbackMessage: string): SpacesError {
+  if (error instanceof SpacesError) {
+    return error;
+  }
+  if (error instanceof Error) {
+    return new SpacesError(error.message, 'SYSTEM_ERROR', 2);
+  }
+  return new SpacesError(fallbackMessage, 'SYSTEM_ERROR', 2);
+}
+
 export function ReviewPage({
   projectName,
   workspaceName,
@@ -44,7 +55,7 @@ export function ReviewPage({
   const [baseBranch, setBaseBranch] = useState<string | null>(null);
   const [headBranch, setHeadBranch] = useState<string | null>(null);
   const [filesLoading, setFilesLoading] = useState(false);
-  const [filesError, setFilesError] = useState<string | null>(null);
+  const [filesError, setFilesError] = useState<SpacesError | null>(null);
 
   const [selectedThreadId, setSelectedThreadId] = useState<string | null>(null);
   const [hoveredThreadId, setHoveredThreadId] = useState<string | null>(null);
@@ -74,7 +85,7 @@ export function ReviewPage({
       });
 
       if (result.op !== 'changed_files') {
-        throw new Error(`Unexpected response for get_changed_files: ${result.op}`);
+        throw new SpacesError(`Unexpected response for get_changed_files: ${result.op}`, 'SYSTEM_ERROR', 2);
       }
 
       setFiles(result.files);
@@ -82,7 +93,7 @@ export function ReviewPage({
       setHeadBranch(result.headBranch);
     } catch (error) {
       setFiles([]);
-      setFilesError(error instanceof Error ? error.message : String(error));
+      setFilesError(toSpacesError(error, 'Failed to load changed files'));
     } finally {
       setFilesLoading(false);
     }
@@ -116,7 +127,7 @@ export function ReviewPage({
     });
 
     if (result.op !== 'file_diff') {
-      throw new Error(`Unexpected response for get_file_diff: ${result.op}`);
+      throw new SpacesError(`Unexpected response for get_file_diff: ${result.op}`, 'SYSTEM_ERROR', 2);
     }
 
     return result.diff;
@@ -140,7 +151,7 @@ export function ReviewPage({
     });
 
     if (result.op !== 'file_context_range') {
-      throw new Error(`Unexpected response for get_file_context_range: ${result.op}`);
+      throw new SpacesError(`Unexpected response for get_file_context_range: ${result.op}`, 'SYSTEM_ERROR', 2);
     }
 
     return result;
@@ -396,7 +407,7 @@ export function ReviewPage({
           color: '#f85149',
           fontSize: '12px',
         }}>
-          Error: {filesError ?? review.error}
+          Error: {filesError?.message ?? review.error}
         </div>
       )}
 

--- a/src/pages/ReviewPage.web.tsx
+++ b/src/pages/ReviewPage.web.tsx
@@ -20,6 +20,7 @@ import { SpacesError } from '../types/errors.js';
 export interface ReviewPageProps {
   projectName: string;
   workspaceName: string;
+  workspaceLabel?: string;
   machineName?: string;
   sendReviewRequest: (operation: ReviewOperation) => Promise<ReviewResult>;
   onBack: () => void;
@@ -45,6 +46,7 @@ function toSpacesError(error: unknown, fallbackMessage: string): SpacesError {
 export function ReviewPage({
   projectName,
   workspaceName,
+  workspaceLabel,
   machineName,
   sendReviewRequest,
   onBack,
@@ -282,7 +284,7 @@ export function ReviewPage({
           )}
           <span style={{ fontSize: '13px', color: '#8b949e' }}>{projectName}</span>
           <span style={{ color: '#30363d' }}>/</span>
-          <span style={{ fontSize: '13px', color: '#e6edf3', fontWeight: 600 }}>{workspaceName}</span>
+          <span style={{ fontSize: '13px', color: '#e6edf3', fontWeight: 600 }}>{workspaceLabel ?? workspaceName}</span>
           {headBranch && (
             <span style={{ fontSize: '11px', color: '#6e7681', background: '#21262d', padding: '1px 6px', borderRadius: '4px', border: '1px solid #30363d' }}>
               {headBranch}

--- a/src/pages/ReviewPage.web.tsx
+++ b/src/pages/ReviewPage.web.tsx
@@ -3,8 +3,8 @@
  * ReviewPage — full review dashboard.
  */
 
-import { useCallback, useEffect, useState } from 'react';
-import { DiffViewer } from '../components/DiffViewer.web.js';
+import { useCallback, useEffect, useState, type MouseEvent as ReactMouseEvent } from 'react';
+import { DiffViewer, type HunkFocusTarget } from '../components/DiffViewer.web.js';
 import { ThreadPanel } from '../components/ThreadPanel.web.js';
 import { useReview } from '../hooks/useReview.web.js';
 import { computeWorkspaceStatus } from '../types/review.js';
@@ -48,7 +48,12 @@ export function ReviewPage({
 
   const [selectedThreadId, setSelectedThreadId] = useState<string | null>(null);
   const [hoveredThreadId, setHoveredThreadId] = useState<string | null>(null);
-  const [showPanel, setShowPanel] = useState(true);
+  const [panelCollapsed, setPanelCollapsed] = useState(false);
+  const [panelWidth, setPanelWidth] = useState(360);
+  const [threadFilter, setThreadFilter] = useState<'all' | 'current-file' | 'current-hunk'>('all');
+  const [currentFilePath, setCurrentFilePath] = useState<string | null>(null);
+  const [currentHunkFocus, setCurrentHunkFocus] = useState<HunkFocusTarget | null>(null);
+  const [focusRequest, setFocusRequest] = useState<{ threadId: string; nonce: number } | null>(null);
 
   const [importing, setImporting] = useState(false);
   const [pushing, setPushing] = useState(false);
@@ -175,8 +180,45 @@ export function ReviewPage({
 
   const openThread = useCallback((threadId: string) => {
     setSelectedThreadId(threadId);
-    setShowPanel(true);
+    setPanelCollapsed(false);
+    setFocusRequest({ threadId, nonce: Date.now() });
   }, []);
+
+  const handleSelectedFileChange = useCallback((filePath: string | null) => {
+    setCurrentFilePath(filePath);
+    if (currentHunkFocus && (!filePath || currentHunkFocus.filePath !== filePath)) {
+      setCurrentHunkFocus(null);
+      setThreadFilter((mode) => (mode === 'current-hunk' ? 'current-file' : mode));
+    }
+  }, [currentHunkFocus]);
+
+  const handleHunkFocus = useCallback((target: HunkFocusTarget | null) => {
+    setCurrentHunkFocus(target);
+    if (target) {
+      setPanelCollapsed(false);
+      setThreadFilter('current-hunk');
+    }
+  }, []);
+
+  const startResize = useCallback((event: ReactMouseEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    const initialClientX = event.clientX;
+    const initialWidth = panelWidth;
+
+    const handleMove = (moveEvent: MouseEvent) => {
+      const delta = initialClientX - moveEvent.clientX;
+      const next = Math.min(640, Math.max(280, initialWidth + delta));
+      setPanelWidth(next);
+    };
+
+    const handleUp = () => {
+      window.removeEventListener('mousemove', handleMove);
+      window.removeEventListener('mouseup', handleUp);
+    };
+
+    window.addEventListener('mousemove', handleMove);
+    window.addEventListener('mouseup', handleUp);
+  }, [panelWidth]);
 
   return (
     <div style={{
@@ -318,7 +360,7 @@ export function ReviewPage({
         </button>
 
         <button
-          onClick={() => setShowPanel((value) => !value)}
+          onClick={() => setPanelCollapsed((value) => !value)}
           style={{
             fontSize: '12px',
             padding: '5px 10px',
@@ -329,7 +371,7 @@ export function ReviewPage({
             cursor: 'pointer',
           }}
         >
-          {showPanel ? '≡ Hide' : '≡ Threads'}
+          {panelCollapsed ? '≡ Threads' : '≡ Hide'}
           {review.threads.filter((thread) => !thread.resolved).length > 0 && (
             <span style={{
               marginLeft: '6px',
@@ -387,7 +429,7 @@ export function ReviewPage({
         </div>
       ) : (
         <div style={{ flex: 1, display: 'flex', overflow: 'hidden' }}>
-          <div style={{ flex: showPanel ? '1 1 70%' : '1 1 100%', overflow: 'hidden' }}>
+          <div style={{ flex: panelCollapsed ? '1 1 100%' : '1 1 auto', overflow: 'hidden' }}>
             <DiffViewer
               files={files}
               threads={review.threads}
@@ -396,19 +438,37 @@ export function ReviewPage({
               onRequestFileDiff={handleGetFileDiff}
               onRequestFileContextRange={handleGetFileContextRange}
               onThreadClick={openThread}
+              onSelectedFileChange={handleSelectedFileChange}
+              onHunkFocus={handleHunkFocus}
+              focusRequest={focusRequest}
               onThreadHover={(threadId) => {
                 setHoveredThreadId(threadId);
                 if (threadId) {
-                  setShowPanel(true);
+                  setPanelCollapsed(false);
                 }
               }}
             />
           </div>
 
-          {showPanel && (
-            <div style={{ flex: '0 0 320px', overflow: 'hidden', borderLeft: '1px solid #30363d' }}>
+          {!panelCollapsed && (
+            <div style={{ display: 'flex', width: `${panelWidth}px`, maxWidth: '60vw', minWidth: '280px' }}>
+              <div
+                onMouseDown={startResize}
+                style={{
+                  width: '6px',
+                  cursor: 'col-resize',
+                  background: 'transparent',
+                  borderLeft: '1px solid #30363d',
+                }}
+              />
+
+              <div style={{ flex: 1, overflow: 'hidden', borderLeft: '1px solid #30363d' }}>
               <ThreadPanel
                 threads={review.threads}
+                currentFilePath={currentFilePath}
+                hunkFocus={currentHunkFocus}
+                filterMode={threadFilter}
+                onFilterModeChange={setThreadFilter}
                 selectedThreadId={selectedThreadId}
                 hoveredThreadId={hoveredThreadId}
                 onResolveThread={(threadId, resolved) => review.updateThread(threadId, { resolved })}
@@ -416,8 +476,10 @@ export function ReviewPage({
                 onUpdateComment={review.updateComment}
                 onDeleteComment={review.deleteComment}
                 onUpdateDecision={(threadId, decision) => review.updateThread(threadId, { decision })}
-                onClose={() => setShowPanel(false)}
+                onOpenThreadTarget={openThread}
+                onClose={() => setPanelCollapsed(true)}
               />
+            </div>
             </div>
           )}
         </div>

--- a/src/pages/ReviewPage.web.tsx
+++ b/src/pages/ReviewPage.web.tsx
@@ -15,7 +15,7 @@ import type {
   ReviewResult,
   ThreadTarget,
 } from '../types/review.js';
-import { SpacesError } from '../types/errors.js';
+import { SpacesError, toSpacesError } from '../types/errors.js';
 
 export interface ReviewPageProps {
   projectName: string;
@@ -32,16 +32,6 @@ const STATUS_LABELS = {
   approved: { label: 'Approved', color: '#22c55e' },
   changes_required: { label: 'Changes required', color: '#f85149' },
 };
-
-function toSpacesError(error: unknown, fallbackMessage: string): SpacesError {
-  if (error instanceof SpacesError) {
-    return error;
-  }
-  if (error instanceof Error) {
-    return new SpacesError(error.message, 'SYSTEM_ERROR', 2);
-  }
-  return new SpacesError(fallbackMessage, 'SYSTEM_ERROR', 2);
-}
 
 export function ReviewPage({
   projectName,

--- a/src/pages/ReviewPage.web.tsx
+++ b/src/pages/ReviewPage.web.tsx
@@ -1,21 +1,20 @@
 /** @jsxImportSource react */
 /**
  * ReviewPage — full review dashboard.
- *
- * Layout:
- *   ┌──────────────────────────────────────────────────┐
- *   │ Header (breadcrumb, status badge, GH buttons)    │
- *   ├──────────────────────────────────────────────────┤
- *   │  Diff viewer (70%)   │  Thread panel (30%)       │
- *   └──────────────────────────────────────────────────┘
  */
 
-import { useEffect, useState, useCallback } from 'react';
-import { useReview } from '../hooks/useReview.web.js';
+import { useCallback, useEffect, useState } from 'react';
 import { DiffViewer } from '../components/DiffViewer.web.js';
 import { ThreadPanel } from '../components/ThreadPanel.web.js';
+import { useReview } from '../hooks/useReview.web.js';
 import { computeWorkspaceStatus } from '../types/review.js';
-import type { ReviewOperation, ReviewResult, ThreadTarget, HunkDecision } from '../types/review.js';
+import type {
+  HunkDecision,
+  ReviewChangedFile,
+  ReviewOperation,
+  ReviewResult,
+  ThreadTarget,
+} from '../types/review.js';
 
 export interface ReviewPageProps {
   projectName: string;
@@ -40,21 +39,59 @@ export function ReviewPage({
   onBack,
 }: ReviewPageProps) {
   const review = useReview({ sendReviewRequest, projectName, workspaceName });
+
+  const [files, setFiles] = useState<ReviewChangedFile[]>([]);
+  const [baseBranch, setBaseBranch] = useState<string | null>(null);
+  const [headBranch, setHeadBranch] = useState<string | null>(null);
+  const [filesLoading, setFilesLoading] = useState(false);
+  const [filesError, setFilesError] = useState<string | null>(null);
+
   const [selectedThreadId, setSelectedThreadId] = useState<string | null>(null);
+  const [hoveredThreadId, setHoveredThreadId] = useState<string | null>(null);
   const [showPanel, setShowPanel] = useState(true);
+
   const [importing, setImporting] = useState(false);
   const [pushing, setPushing] = useState(false);
   const [actionError, setActionError] = useState<string | null>(null);
   const [actionSuccess, setActionSuccess] = useState<string | null>(null);
 
-  // Load diff and threads on mount
-  useEffect(() => {
-    void review.loadDiff();
-    void review.loadThreads();
-  }, [projectName, workspaceName]);
-
   const status = computeWorkspaceStatus(review.threads);
   const statusInfo = STATUS_LABELS[status];
+
+  const loadChangedFiles = useCallback(async () => {
+    setFilesLoading(true);
+    setFilesError(null);
+    try {
+      const result = await sendReviewRequest({
+        op: 'get_changed_files',
+        projectName,
+        workspaceName,
+      });
+
+      if (result.op !== 'changed_files') {
+        throw new Error(`Unexpected response for get_changed_files: ${result.op}`);
+      }
+
+      setFiles(result.files);
+      setBaseBranch(result.baseBranch);
+      setHeadBranch(result.headBranch);
+    } catch (error) {
+      setFiles([]);
+      setFilesError(error instanceof Error ? error.message : String(error));
+    } finally {
+      setFilesLoading(false);
+    }
+  }, [sendReviewRequest, projectName, workspaceName]);
+
+  useEffect(() => {
+    void review.loadThreads();
+    void loadChangedFiles();
+  }, [projectName, workspaceName, loadChangedFiles, review.loadThreads]);
+
+  const handleRefresh = useCallback(() => {
+    void review.loadThreads();
+    void loadChangedFiles();
+  }, [review, loadChangedFiles]);
 
   const handleCreateThread = useCallback(async (target: ThreadTarget, body: string, decision?: HunkDecision) => {
     await review.createThread(target, body, decision);
@@ -64,6 +101,46 @@ export function ReviewPage({
     await review.updateThread(threadId, updates);
   }, [review]);
 
+  const handleGetFileDiff = useCallback(async (filePath: string, prevFilePath?: string) => {
+    const result = await sendReviewRequest({
+      op: 'get_file_diff',
+      projectName,
+      workspaceName,
+      filePath,
+      prevFilePath,
+    });
+
+    if (result.op !== 'file_diff') {
+      throw new Error(`Unexpected response for get_file_diff: ${result.op}`);
+    }
+
+    return result.diff;
+  }, [sendReviewRequest, projectName, workspaceName]);
+
+  const handleGetFileContextRange = useCallback(async (
+    filePath: string,
+    prevFilePath?: string,
+    range?: { oldStart?: number; oldEnd?: number; newStart?: number; newEnd?: number }
+  ) => {
+    const result = await sendReviewRequest({
+      op: 'get_file_context_range',
+      projectName,
+      workspaceName,
+      filePath,
+      prevFilePath,
+      oldStart: range?.oldStart,
+      oldEnd: range?.oldEnd,
+      newStart: range?.newStart,
+      newEnd: range?.newEnd,
+    });
+
+    if (result.op !== 'file_context_range') {
+      throw new Error(`Unexpected response for get_file_context_range: ${result.op}`);
+    }
+
+    return result;
+  }, [sendReviewRequest, projectName, workspaceName]);
+
   const handleImport = useCallback(async () => {
     setImporting(true);
     setActionError(null);
@@ -72,8 +149,8 @@ export function ReviewPage({
       const { imported } = await review.importGitHub();
       setActionSuccess(`Imported ${imported} comment(s) from GitHub.`);
       setTimeout(() => setActionSuccess(null), 4000);
-    } catch (err) {
-      setActionError(err instanceof Error ? err.message : 'Import failed');
+    } catch (error) {
+      setActionError(error instanceof Error ? error.message : 'Import failed');
       setTimeout(() => setActionError(null), 6000);
     } finally {
       setImporting(false);
@@ -88,13 +165,18 @@ export function ReviewPage({
       const { url } = await review.pushGitHub();
       setActionSuccess(`Review submitted: ${url}`);
       setTimeout(() => setActionSuccess(null), 6000);
-    } catch (err) {
-      setActionError(err instanceof Error ? err.message : 'Push failed');
+    } catch (error) {
+      setActionError(error instanceof Error ? error.message : 'Push failed');
       setTimeout(() => setActionError(null), 6000);
     } finally {
       setPushing(false);
     }
   }, [review]);
+
+  const openThread = useCallback((threadId: string) => {
+    setSelectedThreadId(threadId);
+    setShowPanel(true);
+  }, []);
 
   return (
     <div style={{
@@ -107,7 +189,6 @@ export function ReviewPage({
       fontFamily: '-apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif',
       overflow: 'hidden',
     }}>
-      {/* Header */}
       <div style={{
         background: '#161b22',
         borderBottom: '1px solid #30363d',
@@ -137,7 +218,6 @@ export function ReviewPage({
 
         <div style={{ height: '16px', width: '1px', background: '#30363d' }} />
 
-        {/* Breadcrumb */}
         <div style={{ display: 'flex', alignItems: 'center', gap: '6px', minWidth: 0 }}>
           {machineName && (
             <>
@@ -150,23 +230,22 @@ export function ReviewPage({
           <span style={{ fontSize: '13px', color: '#8b949e' }}>{projectName}</span>
           <span style={{ color: '#30363d' }}>/</span>
           <span style={{ fontSize: '13px', color: '#e6edf3', fontWeight: 600 }}>{workspaceName}</span>
-          {review.headBranch && (
+          {headBranch && (
             <span style={{ fontSize: '11px', color: '#6e7681', background: '#21262d', padding: '1px 6px', borderRadius: '4px', border: '1px solid #30363d' }}>
-              {review.headBranch}
+              {headBranch}
             </span>
           )}
-          {review.baseBranch && (
-            <span style={{ fontSize: '11px', color: '#6e7681' }}>← {review.baseBranch}</span>
+          {baseBranch && (
+            <span style={{ fontSize: '11px', color: '#6e7681' }}>← {baseBranch}</span>
           )}
         </div>
 
-        {/* Status badge */}
         <span style={{
           marginLeft: '4px',
           fontSize: '11px',
           padding: '2px 8px',
           borderRadius: '10px',
-          background: statusInfo.color + '22',
+          background: `${statusInfo.color}22`,
           color: statusInfo.color,
           border: `1px solid ${statusInfo.color}44`,
           flexShrink: 0,
@@ -174,15 +253,13 @@ export function ReviewPage({
           {statusInfo.label}
         </span>
 
-        {/* Spacer */}
         <div style={{ flex: 1 }} />
 
-        {/* Action buttons */}
         {(actionError || actionSuccess) && (
           <span style={{
             fontSize: '12px',
             color: actionError ? '#f85149' : '#22c55e',
-            maxWidth: '300px',
+            maxWidth: '320px',
             overflow: 'hidden',
             textOverflow: 'ellipsis',
             whiteSpace: 'nowrap',
@@ -192,8 +269,8 @@ export function ReviewPage({
         )}
 
         <button
-          onClick={() => { void review.loadDiff(); void review.loadThreads(); }}
-          disabled={review.loading}
+          onClick={handleRefresh}
+          disabled={filesLoading || review.loading}
           style={{
             fontSize: '12px',
             padding: '5px 10px',
@@ -204,7 +281,7 @@ export function ReviewPage({
             cursor: 'pointer',
           }}
         >
-          {review.loading ? '...' : '↺ Refresh'}
+          {filesLoading || review.loading ? '...' : '↺ Refresh'}
         </button>
 
         <button
@@ -241,7 +318,7 @@ export function ReviewPage({
         </button>
 
         <button
-          onClick={() => setShowPanel((v) => !v)}
+          onClick={() => setShowPanel((value) => !value)}
           style={{
             fontSize: '12px',
             padding: '5px 10px',
@@ -253,7 +330,7 @@ export function ReviewPage({
           }}
         >
           {showPanel ? '≡ Hide' : '≡ Threads'}
-          {review.threads.filter((t) => !t.resolved).length > 0 && (
+          {review.threads.filter((thread) => !thread.resolved).length > 0 && (
             <span style={{
               marginLeft: '6px',
               fontSize: '10px',
@@ -263,14 +340,13 @@ export function ReviewPage({
               borderRadius: '8px',
               fontWeight: 700,
             }}>
-              {review.threads.filter((t) => !t.resolved).length}
+              {review.threads.filter((thread) => !thread.resolved).length}
             </span>
           )}
         </button>
       </div>
 
-      {/* Error banner */}
-      {review.error && (
+      {(review.error || filesError) && (
         <div style={{
           padding: '8px 16px',
           background: '#f8514922',
@@ -278,12 +354,11 @@ export function ReviewPage({
           color: '#f85149',
           fontSize: '12px',
         }}>
-          Error: {review.error}
+          Error: {filesError ?? review.error}
         </div>
       )}
 
-      {/* Loading state */}
-      {review.loading && !review.diff && (
+      {filesLoading && files.length === 0 ? (
         <div style={{
           flex: 1,
           display: 'flex',
@@ -292,47 +367,9 @@ export function ReviewPage({
           color: '#8b949e',
           fontSize: '13px',
         }}>
-          Loading diff...
+          Loading changed files...
         </div>
-      )}
-
-      {/* Main content */}
-      {review.diff !== null && (
-        <div style={{ flex: 1, display: 'flex', overflow: 'hidden' }}>
-          {/* Diff viewer */}
-          <div style={{ flex: showPanel ? '1 1 70%' : '1 1 100%', overflow: 'hidden' }}>
-            <DiffViewer
-              diff={review.diff}
-              threads={review.threads}
-              onCreateThread={handleCreateThread}
-              onUpdateThread={handleUpdateThread}
-              onThreadClick={(id) => {
-                setSelectedThreadId(id);
-                setShowPanel(true);
-              }}
-            />
-          </div>
-
-          {/* Thread panel */}
-          {showPanel && (
-            <div style={{ flex: '0 0 320px', overflow: 'hidden', borderLeft: '1px solid #30363d' }}>
-              <ThreadPanel
-                threads={review.threads}
-                selectedThreadId={selectedThreadId}
-                onResolveThread={(id, resolved) => review.updateThread(id, { resolved })}
-                onAddReply={review.addReply}
-                onUpdateComment={review.updateComment}
-                onDeleteComment={review.deleteComment}
-                onUpdateDecision={(id, decision) => review.updateThread(id, { decision })}
-                onClose={() => setShowPanel(false)}
-              />
-            </div>
-          )}
-        </div>
-      )}
-
-      {/* Empty diff state */}
-      {review.diff === '' && !review.loading && (
+      ) : files.length === 0 ? (
         <div style={{
           flex: 1,
           display: 'flex',
@@ -343,10 +380,46 @@ export function ReviewPage({
           flexDirection: 'column',
           gap: '8px',
         }}>
-          <div>No changes vs {review.baseBranch ?? 'base branch'}.</div>
+          <div>No changes vs {baseBranch ?? 'base branch'}.</div>
           <div style={{ fontSize: '12px', color: '#6e7681' }}>
             This workspace is up to date with its base branch.
           </div>
+        </div>
+      ) : (
+        <div style={{ flex: 1, display: 'flex', overflow: 'hidden' }}>
+          <div style={{ flex: showPanel ? '1 1 70%' : '1 1 100%', overflow: 'hidden' }}>
+            <DiffViewer
+              files={files}
+              threads={review.threads}
+              onCreateThread={handleCreateThread}
+              onUpdateThread={handleUpdateThread}
+              onRequestFileDiff={handleGetFileDiff}
+              onRequestFileContextRange={handleGetFileContextRange}
+              onThreadClick={openThread}
+              onThreadHover={(threadId) => {
+                setHoveredThreadId(threadId);
+                if (threadId) {
+                  setShowPanel(true);
+                }
+              }}
+            />
+          </div>
+
+          {showPanel && (
+            <div style={{ flex: '0 0 320px', overflow: 'hidden', borderLeft: '1px solid #30363d' }}>
+              <ThreadPanel
+                threads={review.threads}
+                selectedThreadId={selectedThreadId}
+                hoveredThreadId={hoveredThreadId}
+                onResolveThread={(threadId, resolved) => review.updateThread(threadId, { resolved })}
+                onAddReply={review.addReply}
+                onUpdateComment={review.updateComment}
+                onDeleteComment={review.deleteComment}
+                onUpdateDecision={(threadId, decision) => review.updateThread(threadId, { decision })}
+                onClose={() => setShowPanel(false)}
+              />
+            </div>
+          )}
         </div>
       )}
     </div>

--- a/src/pages/ReviewPage.web.tsx
+++ b/src/pages/ReviewPage.web.tsx
@@ -1,0 +1,354 @@
+/** @jsxImportSource react */
+/**
+ * ReviewPage — full review dashboard.
+ *
+ * Layout:
+ *   ┌──────────────────────────────────────────────────┐
+ *   │ Header (breadcrumb, status badge, GH buttons)    │
+ *   ├──────────────────────────────────────────────────┤
+ *   │  Diff viewer (70%)   │  Thread panel (30%)       │
+ *   └──────────────────────────────────────────────────┘
+ */
+
+import { useEffect, useState, useCallback } from 'react';
+import { useReview } from '../hooks/useReview.web.js';
+import { DiffViewer } from '../components/DiffViewer.web.js';
+import { ThreadPanel } from '../components/ThreadPanel.web.js';
+import { computeWorkspaceStatus } from '../types/review.js';
+import type { ReviewOperation, ReviewResult, ThreadTarget, HunkDecision } from '../types/review.js';
+
+export interface ReviewPageProps {
+  projectName: string;
+  workspaceName: string;
+  machineName?: string;
+  sendReviewRequest: (operation: ReviewOperation) => Promise<ReviewResult>;
+  onBack: () => void;
+}
+
+const STATUS_LABELS = {
+  not_started: { label: 'Not started', color: '#6e7681' },
+  in_progress: { label: 'In progress', color: '#d29922' },
+  approved: { label: 'Approved', color: '#22c55e' },
+  changes_required: { label: 'Changes required', color: '#f85149' },
+};
+
+export function ReviewPage({
+  projectName,
+  workspaceName,
+  machineName,
+  sendReviewRequest,
+  onBack,
+}: ReviewPageProps) {
+  const review = useReview({ sendReviewRequest, projectName, workspaceName });
+  const [selectedThreadId, setSelectedThreadId] = useState<string | null>(null);
+  const [showPanel, setShowPanel] = useState(true);
+  const [importing, setImporting] = useState(false);
+  const [pushing, setPushing] = useState(false);
+  const [actionError, setActionError] = useState<string | null>(null);
+  const [actionSuccess, setActionSuccess] = useState<string | null>(null);
+
+  // Load diff and threads on mount
+  useEffect(() => {
+    void review.loadDiff();
+    void review.loadThreads();
+  }, [projectName, workspaceName]);
+
+  const status = computeWorkspaceStatus(review.threads);
+  const statusInfo = STATUS_LABELS[status];
+
+  const handleCreateThread = useCallback(async (target: ThreadTarget, body: string, decision?: HunkDecision) => {
+    await review.createThread(target, body, decision);
+  }, [review]);
+
+  const handleUpdateThread = useCallback(async (threadId: string, updates: { decision?: HunkDecision }) => {
+    await review.updateThread(threadId, updates);
+  }, [review]);
+
+  const handleImport = useCallback(async () => {
+    setImporting(true);
+    setActionError(null);
+    setActionSuccess(null);
+    try {
+      const { imported } = await review.importGitHub();
+      setActionSuccess(`Imported ${imported} comment(s) from GitHub.`);
+      setTimeout(() => setActionSuccess(null), 4000);
+    } catch (err) {
+      setActionError(err instanceof Error ? err.message : 'Import failed');
+      setTimeout(() => setActionError(null), 6000);
+    } finally {
+      setImporting(false);
+    }
+  }, [review]);
+
+  const handlePush = useCallback(async () => {
+    setPushing(true);
+    setActionError(null);
+    setActionSuccess(null);
+    try {
+      const { url } = await review.pushGitHub();
+      setActionSuccess(`Review submitted: ${url}`);
+      setTimeout(() => setActionSuccess(null), 6000);
+    } catch (err) {
+      setActionError(err instanceof Error ? err.message : 'Push failed');
+      setTimeout(() => setActionError(null), 6000);
+    } finally {
+      setPushing(false);
+    }
+  }, [review]);
+
+  return (
+    <div style={{
+      height: '100vh',
+      width: '100vw',
+      display: 'flex',
+      flexDirection: 'column',
+      background: '#0d1117',
+      color: '#e6edf3',
+      fontFamily: '-apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif',
+      overflow: 'hidden',
+    }}>
+      {/* Header */}
+      <div style={{
+        background: '#161b22',
+        borderBottom: '1px solid #30363d',
+        padding: '10px 16px',
+        display: 'flex',
+        alignItems: 'center',
+        gap: '12px',
+        flexShrink: 0,
+        minHeight: '52px',
+      }}>
+        <button
+          onClick={onBack}
+          style={{
+            background: 'none',
+            border: 'none',
+            color: '#8b949e',
+            cursor: 'pointer',
+            fontSize: '13px',
+            padding: '4px',
+            display: 'flex',
+            alignItems: 'center',
+            gap: '4px',
+          }}
+        >
+          ← Workspaces
+        </button>
+
+        <div style={{ height: '16px', width: '1px', background: '#30363d' }} />
+
+        {/* Breadcrumb */}
+        <div style={{ display: 'flex', alignItems: 'center', gap: '6px', minWidth: 0 }}>
+          {machineName && (
+            <>
+              <span style={{ fontSize: '13px', color: '#8b949e', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                {machineName}
+              </span>
+              <span style={{ color: '#30363d' }}>/</span>
+            </>
+          )}
+          <span style={{ fontSize: '13px', color: '#8b949e' }}>{projectName}</span>
+          <span style={{ color: '#30363d' }}>/</span>
+          <span style={{ fontSize: '13px', color: '#e6edf3', fontWeight: 600 }}>{workspaceName}</span>
+          {review.headBranch && (
+            <span style={{ fontSize: '11px', color: '#6e7681', background: '#21262d', padding: '1px 6px', borderRadius: '4px', border: '1px solid #30363d' }}>
+              {review.headBranch}
+            </span>
+          )}
+          {review.baseBranch && (
+            <span style={{ fontSize: '11px', color: '#6e7681' }}>← {review.baseBranch}</span>
+          )}
+        </div>
+
+        {/* Status badge */}
+        <span style={{
+          marginLeft: '4px',
+          fontSize: '11px',
+          padding: '2px 8px',
+          borderRadius: '10px',
+          background: statusInfo.color + '22',
+          color: statusInfo.color,
+          border: `1px solid ${statusInfo.color}44`,
+          flexShrink: 0,
+        }}>
+          {statusInfo.label}
+        </span>
+
+        {/* Spacer */}
+        <div style={{ flex: 1 }} />
+
+        {/* Action buttons */}
+        {(actionError || actionSuccess) && (
+          <span style={{
+            fontSize: '12px',
+            color: actionError ? '#f85149' : '#22c55e',
+            maxWidth: '300px',
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+          }}>
+            {actionError || actionSuccess}
+          </span>
+        )}
+
+        <button
+          onClick={() => { void review.loadDiff(); void review.loadThreads(); }}
+          disabled={review.loading}
+          style={{
+            fontSize: '12px',
+            padding: '5px 10px',
+            background: '#21262d',
+            color: '#8b949e',
+            border: '1px solid #30363d',
+            borderRadius: '6px',
+            cursor: 'pointer',
+          }}
+        >
+          {review.loading ? '...' : '↺ Refresh'}
+        </button>
+
+        <button
+          onClick={() => void handleImport()}
+          disabled={importing}
+          style={{
+            fontSize: '12px',
+            padding: '5px 10px',
+            background: '#21262d',
+            color: '#58a6ff',
+            border: '1px solid #30363d',
+            borderRadius: '6px',
+            cursor: 'pointer',
+          }}
+        >
+          {importing ? '...' : '↓ Import GH'}
+        </button>
+
+        <button
+          onClick={() => void handlePush()}
+          disabled={pushing || review.threads.length === 0}
+          style={{
+            fontSize: '12px',
+            padding: '5px 10px',
+            background: pushing ? '#21262d' : '#22c55e',
+            color: pushing ? '#8b949e' : '#0d1117',
+            border: '1px solid #30363d',
+            borderRadius: '6px',
+            cursor: review.threads.length === 0 ? 'not-allowed' : 'pointer',
+            fontWeight: 600,
+          }}
+        >
+          {pushing ? '...' : '↑ Push to GH'}
+        </button>
+
+        <button
+          onClick={() => setShowPanel((v) => !v)}
+          style={{
+            fontSize: '12px',
+            padding: '5px 10px',
+            background: '#21262d',
+            color: '#8b949e',
+            border: '1px solid #30363d',
+            borderRadius: '6px',
+            cursor: 'pointer',
+          }}
+        >
+          {showPanel ? '≡ Hide' : '≡ Threads'}
+          {review.threads.filter((t) => !t.resolved).length > 0 && (
+            <span style={{
+              marginLeft: '6px',
+              fontSize: '10px',
+              padding: '0 5px',
+              background: '#58a6ff',
+              color: '#0d1117',
+              borderRadius: '8px',
+              fontWeight: 700,
+            }}>
+              {review.threads.filter((t) => !t.resolved).length}
+            </span>
+          )}
+        </button>
+      </div>
+
+      {/* Error banner */}
+      {review.error && (
+        <div style={{
+          padding: '8px 16px',
+          background: '#f8514922',
+          borderBottom: '1px solid #f8514944',
+          color: '#f85149',
+          fontSize: '12px',
+        }}>
+          Error: {review.error}
+        </div>
+      )}
+
+      {/* Loading state */}
+      {review.loading && !review.diff && (
+        <div style={{
+          flex: 1,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          color: '#8b949e',
+          fontSize: '13px',
+        }}>
+          Loading diff...
+        </div>
+      )}
+
+      {/* Main content */}
+      {review.diff !== null && (
+        <div style={{ flex: 1, display: 'flex', overflow: 'hidden' }}>
+          {/* Diff viewer */}
+          <div style={{ flex: showPanel ? '1 1 70%' : '1 1 100%', overflow: 'hidden' }}>
+            <DiffViewer
+              diff={review.diff}
+              threads={review.threads}
+              onCreateThread={handleCreateThread}
+              onUpdateThread={handleUpdateThread}
+              onThreadClick={(id) => {
+                setSelectedThreadId(id);
+                setShowPanel(true);
+              }}
+            />
+          </div>
+
+          {/* Thread panel */}
+          {showPanel && (
+            <div style={{ flex: '0 0 320px', overflow: 'hidden', borderLeft: '1px solid #30363d' }}>
+              <ThreadPanel
+                threads={review.threads}
+                selectedThreadId={selectedThreadId}
+                onResolveThread={(id, resolved) => review.updateThread(id, { resolved })}
+                onAddReply={review.addReply}
+                onUpdateComment={review.updateComment}
+                onDeleteComment={review.deleteComment}
+                onUpdateDecision={(id, decision) => review.updateThread(id, { decision })}
+                onClose={() => setShowPanel(false)}
+              />
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Empty diff state */}
+      {review.diff === '' && !review.loading && (
+        <div style={{
+          flex: 1,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          color: '#8b949e',
+          fontSize: '13px',
+          flexDirection: 'column',
+          gap: '8px',
+        }}>
+          <div>No changes vs {review.baseBranch ?? 'base branch'}.</div>
+          <div style={{ fontSize: '12px', color: '#6e7681' }}>
+            This workspace is up to date with its base branch.
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/pages/ReviewPage.web.tsx
+++ b/src/pages/ReviewPage.web.tsx
@@ -105,12 +105,12 @@ export function ReviewPage({
   }, [sendReviewRequest, projectName, workspaceName]);
 
   useEffect(() => {
-    void loadThreads();
+    void loadThreads().catch(() => {});
     void loadChangedFiles();
   }, [projectName, workspaceName, loadChangedFiles, loadThreads]);
 
   const handleRefresh = useCallback(() => {
-    void loadThreads();
+    void loadThreads().catch(() => {});
     void loadChangedFiles();
   }, [loadThreads, loadChangedFiles]);
 

--- a/src/pages/ReviewPage.web.tsx
+++ b/src/pages/ReviewPage.web.tsx
@@ -168,7 +168,7 @@ export function ReviewPage({
     setActionSuccess(null);
     try {
       const { imported } = await importGitHub();
-      setActionSuccess(`Imported ${imported} comment(s) from GitHub.`);
+      setActionSuccess(`Imported ${imported} new thread(s) from GitHub.`);
       setTimeout(() => setActionSuccess(null), 4000);
     } catch (error) {
       setActionError(error instanceof Error ? error.message : 'Import failed');

--- a/src/pages/ReviewPage.web.tsx
+++ b/src/pages/ReviewPage.web.tsx
@@ -3,7 +3,7 @@
  * ReviewPage — full review dashboard.
  */
 
-import { useCallback, useEffect, useState, type MouseEvent as ReactMouseEvent } from 'react';
+import { useCallback, useEffect, useRef, useState, type MouseEvent as ReactMouseEvent } from 'react';
 import { DiffViewer, type HunkFocusTarget } from '../components/DiffViewer.web.js';
 import { ThreadPanel } from '../components/ThreadPanel.web.js';
 import { useReview } from '../hooks/useReview.web.js';
@@ -69,6 +69,7 @@ export function ReviewPage({
   const [threadFilter, setThreadFilter] = useState<'all' | 'current-file' | 'current-hunk'>('all');
   const [currentFilePath, setCurrentFilePath] = useState<string | null>(null);
   const [currentHunkFocus, setCurrentHunkFocus] = useState<HunkFocusTarget | null>(null);
+  const currentHunkFocusRef = useRef<HunkFocusTarget | null>(null);
   const [focusRequest, setFocusRequest] = useState<{ threadId: string; nonce: number } | null>(null);
 
   const [importing, setImporting] = useState(false);
@@ -202,10 +203,15 @@ export function ReviewPage({
 
   const handleSelectedFileChange = useCallback((filePath: string | null) => {
     setCurrentFilePath(filePath);
-    if (currentHunkFocus && (!filePath || currentHunkFocus.filePath !== filePath)) {
+    const currentFocus = currentHunkFocusRef.current;
+    if (currentFocus && (!filePath || currentFocus.filePath !== filePath)) {
       setCurrentHunkFocus(null);
       setThreadFilter((mode) => (mode === 'current-hunk' ? 'current-file' : mode));
     }
+  }, []);
+
+  useEffect(() => {
+    currentHunkFocusRef.current = currentHunkFocus;
   }, [currentHunkFocus]);
 
   const handleHunkFocus = useCallback((target: HunkFocusTarget | null) => {

--- a/src/session/__tests__/backend-manager.test.ts
+++ b/src/session/__tests__/backend-manager.test.ts
@@ -61,6 +61,9 @@ class FakeBackend implements SessionBackend {
   async markInboxRead(_id: string): Promise<void> {}
   async getNotificationConfig(): Promise<void> {}
   async updateNotificationConfig(): Promise<void> {}
+  async sendReviewRequest(): Promise<never> {
+    throw new Error('not implemented');
+  }
 }
 
 describe('BackendManager', () => {

--- a/src/session/__tests__/useRemoteSessionClient.test.ts
+++ b/src/session/__tests__/useRemoteSessionClient.test.ts
@@ -170,6 +170,10 @@ class FakeRemoteBackend implements RemoteSessionPtyBackend {
     this.updateNotificationConfigCalls.push(config)
   }
 
+  async sendReviewRequest(): Promise<never> {
+    throw new Error('not implemented')
+  }
+
   async writePtyData(data: Uint8Array): Promise<void> {
     this.ptyWrites.push(new Uint8Array(data))
   }

--- a/src/session/__tests__/workspace-shell-hooks.integration.test.ts
+++ b/src/session/__tests__/workspace-shell-hooks.integration.test.ts
@@ -1,0 +1,270 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { send } from '../../lib/tmux-lite/cli.js';
+import { decodeControl, encodeControl, encodePTY, FrameType, parseFrames } from '../../lib/tmux-lite/protocol.js';
+import { buildWorkspaceSessionHooks } from '../workspace-shell-hooks.js';
+
+type EnvSnapshot = {
+  TMUX_LITE_SOCKET?: string;
+  TMUX_LITE_SESSION_DIR?: string;
+  TMUX_LITE_PID_FILE?: string;
+  SHELL?: string;
+  PATH?: string;
+};
+
+function setOptionalEnvVar(key: keyof EnvSnapshot, value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[key];
+    return;
+  }
+  process.env[key] = value;
+}
+
+function captureEnv(): EnvSnapshot {
+  return {
+    TMUX_LITE_SOCKET: process.env.TMUX_LITE_SOCKET,
+    TMUX_LITE_SESSION_DIR: process.env.TMUX_LITE_SESSION_DIR,
+    TMUX_LITE_PID_FILE: process.env.TMUX_LITE_PID_FILE,
+    SHELL: process.env.SHELL,
+    PATH: process.env.PATH,
+  };
+}
+
+function restoreEnv(env: EnvSnapshot): void {
+  setOptionalEnvVar('TMUX_LITE_SOCKET', env.TMUX_LITE_SOCKET);
+  setOptionalEnvVar('TMUX_LITE_SESSION_DIR', env.TMUX_LITE_SESSION_DIR);
+  setOptionalEnvVar('TMUX_LITE_PID_FILE', env.TMUX_LITE_PID_FILE);
+  setOptionalEnvVar('SHELL', env.SHELL);
+  setOptionalEnvVar('PATH', env.PATH);
+}
+
+async function runCommandInSession(socketPath: string, command: string): Promise<string> {
+  return new Promise(async (resolve, reject) => {
+    let buffer = Buffer.alloc(0);
+    let output = '';
+    let commandSent = false;
+    let settled = false;
+    let socket: Awaited<ReturnType<typeof Bun.connect>> | null = null;
+
+    const finish = (value: { output?: string; error?: Error }) => {
+      if (settled) return;
+      settled = true;
+      timeout.unref?.();
+      if (value.error) {
+        socket?.end();
+        reject(value.error);
+        return;
+      }
+      resolve(value.output ?? output);
+    };
+
+    const timeout = setTimeout(() => {
+      finish({ error: new Error('Timed out waiting for workspace session output') });
+    }, 10000);
+
+    try {
+      socket = await Bun.connect({
+        unix: socketPath,
+        socket: {
+          data(_socket, data) {
+            let incoming = Buffer.from(data);
+            if (buffer.length > 0) {
+              incoming = Buffer.concat([buffer, incoming]);
+            }
+
+            let parsed;
+            try {
+              parsed = parseFrames(incoming);
+            } catch (error) {
+              const message = error instanceof Error ? error.message : String(error);
+              finish({ error: new Error(`Failed to parse framed PTY data: ${message}`) });
+              return;
+            }
+
+            buffer = Buffer.from(parsed.remaining);
+
+            for (const frame of parsed.frames) {
+              if (frame.type === FrameType.PTY) {
+                output += frame.payload.toString('utf8');
+                continue;
+              }
+
+              if (frame.type !== FrameType.CONTROL) {
+                continue;
+              }
+
+              const event = decodeControl(frame.payload) as { type?: string; code?: number };
+              if (event.type === 'attached' && !commandSent) {
+                commandSent = true;
+                socket?.write(encodePTY(Buffer.from(command, 'utf8')));
+              }
+
+              if (event.type === 'exited') {
+                finish({ output });
+                return;
+              }
+            }
+          },
+          error(_socket, err) {
+            finish({ error: err });
+          },
+          close() {
+            if (!settled) {
+              finish({ error: new Error('Session socket closed before exit event') });
+            }
+          },
+        },
+      });
+
+      socket.write(encodeControl({ type: 'attach-init', cols: 120, rows: 40, clientType: 'cli' }));
+      socket.write(encodeControl({ type: 'resize', cols: 120, rows: 40 }));
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      finish({ error: new Error(`Failed to connect to session socket: ${message}`) });
+    }
+  });
+}
+
+async function waitForServerReady(routerSocket: string): Promise<void> {
+  for (let i = 0; i < 50; i += 1) {
+    if (existsSync(routerSocket)) {
+      try {
+        const response = await send({ type: 'list' });
+        if (response.type === 'sessions') {
+          return;
+        }
+      } catch {
+        // Socket might exist before server accepts commands.
+      }
+    }
+    await Bun.sleep(100);
+  }
+
+  throw new Error('Timed out waiting for tmux-lite server startup');
+}
+
+async function readProcessStream(
+  stream: number | ReadableStream<Uint8Array<ArrayBuffer>> | undefined
+): Promise<string> {
+  if (!stream || typeof stream === 'number') {
+    return '';
+  }
+  return new Response(stream).text();
+}
+
+describe('workspace shell hooks integration', () => {
+  let envSnapshot: EnvSnapshot;
+  let tempRoot: string;
+  let serverProcess: Bun.Subprocess | null = null;
+
+  beforeEach(() => {
+    envSnapshot = captureEnv();
+    tempRoot = mkdtempSync('/tmp/tl-hooks-');
+
+    const sessionDir = join(tempRoot, 'sessions');
+    const binDir = join(tempRoot, 'bin');
+    mkdirSync(sessionDir, { recursive: true });
+    mkdirSync(binDir, { recursive: true });
+
+    const fakeGsshPath = join(binDir, 'gssh');
+    writeFileSync(
+      fakeGsshPath,
+      '#!/bin/sh\nfor arg in "$@"; do\n  printf "__GSSH_ARGV__%s\\n" "$arg"\ndone\n'
+    );
+    chmodSync(fakeGsshPath, 0o755);
+
+    process.env.TMUX_LITE_SOCKET = join(tempRoot, 'router.sock');
+    process.env.TMUX_LITE_SESSION_DIR = sessionDir;
+    process.env.TMUX_LITE_PID_FILE = join(tempRoot, 'tmux-lite.pid');
+    process.env.SHELL = '/bin/bash';
+    const basePath = envSnapshot.PATH ?? '/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin';
+    process.env.PATH = `${binDir}:${basePath}`;
+
+    const serverScript = join(import.meta.dir, '../../lib/tmux-lite/server.ts');
+    serverProcess = Bun.spawn({
+      cmd: [process.execPath, 'run', serverScript],
+      env: process.env as Record<string, string>,
+      stdout: 'pipe',
+      stderr: 'pipe',
+    });
+  });
+
+  afterEach(async () => {
+    if (serverProcess) {
+      try {
+        await send({ type: 'kill-server' });
+      } catch {
+        try {
+          serverProcess.kill();
+        } catch {
+          // no-op
+        }
+      }
+
+      try {
+        await serverProcess.exited;
+      } catch {
+        // no-op
+      }
+      serverProcess = null;
+    }
+
+    try {
+      rmSync(tempRoot, { recursive: true, force: true });
+    } catch {
+      // no-op
+    }
+
+    restoreEnv(envSnapshot);
+  });
+
+  it('invokes injected space() function with workspace-scoped args', async () => {
+    const projectName = "proj with 'quote'";
+    const workspaceName = 'feature one';
+
+    try {
+      await waitForServerReady(process.env.TMUX_LITE_SOCKET || '');
+    } catch (error) {
+      const stdout = await readProcessStream(serverProcess?.stdout);
+      const stderr = await readProcessStream(serverProcess?.stderr);
+      const message = error instanceof Error ? error.message : String(error);
+      throw new Error(`${message}\nserver stdout:\n${stdout}\nserver stderr:\n${stderr}`);
+    }
+
+    const response = await send({
+      type: 'new',
+      name: 'workspace-hooks-e2e',
+      cwd: process.cwd(),
+      hooks: buildWorkspaceSessionHooks(projectName, workspaceName),
+    });
+    if (response.type !== 'session') {
+      throw new Error(`Expected session response, got ${response.type}`);
+    }
+    const session = response.session;
+
+    const output = await runCommandInSession(
+      session.socketPath,
+      'space review notes --format json; printf "__SPACE_EXIT__%s\\n" "$?"; exit\n'
+    );
+
+    const normalized = output.replace(/\r/g, '');
+    const argv = normalized
+      .split('\n')
+      .filter((line) => line.startsWith('__GSSH_ARGV__'))
+      .map((line) => line.replace('__GSSH_ARGV__', ''));
+
+    expect(argv).toEqual([
+      'space',
+      '--project',
+      projectName,
+      '--workspace',
+      workspaceName,
+      'review',
+      'notes',
+      '--format',
+      'json',
+    ]);
+    expect(normalized).toContain('__SPACE_EXIT__0');
+  });
+});

--- a/src/session/__tests__/workspace-shell-hooks.integration.test.ts
+++ b/src/session/__tests__/workspace-shell-hooks.integration.test.ts
@@ -170,7 +170,7 @@ describe('workspace shell hooks integration', () => {
     const fakeGsshPath = join(binDir, 'gssh');
     writeFileSync(
       fakeGsshPath,
-      '#!/bin/sh\nfor arg in "$@"; do\n  printf "__GSSH_ARGV__%s\\n" "$arg"\ndone\n'
+      '#!/bin/sh\nprintf "__GSSH_ENV_PROJECT__%s\\n" "$GSSH_SPACE_PROJECT"\nprintf "__GSSH_ENV_WORKSPACE__%s\\n" "$GSSH_SPACE_WORKSPACE"\nfor arg in "$@"; do\n  printf "__GSSH_ARGV__%s\\n" "$arg"\ndone\n'
     );
     chmodSync(fakeGsshPath, 0o755);
 
@@ -256,15 +256,13 @@ describe('workspace shell hooks integration', () => {
 
     expect(argv).toEqual([
       'space',
-      '--project',
-      projectName,
-      '--workspace',
-      workspaceName,
       'review',
       'notes',
       '--format',
       'json',
     ]);
+    expect(normalized).toContain(`__GSSH_ENV_PROJECT__${projectName}`);
+    expect(normalized).toContain(`__GSSH_ENV_WORKSPACE__${workspaceName}`);
     expect(normalized).toContain('__SPACE_EXIT__0');
   });
 });

--- a/src/session/__tests__/workspace-shell-hooks.test.ts
+++ b/src/session/__tests__/workspace-shell-hooks.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'bun:test';
+import { buildWorkspaceSessionHooks } from '../workspace-shell-hooks.js';
+
+describe('buildWorkspaceSessionHooks', () => {
+  it('injects workspace environment context', () => {
+    const hooks = buildWorkspaceSessionHooks('acme', 'feature-1');
+
+    expect(hooks.env).toEqual({
+      GSSH_SESSION_MODE: 'workspace',
+      GSSH_SPACE_PROJECT: 'acme',
+      GSSH_SPACE_WORKSPACE: 'feature-1',
+    });
+  });
+
+  it('builds bash and zsh space function with escaped args', () => {
+    const hooks = buildWorkspaceSessionHooks("acme's repo", 'feat one');
+
+    const expected =
+      `space() { gssh space --project 'acme'\\''s repo' --workspace 'feat one' "$@"; }`;
+
+    expect(hooks.shellInit?.bash).toBe(expected);
+    expect(hooks.shellInit?.zsh).toBe(expected);
+  });
+});

--- a/src/session/__tests__/workspace-shell-hooks.test.ts
+++ b/src/session/__tests__/workspace-shell-hooks.test.ts
@@ -16,7 +16,7 @@ describe('buildWorkspaceSessionHooks', () => {
     const hooks = buildWorkspaceSessionHooks("acme's repo", 'feat one');
 
     const expected =
-      `space() { gssh space --project 'acme'\\''s repo' --workspace 'feat one' "$@"; }`;
+      `space() { GSSH_SPACE_PROJECT='acme'\\''s repo' GSSH_SPACE_WORKSPACE='feat one' gssh space "$@"; }`;
 
     expect(hooks.shellInit?.bash).toBe(expected);
     expect(hooks.shellInit?.zsh).toBe(expected);

--- a/src/session/backend.ts
+++ b/src/session/backend.ts
@@ -4,6 +4,7 @@ import type {
   BundleRefreshPlan,
   BundleRefreshSubmission,
 } from '../types/bundle-refresh.js';
+import type { ReviewOperation, ReviewResult } from '../types/review.js';
 
 export type BackendKey = string;
 export type BackendKind = 'local' | 'remote';
@@ -70,6 +71,8 @@ export interface SessionBackend {
 
   getNotificationConfig(): Promise<void>;
   updateNotificationConfig(config: NotificationConfig): Promise<void>;
+
+  sendReviewRequest(operation: ReviewOperation): Promise<ReviewResult>;
 
   writePtyData?(data: Uint8Array): Promise<void>;
   resizePty?(cols: number, rows: number): Promise<void>;

--- a/src/session/backends/local-session-backend.ts
+++ b/src/session/backends/local-session-backend.ts
@@ -35,6 +35,7 @@ import {
 import { createBufferedSocketWriter } from '../../utils/bun-socket-writer.js';
 import { findUtf8Boundary } from '../../utils/utf8.js';
 import { buildSessionName } from '../session-name.js';
+import { buildWorkspaceSessionHooks } from '../workspace-shell-hooks.js';
 import type {
   AttachSessionParams,
   BackendDescriptor,
@@ -537,7 +538,9 @@ export class LocalSessionBackend implements SessionBackend {
         requestedName: params.sessionName,
         sessions,
       });
-      targetSession = await this.deps.createSession(fullName, workspace.path);
+      targetSession = await this.deps.createSession(fullName, workspace.path, {
+        hooks: buildWorkspaceSessionHooks(workspace.projectName, workspace.id),
+      });
     } else {
       throw new SpacesError('attachSession requires sessionId or workspaceId', 'USER_ERROR', 1);
     }

--- a/src/session/backends/local-session-backend.ts
+++ b/src/session/backends/local-session-backend.ts
@@ -44,6 +44,8 @@ import type {
 import type { BackendEvent } from '../events.js';
 import type { NotificationConfig } from '../../notifications/types.js';
 import type { BundleRefreshPlan, BundleRefreshSubmission } from '../../types/bundle-refresh.js';
+import type { ReviewOperation, ReviewResult } from '../../types/review.js';
+import { executeLocalReviewOperation } from '../../core/review-executor.js';
 import {
   SpacesError,
   WorkspaceDeleteError,
@@ -665,6 +667,10 @@ export class LocalSessionBackend implements SessionBackend {
   ): Promise<void> {
     const workspace = await this.resolveWorkspace(projectName, workspaceId);
     await this.deps.applyBundleRefreshSubmission(projectName, workspace.path, submission);
+  }
+
+  async sendReviewRequest(operation: ReviewOperation): Promise<ReviewResult> {
+    return executeLocalReviewOperation(operation, this.deps.scanWorkspaces);
   }
 
   async requestInbox(): Promise<void> {

--- a/src/session/backends/local-session-backend.ts
+++ b/src/session/backends/local-session-backend.ts
@@ -34,6 +34,11 @@ import {
 } from '../../core/bundle-refresh.js';
 import { createBufferedSocketWriter } from '../../utils/bun-socket-writer.js';
 import { findUtf8Boundary } from '../../utils/utf8.js';
+import {
+  matchesWorkspaceId,
+  resolveWorkspaceName,
+  toCanonicalWorkspaceId,
+} from '../../utils/workspace-id.js';
 import { buildSessionName } from '../session-name.js';
 import { buildWorkspaceSessionHooks } from '../workspace-shell-hooks.js';
 import type {
@@ -98,22 +103,6 @@ const DEFAULT_DESCRIPTOR: BackendDescriptor = {
   kind: 'local',
   label: 'Local',
 };
-
-function toWorkspaceId(projectName: string, workspaceName: string): string {
-  return `${projectName}:${workspaceName}`;
-}
-
-function toCanonicalWorkspaceId(workspace: { projectName: string; id: string }): string {
-  return toWorkspaceId(workspace.projectName, workspace.id);
-}
-
-function resolveWorkspaceName(projectName: string, workspaceId: string): string {
-  const prefix = `${projectName}:`;
-  if (workspaceId.startsWith(prefix)) {
-    return workspaceId.slice(prefix.length);
-  }
-  return workspaceId;
-}
 
 function toSessionInfo(
   session: TmuxSession,
@@ -455,14 +444,13 @@ export class LocalSessionBackend implements SessionBackend {
         throw toExitedSessionError(targetSession);
       }
     } else if (params.workspaceId) {
+      const workspaceId = params.workspaceId;
       const workspaces = await this.deps.scanWorkspaces();
       const workspace = workspaces.find(
-        (item) =>
-          item.id === params.workspaceId ||
-          toCanonicalWorkspaceId(item) === params.workspaceId
+        (item) => matchesWorkspaceId(item, workspaceId)
       );
       if (!workspace) {
-        throw new SpacesError(`Workspace not found: ${params.workspaceId}`, 'USER_ERROR', 1);
+        throw new SpacesError(`Workspace not found: ${workspaceId}`, 'USER_ERROR', 1);
       }
 
       let currentPhase: 'pre' | 'setup' | 'select' = 'pre';
@@ -892,7 +880,7 @@ export class LocalSessionBackend implements SessionBackend {
     const workspace = workspaces.find(
       (item) =>
         item.projectName === projectName &&
-        (item.id === resolvedWorkspaceId || toCanonicalWorkspaceId(item) === workspaceId)
+        (item.id === resolvedWorkspaceId || matchesWorkspaceId(item, workspaceId))
     );
 
     if (!workspace) {

--- a/src/session/backends/remote-session-backend.ts
+++ b/src/session/backends/remote-session-backend.ts
@@ -28,6 +28,7 @@ import type { ReviewOperation, ReviewResult } from '../../types/review.js';
 import { findUtf8Boundary } from '../../utils/utf8.js';
 import type { NotificationConfig } from '../../notifications/types.js';
 import {
+  ReviewRequestError,
   WorkspaceDeleteError,
   type WorkspaceDeleteErrorCode,
 } from '../../types/errors.js';
@@ -323,6 +324,7 @@ export class RemoteSessionBackend<TSocket, THandshakeState, TServerHello, TServe
       }
     | null = null;
   private pendingReviewRequests = new Map<string, {
+    op: ReviewOperation['op'];
     resolve: (result: ReviewResult) => void;
     reject: (error: Error) => void;
     timeout: ReturnType<typeof setTimeout>;
@@ -611,10 +613,21 @@ export class RemoteSessionBackend<TSocket, THandshakeState, TServerHello, TServe
           return;
         }
         this.pendingReviewRequests.delete(requestId);
-        reject(new Error(`Timed out waiting for review response (${operation.op})`));
+        reject(
+          new ReviewRequestError(
+            `Timed out waiting for review response (${operation.op})`,
+            'REVIEW_TIMEOUT',
+            { op: operation.op, requestId }
+          )
+        );
       }, 30000);
 
-      this.pendingReviewRequests.set(requestId, { resolve, reject, timeout });
+      this.pendingReviewRequests.set(requestId, {
+        op: operation.op,
+        resolve,
+        reject,
+        timeout,
+      });
 
       void this.sendCommand(command).catch((error) => {
         const pending = this.pendingReviewRequests.get(requestId);
@@ -623,7 +636,13 @@ export class RemoteSessionBackend<TSocket, THandshakeState, TServerHello, TServe
         }
         clearTimeout(pending.timeout);
         this.pendingReviewRequests.delete(requestId);
-        reject(error instanceof Error ? error : new Error(String(error)));
+        const message = error instanceof Error ? error.message : String(error);
+        reject(
+          new ReviewRequestError(message, 'REVIEW_FAILED', {
+            op: pending.op,
+            requestId,
+          })
+        );
       });
     });
   }
@@ -1080,19 +1099,34 @@ export class RemoteSessionBackend<TSocket, THandshakeState, TServerHello, TServe
     clearTimeout(pending.timeout);
     this.pendingReviewRequests.delete(message.requestId);
     if (message.error) {
-      pending.reject(new Error(message.error.message));
+      pending.reject(
+        new ReviewRequestError(
+          message.error.message,
+          message.error.code || 'REVIEW_FAILED',
+          { op: pending.op, requestId: message.requestId }
+        )
+      );
     } else if (message.result) {
       pending.resolve(message.result);
     } else {
-      pending.reject(new Error('Review response missing result'));
+      pending.reject(
+        new ReviewRequestError('Review response missing result', 'REVIEW_MISSING_RESULT', {
+          op: pending.op,
+          requestId: message.requestId,
+        })
+      );
     }
   }
 
   private rejectAllPendingReviewRequests(message: string): void {
-    const error = new Error(message);
     for (const [requestId, pending] of this.pendingReviewRequests) {
       clearTimeout(pending.timeout);
-      pending.reject(error);
+      pending.reject(
+        new ReviewRequestError(message, 'REVIEW_FAILED', {
+          op: pending.op,
+          requestId,
+        })
+      );
       this.pendingReviewRequests.delete(requestId);
     }
   }

--- a/src/session/backends/remote-session-backend.ts
+++ b/src/session/backends/remote-session-backend.ts
@@ -17,11 +17,14 @@ import {
   type ListWorkspacesRequest,
   type MachineToClientMessage,
   type MarkInboxReadRequest,
+  type ReviewRequest,
+  type ReviewResponse,
   type ScriptOutputResponse,
   type SessionCtrl,
   type UpdateNotificationConfigRequest,
 } from '../../lib/remote-session/protocol.js';
 import type { BundleRefreshPlan, BundleRefreshSubmission } from '../../types/bundle-refresh.js';
+import type { ReviewOperation, ReviewResult } from '../../types/review.js';
 import { findUtf8Boundary } from '../../utils/utf8.js';
 import type { NotificationConfig } from '../../notifications/types.js';
 import {
@@ -164,6 +167,7 @@ const MACHINE_TO_CLIENT_TYPES = new Set<string>([
   'script_output',
   'bundle_refresh_plan',
   'bundle_refresh_applied',
+  'review_response',
 ]);
 
 function isHandshakeEnvelope(value: unknown): value is HandshakeEnvelope {
@@ -318,6 +322,11 @@ export class RemoteSessionBackend<TSocket, THandshakeState, TServerHello, TServe
         timeout: ReturnType<typeof setTimeout>;
       }
     | null = null;
+  private pendingReviewRequests = new Map<string, {
+    resolve: (result: ReviewResult) => void;
+    reject: (error: Error) => void;
+    timeout: ReturnType<typeof setTimeout>;
+  }>();
   private ptyOutputHandler: ((data: Uint8Array) => void) | null = null;
   private pendingPtyChunks: Uint8Array[] = [];
   private pendingUtf8Bytes = new Uint8Array(0);
@@ -587,6 +596,38 @@ export class RemoteSessionBackend<TSocket, THandshakeState, TServerHello, TServe
     await this.sendCommand(command);
   }
 
+  async sendReviewRequest(operation: ReviewOperation): Promise<ReviewResult> {
+    const requestId = crypto.randomUUID();
+
+    const command: ReviewRequest = {
+      type: 'review_request',
+      requestId,
+      operation,
+    };
+
+    return new Promise<ReviewResult>((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        if (!this.pendingReviewRequests.has(requestId)) {
+          return;
+        }
+        this.pendingReviewRequests.delete(requestId);
+        reject(new Error(`Timed out waiting for review response (${operation.op})`));
+      }, 30000);
+
+      this.pendingReviewRequests.set(requestId, { resolve, reject, timeout });
+
+      void this.sendCommand(command).catch((error) => {
+        const pending = this.pendingReviewRequests.get(requestId);
+        if (!pending) {
+          return;
+        }
+        clearTimeout(pending.timeout);
+        this.pendingReviewRequests.delete(requestId);
+        reject(error instanceof Error ? error : new Error(String(error)));
+      });
+    });
+  }
+
   async writePtyData(data: Uint8Array): Promise<void> {
     this.assertConnected();
 
@@ -630,6 +671,7 @@ export class RemoteSessionBackend<TSocket, THandshakeState, TServerHello, TServe
         this.rejectConnect(error);
         this.rejectPendingBundleRefreshRequests(error.message);
         this.rejectPendingWorkspaceDelete('DELETE_FAILED', error.message);
+        this.rejectAllPendingReviewRequests(error.message);
         this.emit({ type: 'status', status: 'error', error: error.message });
       },
     });
@@ -898,6 +940,10 @@ export class RemoteSessionBackend<TSocket, THandshakeState, TServerHello, TServe
         this.resolveBundleRefreshApply(message);
         return;
       }
+      case 'review_response': {
+        this.resolveReviewRequest(message);
+        return;
+      }
       case 'error':
         this.rejectPendingBundleRefreshRequests(message.message);
         if (message.workspaceId) {
@@ -1026,6 +1072,31 @@ export class RemoteSessionBackend<TSocket, THandshakeState, TServerHello, TServe
     pending.reject(new WorkspaceDeleteError(message, toWorkspaceDeleteErrorCode(code)));
   }
 
+  private resolveReviewRequest(message: ReviewResponse): void {
+    const pending = this.pendingReviewRequests.get(message.requestId);
+    if (!pending) {
+      return;
+    }
+    clearTimeout(pending.timeout);
+    this.pendingReviewRequests.delete(message.requestId);
+    if (message.error) {
+      pending.reject(new Error(message.error.message));
+    } else if (message.result) {
+      pending.resolve(message.result);
+    } else {
+      pending.reject(new Error('Review response missing result'));
+    }
+  }
+
+  private rejectAllPendingReviewRequests(message: string): void {
+    const error = new Error(message);
+    for (const [requestId, pending] of this.pendingReviewRequests) {
+      clearTimeout(pending.timeout);
+      pending.reject(error);
+      this.pendingReviewRequests.delete(requestId);
+    }
+  }
+
   private emitPtyData(data: Uint8Array): void {
     if (!this.ptyOutputHandler) {
       this.pendingPtyChunks.push(data);
@@ -1112,6 +1183,7 @@ export class RemoteSessionBackend<TSocket, THandshakeState, TServerHello, TServe
     this.pendingUtf8Bytes = new Uint8Array(0);
     this.rejectPendingBundleRefreshRequests('Remote session disconnected');
     this.rejectPendingWorkspaceDelete('DELETE_FAILED', 'Remote session disconnected', undefined, true);
+    this.rejectAllPendingReviewRequests('Remote session disconnected');
     this.connectPromise = null;
     this.connectResolve = null;
     this.connectReject = null;

--- a/src/session/events.ts
+++ b/src/session/events.ts
@@ -6,6 +6,7 @@ import type {
   WorkspaceInfo,
 } from '../lib/remote-session/protocol.js';
 import type { NotificationConfig } from '../notifications/types.js';
+import type { ReviewOperation, ReviewResult } from '../types/review.js';
 
 export type BackendEvent =
   | { type: 'status'; status: 'disconnected' | 'connecting' | 'connected' | 'error'; error?: string }
@@ -26,4 +27,8 @@ export type BackendEvent =
   | { type: 'detached' }
   | { type: 'session_exited'; sessionId: string; exitCode?: number }
   | { type: 'command_error'; code?: string; message: string }
-  | { type: 'error'; message: string };
+  | { type: 'error'; message: string }
+  | { type: 'review_response'; requestId: string; result?: ReviewResult; error?: { code: string; message: string } };
+
+// Re-export for convenience
+export type { ReviewOperation, ReviewResult };

--- a/src/session/useRemoteSessionClient.ts
+++ b/src/session/useRemoteSessionClient.ts
@@ -17,6 +17,7 @@ import type {
   BundleRefreshPlan,
   BundleRefreshSubmission,
 } from '../types/bundle-refresh.js';
+import type { ReviewOperation, ReviewResult } from '../types/review.js';
 import { useSessionEngine } from './useSessionEngine.js';
 
 export type RemoteSessionConnectionStatus =
@@ -87,6 +88,8 @@ export interface UseRemoteSessionClientReturn<ConnectParams> {
   requestNotificationConfig: () => void;
   updateNotificationConfig: (config: NotificationConfig) => void;
   notificationConfig: NotificationConfig | null;
+
+  sendReviewRequest: (operation: ReviewOperation) => Promise<ReviewResult>;
 
   scriptState: ScriptRuntimeState | null;
   commandError: { code?: string; message: string } | null;
@@ -305,6 +308,17 @@ export function useRemoteSessionClient<ConnectParams>(
     );
   }, [engine, withActiveBackend]);
 
+  const sendReviewRequest = useCallback(
+    async (operation: ReviewOperation): Promise<ReviewResult> => {
+      const backendKey = activeBackendKeyRef.current;
+      if (!backendKey) {
+        throw new Error('No active backend connection');
+      }
+      return engine.sendReviewRequest(backendKey, operation);
+    },
+    [engine]
+  );
+
   useEffect(() => {
     return () => {
       const backendKey = activeBackendKeyRef.current;
@@ -356,6 +370,8 @@ export function useRemoteSessionClient<ConnectParams>(
     requestNotificationConfig,
     updateNotificationConfig,
     notificationConfig: activeBackendState?.notificationConfig ?? null,
+
+    sendReviewRequest,
 
     scriptState: activeBackendState?.scriptState ?? null,
     commandError: activeBackendState?.commandError ?? null,

--- a/src/session/useRemoteSessionClient.ts
+++ b/src/session/useRemoteSessionClient.ts
@@ -18,6 +18,7 @@ import type {
   BundleRefreshSubmission,
 } from '../types/bundle-refresh.js';
 import type { ReviewOperation, ReviewResult } from '../types/review.js';
+import { SpacesError } from '../types/errors.js';
 import { useSessionEngine } from './useSessionEngine.js';
 
 export type RemoteSessionConnectionStatus =
@@ -312,7 +313,7 @@ export function useRemoteSessionClient<ConnectParams>(
     async (operation: ReviewOperation): Promise<ReviewResult> => {
       const backendKey = activeBackendKeyRef.current;
       if (!backendKey) {
-        throw new Error('No active backend connection');
+        throw new SpacesError('No active backend connection', 'SYSTEM_ERROR', 2);
       }
       return engine.sendReviewRequest(backendKey, operation);
     },

--- a/src/session/useSessionEngine.ts
+++ b/src/session/useSessionEngine.ts
@@ -10,6 +10,7 @@ import type {
   BundleRefreshPlan,
   BundleRefreshSubmission,
 } from '../types/bundle-refresh.js';
+import type { ReviewOperation, ReviewResult } from '../types/review.js';
 import type { ScriptPhase } from '../types/script-phase.js';
 import { BackendManager } from './backend-manager.js';
 import {
@@ -129,6 +130,9 @@ export function useSessionEngine() {
             status: 'error',
             error: event.message,
           });
+          break;
+        case 'review_response':
+          // Handled directly by RemoteSessionBackend's pending map — no state dispatch needed.
           break;
         default:
           break;
@@ -295,6 +299,20 @@ export function useSessionEngine() {
     await withBackend(backendKey, (backend) => backend.updateNotificationConfig(config));
   }, [withBackend]);
 
+  const sendReviewRequest = useCallback(async (
+    backendKey: BackendKey,
+    operation: ReviewOperation
+  ): Promise<ReviewResult> => {
+    let result: ReviewResult | null = null;
+    await withBackend(backendKey, async (backend) => {
+      result = await backend.sendReviewRequest(operation);
+    });
+    if (!result) {
+      throw new SpacesError('Review request was not handled by backend', 'SYSTEM_ERROR', 2);
+    }
+    return result;
+  }, [withBackend]);
+
   return useMemo(() => ({
     state,
     activeBackendKey: getActiveBackendKey(state),
@@ -323,6 +341,7 @@ export function useSessionEngine() {
     markInboxRead,
     getNotificationConfig,
     updateNotificationConfig,
+    sendReviewRequest,
   }), [
     state,
     registerBackend,
@@ -344,5 +363,6 @@ export function useSessionEngine() {
     markInboxRead,
     getNotificationConfig,
     updateNotificationConfig,
+    sendReviewRequest,
   ]);
 }

--- a/src/session/workspace-shell-hooks.ts
+++ b/src/session/workspace-shell-hooks.ts
@@ -1,0 +1,30 @@
+import type { SessionCreateHooks } from '../lib/tmux-lite/protocol.js';
+import { escapeShellArg } from '../utils/shell-escape.js';
+
+/**
+ * Build generic tmux-lite session hooks for workspace-scoped shells.
+ *
+ * This keeps tmux-lite gssh-agnostic while allowing gssh to inject
+ * workspace context and convenience commands.
+ */
+export function buildWorkspaceSessionHooks(
+  projectName: string,
+  workspaceName: string
+): SessionCreateHooks {
+  const escapedProject = escapeShellArg(projectName);
+  const escapedWorkspace = escapeShellArg(workspaceName);
+
+  const spaceFunction = `space() { gssh space --project ${escapedProject} --workspace ${escapedWorkspace} "$@"; }`;
+
+  return {
+    env: {
+      GSSH_SESSION_MODE: 'workspace',
+      GSSH_SPACE_PROJECT: projectName,
+      GSSH_SPACE_WORKSPACE: workspaceName,
+    },
+    shellInit: {
+      bash: spaceFunction,
+      zsh: spaceFunction,
+    },
+  };
+}

--- a/src/session/workspace-shell-hooks.ts
+++ b/src/session/workspace-shell-hooks.ts
@@ -14,7 +14,9 @@ export function buildWorkspaceSessionHooks(
   const escapedProject = escapeShellArg(projectName);
   const escapedWorkspace = escapeShellArg(workspaceName);
 
-  const spaceFunction = `space() { gssh space --project ${escapedProject} --workspace ${escapedWorkspace} "$@"; }`;
+  // Keep defaults in env so Commander leaf subcommands can still parse
+  // explicit --project/--workspace flags passed by users.
+  const spaceFunction = `space() { GSSH_SPACE_PROJECT=${escapedProject} GSSH_SPACE_WORKSPACE=${escapedWorkspace} gssh space "$@"; }`;
 
   return {
     env: {

--- a/src/session/workspace-shell-hooks.ts
+++ b/src/session/workspace-shell-hooks.ts
@@ -6,13 +6,16 @@ import { escapeShellArg } from '../utils/shell-escape.js';
  *
  * This keeps tmux-lite gssh-agnostic while allowing gssh to inject
  * workspace context and convenience commands.
+ *
+ * Note: GSSH_SPACE_WORKSPACE stores the workspace ID (directory/worktree id),
+ * not a display label.
  */
 export function buildWorkspaceSessionHooks(
   projectName: string,
-  workspaceName: string
+  workspaceId: string
 ): SessionCreateHooks {
   const escapedProject = escapeShellArg(projectName);
-  const escapedWorkspace = escapeShellArg(workspaceName);
+  const escapedWorkspace = escapeShellArg(workspaceId);
 
   // Keep defaults in env so Commander leaf subcommands can still parse
   // explicit --project/--workspace flags passed by users.
@@ -22,7 +25,7 @@ export function buildWorkspaceSessionHooks(
     env: {
       GSSH_SESSION_MODE: 'workspace',
       GSSH_SPACE_PROJECT: projectName,
-      GSSH_SPACE_WORKSPACE: workspaceName,
+      GSSH_SPACE_WORKSPACE: workspaceId,
     },
     shellInit: {
       bash: spaceFunction,

--- a/src/types/errors.ts
+++ b/src/types/errors.ts
@@ -40,6 +40,16 @@ export class SpacesError extends Error {
   }
 }
 
+export function toSpacesError(error: unknown, fallbackMessage: string): SpacesError {
+  if (error instanceof SpacesError) {
+    return error;
+  }
+  if (error instanceof Error) {
+    return new SpacesError(error.message, 'SYSTEM_ERROR', 2);
+  }
+  return new SpacesError(fallbackMessage, 'SYSTEM_ERROR', 2);
+}
+
 /**
  * Error thrown when a dependency is missing
  */

--- a/src/types/errors.ts
+++ b/src/types/errors.ts
@@ -235,6 +235,35 @@ export class WorkspaceDeleteError extends Error {
   }
 }
 
+export type ReviewRequestErrorCode =
+  | 'REVIEW_TIMEOUT'
+  | 'REVIEW_FAILED'
+  | 'REVIEW_MISSING_RESULT'
+  | (string & {});
+
+/**
+ * Error thrown when remote review requests fail or time out.
+ */
+export class ReviewRequestError extends Error {
+  public readonly code: ReviewRequestErrorCode;
+  public readonly metadata?: { op?: string; requestId?: string };
+
+  constructor(
+    message: string,
+    code: ReviewRequestErrorCode,
+    metadata?: { op?: string; requestId?: string }
+  ) {
+    super(message);
+    this.name = 'ReviewRequestError';
+    this.code = code;
+    this.metadata = metadata;
+
+    if (typeof Error.captureStackTrace === 'function') {
+      Error.captureStackTrace(this, this.constructor);
+    }
+  }
+}
+
 /**
  * Error thrown when a requested session name already exists.
  */

--- a/src/types/review.ts
+++ b/src/types/review.ts
@@ -174,9 +174,47 @@ export type ReviewOperation =
       threadId: string;
       commentId: string;
     }
+  | { op: 'get_changed_files'; projectName: string; workspaceName: string }
   | { op: 'get_diff'; projectName: string; workspaceName: string }
+  | {
+      op: 'get_file_diff';
+      projectName: string;
+      workspaceName: string;
+      filePath: string;
+      prevFilePath?: string;
+    }
+  | {
+      op: 'get_file_versions';
+      projectName: string;
+      workspaceName: string;
+      filePath: string;
+      /** Optional old path for renames (rename from) */
+      prevFilePath?: string;
+    }
+  | {
+      op: 'get_file_context_range';
+      projectName: string;
+      workspaceName: string;
+      filePath: string;
+      /** Optional old path for renames (rename from) */
+      prevFilePath?: string;
+      /** 1-based inclusive range on old/base side. Omit for full file */
+      oldStart?: number;
+      /** 1-based inclusive range on old/base side. Omit for full file */
+      oldEnd?: number;
+      /** 1-based inclusive range on new/head side. Omit for full file */
+      newStart?: number;
+      /** 1-based inclusive range on new/head side. Omit for full file */
+      newEnd?: number;
+    }
   | { op: 'import_github'; projectName: string; workspaceName: string; prNumber?: number }
   | { op: 'push_github'; projectName: string; workspaceName: string; prNumber?: number };
+
+export interface ReviewChangedFile {
+  filePath: string;
+  prevFilePath?: string;
+  changeType: 'new' | 'deleted' | 'renamed' | 'modified';
+}
 
 /** Results returned from machine to client */
 export type ReviewResult =
@@ -186,7 +224,37 @@ export type ReviewResult =
   | { op: 'comment_added'; thread: ReviewThread }
   | { op: 'comment_updated'; thread: ReviewThread }
   | { op: 'comment_deleted'; thread: ReviewThread }
+  | {
+      op: 'changed_files';
+      files: ReviewChangedFile[];
+      baseBranch: string;
+      headBranch: string;
+    }
   | { op: 'diff'; diff: string; baseBranch: string; headBranch: string }
+  | {
+      op: 'file_diff';
+      filePath: string;
+      prevFilePath?: string;
+      diff: string;
+    }
+  | {
+      op: 'file_versions';
+      filePath: string;
+      prevFilePath?: string;
+      oldContents: string | null;
+      newContents: string | null;
+    }
+  | {
+      op: 'file_context_range';
+      filePath: string;
+      prevFilePath?: string;
+      oldStart: number;
+      oldLines: string[];
+      oldTotal: number;
+      newStart: number;
+      newLines: string[];
+      newTotal: number;
+    }
   | { op: 'github_imported'; imported: number; threads: ReviewThread[] }
   | { op: 'github_pushed'; prNumber: number; url: string };
 

--- a/src/types/review.ts
+++ b/src/types/review.ts
@@ -62,6 +62,8 @@ export interface ReviewComment {
   createdAt: string;
   /** Set when synced from/to GitHub */
   githubId?: number;
+  /** Set for local comments once they have been pushed to GitHub */
+  syncedToGitHubAt?: string;
 }
 
 // ============================================================================

--- a/src/types/review.ts
+++ b/src/types/review.ts
@@ -1,0 +1,278 @@
+/**
+ * Review system types
+ *
+ * Supports threaded code review with hunk-level approve/reject decisions,
+ * line-range comments, file-level notes, and workspace-level notes.
+ * Bidirectionally syncs with GitHub PR review comments.
+ */
+
+// ============================================================================
+// Thread Targets
+// ============================================================================
+
+/** Attach to a specific diff hunk (@@ block) — can carry an approve/reject decision */
+export interface HunkTarget {
+  kind: 'hunk';
+  file: string;
+  /** The @@ -start,lines +start,lines @@ header string — used as stable hunk ID */
+  hunkHeader: string;
+}
+
+/** Attach to a range of lines in a file */
+export interface LineTarget {
+  kind: 'line';
+  file: string;
+  startLine: number;
+  endLine: number;
+  /** Which side of the diff — LEFT (old) or RIGHT (new) */
+  side: 'LEFT' | 'RIGHT';
+}
+
+/** Attach to an entire file */
+export interface FileTarget {
+  kind: 'file';
+  file: string;
+}
+
+/** Attach to the workspace as a whole — general review comment */
+export interface WorkspaceTarget {
+  kind: 'workspace';
+}
+
+export type ThreadTarget = HunkTarget | LineTarget | FileTarget | WorkspaceTarget;
+
+// ============================================================================
+// Hunk Decision
+// ============================================================================
+
+/** Decision on a diff hunk — only valid when thread target is 'hunk' */
+export type HunkDecision = 'approved' | 'rejected' | 'pending';
+
+// ============================================================================
+// Comment (thread reply)
+// ============================================================================
+
+export interface ReviewComment {
+  id: string;
+  /** The thread this comment belongs to */
+  threadId: string;
+  body: string;
+  /** 'local' for locally-authored, or GitHub username when imported */
+  author: string;
+  createdAt: string;
+  /** Set when synced from/to GitHub */
+  githubId?: number;
+}
+
+// ============================================================================
+// Thread (the unified container for all review activity)
+// ============================================================================
+
+export interface ReviewThread {
+  id: string;
+  target: ThreadTarget;
+  /**
+   * Approve/reject decision — only populated when target.kind === 'hunk'.
+   * undefined means not yet reviewed (equivalent to 'pending').
+   */
+  decision?: HunkDecision;
+  /** Whether this thread has been resolved */
+  resolved: boolean;
+  /** Flat list: first comment is the root, subsequent are replies */
+  comments: ReviewComment[];
+  createdAt: string;
+  updatedAt: string;
+}
+
+// ============================================================================
+// Review Session (the notes.json file content)
+// ============================================================================
+
+export interface ReviewSession {
+  version: '1.0';
+  workspaceName: string;
+  baseBranch: string;
+  /** Set when associated with a GitHub PR */
+  prNumber: number | null;
+  threads: ReviewThread[];
+  createdAt: string;
+  updatedAt: string;
+}
+
+// ============================================================================
+// Derived Statuses (computed, never stored)
+// ============================================================================
+
+/** Per-file review status derived from hunk decisions */
+export type FileReviewStatus =
+  | 'not_reviewed'   // No hunk decisions made
+  | 'in_progress'    // Some hunks reviewed, some pending
+  | 'approved'       // All hunks approved, none rejected
+  | 'needs_changes'; // At least one hunk rejected
+
+/** Overall workspace review status derived from all files */
+export type WorkspaceReviewStatus =
+  | 'not_started'     // No threads at all
+  | 'in_progress'     // Some threads exist but not all hunks reviewed
+  | 'approved'        // All files approved
+  | 'changes_required'; // At least one file needs changes
+
+/** Summary of a file's review state */
+export interface FileReviewSummary {
+  file: string;
+  status: FileReviewStatus;
+  totalHunks: number;
+  approvedHunks: number;
+  rejectedHunks: number;
+  pendingHunks: number;
+  threadCount: number;
+  unresolvedThreadCount: number;
+}
+
+// ============================================================================
+// Review Operations (the request/response contract for WebSocket messages)
+// ============================================================================
+
+/** Operations that can be sent from client to machine */
+export type ReviewOperation =
+  | { op: 'get_threads'; projectName: string; workspaceName: string }
+  | {
+      op: 'create_thread';
+      projectName: string;
+      workspaceName: string;
+      target: ThreadTarget;
+      body: string;
+      decision?: HunkDecision;
+    }
+  | {
+      op: 'add_reply';
+      projectName: string;
+      workspaceName: string;
+      threadId: string;
+      body: string;
+    }
+  | {
+      op: 'update_thread';
+      projectName: string;
+      workspaceName: string;
+      threadId: string;
+      resolved?: boolean;
+      decision?: HunkDecision;
+    }
+  | {
+      op: 'update_comment';
+      projectName: string;
+      workspaceName: string;
+      threadId: string;
+      commentId: string;
+      body: string;
+    }
+  | {
+      op: 'delete_comment';
+      projectName: string;
+      workspaceName: string;
+      threadId: string;
+      commentId: string;
+    }
+  | { op: 'get_diff'; projectName: string; workspaceName: string }
+  | { op: 'import_github'; projectName: string; workspaceName: string; prNumber?: number }
+  | { op: 'push_github'; projectName: string; workspaceName: string; prNumber?: number };
+
+/** Results returned from machine to client */
+export type ReviewResult =
+  | { op: 'threads'; threads: ReviewThread[] }
+  | { op: 'thread_created'; thread: ReviewThread }
+  | { op: 'thread_updated'; thread: ReviewThread }
+  | { op: 'comment_added'; thread: ReviewThread }
+  | { op: 'comment_updated'; thread: ReviewThread }
+  | { op: 'comment_deleted'; thread: ReviewThread }
+  | { op: 'diff'; diff: string; baseBranch: string; headBranch: string }
+  | { op: 'github_imported'; imported: number; threads: ReviewThread[] }
+  | { op: 'github_pushed'; prNumber: number; url: string };
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/** Compute per-file review status from threads */
+export function computeFileStatuses(threads: ReviewThread[]): Map<string, FileReviewSummary> {
+  const fileMap = new Map<string, FileReviewSummary>();
+
+  const getOrCreate = (file: string): FileReviewSummary => {
+    if (!fileMap.has(file)) {
+      fileMap.set(file, {
+        file,
+        status: 'not_reviewed',
+        totalHunks: 0,
+        approvedHunks: 0,
+        rejectedHunks: 0,
+        pendingHunks: 0,
+        threadCount: 0,
+        unresolvedThreadCount: 0,
+      });
+    }
+    return fileMap.get(file)!;
+  };
+
+  for (const thread of threads) {
+    const file = thread.target.kind === 'workspace' ? null : thread.target.file;
+    if (!file) continue;
+
+    const summary = getOrCreate(file);
+    summary.threadCount++;
+    if (!thread.resolved) {
+      summary.unresolvedThreadCount++;
+    }
+
+    if (thread.target.kind === 'hunk') {
+      summary.totalHunks++;
+      const decision = thread.decision ?? 'pending';
+      if (decision === 'approved') summary.approvedHunks++;
+      else if (decision === 'rejected') summary.rejectedHunks++;
+      else summary.pendingHunks++;
+    }
+  }
+
+  // Compute derived status for each file
+  for (const summary of fileMap.values()) {
+    if (summary.totalHunks === 0) {
+      summary.status = 'not_reviewed';
+    } else if (summary.rejectedHunks > 0) {
+      summary.status = 'needs_changes';
+    } else if (summary.pendingHunks > 0) {
+      summary.status = 'in_progress';
+    } else {
+      summary.status = 'approved';
+    }
+  }
+
+  return fileMap;
+}
+
+/** Compute overall workspace review status */
+export function computeWorkspaceStatus(threads: ReviewThread[]): WorkspaceReviewStatus {
+  if (threads.length === 0) return 'not_started';
+
+  const fileStatuses = computeFileStatuses(threads);
+
+  // If all threads are workspace-level they don't appear in fileStatuses.
+  // Treat that as in_progress (reviewer has left notes but made no hunk decisions).
+  if (fileStatuses.size === 0) return 'in_progress';
+
+  let anyChangesRequired = false;
+  let anyInProgress = false;
+  let anyNotReviewed = false;
+
+  for (const summary of fileStatuses.values()) {
+    if (summary.status === 'needs_changes') anyChangesRequired = true;
+    else if (summary.status === 'in_progress') anyInProgress = true;
+    else if (summary.status === 'not_reviewed') anyNotReviewed = true;
+  }
+
+  if (anyChangesRequired) return 'changes_required';
+  // Files with only non-hunk threads (comments but no hunk decisions) are
+  // 'not_reviewed'. That means the reviewer has started looking but hasn't
+  // approved/rejected anything — call that 'in_progress'.
+  if (anyInProgress || anyNotReviewed) return 'in_progress';
+  return 'approved';
+}

--- a/src/types/review.ts
+++ b/src/types/review.ts
@@ -214,8 +214,9 @@ export type ReviewOperation =
 
 export interface ReviewChangedFile {
   filePath: string;
+  /** Optional old path for renames/copies (source path) */
   prevFilePath?: string;
-  changeType: 'new' | 'deleted' | 'renamed' | 'modified';
+  changeType: 'new' | 'deleted' | 'renamed' | 'copied' | 'modified';
 }
 
 /** Results returned from machine to client */

--- a/src/utils/hunk-header.ts
+++ b/src/utils/hunk-header.ts
@@ -1,0 +1,17 @@
+export function normalizeHunkHeader(header: string): string {
+  const trimmed = header.trim();
+  if (!trimmed) {
+    return '@@ @@';
+  }
+
+  const match = trimmed.match(/^@@\s*(.*?)\s*@@(?:\s*(.*))?$/);
+  if (!match) {
+    return trimmed.replace(/\s+/g, ' ');
+  }
+
+  const specs = (match[1] ?? '').trim().replace(/\s+/g, ' ');
+  const context = (match[2] ?? '').trim().replace(/\s+/g, ' ');
+
+  const headerCore = specs ? `@@ ${specs} @@` : '@@ @@';
+  return context ? `${headerCore} ${context}` : headerCore;
+}

--- a/src/utils/id.ts
+++ b/src/utils/id.ts
@@ -1,0 +1,9 @@
+/**
+ * Generate a reasonably unique identifier.
+ */
+export function generateId(): string {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
+}

--- a/src/utils/workspace-id.ts
+++ b/src/utils/workspace-id.ts
@@ -1,3 +1,5 @@
+import { isAbsolute, relative, resolve, sep } from 'path';
+
 export function toWorkspaceId(projectName: string, workspaceName: string): string {
   return `${projectName}:${workspaceName}`;
 }
@@ -19,4 +21,35 @@ export function resolveWorkspaceName(projectName: string, workspaceId: string): 
     return workspaceId.slice(prefix.length);
   }
   return workspaceId;
+}
+
+export function detectWorkspaceContextFromCwd(
+  cwd: string,
+  gitspaceDir: string
+): { projectName: string; workspaceName: string } | null {
+  const resolvedCwd = resolve(cwd);
+  const resolvedGitspaceDir = resolve(gitspaceDir);
+
+  const cwdRelativeToGitspace = relative(resolvedGitspaceDir, resolvedCwd);
+  if (
+    cwdRelativeToGitspace === '' ||
+    cwdRelativeToGitspace === '.' ||
+    cwdRelativeToGitspace.startsWith('..') ||
+    isAbsolute(cwdRelativeToGitspace)
+  ) {
+    return null;
+  }
+
+  const parts = cwdRelativeToGitspace.split(sep).filter(Boolean);
+  if (parts.length < 3 || parts[1] !== 'workspaces') {
+    return null;
+  }
+
+  const projectName = parts[0];
+  const workspaceName = parts[2];
+  if (!projectName || !workspaceName) {
+    return null;
+  }
+
+  return { projectName, workspaceName };
 }

--- a/src/utils/workspace-id.ts
+++ b/src/utils/workspace-id.ts
@@ -1,0 +1,22 @@
+export function toWorkspaceId(projectName: string, workspaceName: string): string {
+  return `${projectName}:${workspaceName}`;
+}
+
+export function toCanonicalWorkspaceId(workspace: { projectName: string; id: string }): string {
+  return toWorkspaceId(workspace.projectName, workspace.id);
+}
+
+export function matchesWorkspaceId(
+  workspace: { projectName: string; id: string },
+  workspaceId: string
+): boolean {
+  return workspace.id === workspaceId || toCanonicalWorkspaceId(workspace) === workspaceId;
+}
+
+export function resolveWorkspaceName(projectName: string, workspaceId: string): string {
+  const prefix = `${projectName}:`;
+  if (workspaceId.startsWith(prefix)) {
+    return workspaceId.slice(prefix.length);
+  }
+  return workspaceId;
+}

--- a/web/bun.lock
+++ b/web/bun.lock
@@ -8,6 +8,7 @@
         "@noble/ciphers": "^2.1.1",
         "@noble/curves": "^2.0.1",
         "@noble/hashes": "^2.0.1",
+        "@pierre/diffs": "^1.0.11",
         "ghostty-web": "^0.4.0",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
@@ -165,6 +166,8 @@
 
     "@noble/hashes": ["@noble/hashes@2.0.1", "", {}, "sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw=="],
 
+    "@pierre/diffs": ["@pierre/diffs@1.0.11", "", { "dependencies": { "@shikijs/core": "^3.0.0", "@shikijs/engine-javascript": "^3.0.0", "@shikijs/transformers": "^3.0.0", "diff": "8.0.3", "hast-util-to-html": "9.0.5", "lru_map": "0.4.1", "shiki": "^3.0.0" }, "peerDependencies": { "react": "^18.3.1 || ^19.0.0", "react-dom": "^18.3.1 || ^19.0.0" } }, "sha512-j6zIEoyImQy1HfcJqbrDwP0O5I7V2VNXAaw53FqQ+SykRfaNwABeZHs9uibXO4supaXPmTx6LEH9Lffr03e1Tw=="],
+
     "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-beta.53", "", {}, "sha512-vENRlFU4YbrwVqNDZ7fLvy+JR1CRkyr01jhSiDpE1u6py3OMzQfztQU2jxykW3ALNxO4kSlqIDeYyD0Y9RcQeQ=="],
 
     "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.54.0", "", { "os": "android", "cpu": "arm" }, "sha512-OywsdRHrFvCdvsewAInDKCNyR3laPA2mc9bRYJ6LBp5IyvF3fvXbbNR0bSzHlZVFtn6E0xw2oZlyjg4rKCVcng=="],
@@ -211,6 +214,22 @@
 
     "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.54.0", "", { "os": "win32", "cpu": "x64" }, "sha512-hYT5d3YNdSh3mbCU1gwQyPgQd3T2ne0A3KG8KSBdav5TiBg6eInVmV+TeR5uHufiIgSFg0XsOWGW5/RhNcSvPg=="],
 
+    "@shikijs/core": ["@shikijs/core@3.22.0", "", { "dependencies": { "@shikijs/types": "3.22.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4", "hast-util-to-html": "^9.0.5" } }, "sha512-iAlTtSDDbJiRpvgL5ugKEATDtHdUVkqgHDm/gbD2ZS9c88mx7G1zSYjjOxp5Qa0eaW0MAQosFRmJSk354PRoQA=="],
+
+    "@shikijs/engine-javascript": ["@shikijs/engine-javascript@3.22.0", "", { "dependencies": { "@shikijs/types": "3.22.0", "@shikijs/vscode-textmate": "^10.0.2", "oniguruma-to-es": "^4.3.4" } }, "sha512-jdKhfgW9CRtj3Tor0L7+yPwdG3CgP7W+ZEqSsojrMzCjD1e0IxIbwUMDDpYlVBlC08TACg4puwFGkZfLS+56Tw=="],
+
+    "@shikijs/engine-oniguruma": ["@shikijs/engine-oniguruma@3.22.0", "", { "dependencies": { "@shikijs/types": "3.22.0", "@shikijs/vscode-textmate": "^10.0.2" } }, "sha512-DyXsOG0vGtNtl7ygvabHd7Mt5EY8gCNqR9Y7Lpbbd/PbJvgWrqaKzH1JW6H6qFkuUa8aCxoiYVv8/YfFljiQxA=="],
+
+    "@shikijs/langs": ["@shikijs/langs@3.22.0", "", { "dependencies": { "@shikijs/types": "3.22.0" } }, "sha512-x/42TfhWmp6H00T6uwVrdTJGKgNdFbrEdhaDwSR5fd5zhQ1Q46bHq9EO61SCEWJR0HY7z2HNDMaBZp8JRmKiIA=="],
+
+    "@shikijs/themes": ["@shikijs/themes@3.22.0", "", { "dependencies": { "@shikijs/types": "3.22.0" } }, "sha512-o+tlOKqsr6FE4+mYJG08tfCFDS+3CG20HbldXeVoyP+cYSUxDhrFf3GPjE60U55iOkkjbpY2uC3It/eeja35/g=="],
+
+    "@shikijs/transformers": ["@shikijs/transformers@3.22.0", "", { "dependencies": { "@shikijs/core": "3.22.0", "@shikijs/types": "3.22.0" } }, "sha512-E7eRV7mwDBjueLF6852n2oYeJYxBq3NSsDk+uyruYAXONv4U8holGmIrT+mPRJQ1J1SNOH6L8G19KRzmBawrFw=="],
+
+    "@shikijs/types": ["@shikijs/types@3.22.0", "", { "dependencies": { "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-491iAekgKDBFE67z70Ok5a8KBMsQ2IJwOWw3us/7ffQkIBCyOQfm/aNwVMBUriP02QshIfgHCBSIYAl3u2eWjg=="],
+
+    "@shikijs/vscode-textmate": ["@shikijs/vscode-textmate@10.0.2", "", {}, "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg=="],
+
     "@tailwindcss/node": ["@tailwindcss/node@4.1.18", "", { "dependencies": { "@jridgewell/remapping": "^2.3.4", "enhanced-resolve": "^5.18.3", "jiti": "^2.6.1", "lightningcss": "1.30.2", "magic-string": "^0.30.21", "source-map-js": "^1.2.1", "tailwindcss": "4.1.18" } }, "sha512-DoR7U1P7iYhw16qJ49fgXUlry1t4CpXeErJHnQ44JgTSKMaZUdf17cfn5mHchfJ4KRBZRFA/Coo+MUF5+gOaCQ=="],
 
     "@tailwindcss/oxide": ["@tailwindcss/oxide@4.1.18", "", { "optionalDependencies": { "@tailwindcss/oxide-android-arm64": "4.1.18", "@tailwindcss/oxide-darwin-arm64": "4.1.18", "@tailwindcss/oxide-darwin-x64": "4.1.18", "@tailwindcss/oxide-freebsd-x64": "4.1.18", "@tailwindcss/oxide-linux-arm-gnueabihf": "4.1.18", "@tailwindcss/oxide-linux-arm64-gnu": "4.1.18", "@tailwindcss/oxide-linux-arm64-musl": "4.1.18", "@tailwindcss/oxide-linux-x64-gnu": "4.1.18", "@tailwindcss/oxide-linux-x64-musl": "4.1.18", "@tailwindcss/oxide-wasm32-wasi": "4.1.18", "@tailwindcss/oxide-win32-arm64-msvc": "4.1.18", "@tailwindcss/oxide-win32-x64-msvc": "4.1.18" } }, "sha512-EgCR5tTS5bUSKQgzeMClT6iCY3ToqE1y+ZB0AKldj809QXk1Y+3jB0upOYZrn9aGIzPtUsP7sX4QQ4XtjBB95A=="],
@@ -251,13 +270,19 @@
 
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
+    "@types/hast": ["@types/hast@3.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ=="],
+
     "@types/json-schema": ["@types/json-schema@7.0.15", "", {}, "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="],
+
+    "@types/mdast": ["@types/mdast@4.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA=="],
 
     "@types/node": ["@types/node@25.0.3", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-W609buLVRVmeW693xKfzHeIV6nJGGz98uCPfeXI1ELMLXVeKYZ9m15fAMSaUPBHYLGFsVRcMmSCksQOrZV9BYA=="],
 
     "@types/react": ["@types/react@19.2.7", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg=="],
 
     "@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
+
+    "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
 
     "@typescript-eslint/eslint-plugin": ["@typescript-eslint/eslint-plugin@8.50.1", "", { "dependencies": { "@eslint-community/regexpp": "^4.10.0", "@typescript-eslint/scope-manager": "8.50.1", "@typescript-eslint/type-utils": "8.50.1", "@typescript-eslint/utils": "8.50.1", "@typescript-eslint/visitor-keys": "8.50.1", "ignore": "^7.0.0", "natural-compare": "^1.4.0", "ts-api-utils": "^2.1.0" }, "peerDependencies": { "@typescript-eslint/parser": "^8.50.1", "eslint": "^8.57.0 || ^9.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-PKhLGDq3JAg0Jk/aK890knnqduuI/Qj+udH7wCf0217IGi4gt+acgCyPVe79qoT+qKUvHMDQkwJeKW9fwl8Cyw=="],
 
@@ -278,6 +303,8 @@
     "@typescript-eslint/utils": ["@typescript-eslint/utils@8.50.1", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.7.0", "@typescript-eslint/scope-manager": "8.50.1", "@typescript-eslint/types": "8.50.1", "@typescript-eslint/typescript-estree": "8.50.1" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-lCLp8H1T9T7gPbEuJSnHwnSuO9mDf8mfK/Nion5mZmiEaQD9sWf9W4dfeFqRyqRjF06/kBuTmAqcs9sewM2NbQ=="],
 
     "@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.50.1", "", { "dependencies": { "@typescript-eslint/types": "8.50.1", "eslint-visitor-keys": "^4.2.1" } }, "sha512-IrDKrw7pCRUR94zeuCSUWQ+w8JEf5ZX5jl/e6AHGSLi1/zIr0lgutfn/7JpfCey+urpgQEdrZVYzCaVVKiTwhQ=="],
+
+    "@ungap/structured-clone": ["@ungap/structured-clone@1.3.0", "", {}, "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g=="],
 
     "@vitejs/plugin-react": ["@vitejs/plugin-react@5.1.2", "", { "dependencies": { "@babel/core": "^7.28.5", "@babel/plugin-transform-react-jsx-self": "^7.27.1", "@babel/plugin-transform-react-jsx-source": "^7.27.1", "@rolldown/pluginutils": "1.0.0-beta.53", "@types/babel__core": "^7.20.5", "react-refresh": "^0.18.0" }, "peerDependencies": { "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0" } }, "sha512-EcA07pHJouywpzsoTUqNh5NwGayl2PPVEJKUSinGGSxFGYn+shYbqMGBg6FXDqgXum9Ou/ecb+411ssw8HImJQ=="],
 
@@ -303,11 +330,19 @@
 
     "caniuse-lite": ["caniuse-lite@1.0.30001761", "", {}, "sha512-JF9ptu1vP2coz98+5051jZ4PwQgd2ni8A+gYSN7EA7dPKIMf0pDlSUxhdmVOaV3/fYK5uWBkgSXJaRLr4+3A6g=="],
 
+    "ccount": ["ccount@2.0.1", "", {}, "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg=="],
+
     "chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
+
+    "character-entities-html4": ["character-entities-html4@2.1.0", "", {}, "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA=="],
+
+    "character-entities-legacy": ["character-entities-legacy@3.0.0", "", {}, "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ=="],
 
     "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
 
     "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
+
+    "comma-separated-tokens": ["comma-separated-tokens@2.0.3", "", {}, "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg=="],
 
     "concat-map": ["concat-map@0.0.1", "", {}, "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="],
 
@@ -323,7 +358,13 @@
 
     "deep-is": ["deep-is@0.1.4", "", {}, "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="],
 
+    "dequal": ["dequal@2.0.3", "", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
+
     "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
+
+    "devlop": ["devlop@1.1.0", "", { "dependencies": { "dequal": "^2.0.0" } }, "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA=="],
+
+    "diff": ["diff@8.0.3", "", {}, "sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ=="],
 
     "electron-to-chromium": ["electron-to-chromium@1.5.267", "", {}, "sha512-0Drusm6MVRXSOJpGbaSVgcQsuB4hEkMpHXaVstcPmhu5LIedxs1xNK/nIxmQIU/RPC0+1/o0AVZfBTkTNJOdUw=="],
 
@@ -385,9 +426,15 @@
 
     "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
 
+    "hast-util-to-html": ["hast-util-to-html@9.0.5", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "ccount": "^2.0.0", "comma-separated-tokens": "^2.0.0", "hast-util-whitespace": "^3.0.0", "html-void-elements": "^3.0.0", "mdast-util-to-hast": "^13.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0", "stringify-entities": "^4.0.0", "zwitch": "^2.0.4" } }, "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw=="],
+
+    "hast-util-whitespace": ["hast-util-whitespace@3.0.0", "", { "dependencies": { "@types/hast": "^3.0.0" } }, "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw=="],
+
     "hermes-estree": ["hermes-estree@0.25.1", "", {}, "sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw=="],
 
     "hermes-parser": ["hermes-parser@0.25.1", "", { "dependencies": { "hermes-estree": "0.25.1" } }, "sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA=="],
+
+    "html-void-elements": ["html-void-elements@3.0.0", "", {}, "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg=="],
 
     "ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
 
@@ -451,7 +498,21 @@
 
     "lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
 
+    "lru_map": ["lru_map@0.4.1", "", {}, "sha512-I+lBvqMMFfqaV8CJCISjI3wbjmwVu/VyOoU7+qtu9d7ioW5klMgsTTiUOUp+DJvfTTzKXoPbyC6YfgkNcyPSOg=="],
+
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
+
+    "mdast-util-to-hast": ["mdast-util-to-hast@13.2.1", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "@ungap/structured-clone": "^1.0.0", "devlop": "^1.0.0", "micromark-util-sanitize-uri": "^2.0.0", "trim-lines": "^3.0.0", "unist-util-position": "^5.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" } }, "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA=="],
+
+    "micromark-util-character": ["micromark-util-character@2.1.1", "", { "dependencies": { "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q=="],
+
+    "micromark-util-encode": ["micromark-util-encode@2.0.1", "", {}, "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw=="],
+
+    "micromark-util-sanitize-uri": ["micromark-util-sanitize-uri@2.0.1", "", { "dependencies": { "micromark-util-character": "^2.0.0", "micromark-util-encode": "^2.0.0", "micromark-util-symbol": "^2.0.0" } }, "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ=="],
+
+    "micromark-util-symbol": ["micromark-util-symbol@2.0.1", "", {}, "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q=="],
+
+    "micromark-util-types": ["micromark-util-types@2.0.2", "", {}, "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA=="],
 
     "minimatch": ["minimatch@3.1.2", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw=="],
 
@@ -462,6 +523,10 @@
     "natural-compare": ["natural-compare@1.4.0", "", {}, "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="],
 
     "node-releases": ["node-releases@2.0.27", "", {}, "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA=="],
+
+    "oniguruma-parser": ["oniguruma-parser@0.12.1", "", {}, "sha512-8Unqkvk1RYc6yq2WBYRj4hdnsAxVze8i7iPfQr8e4uSP3tRv0rpZcbGUDvxfQQcdwHt/e9PrMvGCsa8OqG9X3w=="],
+
+    "oniguruma-to-es": ["oniguruma-to-es@4.3.4", "", { "dependencies": { "oniguruma-parser": "^0.12.1", "regex": "^6.0.1", "regex-recursion": "^6.0.2" } }, "sha512-3VhUGN3w2eYxnTzHn+ikMI+fp/96KoRSVK9/kMTcFqj1NRDh2IhQCKvYxDnWePKRXY/AqH+Fuiyb7VHSzBjHfA=="],
 
     "optionator": ["optionator@0.9.4", "", { "dependencies": { "deep-is": "^0.1.3", "fast-levenshtein": "^2.0.6", "levn": "^0.4.1", "prelude-ls": "^1.2.1", "type-check": "^0.4.0", "word-wrap": "^1.2.5" } }, "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g=="],
 
@@ -483,6 +548,8 @@
 
     "prelude-ls": ["prelude-ls@1.2.1", "", {}, "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="],
 
+    "property-information": ["property-information@7.1.0", "", {}, "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ=="],
+
     "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
 
     "react": ["react@19.2.3", "", {}, "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA=="],
@@ -494,6 +561,12 @@
     "react-router": ["react-router@7.11.0", "", { "dependencies": { "cookie": "^1.0.1", "set-cookie-parser": "^2.6.0" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18" }, "optionalPeers": ["react-dom"] }, "sha512-uI4JkMmjbWCZc01WVP2cH7ZfSzH91JAZUDd7/nIprDgWxBV1TkkmLToFh7EbMTcMak8URFRa2YoBL/W8GWnCTQ=="],
 
     "react-router-dom": ["react-router-dom@7.11.0", "", { "dependencies": { "react-router": "7.11.0" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18" } }, "sha512-e49Ir/kMGRzFOOrYQBdoitq3ULigw4lKbAyKusnvtDu2t4dBX4AGYPrzNvorXmVuOyeakai6FUPW5MmibvVG8g=="],
+
+    "regex": ["regex@6.1.0", "", { "dependencies": { "regex-utilities": "^2.3.0" } }, "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg=="],
+
+    "regex-recursion": ["regex-recursion@6.0.2", "", { "dependencies": { "regex-utilities": "^2.3.0" } }, "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg=="],
+
+    "regex-utilities": ["regex-utilities@2.3.0", "", {}, "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng=="],
 
     "resolve-from": ["resolve-from@4.0.0", "", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
 
@@ -509,9 +582,15 @@
 
     "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
 
+    "shiki": ["shiki@3.22.0", "", { "dependencies": { "@shikijs/core": "3.22.0", "@shikijs/engine-javascript": "3.22.0", "@shikijs/engine-oniguruma": "3.22.0", "@shikijs/langs": "3.22.0", "@shikijs/themes": "3.22.0", "@shikijs/types": "3.22.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-LBnhsoYEe0Eou4e1VgJACes+O6S6QC0w71fCSp5Oya79inkwkm15gQ1UF6VtQ8j/taMDh79hAB49WUk8ALQW3g=="],
+
     "sonner": ["sonner@1.7.4", "", { "peerDependencies": { "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc", "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc" } }, "sha512-DIS8z4PfJRbIyfVFDVnK9rO3eYDtse4Omcm6bt0oEr5/jtLgysmjuBl1frJ9E/EQZrFmKx2A8m/s5s9CRXIzhw=="],
 
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
+
+    "space-separated-tokens": ["space-separated-tokens@2.0.2", "", {}, "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q=="],
+
+    "stringify-entities": ["stringify-entities@4.0.4", "", { "dependencies": { "character-entities-html4": "^2.0.0", "character-entities-legacy": "^3.0.0" } }, "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg=="],
 
     "strip-json-comments": ["strip-json-comments@3.1.1", "", {}, "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="],
 
@@ -523,6 +602,8 @@
 
     "tinyglobby": ["tinyglobby@0.2.15", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.3" } }, "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ=="],
 
+    "trim-lines": ["trim-lines@3.0.1", "", {}, "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg=="],
+
     "ts-api-utils": ["ts-api-utils@2.1.0", "", { "peerDependencies": { "typescript": ">=4.8.4" } }, "sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ=="],
 
     "type-check": ["type-check@0.4.0", "", { "dependencies": { "prelude-ls": "^1.2.1" } }, "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew=="],
@@ -533,9 +614,23 @@
 
     "undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 
+    "unist-util-is": ["unist-util-is@6.0.1", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g=="],
+
+    "unist-util-position": ["unist-util-position@5.0.0", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA=="],
+
+    "unist-util-stringify-position": ["unist-util-stringify-position@4.0.0", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ=="],
+
+    "unist-util-visit": ["unist-util-visit@5.1.0", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-is": "^6.0.0", "unist-util-visit-parents": "^6.0.0" } }, "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg=="],
+
+    "unist-util-visit-parents": ["unist-util-visit-parents@6.0.2", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-is": "^6.0.0" } }, "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ=="],
+
     "update-browserslist-db": ["update-browserslist-db@1.2.3", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": { "update-browserslist-db": "cli.js" } }, "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w=="],
 
     "uri-js": ["uri-js@4.4.1", "", { "dependencies": { "punycode": "^2.1.0" } }, "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg=="],
+
+    "vfile": ["vfile@6.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "vfile-message": "^4.0.0" } }, "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q=="],
+
+    "vfile-message": ["vfile-message@4.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-stringify-position": "^4.0.0" } }, "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw=="],
 
     "vite": ["vite@7.3.0", "", { "dependencies": { "esbuild": "^0.27.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-dZwN5L1VlUBewiP6H9s2+B3e3Jg96D0vzN+Ry73sOefebhYr9f94wwkMNN/9ouoU8pV1BqA1d1zGk8928cx0rg=="],
 
@@ -550,6 +645,8 @@
     "zod": ["zod@4.2.1", "", {}, "sha512-0wZ1IRqGGhMP76gLqz8EyfBXKk0J2qo2+H3fi4mcUP/KtTocoX08nmIAHl1Z2kJIZbZee8KOpBCSNPRgauucjw=="],
 
     "zod-validation-error": ["zod-validation-error@4.0.2", "", { "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ=="],
+
+    "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
 
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
 

--- a/web/package.json
+++ b/web/package.json
@@ -13,6 +13,7 @@
     "@noble/ciphers": "^2.1.1",
     "@noble/curves": "^2.0.1",
     "@noble/hashes": "^2.0.1",
+    "@pierre/diffs": "^1.0.11",
     "ghostty-web": "^0.4.0",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",

--- a/web/tsconfig.app.json
+++ b/web/tsconfig.app.json
@@ -13,7 +13,9 @@
     "baseUrl": ".",
     "paths": {
       "ghostty-web": ["./node_modules/ghostty-web"],
-      "sonner": ["./node_modules/sonner"]
+      "sonner": ["./node_modules/sonner"],
+      "@pierre/diffs/react": ["./node_modules/@pierre/diffs/dist/react/index.d.ts"],
+      "@pierre/diffs": ["./node_modules/@pierre/diffs/dist/index.d.ts"]
     },
     "allowImportingTsExtensions": true,
     "verbatimModuleSyntax": true,

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -22,6 +22,9 @@ export default defineConfig({
       'react-dom': path.resolve(__dirname, 'node_modules/react-dom'),
       'ghostty-web': path.resolve(__dirname, 'node_modules/ghostty-web'),
       'sonner': path.resolve(__dirname, 'node_modules/sonner'),
+      // @pierre/diffs is installed in web/node_modules; alias so src/ imports resolve
+      '@pierre/diffs/react': path.resolve(__dirname, 'node_modules/@pierre/diffs/dist/react/index.js'),
+      '@pierre/diffs': path.resolve(__dirname, 'node_modules/@pierre/diffs/dist/index.js'),
     },
   },
   server: {


### PR DESCRIPTION
## Summary
- add a full review workflow for workspaces, including per-file diff loading, on-demand context expansion, thread interactions, and hover-linked thread navigation in the web UI
- expand review backend and CLI capabilities with changed-file/diff/context operations plus `review hunks`, `add-hunk`, `add-file`, and `add-line` commands with AI-friendly target references
- introduce workspace-scoped tmux-lite session hooks and hidden `gssh space` command surface, including workspace-mode command restrictions and bash/zsh `space()` injection
- add tests for workspace shell hook generation and end-to-end session hook execution, and document workspace session mode usage in README

## Validation
- `bun run typecheck`
- `bun test src/lib/tmux-lite/protocol.test.ts`
- `bun test src/lib/tmux-lite/server-lifecycle.test.ts`
- `bun test src/session/__tests__/workspace-shell-hooks.test.ts src/session/__tests__/workspace-shell-hooks.integration.test.ts`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Large cross-cutting change adding new persistence under `.gitspace/`, new git diff/context plumbing, and GitHub API write operations via `gh`, which increases risk of data loss/mis-sync and workflow regressions.
> 
> **Overview**
> Adds an end-to-end **workspace code review workflow**: a new web `review` view (launchable via URL or a new *Review* action in the spaces browser) with per-file diff loading, inline hunk approve/reject controls, line-range commenting, and a thread side panel for resolving/replying/editing/deleting comments.
> 
> Introduces a new `gssh review` CLI surface to open the UI and manage review data (`notes`, `hunks`, `add-hunk`/`add-file`/`add-line`), plus a local review operation executor and Git-backed APIs for changed-files, per-file diffs, and on-demand context ranges. Adds GitHub PR sync (`review import`/`push`) via the `gh` CLI and stores review notes under `.gitspace/review/` (now gitignored by default).
> 
> Also tightens workspace context detection in `bundle refresh` and adds tmux-lite workspace session hooks wiring so workspace-scoped commands can be injected/restricted; documentation updates describe the `space` session mode.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4a4db50e69cb1655389c6243ea67cf8f4f0c5aec. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full in-app code review: review dashboard with diff viewer, threaded comments, per-hunk decisions, approve/reject controls, and a thread panel.
  * Review accessible from the spaces browser and terminal; workspace-scoped session mode that injects session hooks.
  * CLI review commands plus GitHub PR import and push sync.

* **Documentation**
  * Added "Workspace Session Mode (space)" with usage examples.

* **Chores**
  * Added workspace review notes ignore entry to .gitignore.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->