### PR TITLE
Add account-host relay start and machine relay selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -541,6 +541,7 @@ For self-hosted relay servers:
 |---------|-------------|
 | `gssh relay start` | Start relay server |
 | `gssh relay stop` | Stop relay server |
+| `gssh relay status` | Show relay server status |
 | `gssh invite relay-machine create --relay <url> --machine-signing-key <k> --machine-key-exchange-key <k>` | Create machine enrollment invite |
 | `gssh relay machines list` | List registered machines |
 | `gssh relay machines revoke <machine-id>` | Revoke machine registration |

--- a/README.md
+++ b/README.md
@@ -458,8 +458,12 @@ gssh invite relay-machine create --relay ws://localhost:4480/ws --machine-signin
 # Terminal 3: Initialize identity, enroll, and start serving
 gssh user identity init
 gssh machine enroll --invite "ws://localhost:4480/ws#<TOKEN>" --label "My MacBook"
-gssh machine serve start --relay ws://localhost:4480/ws
+gssh machine serve start
 ```
+
+When `--relay` is omitted, `gssh machine serve start` lets you choose from:
+- local relay (`ws://127.0.0.1:4480/ws`) if running
+- account relays (`*.gitspace.sh`) discovered from your host config/account
 
 ### Identity Management
 
@@ -536,6 +540,7 @@ For self-hosted relay servers:
 | Command | Description |
 |---------|-------------|
 | `gssh relay start` | Start relay server |
+| `gssh relay stop` | Stop relay server |
 | `gssh invite relay-machine create --relay <url> --machine-signing-key <k> --machine-key-exchange-key <k>` | Create machine enrollment invite |
 | `gssh relay machines list` | List registered machines |
 | `gssh relay machines revoke <machine-id>` | Revoke machine registration |

--- a/src/cli/commands/machine.ts
+++ b/src/cli/commands/machine.ts
@@ -50,7 +50,7 @@ function registerMachineServeCommands(machine: Command): void {
   // gssh machine serve start
   serve
     .command('start')
-    .description('Start the serve daemon')
+    .description('Start the serve daemon (auto-select relay when omitted)')
     .option('--relay <url>', 'Override default relay URL')
     .option('--relay-pubkey <pubkey>', 'Relay public key for explicit trust (base64)')
     .option('--bootstrap-token <token>', 'One-time bootstrap token for cloud machine registration')

--- a/src/cli/commands/relay.ts
+++ b/src/cli/commands/relay.ts
@@ -49,6 +49,15 @@ export function registerRelayCommands(parent: Command): void {
       await stopRelay();
     }, { skipSetupCheck: true }));
 
+  cmd
+    .command('status')
+    .description('Show relay server status')
+    .option('--json', 'Output in JSON format')
+    .action(withErrorHandler(async (options) => {
+      const { relayStatus } = await import('../../commands/relay.js');
+      await relayStatus(options);
+    }, { skipSetupCheck: true }));
+
   const machines = cmd
     .command('machines')
     .description('Manage machines registered to this relay');

--- a/src/cli/commands/relay.ts
+++ b/src/cli/commands/relay.ts
@@ -26,7 +26,7 @@ export function registerRelayCommands(parent: Command): void {
 
   cmd
     .command('start')
-    .description('Start the relay server')
+    .description('Start relay server (auto-binds account host tunnel when available)')
     .option('--port <port>', 'Port to listen on', '4480')
     .option('--bind <address>', 'Address to bind to', '0.0.0.0')
     .option('--hostname <host>', 'Only serve requests for this domain (optional)')
@@ -39,6 +39,14 @@ export function registerRelayCommands(parent: Command): void {
         hostname: options.hostname,
         label: options.label,
       });
+    }, { skipSetupCheck: true }));
+
+  cmd
+    .command('stop')
+    .description('Stop the relay server')
+    .action(withErrorHandler(async () => {
+      const { stopRelay } = await import('../../commands/relay.js');
+      await stopRelay();
     }, { skipSetupCheck: true }));
 
   const machines = cmd

--- a/src/commands/host.ts
+++ b/src/commands/host.ts
@@ -55,8 +55,16 @@ interface SubdomainCreateResponse {
   isPrimary: boolean;
 }
 
+function normalizeSubdomain(subdomain: string): string {
+  return subdomain.toLowerCase().trim();
+}
+
+export function getTunnelTokenKey(subdomain: string): string {
+  return `TUNNEL_TOKEN_${normalizeSubdomain(subdomain)}`;
+}
+
 export function getServeTokenKey(subdomain: string): string {
-  return `TUNNEL_TOKEN_${subdomain}_serve`;
+  return `${getTunnelTokenKey(subdomain)}_serve`;
 }
 
 // ============================================================================
@@ -163,7 +171,7 @@ export async function syncHostConfig(interactive: boolean = false): Promise<void
       });
 
       // Sync tunnel token if not present (e.g., new machine with existing account)
-      const existingToken = await getSecret(`TUNNEL_TOKEN_${primary.subdomain}`);
+      const existingToken = await getSecret(getTunnelTokenKey(primary.subdomain));
       if (!existingToken) {
         if (interactive) {
           logger.dim(`Fetching tunnel credentials for ${primary.subdomain}.gitspace.sh...`);
@@ -172,7 +180,7 @@ export async function syncHostConfig(interactive: boolean = false): Promise<void
           const tokenRes = await fetch(`${API_BASE}/subdomains/${primary.subdomain}/token`, { headers });
           if (tokenRes.ok) {
             const { tunnelToken } = await tokenRes.json();
-            await setSecret(`TUNNEL_TOKEN_${primary.subdomain}`, tunnelToken);
+            await setSecret(getTunnelTokenKey(primary.subdomain), tunnelToken);
             if (interactive) {
               logger.success('Tunnel credentials saved');
             }
@@ -272,34 +280,50 @@ export async function listAccountSubdomains(): Promise<AccountSubdomain[]> {
  */
 export async function resolveRelaySubdomains(hostConfig: HostConfig | null = readHostConfig()): Promise<string[]> {
   let subdomains: string[] = [];
+  let apiPrimarySubdomain: string | null = null;
 
   try {
-    subdomains = (await listAccountSubdomains()).map((entry) => entry.subdomain);
+    const accountSubdomains = (await listAccountSubdomains())
+      .filter((entry) => !entry.subdomain.endsWith('.serve'));
+    apiPrimarySubdomain = accountSubdomains.find((entry) => entry.isPrimary)?.subdomain ?? null;
+    subdomains = accountSubdomains.map((entry) => entry.subdomain);
   } catch {
     // Account discovery is best-effort; fallback to cached host config.
   }
 
   if (subdomains.length === 0) {
     if (hostConfig?.subdomains?.length) {
-      subdomains = [...hostConfig.subdomains];
-    } else if (hostConfig?.subdomain) {
+      subdomains = hostConfig.subdomains.filter((subdomain) => !subdomain.endsWith('.serve'));
+    } else if (hostConfig?.subdomain && !hostConfig.subdomain.endsWith('.serve')) {
       subdomains = [hostConfig.subdomain];
     }
   }
 
+  const preferredPrimarySubdomain = hostConfig?.subdomain ?? apiPrimarySubdomain;
+
   return [...new Set(subdomains)].sort((a, b) => {
-    if (hostConfig?.subdomain === a) return -1;
-    if (hostConfig?.subdomain === b) return 1;
+    if (preferredPrimarySubdomain === a) return -1;
+    if (preferredPrimarySubdomain === b) return 1;
     return a.localeCompare(b);
   });
 }
 
 export async function ensureSubdomainTunnelToken(subdomain: string): Promise<string> {
-  const normalizedSubdomain = subdomain.toLowerCase().trim();
-  const secretKey = `TUNNEL_TOKEN_${normalizedSubdomain}`;
+  const normalizedSubdomain = normalizeSubdomain(subdomain);
+  const secretKey = getTunnelTokenKey(normalizedSubdomain);
   const existingToken = await getSecret(secretKey);
   if (existingToken) {
     return existingToken;
+  }
+
+  const legacyKey = `TUNNEL_TOKEN_${subdomain}`;
+  if (legacyKey !== secretKey) {
+    const legacyToken = await getSecret(legacyKey);
+    if (legacyToken) {
+      await setSecret(secretKey, legacyToken);
+      await deleteSecret(legacyKey);
+      return legacyToken;
+    }
   }
 
   const headers = await getAuthHeaders();
@@ -337,7 +361,7 @@ export async function hostReserve(subdomain: string): Promise<void> {
   const jsonHeaders = { ...headers, 'Content-Type': 'application/json' };
 
   // Normalize subdomain
-  subdomain = subdomain.toLowerCase().trim();
+  subdomain = normalizeSubdomain(subdomain);
 
   // Check availability
   logger.info('Checking availability...');
@@ -425,7 +449,7 @@ export async function hostReserve(subdomain: string): Promise<void> {
     throw new SpacesError('Failed to get serve tunnel token', 'SYSTEM_ERROR');
   }
 
-  await setSecret(`TUNNEL_TOKEN_${subdomain}`, tunnelToken);
+  await setSecret(getTunnelTokenKey(subdomain), tunnelToken);
   await setSecret(getServeTokenKey(subdomain), serveTunnelToken);
 
   // Update local host config
@@ -464,7 +488,7 @@ export async function hostRelease(subdomain?: string): Promise<void> {
     return;
   }
 
-  subdomain = subdomain.toLowerCase().trim();
+  subdomain = normalizeSubdomain(subdomain);
 
   const res = await fetch(`${API_BASE}/subdomains/${subdomain}`, {
     method: 'DELETE',
@@ -477,7 +501,7 @@ export async function hostRelease(subdomain?: string): Promise<void> {
   }
 
   // Clear local tunnel token
-  await deleteSecret(`TUNNEL_TOKEN_${subdomain}`);
+  await deleteSecret(getTunnelTokenKey(subdomain));
   if (!subdomain.endsWith('.serve')) {
     await deleteSecret(getServeTokenKey(subdomain));
   }
@@ -537,7 +561,7 @@ export async function hostList(): Promise<void> {
  */
 export async function hostSetPrimary(subdomain: string): Promise<void> {
   const headers = await getAuthHeaders();
-  subdomain = subdomain.toLowerCase().trim();
+  subdomain = normalizeSubdomain(subdomain);
 
   const res = await fetch(`${API_BASE}/subdomains/${subdomain}/set-primary`, {
     method: 'POST',
@@ -598,7 +622,7 @@ export async function hostStatus(): Promise<void> {
     logger.log(`Serve: ${serveSubdomain}.gitspace.sh`);
 
     // Check if tunnel token exists locally
-    let tunnelToken = await getSecret(`TUNNEL_TOKEN_${primary.subdomain}`);
+    let tunnelToken = await getSecret(getTunnelTokenKey(primary.subdomain));
     let serveTunnelToken = await getSecret(getServeTokenKey(primary.subdomain));
 
     // Auto-fetch token if missing
@@ -608,7 +632,7 @@ export async function hostStatus(): Promise<void> {
         const tokenRes = await fetch(`${API_BASE}/subdomains/${primary.subdomain}/token`, { headers });
         if (tokenRes.ok) {
           const { tunnelToken: newToken } = await tokenRes.json();
-          await setSecret(`TUNNEL_TOKEN_${primary.subdomain}`, newToken);
+          await setSecret(getTunnelTokenKey(primary.subdomain), newToken);
           tunnelToken = newToken;
           logger.success('Tunnel credentials synced');
         }

--- a/src/commands/host.ts
+++ b/src/commands/host.ts
@@ -355,6 +355,9 @@ export async function ensureSubdomainTunnelToken(subdomain: string): Promise<str
 
   const tokenPayload = await tokenRes.json() as { tunnelToken?: string };
   if (!tokenPayload.tunnelToken) {
+    logger.error(
+      `No tunnel token returned for ${normalizedSubdomain}.gitspace.sh payload=${JSON.stringify(tokenPayload).slice(0, 500)}`,
+    );
     throw new SpacesError(
       `No tunnel token returned for ${normalizedSubdomain}.gitspace.sh`,
       'SYSTEM_ERROR',

--- a/src/commands/host.ts
+++ b/src/commands/host.ts
@@ -39,6 +39,12 @@ interface SubdomainInfo {
   updated_at: number;
 }
 
+export interface AccountSubdomain {
+  subdomain: string;
+  isPrimary: boolean;
+  status: string;
+}
+
 interface SubdomainCreateResponse {
   id: string;
   subdomain: string;
@@ -233,6 +239,55 @@ async function getAuthHeaders(
     'X-Device-Fingerprint': identity.signingPublicKey,
     ...extra,
   };
+}
+
+export async function listAccountSubdomains(): Promise<AccountSubdomain[]> {
+  const headers = await getAuthHeaders();
+  const res = await fetch(`${API_BASE}/subdomains`, { headers });
+
+  if (!res.ok) {
+    throw new SpacesError(`Failed to list subdomains: ${res.statusText}`, 'SYSTEM_ERROR', 2);
+  }
+
+  const subdomains: SubdomainInfo[] = await res.json();
+  return subdomains
+    .filter((subdomain) => subdomain.status === 'active')
+    .map((subdomain) => ({
+      subdomain: subdomain.subdomain,
+      isPrimary: Boolean(subdomain.is_primary),
+      status: subdomain.status,
+    }));
+}
+
+export async function ensureSubdomainTunnelToken(subdomain: string): Promise<string> {
+  const normalizedSubdomain = subdomain.toLowerCase().trim();
+  const secretKey = `TUNNEL_TOKEN_${normalizedSubdomain}`;
+  const existingToken = await getSecret(secretKey);
+  if (existingToken) {
+    return existingToken;
+  }
+
+  const headers = await getAuthHeaders();
+  const tokenRes = await fetch(`${API_BASE}/subdomains/${normalizedSubdomain}/token`, { headers });
+  if (!tokenRes.ok) {
+    throw new SpacesError(
+      `Failed to fetch tunnel token for ${normalizedSubdomain}.gitspace.sh`,
+      'SYSTEM_ERROR',
+      2,
+    );
+  }
+
+  const tokenPayload = await tokenRes.json() as { tunnelToken?: string };
+  if (!tokenPayload.tunnelToken) {
+    throw new SpacesError(
+      `No tunnel token returned for ${normalizedSubdomain}.gitspace.sh`,
+      'SYSTEM_ERROR',
+      2,
+    );
+  }
+
+  await setSecret(secretKey, tokenPayload.tunnelToken);
+  return tokenPayload.tunnelToken;
 }
 
 // ============================================================================

--- a/src/commands/host.ts
+++ b/src/commands/host.ts
@@ -259,6 +259,41 @@ export async function listAccountSubdomains(): Promise<AccountSubdomain[]> {
     }));
 }
 
+/**
+ * Resolve relay-capable subdomains in stable priority order.
+ *
+ * Priority:
+ * 1. Active account subdomains from API (if available)
+ * 2. Cached host config fallback
+ *
+ * Ordering:
+ * - Primary subdomain first (from host config)
+ * - Remaining subdomains alphabetically
+ */
+export async function resolveRelaySubdomains(hostConfig: HostConfig | null = readHostConfig()): Promise<string[]> {
+  let subdomains: string[] = [];
+
+  try {
+    subdomains = (await listAccountSubdomains()).map((entry) => entry.subdomain);
+  } catch {
+    // Account discovery is best-effort; fallback to cached host config.
+  }
+
+  if (subdomains.length === 0) {
+    if (hostConfig?.subdomains?.length) {
+      subdomains = [...hostConfig.subdomains];
+    } else if (hostConfig?.subdomain) {
+      subdomains = [hostConfig.subdomain];
+    }
+  }
+
+  return [...new Set(subdomains)].sort((a, b) => {
+    if (hostConfig?.subdomain === a) return -1;
+    if (hostConfig?.subdomain === b) return 1;
+    return a.localeCompare(b);
+  });
+}
+
 export async function ensureSubdomainTunnelToken(subdomain: string): Promise<string> {
   const normalizedSubdomain = subdomain.toLowerCase().trim();
   const secretKey = `TUNNEL_TOKEN_${normalizedSubdomain}`;

--- a/src/commands/host.ts
+++ b/src/commands/host.ts
@@ -35,6 +35,7 @@ interface SubdomainInfo {
   subdomain: string;
   status: string;
   is_primary: number;
+  relay?: boolean | number | null;
   created_at: number;
   updated_at: number;
 }
@@ -57,6 +58,12 @@ interface SubdomainCreateResponse {
 
 function normalizeSubdomain(subdomain: string): string {
   return subdomain.toLowerCase().trim();
+}
+
+async function logApiFailure(context: string, response: Response): Promise<void> {
+  const body = (await response.text().catch(() => '')).trim();
+  const bodyPreview = body ? ` body=${JSON.stringify(body.slice(0, 500))}` : '';
+  logger.error(`${context}: ${response.status} ${response.statusText}${bodyPreview}`);
 }
 
 export function getTunnelTokenKey(subdomain: string): string {
@@ -254,12 +261,21 @@ export async function listAccountSubdomains(): Promise<AccountSubdomain[]> {
   const res = await fetch(`${API_BASE}/subdomains`, { headers });
 
   if (!res.ok) {
+    await logApiFailure('Failed to list subdomains', res);
     throw new SpacesError(`Failed to list subdomains: ${res.statusText}`, 'SYSTEM_ERROR', 2);
   }
 
   const subdomains: SubdomainInfo[] = await res.json();
   return subdomains
-    .filter((subdomain) => subdomain.status === 'active')
+    .filter((subdomain) => {
+      if (subdomain.status !== 'active') {
+        return false;
+      }
+
+      // Some API versions include a relay capability flag. Respect it when
+      // present while remaining compatible with older payloads.
+      return subdomain.relay == null || Boolean(subdomain.relay);
+    })
     .map((subdomain) => ({
       subdomain: subdomain.subdomain,
       isPrimary: Boolean(subdomain.is_primary),
@@ -329,6 +345,7 @@ export async function ensureSubdomainTunnelToken(subdomain: string): Promise<str
   const headers = await getAuthHeaders();
   const tokenRes = await fetch(`${API_BASE}/subdomains/${normalizedSubdomain}/token`, { headers });
   if (!tokenRes.ok) {
+    await logApiFailure(`Failed to fetch tunnel token for ${normalizedSubdomain}.gitspace.sh`, tokenRes);
     throw new SpacesError(
       `Failed to fetch tunnel token for ${normalizedSubdomain}.gitspace.sh`,
       'SYSTEM_ERROR',

--- a/src/commands/relay.ts
+++ b/src/commands/relay.ts
@@ -44,6 +44,21 @@ interface RelayRuntimeState {
   tunnelSubdomain?: string;
 }
 
+interface RelayStatusSnapshot {
+  running: boolean;
+  staleState: boolean;
+  pid: number | null;
+  tunnelPid: number | null;
+  tunnelRunning: boolean;
+  bind: string | null;
+  port: number | null;
+  hostname: string | null;
+  tunnelSubdomain: string | null;
+  relayUrl: string | null;
+  publicRelayUrl: string | null;
+  startedAt: number | null;
+}
+
 function getRelayRuntimeDir(): string {
   return join(getSpacesDir(), RELAY_RUNTIME_DIR);
 }
@@ -406,6 +421,91 @@ export async function stopRelay(): Promise<void> {
   await stopPid(state.pid);
   clearRelayState();
   logger.success("relay stopped");
+}
+
+function getRelayStatusSnapshot(): RelayStatusSnapshot {
+  const state = readRelayState();
+  if (!state) {
+    return {
+      running: false,
+      staleState: false,
+      pid: null,
+      tunnelPid: null,
+      tunnelRunning: false,
+      bind: null,
+      port: null,
+      hostname: null,
+      tunnelSubdomain: null,
+      relayUrl: null,
+      publicRelayUrl: null,
+      startedAt: null,
+    };
+  }
+
+  const running = isProcessRunning(state.pid);
+  const tunnelRunning = typeof state.tunnelPid === "number" && isProcessRunning(state.tunnelPid);
+
+  const relayUrl = `ws://${state.hostname || state.bind}:${state.port}`;
+  const publicRelayUrl = state.tunnelSubdomain
+    ? `wss://${state.tunnelSubdomain}.gitspace.sh/ws`
+    : null;
+
+  return {
+    running,
+    staleState: !running,
+    pid: state.pid,
+    tunnelPid: state.tunnelPid ?? null,
+    tunnelRunning,
+    bind: state.bind,
+    port: state.port,
+    hostname: state.hostname ?? null,
+    tunnelSubdomain: state.tunnelSubdomain ?? null,
+    relayUrl,
+    publicRelayUrl,
+    startedAt: state.startedAt,
+  };
+}
+
+export async function relayStatus(options: { json?: boolean } = {}): Promise<void> {
+  const snapshot = getRelayStatusSnapshot();
+
+  if (options.json) {
+    logger.log(JSON.stringify(snapshot, null, 2));
+    return;
+  }
+
+  if (!snapshot.running) {
+    if (snapshot.staleState) {
+      clearRelayState();
+      logger.warning("relay not running (stale runtime state cleaned)");
+    } else {
+      logger.info("relay not running");
+    }
+    return;
+  }
+
+  logger.bold("Relay Status");
+  logger.log("");
+  logger.log(`  State:      ${chalk.green("running")}`);
+  logger.log(`  PID:        ${snapshot.pid}`);
+  logger.log(`  Relay URL:  ${snapshot.relayUrl ?? "-"}`);
+  logger.log(`  Bind:       ${snapshot.bind ?? "-"}`);
+  logger.log(`  Port:       ${snapshot.port ?? "-"}`);
+  if (snapshot.hostname) {
+    logger.log(`  Hostname:   ${snapshot.hostname}`);
+  }
+
+  if (snapshot.startedAt) {
+    logger.log(`  Started:    ${new Date(snapshot.startedAt).toISOString()}`);
+  }
+
+  if (snapshot.tunnelSubdomain) {
+    const tunnelState = snapshot.tunnelRunning
+      ? chalk.green("running")
+      : chalk.yellow("not running");
+    logger.log(`  Tunnel:     ${snapshot.tunnelSubdomain}.gitspace.sh (${tunnelState})`);
+    logger.log(`  Public URL: ${snapshot.publicRelayUrl ?? "-"}`);
+  }
 }
 
 async function requireOwnerUserRootId(): Promise<string> {

--- a/src/commands/relay.ts
+++ b/src/commands/relay.ts
@@ -114,6 +114,7 @@ function clearRelayState(): void {
 }
 
 type RelayProcessKind = "relay" | "tunnel";
+type StaleRelayCleanupResult = "cleaned" | "preserved";
 
 function getProcessCommand(pid: number): string | null {
   if (process.platform === "win32") {
@@ -137,12 +138,7 @@ function getProcessCommand(pid: number): string | null {
   }
 }
 
-function isOwnedProcess(pid: number, kind: RelayProcessKind): boolean {
-  const command = getProcessCommand(pid);
-  if (!command) {
-    return true;
-  }
-
+function isOwnedProcessCommand(command: string, kind: RelayProcessKind): boolean {
   const normalizedCommand = command.toLowerCase();
 
   if (kind === "tunnel") {
@@ -152,6 +148,16 @@ function isOwnedProcess(pid: number, kind: RelayProcessKind): boolean {
   }
 
   return normalizedCommand.includes("relay start");
+}
+
+function isOwnedProcess(pid: number, kind: RelayProcessKind): boolean {
+  const command = getProcessCommand(pid);
+  if (!command) {
+    logger.warning(`Unable to verify ownership for PID ${pid}; refusing to signal it.`);
+    return false;
+  }
+
+  return isOwnedProcessCommand(command, kind);
 }
 
 async function stopTrackedProcess(pid: number | undefined, kind: RelayProcessKind): Promise<"not-running" | "stopped" | "not-owned"> {
@@ -187,17 +193,25 @@ async function stopTrackedProcess(pid: number | undefined, kind: RelayProcessKin
   return "stopped";
 }
 
-async function cleanupStaleRelayState(state: RelayRuntimeState): Promise<void> {
+async function cleanupStaleRelayState(state: RelayRuntimeState): Promise<StaleRelayCleanupResult> {
+  let preserveState = false;
+
   if (state.tunnelPid && isProcessRunning(state.tunnelPid)) {
     const tunnelStopResult = await stopTrackedProcess(state.tunnelPid, "tunnel");
     if (tunnelStopResult === "not-owned") {
       logger.warning(
         `Found stale tunnel PID ${state.tunnelPid} that does not look like a managed cloudflared process; leaving it untouched.`,
       );
+      preserveState = true;
     }
   }
 
+  if (preserveState) {
+    return "preserved";
+  }
+
   clearRelayState();
+  return "cleaned";
 }
 
 function isReadableStream(value: unknown): value is ReadableStream<Uint8Array> {
@@ -333,7 +347,16 @@ export async function startRelay(options: {
 }): Promise<void> {
   const existingState = readRelayState();
   if (existingState?.pid && isProcessRunning(existingState.pid)) {
-    if (isOwnedProcess(existingState.pid, "relay")) {
+    const existingCommand = getProcessCommand(existingState.pid);
+    if (!existingCommand) {
+      throw new SpacesError(
+        `Relay runtime state points to running PID ${existingState.pid}, but ownership could not be verified. Run \`gssh relay stop\` and retry.`,
+        "USER_ERROR",
+        1,
+      );
+    }
+
+    if (isOwnedProcessCommand(existingCommand, "relay")) {
       throw new SpacesError(
         `Relay is already running (pid ${existingState.pid}). Stop it first with \`gssh relay stop\`.`,
         "USER_ERROR",
@@ -344,9 +367,23 @@ export async function startRelay(options: {
     logger.warning(
       `Found stale relay runtime state pointing to PID ${existingState.pid}; cleaning stale state and continuing.`,
     );
-    await cleanupStaleRelayState(existingState);
+    const staleCleanup = await cleanupStaleRelayState(existingState);
+    if (staleCleanup === "preserved") {
+      throw new SpacesError(
+        "Found a live unmanaged tunnel process tied to stale relay state. Stop it with `gssh relay stop` before starting a new relay.",
+        "USER_ERROR",
+        1,
+      );
+    }
   } else if (existingState) {
-    await cleanupStaleRelayState(existingState);
+    const staleCleanup = await cleanupStaleRelayState(existingState);
+    if (staleCleanup === "preserved") {
+      throw new SpacesError(
+        "Found a live unmanaged tunnel process tied to stale relay state. Stop it with `gssh relay stop` before starting a new relay.",
+        "USER_ERROR",
+        1,
+      );
+    }
   }
 
   const port = options.port ?? parseInt(process.env.PORT ?? String(DEFAULT_PORT), 10);
@@ -489,6 +526,11 @@ export async function stopRelay(): Promise<void> {
     );
   }
 
+  if (relayStopResult === "not-owned" || tunnelStopResult === "not-owned") {
+    logger.warning("relay stop did not clear runtime state because one or more running PIDs could not be verified as owned");
+    return;
+  }
+
   clearRelayState();
   if (relayStopResult === "not-running" && tunnelStopResult === "not-running") {
     logger.info("relay not running (stale state cleaned)");
@@ -551,6 +593,12 @@ export async function relayStatus(options: { json?: boolean } = {}): Promise<voi
 
   if (!snapshot.running) {
     if (snapshot.staleState) {
+      if (snapshot.tunnelRunning && snapshot.tunnelPid !== null) {
+        logger.warning(
+          `relay not running, but tunnel PID ${snapshot.tunnelPid} is still active; keeping runtime state so \`gssh relay stop\` can clean it up`,
+        );
+        return;
+      }
       clearRelayState();
       logger.warning("relay not running (stale runtime state cleaned)");
     } else {

--- a/src/commands/relay.ts
+++ b/src/commands/relay.ts
@@ -10,18 +10,235 @@ import { logger } from "../utils/logger.js";
 import { createRelayServer } from "../relay/server.js";
 import { SpacesError } from "../types/errors.js";
 import chalk from "chalk";
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
 import {
   loadOrCreateRelayIdentity,
   formatRelayFingerprint,
 } from "../relay/identity.js";
 import { loadUserRootIdentity } from "../core/user-identity.js";
+import { getSpacesDir } from "../core/config.js";
 import {
   listVaultMachinesForOwner,
   removeVaultMachineForOwner,
 } from "../relay/control/store.js";
+import {
+  ensureSubdomainTunnelToken,
+  listAccountSubdomains,
+  readHostConfig,
+} from "./host.js";
+import { selectOne } from "../utils/prompts.js";
 
 /** Default port for relay server (4480 = "GIT0" on phone keypad) */
 const DEFAULT_PORT = 4480;
+const RELAY_RUNTIME_DIR = ".relay/runtime";
+const RELAY_STATE_FILE = "relay-state.json";
+
+interface RelayRuntimeState {
+  pid: number;
+  startedAt: number;
+  port: number;
+  bind: string;
+  hostname?: string;
+  tunnelPid?: number;
+  tunnelSubdomain?: string;
+}
+
+function getRelayRuntimeDir(): string {
+  return join(getSpacesDir(), RELAY_RUNTIME_DIR);
+}
+
+function getRelayStatePath(): string {
+  return join(getRelayRuntimeDir(), RELAY_STATE_FILE);
+}
+
+function isProcessRunning(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function readRelayState(): RelayRuntimeState | null {
+  const statePath = getRelayStatePath();
+  if (!existsSync(statePath)) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(readFileSync(statePath, "utf-8")) as RelayRuntimeState;
+  } catch {
+    return null;
+  }
+}
+
+function writeRelayState(state: RelayRuntimeState): void {
+  const runtimeDir = getRelayRuntimeDir();
+  if (!existsSync(runtimeDir)) {
+    mkdirSync(runtimeDir, { recursive: true, mode: 0o700 });
+  }
+
+  writeFileSync(getRelayStatePath(), JSON.stringify(state, null, 2), {
+    encoding: "utf-8",
+    mode: 0o600,
+  });
+}
+
+function clearRelayState(): void {
+  const statePath = getRelayStatePath();
+  if (!existsSync(statePath)) {
+    return;
+  }
+
+  rmSync(statePath, { force: true });
+}
+
+async function isCloudflaredInstalled(): Promise<boolean> {
+  const proc = Bun.spawn(["which", "cloudflared"], {
+    stdout: "ignore",
+    stderr: "ignore",
+  });
+  return (await proc.exited) === 0;
+}
+
+function isReadableStream(value: unknown): value is ReadableStream<Uint8Array> {
+  return typeof value === "object" && value !== null && "getReader" in value;
+}
+
+function trackCloudflaredOutput(proc: ReturnType<typeof Bun.spawn>): void {
+  const streamReader = async (
+    stream: unknown,
+    prefix: "warning" | "dim",
+  ) => {
+    if (!isReadableStream(stream)) {
+      return;
+    }
+
+    const reader = stream.getReader();
+    const decoder = new TextDecoder();
+
+    try {
+      while (true) {
+        const { value, done } = await reader.read();
+        if (done) {
+          break;
+        }
+
+        const text = decoder.decode(value, { stream: true }).trim();
+        if (!text) {
+          continue;
+        }
+
+        if (prefix === "warning") {
+          logger.warning(`[cloudflared] ${text}`);
+        } else {
+          logger.dim(`[cloudflared] ${text}`);
+        }
+      }
+    } catch {
+      // Ignore reader errors when process exits.
+    } finally {
+      reader.releaseLock();
+    }
+  };
+
+  void streamReader(proc.stdout, "dim");
+  void streamReader(proc.stderr, "warning");
+}
+
+async function startCloudflaredTunnel(token: string): Promise<ReturnType<typeof Bun.spawn>> {
+  if (!(await isCloudflaredInstalled())) {
+    throw new SpacesError(
+      "cloudflared is not installed. Install it first (brew install cloudflared).",
+      "USER_ERROR",
+      1,
+    );
+  }
+
+  const cloudflared = Bun.spawn(["cloudflared", "tunnel", "run"], {
+    env: {
+      ...process.env,
+      TUNNEL_TOKEN: token,
+    },
+    stdin: "ignore",
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  trackCloudflaredOutput(cloudflared);
+  await Bun.sleep(1200);
+
+  const exitCode = await Promise.race([
+    cloudflared.exited,
+    Bun.sleep(100).then(() => null),
+  ]);
+
+  if (typeof exitCode === "number") {
+    throw new SpacesError(`cloudflared exited immediately with code ${exitCode}`, "SYSTEM_ERROR", 2);
+  }
+
+  return cloudflared;
+}
+
+async function resolveAccountRelayTarget(): Promise<{
+  hostname: string;
+  subdomain: string;
+  tunnelToken: string;
+} | null> {
+  let subdomains: string[] = [];
+  try {
+    const accountSubdomains = await listAccountSubdomains();
+    subdomains = accountSubdomains.map((entry) => entry.subdomain);
+  } catch {
+    // Not logged in or API unavailable; account relay auto-bind is optional.
+  }
+
+  if (subdomains.length === 0) {
+    const localHostConfig = readHostConfig();
+    subdomains = localHostConfig?.subdomains?.length
+      ? [...localHostConfig.subdomains]
+      : localHostConfig?.subdomain
+        ? [localHostConfig.subdomain]
+        : [];
+  }
+
+  if (subdomains.length === 0) {
+    return null;
+  }
+
+  const hostConfig = readHostConfig();
+  subdomains = [...new Set(subdomains)].sort((a, b) => {
+    if (hostConfig?.subdomain === a) return -1;
+    if (hostConfig?.subdomain === b) return 1;
+    return a.localeCompare(b);
+  });
+
+  let selectedSubdomain = subdomains[0];
+  if (subdomains.length > 1 && process.stdout.isTTY && process.stdin.isTTY) {
+    const picked = await selectOne(
+      subdomains.map((subdomain) => ({
+        label: `${subdomain}.gitspace.sh`,
+        value: subdomain,
+        description: hostConfig?.subdomain === subdomain ? "Primary subdomain" : undefined,
+      })),
+      "Select account host for relay tunnel",
+    );
+
+    if (!picked) {
+      throw new SpacesError("Cancelled", "USER_ERROR", 1);
+    }
+    selectedSubdomain = picked;
+  }
+
+  const tunnelToken = await ensureSubdomainTunnelToken(selectedSubdomain);
+  return {
+    hostname: `${selectedSubdomain}.gitspace.sh`,
+    subdomain: selectedSubdomain,
+    tunnelToken,
+  };
+}
 
 /**
  * Start the relay server
@@ -34,9 +251,30 @@ export async function startRelay(options: {
   bind?: string;
   label?: string;
 }): Promise<void> {
+  const existingState = readRelayState();
+  if (existingState?.pid && isProcessRunning(existingState.pid)) {
+    throw new SpacesError(
+      `Relay is already running (pid ${existingState.pid}). Stop it first with \`gssh relay stop\`.`,
+      "USER_ERROR",
+      1,
+    );
+  }
+
   const port = options.port ?? parseInt(process.env.PORT ?? String(DEFAULT_PORT), 10);
   const bind = options.bind ?? process.env.RELAY_BIND ?? "0.0.0.0";
-  const hostname = options.hostname ?? process.env.RELAY_HOST;
+  let hostname = options.hostname ?? process.env.RELAY_HOST;
+  let tunnelSubdomain: string | undefined;
+  let tunnelToken: string | undefined;
+
+  if (!hostname) {
+    const accountTarget = await resolveAccountRelayTarget();
+    if (accountTarget) {
+      hostname = accountTarget.hostname;
+      tunnelSubdomain = accountTarget.subdomain;
+      tunnelToken = accountTarget.tunnelToken;
+      logger.info(`Using account host ${hostname} for relay tunnel`);
+    }
+  }
 
   // Load or create relay identity
   const identity = await loadOrCreateRelayIdentity(options.label);
@@ -61,7 +299,12 @@ export async function startRelay(options: {
   if (hostname) {
     logger.log(`  Hostname: ${hostname} (only serving this domain)`);
   }
+  if (tunnelSubdomain) {
+    logger.log(`  Tunnel:   ${tunnelSubdomain}.gitspace.sh`);
+  }
   logger.log("");
+
+  let tunnelProcess: ReturnType<typeof Bun.spawn> | null = null;
 
   try {
     const server = await createRelayServer({
@@ -71,7 +314,24 @@ export async function startRelay(options: {
       identity,
     });
 
+    if (tunnelToken) {
+      tunnelProcess = await startCloudflaredTunnel(tunnelToken);
+    }
+
+    writeRelayState({
+      pid: process.pid,
+      startedAt: Date.now(),
+      port,
+      bind,
+      hostname,
+      tunnelPid: tunnelProcess?.pid,
+      tunnelSubdomain,
+    });
+
     logger.success(`Relay listening on ws://${hostname || bind}:${port}`);
+    if (tunnelSubdomain) {
+      logger.success(`Public relay URL: wss://${tunnelSubdomain}.gitspace.sh/ws`);
+    }
     logger.log("");
     logger.dim("Press Ctrl+C to stop");
     logger.log("");
@@ -80,7 +340,11 @@ export async function startRelay(options: {
     const shutdown = () => {
       logger.log("");
       logger.info("Shutting down relay...");
+      if (tunnelProcess) {
+        tunnelProcess.kill();
+      }
       server.stop();
+      clearRelayState();
       process.exit(0);
     };
 
@@ -92,12 +356,56 @@ export async function startRelay(options: {
       // Never resolves
     });
   } catch (error) {
+    if (tunnelProcess) {
+      tunnelProcess.kill();
+    }
+    clearRelayState();
     throw new SpacesError(
       `Failed to start relay: ${error instanceof Error ? error.message : String(error)}`,
       "SYSTEM_ERROR",
       2
     );
   }
+}
+
+export async function stopRelay(): Promise<void> {
+  const state = readRelayState();
+  if (!state) {
+    logger.info("relay not running");
+    return;
+  }
+
+  const stopPid = async (pid: number | undefined): Promise<void> => {
+    if (!pid || !isProcessRunning(pid)) {
+      return;
+    }
+
+    try {
+      process.kill(pid, "SIGTERM");
+    } catch {
+      return;
+    }
+
+    for (let attempt = 0; attempt < 20; attempt += 1) {
+      if (!isProcessRunning(pid)) {
+        return;
+      }
+      await Bun.sleep(100);
+    }
+
+    if (isProcessRunning(pid)) {
+      try {
+        process.kill(pid, "SIGKILL");
+      } catch {
+        // Ignore kill errors.
+      }
+    }
+  };
+
+  await stopPid(state.tunnelPid);
+  await stopPid(state.pid);
+  clearRelayState();
+  logger.success("relay stopped");
 }
 
 async function requireOwnerUserRootId(): Promise<string> {

--- a/src/commands/relay.ts
+++ b/src/commands/relay.ts
@@ -24,8 +24,8 @@ import {
 } from "../relay/control/store.js";
 import {
   ensureSubdomainTunnelToken,
-  listAccountSubdomains,
   readHostConfig,
+  resolveRelaySubdomains,
 } from "./host.js";
 import { selectOne } from "../utils/prompts.js";
 
@@ -33,6 +33,8 @@ import { selectOne } from "../utils/prompts.js";
 const DEFAULT_PORT = 4480;
 const RELAY_RUNTIME_DIR = ".relay/runtime";
 const RELAY_STATE_FILE = "relay-state.json";
+const CLOUDFLARED_STARTUP_DELAY_MS = 1200;
+const CLOUDFLARED_EARLY_EXIT_RACE_MS = 100;
 
 interface RelayRuntimeState {
   pid: number;
@@ -111,7 +113,8 @@ function clearRelayState(): void {
 }
 
 async function isCloudflaredInstalled(): Promise<boolean> {
-  const proc = Bun.spawn(["which", "cloudflared"], {
+  const lookupCommand = process.platform === "win32" ? "where" : "which";
+  const proc = Bun.spawn([lookupCommand, "cloudflared"], {
     stdout: "ignore",
     stderr: "ignore",
   });
@@ -183,11 +186,13 @@ async function startCloudflaredTunnel(token: string): Promise<ReturnType<typeof 
   });
 
   trackCloudflaredOutput(cloudflared);
-  await Bun.sleep(1200);
+  // Give cloudflared a short window to initialize and surface immediate failures.
+  await Bun.sleep(CLOUDFLARED_STARTUP_DELAY_MS);
 
   const exitCode = await Promise.race([
     cloudflared.exited,
-    Bun.sleep(100).then(() => null),
+    // Keep this race short so successful startup does not block relay start.
+    Bun.sleep(CLOUDFLARED_EARLY_EXIT_RACE_MS).then(() => null),
   ]);
 
   if (typeof exitCode === "number") {
@@ -200,35 +205,13 @@ async function startCloudflaredTunnel(token: string): Promise<ReturnType<typeof 
 async function resolveAccountRelayTarget(): Promise<{
   hostname: string;
   subdomain: string;
-  tunnelToken: string;
 } | null> {
-  let subdomains: string[] = [];
-  try {
-    const accountSubdomains = await listAccountSubdomains();
-    subdomains = accountSubdomains.map((entry) => entry.subdomain);
-  } catch {
-    // Not logged in or API unavailable; account relay auto-bind is optional.
-  }
-
-  if (subdomains.length === 0) {
-    const localHostConfig = readHostConfig();
-    subdomains = localHostConfig?.subdomains?.length
-      ? [...localHostConfig.subdomains]
-      : localHostConfig?.subdomain
-        ? [localHostConfig.subdomain]
-        : [];
-  }
+  const hostConfig = readHostConfig();
+  const subdomains = await resolveRelaySubdomains(hostConfig);
 
   if (subdomains.length === 0) {
     return null;
   }
-
-  const hostConfig = readHostConfig();
-  subdomains = [...new Set(subdomains)].sort((a, b) => {
-    if (hostConfig?.subdomain === a) return -1;
-    if (hostConfig?.subdomain === b) return 1;
-    return a.localeCompare(b);
-  });
 
   let selectedSubdomain = subdomains[0];
   if (subdomains.length > 1 && process.stdout.isTTY && process.stdin.isTTY) {
@@ -245,13 +228,16 @@ async function resolveAccountRelayTarget(): Promise<{
       throw new SpacesError("Cancelled", "USER_ERROR", 1);
     }
     selectedSubdomain = picked;
+  } else if (subdomains.length > 1) {
+    logger.warning(
+      `Multiple account hosts available; auto-selecting ${selectedSubdomain}.gitspace.sh in non-interactive mode. `
+      + "Run interactively to choose a different host.",
+    );
   }
 
-  const tunnelToken = await ensureSubdomainTunnelToken(selectedSubdomain);
   return {
     hostname: `${selectedSubdomain}.gitspace.sh`,
     subdomain: selectedSubdomain,
-    tunnelToken,
   };
 }
 
@@ -284,10 +270,18 @@ export async function startRelay(options: {
   if (!hostname) {
     const accountTarget = await resolveAccountRelayTarget();
     if (accountTarget) {
-      hostname = accountTarget.hostname;
-      tunnelSubdomain = accountTarget.subdomain;
-      tunnelToken = accountTarget.tunnelToken;
-      logger.info(`Using account host ${hostname} for relay tunnel`);
+      try {
+        tunnelToken = await ensureSubdomainTunnelToken(accountTarget.subdomain);
+        hostname = accountTarget.hostname;
+        tunnelSubdomain = accountTarget.subdomain;
+        logger.info(`Using account host ${hostname} for relay tunnel`);
+      } catch (error) {
+        logger.warning(
+          `Could not load tunnel token for ${accountTarget.subdomain}.gitspace.sh. `
+          + "Falling back to local relay start without tunnel.",
+        );
+        logger.dim(error instanceof Error ? error.message : String(error));
+      }
     }
   }
 
@@ -320,9 +314,10 @@ export async function startRelay(options: {
   logger.log("");
 
   let tunnelProcess: ReturnType<typeof Bun.spawn> | null = null;
+  let server: ReturnType<typeof createRelayServer> | null = null;
 
   try {
-    const server = await createRelayServer({
+    server = await createRelayServer({
       port,
       bind,
       hostname,
@@ -358,7 +353,7 @@ export async function startRelay(options: {
       if (tunnelProcess) {
         tunnelProcess.kill();
       }
-      server.stop();
+      server?.stop();
       clearRelayState();
       process.exit(0);
     };
@@ -374,6 +369,7 @@ export async function startRelay(options: {
     if (tunnelProcess) {
       tunnelProcess.kill();
     }
+    server?.stop();
     clearRelayState();
     throw new SpacesError(
       `Failed to start relay: ${error instanceof Error ? error.message : String(error)}`,

--- a/src/commands/relay.ts
+++ b/src/commands/relay.ts
@@ -28,7 +28,7 @@ import {
   resolveRelaySubdomains,
 } from "./host.js";
 import { selectOne } from "../utils/prompts.js";
-import { isCloudflaredInstalled } from "../utils/cloudflared.js";
+import { isCloudflaredInstalled, trackCloudflaredOutput } from "../utils/cloudflared.js";
 
 /** Default port for relay server (4480 = "GIT0" on phone keypad) */
 const DEFAULT_PORT = 4480;
@@ -115,9 +115,14 @@ function clearRelayState(): void {
 
 type RelayProcessKind = "relay" | "tunnel";
 type StaleRelayCleanupResult = "cleaned" | "preserved";
+let warnedWindowsOwnershipUnsupported = false;
 
 function getProcessCommand(pid: number): string | null {
   if (process.platform === "win32") {
+    if (!warnedWindowsOwnershipUnsupported) {
+      logger.warning("relay process ownership checks are not supported on Windows; refusing to signal managed PIDs on this platform");
+      warnedWindowsOwnershipUnsupported = true;
+    }
     return null;
   }
 
@@ -153,7 +158,9 @@ function isOwnedProcessCommand(command: string, kind: RelayProcessKind): boolean
 function isOwnedProcess(pid: number, kind: RelayProcessKind): boolean {
   const command = getProcessCommand(pid);
   if (!command) {
-    logger.warning(`Unable to verify ownership for PID ${pid}; refusing to signal it.`);
+    if (process.platform !== "win32") {
+      logger.warning(`Unable to verify ownership for PID ${pid}; refusing to signal it.`);
+    }
     return false;
   }
 
@@ -212,51 +219,6 @@ async function cleanupStaleRelayState(state: RelayRuntimeState): Promise<StaleRe
 
   clearRelayState();
   return "cleaned";
-}
-
-function isReadableStream(value: unknown): value is ReadableStream<Uint8Array> {
-  return typeof value === "object" && value !== null && "getReader" in value;
-}
-
-function trackCloudflaredOutput(proc: ReturnType<typeof Bun.spawn>): void {
-  const streamReader = async (
-    stream: unknown,
-    prefix: "warning" | "dim",
-  ) => {
-    if (!isReadableStream(stream)) {
-      return;
-    }
-
-    const reader = stream.getReader();
-    const decoder = new TextDecoder();
-
-    try {
-      while (true) {
-        const { value, done } = await reader.read();
-        if (done) {
-          break;
-        }
-
-        const text = decoder.decode(value, { stream: true }).trim();
-        if (!text) {
-          continue;
-        }
-
-        if (prefix === "warning") {
-          logger.warning(`[cloudflared] ${text}`);
-        } else {
-          logger.dim(`[cloudflared] ${text}`);
-        }
-      }
-    } catch {
-      // Ignore reader errors when process exits.
-    } finally {
-      reader.releaseLock();
-    }
-  };
-
-  void streamReader(proc.stdout, "dim");
-  void streamReader(proc.stderr, "warning");
 }
 
 async function startCloudflaredTunnel(token: string): Promise<ReturnType<typeof Bun.spawn>> {

--- a/src/commands/relay.ts
+++ b/src/commands/relay.ts
@@ -28,6 +28,7 @@ import {
   resolveRelaySubdomains,
 } from "./host.js";
 import { selectOne } from "../utils/prompts.js";
+import { isCloudflaredInstalled } from "../utils/cloudflared.js";
 
 /** Default port for relay server (4480 = "GIT0" on phone keypad) */
 const DEFAULT_PORT = 4480;
@@ -112,13 +113,91 @@ function clearRelayState(): void {
   rmSync(statePath, { force: true });
 }
 
-async function isCloudflaredInstalled(): Promise<boolean> {
-  const lookupCommand = process.platform === "win32" ? "where" : "which";
-  const proc = Bun.spawn([lookupCommand, "cloudflared"], {
-    stdout: "ignore",
-    stderr: "ignore",
-  });
-  return (await proc.exited) === 0;
+type RelayProcessKind = "relay" | "tunnel";
+
+function getProcessCommand(pid: number): string | null {
+  if (process.platform === "win32") {
+    return null;
+  }
+
+  try {
+    const proc = Bun.spawnSync(["ps", "-p", String(pid), "-o", "command="], {
+      stdout: "pipe",
+      stderr: "ignore",
+    });
+
+    if (proc.exitCode !== 0 || !proc.stdout) {
+      return null;
+    }
+
+    const command = Buffer.from(proc.stdout).toString("utf-8").trim();
+    return command.length > 0 ? command : null;
+  } catch {
+    return null;
+  }
+}
+
+function isOwnedProcess(pid: number, kind: RelayProcessKind): boolean {
+  const command = getProcessCommand(pid);
+  if (!command) {
+    return true;
+  }
+
+  const normalizedCommand = command.toLowerCase();
+
+  if (kind === "tunnel") {
+    return normalizedCommand.includes("cloudflared")
+      && normalizedCommand.includes("tunnel")
+      && normalizedCommand.includes("run");
+  }
+
+  return normalizedCommand.includes("relay start");
+}
+
+async function stopTrackedProcess(pid: number | undefined, kind: RelayProcessKind): Promise<"not-running" | "stopped" | "not-owned"> {
+  if (!pid || !isProcessRunning(pid)) {
+    return "not-running";
+  }
+
+  if (!isOwnedProcess(pid, kind)) {
+    return "not-owned";
+  }
+
+  try {
+    process.kill(pid, "SIGTERM");
+  } catch {
+    return "not-running";
+  }
+
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    if (!isProcessRunning(pid)) {
+      return "stopped";
+    }
+    await Bun.sleep(100);
+  }
+
+  if (isProcessRunning(pid)) {
+    try {
+      process.kill(pid, "SIGKILL");
+    } catch {
+      return "stopped";
+    }
+  }
+
+  return "stopped";
+}
+
+async function cleanupStaleRelayState(state: RelayRuntimeState): Promise<void> {
+  if (state.tunnelPid && isProcessRunning(state.tunnelPid)) {
+    const tunnelStopResult = await stopTrackedProcess(state.tunnelPid, "tunnel");
+    if (tunnelStopResult === "not-owned") {
+      logger.warning(
+        `Found stale tunnel PID ${state.tunnelPid} that does not look like a managed cloudflared process; leaving it untouched.`,
+      );
+    }
+  }
+
+  clearRelayState();
 }
 
 function isReadableStream(value: unknown): value is ReadableStream<Uint8Array> {
@@ -254,11 +333,20 @@ export async function startRelay(options: {
 }): Promise<void> {
   const existingState = readRelayState();
   if (existingState?.pid && isProcessRunning(existingState.pid)) {
-    throw new SpacesError(
-      `Relay is already running (pid ${existingState.pid}). Stop it first with \`gssh relay stop\`.`,
-      "USER_ERROR",
-      1,
+    if (isOwnedProcess(existingState.pid, "relay")) {
+      throw new SpacesError(
+        `Relay is already running (pid ${existingState.pid}). Stop it first with \`gssh relay stop\`.`,
+        "USER_ERROR",
+        1,
+      );
+    }
+
+    logger.warning(
+      `Found stale relay runtime state pointing to PID ${existingState.pid}; cleaning stale state and continuing.`,
     );
+    await cleanupStaleRelayState(existingState);
+  } else if (existingState) {
+    await cleanupStaleRelayState(existingState);
   }
 
   const port = options.port ?? parseInt(process.env.PORT ?? String(DEFAULT_PORT), 10);
@@ -386,36 +474,27 @@ export async function stopRelay(): Promise<void> {
     return;
   }
 
-  const stopPid = async (pid: number | undefined): Promise<void> => {
-    if (!pid || !isProcessRunning(pid)) {
-      return;
-    }
+  const tunnelStopResult = await stopTrackedProcess(state.tunnelPid, "tunnel");
+  const relayStopResult = await stopTrackedProcess(state.pid, "relay");
 
-    try {
-      process.kill(pid, "SIGTERM");
-    } catch {
-      return;
-    }
+  if (tunnelStopResult === "not-owned") {
+    logger.warning(
+      `Refusing to kill PID ${state.tunnelPid} because it does not look like a managed cloudflared tunnel process.`,
+    );
+  }
 
-    for (let attempt = 0; attempt < 20; attempt += 1) {
-      if (!isProcessRunning(pid)) {
-        return;
-      }
-      await Bun.sleep(100);
-    }
+  if (relayStopResult === "not-owned") {
+    logger.warning(
+      `Refusing to kill PID ${state.pid} because it does not look like a managed relay process.`,
+    );
+  }
 
-    if (isProcessRunning(pid)) {
-      try {
-        process.kill(pid, "SIGKILL");
-      } catch {
-        // Ignore kill errors.
-      }
-    }
-  };
-
-  await stopPid(state.tunnelPid);
-  await stopPid(state.pid);
   clearRelayState();
+  if (relayStopResult === "not-running" && tunnelStopResult === "not-running") {
+    logger.info("relay not running (stale state cleaned)");
+    return;
+  }
+
   logger.success("relay stopped");
 }
 

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -14,7 +14,7 @@ import { join } from 'path';
 import { createHash } from 'crypto';
 import { spawn, type Subprocess } from 'bun';
 import { logger } from '../utils/logger.js';
-import { promptPassword, promptConfirm } from '../utils/prompts.js';
+import { promptPassword, promptConfirm, selectOne } from '../utils/prompts.js';
 import { getSecret } from '../utils/secrets.js';
 import {
   isRelayTrusted,
@@ -40,7 +40,7 @@ import {
   NoIdentityError,
   SpacesError,
 } from '../types/errors.js';
-import { getServeTokenKey, readHostConfig, type HostConfig } from './host.js';
+import { getServeTokenKey, listAccountSubdomains, readHostConfig, type HostConfig } from './host.js';
 import { createRelayServer } from '../relay/server.js';
 import { formatRelayFingerprint, loadOrCreateRelayIdentity } from '../relay/identity.js';
 import { deserializeIdentity, getPublicIdentity as getPublicIdentityFromPrivate } from '../lib/tmux-lite/crypto/identity.js';
@@ -109,6 +109,13 @@ interface UserRootAuthorizationConfig {
   ownerUserRootId: string;
 }
 
+interface RelayCandidate {
+  url: string;
+  label: string;
+  source: 'local' | 'account';
+  description?: string;
+}
+
 function resolveOwnerUserRootIdFromEnrollmentToken(enrollmentToken: string | undefined): string {
   if (!enrollmentToken) {
     throw new SpacesError('Unlock mode requires --enrollment-token', 'USER_ERROR', 1);
@@ -150,6 +157,126 @@ async function resolveUserRootAuthorizationConfig(): Promise<UserRootAuthorizati
   return {
     ownerUserRootId: userRoot.id,
   };
+}
+
+async function isRelayHealthy(relayUrl: string): Promise<boolean> {
+  try {
+    const relay = new URL(relayUrl);
+    const protocol = relay.protocol === 'wss:' ? 'https:' : 'http:';
+    const healthUrl = `${protocol}//${relay.host}/health`;
+
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 1200);
+    try {
+      const response = await fetch(healthUrl, { signal: controller.signal });
+      return response.ok;
+    } finally {
+      clearTimeout(timeout);
+    }
+  } catch {
+    return false;
+  }
+}
+
+async function discoverRelayCandidates(hostConfig: HostConfig | null): Promise<RelayCandidate[]> {
+  const candidates: RelayCandidate[] = [];
+
+  const localRelayUrl = `ws://127.0.0.1:${LOCAL_RELAY_PORT}/ws`;
+  if (await isRelayHealthy(localRelayUrl)) {
+    candidates.push({
+      url: localRelayUrl,
+      label: `Local relay (${localRelayUrl})`,
+      source: 'local',
+      description: 'Detected running on this machine',
+    });
+  }
+
+  let accountSubdomains: string[] = [];
+  try {
+    accountSubdomains = (await listAccountSubdomains()).map((entry) => entry.subdomain);
+  } catch {
+    // Account discovery is best-effort; fallback to cached host config below.
+  }
+
+  if (accountSubdomains.length === 0) {
+    if (hostConfig?.subdomains?.length) {
+      accountSubdomains = [...hostConfig.subdomains];
+    } else if (hostConfig?.subdomain) {
+      accountSubdomains = [hostConfig.subdomain];
+    }
+  }
+
+  const deduped = [...new Set(accountSubdomains)].sort((a, b) => {
+    if (hostConfig?.subdomain === a) return -1;
+    if (hostConfig?.subdomain === b) return 1;
+    return a.localeCompare(b);
+  });
+
+  for (const subdomain of deduped) {
+    candidates.push({
+      url: `wss://${subdomain}.gitspace.sh/ws`,
+      label: `${subdomain}.gitspace.sh`,
+      source: 'account',
+      description: hostConfig?.subdomain === subdomain ? 'Primary account relay' : 'Account relay',
+    });
+  }
+
+  return candidates;
+}
+
+async function resolveRelayUrlForServe(
+  explicitRelayUrl: string | undefined,
+  hostConfig: HostConfig | null,
+): Promise<string> {
+  if (explicitRelayUrl) {
+    return explicitRelayUrl;
+  }
+
+  const candidates = await discoverRelayCandidates(hostConfig);
+  if (candidates.length === 0) {
+    throw new SpacesError(
+      'No relay found.\n\n'
+      + 'Start a local relay:\n'
+      + '  gssh relay start\n\n'
+      + 'Or configure account hosting:\n'
+      + '  gssh user auth login\n'
+      + '  gssh user host reserve <subdomain>\n\n'
+      + 'Or pass one explicitly:\n'
+      + '  gssh machine serve start --relay ws://localhost:4480/ws',
+      'USER_ERROR',
+      1,
+    );
+  }
+
+  if (candidates.length === 1) {
+    logger.info(`Using relay ${candidates[0].url}`);
+    return candidates[0].url;
+  }
+
+  if (!process.stdout.isTTY || !process.stdin.isTTY) {
+    const optionsList = candidates.map((candidate) => `  - ${candidate.url}`).join('\n');
+    throw new SpacesError(
+      'Multiple relays available; choose one with --relay.\n\n'
+      + `Available relays:\n${optionsList}`,
+      'USER_ERROR',
+      1,
+    );
+  }
+
+  const selectedRelay = await selectOne(
+    candidates.map((candidate) => ({
+      label: candidate.label,
+      value: candidate.url,
+      description: candidate.description,
+    })),
+    'Select relay for machine serve',
+  );
+
+  if (!selectedRelay) {
+    throw new SpacesError('Cancelled', 'USER_ERROR', 1);
+  }
+
+  return selectedRelay;
 }
 
 /**
@@ -1160,27 +1287,13 @@ export async function serveStart(options: {
 
   // Check for gitspace.sh hosting
   const hostConfig = readHostConfig();
-  const relayUrl = options.relay; // No default - must use hosting or explicit --relay
-
-  // If no hosting config and no explicit relay, error out
-  if (!hostConfig?.subdomain && !relayUrl) {
+  let effectiveRelayUrl: string;
+  try {
+    effectiveRelayUrl = await resolveRelayUrlForServe(options.relay, hostConfig);
+  } catch (error) {
     cleanupServeFiles();
-    throw new SpacesError(
-      'No relay configured.\n\n' +
-      'Either set up gitspace.sh hosting:\n' +
-      '  gssh user auth login\n' +
-      '  gssh user host reserve <subdomain>\n\n' +
-      'Or specify a relay explicitly:\n' +
-      '  gssh machine serve start --relay ws://localhost:4480/ws',
-      'USER_ERROR'
-    );
+    throw error;
   }
-
-  let localRelayServer: ReturnType<typeof createRelayServer> | null = null;
-  let localRelayIdentity: Awaited<ReturnType<typeof loadOrCreateRelayIdentity>> | null = null;
-  let effectiveRelayUrl = relayUrl || '';
-  let processHostManager: ServeProcessHostManager | null = null;
-  let processHostRefreshTimer: ReturnType<typeof setInterval> | null = null;
 
   // Initialize daemon state
   setDaemonState({
@@ -1197,65 +1310,11 @@ export async function serveStart(options: {
     } : undefined,
   });
 
-  if (hostConfig?.subdomain) {
-    ensureControlStore();
-
-    // Load or create persistent relay identity for control mode
-    localRelayIdentity = await loadOrCreateRelayIdentity('control-relay');
-    bindControlRelayIdentity({
-      relayIdentityId: localRelayIdentity.id,
-      relaySigningPublicKey: localRelayIdentity.signingPublicKey,
-      relayFingerprint: formatRelayFingerprint(localRelayIdentity.signingPublicKey),
-    });
-
-    // Start local relay server with this machine pre-authorized
-    try {
-      localRelayServer = createRelayServer({
-        port: LOCAL_RELAY_PORT,
-        bind: '127.0.0.1',
-        identity: localRelayIdentity,
-        preAuthorizedMachines: [publicIdentity.signingPublicKey],
-      });
-      logger.success(`Local relay started on port ${LOCAL_RELAY_PORT}`);
-    } catch (error) {
-      cleanupServeFiles();
-      throw new SpacesError('Failed to start local relay server', 'SYSTEM_ERROR', 2);
-    }
-
-    // Start cloudflared tunnel
-    const tunnelStarted = await startCloudflared(hostConfig.subdomain);
-    if (tunnelStarted) {
-      updateDaemonState({
-        hosting: {
-          subdomain: hostConfig.subdomain,
-          tunnelActive: true,
-        },
-      });
-    }
-
-    processHostManager = await startServeProcessHosting(hostConfig);
-    if (processHostManager) {
-      processHostRefreshTimer = setInterval(() => {
-        void processHostManager?.refresh();
-      }, SERVE_REFRESH_INTERVAL_MS);
-    }
-
-    // Use local relay (machine will authenticate via challenge-response)
-    effectiveRelayUrl = `ws://127.0.0.1:${LOCAL_RELAY_PORT}/ws`;
-  }
-
-  const remoteSessionOptions = processHostManager
-    ? {
-        processHostDomain: processHostManager.domain,
-        onProcessesChanged: () => processHostManager?.refresh(),
-      }
-    : undefined;
-
   // Create session manager
   const sessionManager = new ClientSessionManager({
     relay: effectiveRelayUrl,
     identity,
-    remoteSessionOptions,
+    remoteSessionOptions: undefined,
     ownerUserRootId,
   });
 
@@ -1299,8 +1358,6 @@ export async function serveStart(options: {
     );
     updateDaemonState({ relay: { url: effectiveRelayUrl, status: 'connected' } });
   } catch (error) {
-    localRelayServer?.stop();
-    stopCloudflared();
     cleanupServeFiles();
     throw new SpacesError(
       `Failed to connect to relay: ${error instanceof Error ? error.message : String(error)}`,
@@ -1317,7 +1374,7 @@ export async function serveStart(options: {
   });
 
   // Set up shutdown handlers with daemon cleanup
-  setupShutdownHandlers(sessionManager, true, () => stopServeProcessHosting(processHostManager, processHostRefreshTimer));
+  setupShutdownHandlers(sessionManager, true);
 
   // Keep process alive
   await new Promise(() => {});

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -41,7 +41,6 @@ import {
   SpacesError,
 } from '../types/errors.js';
 import {
-  getTunnelTokenKey,
   getServeTokenKey,
   readHostConfig,
   resolveRelaySubdomains,
@@ -100,11 +99,6 @@ const PACKAGE_VERSION = '1.0.0';
 
 /** Local relay port for gitspace.sh hosting */
 const LOCAL_RELAY_PORT = 4480;
-
-/** Cloudflared process reference */
-let cloudflaredProcess: Subprocess | null = null;
-let cloudflaredSubdomain: string | null = null;
-let cloudflaredRestartAttempts = 0;
 const MAX_CLOUDFLARED_RESTARTS = 5;
 const CLOUDFLARED_RESTART_DELAY = 5000;
 
@@ -416,150 +410,46 @@ async function fetchIdentityViaUnlockToken(
 }
 
 // ============================================================================
-// Cloudflared Management
-// ============================================================================
-
-/**
- * Start cloudflared tunnel for a subdomain
- *
- * @param subdomain - The subdomain to tunnel (e.g., 'brad' for brad.gitspace.sh)
- * @returns true if started successfully
- */
-async function startCloudflared(subdomain: string): Promise<boolean> {
-  // Get tunnel token from keychain
-  const tunnelToken = await getSecret(getTunnelTokenKey(subdomain));
-  if (!tunnelToken) {
-    logger.warning(`No tunnel token found for ${subdomain}.gitspace.sh`);
-    logger.dim('Run: gssh user host reserve ' + subdomain + ' (to get token)');
-    return false;
-  }
-
-  // Check if cloudflared is installed
-  if (!await isCloudflaredInstalled()) {
-    logger.warning('cloudflared is not installed');
-    logger.dim('Install: brew install cloudflared (macOS) or see https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/downloads/');
-    return false;
-  }
-
-  cloudflaredSubdomain = subdomain;
-
-  // Start cloudflared with tunnel token via TUNNEL_TOKEN env var to avoid argv exposure
-  logger.info(`Starting tunnel for ${subdomain}.gitspace.sh...`);
-
-  try {
-    cloudflaredProcess = spawn(['cloudflared', 'tunnel', 'run'], {
-      env: { ...process.env, TUNNEL_TOKEN: tunnelToken },
-      stdin: 'ignore',
-      stdout: 'pipe',
-      stderr: 'pipe',
-    });
-
-    // Handle cloudflared output
-    handleCloudflaredOutput(cloudflaredProcess);
-
-    // Monitor process exit
-    cloudflaredProcess.exited.then((exitCode) => {
-      if (exitCode !== 0 && cloudflaredSubdomain) {
-        logger.warning(`cloudflared exited with code ${exitCode}`);
-        handleCloudflaredCrash();
-      }
-    });
-
-    logger.success(`Tunnel active: https://${subdomain}.gitspace.sh`);
-    logger.dim(`  Wildcard: https://*.${subdomain}.gitspace.sh`);
-    return true;
-  } catch (error) {
-    logger.error(`Failed to start cloudflared: ${error instanceof Error ? error.message : String(error)}`);
-    return false;
-  }
-}
-
-/**
- * Handle cloudflared stdout/stderr
- */
-function handleCloudflaredOutput(proc: Subprocess): void {
-  // Read stdout
-  const stdout = proc.stdout;
-  if (stdout && typeof stdout !== 'number') {
-    (async () => {
-      const reader = stdout.getReader();
-      try {
-        while (true) {
-          const { done, value } = await reader.read();
-          if (done) break;
-          const text = new TextDecoder().decode(value);
-          // Only log important messages, skip routine output
-          if (text.includes('ERR') || text.includes('error') || text.includes('failed')) {
-            logger.dim(`[cloudflared] ${text.trim()}`);
-          }
-        }
-      } catch {
-        // Stream closed
-      }
-    })();
-  }
-
-  // Read stderr
-  const stderr = proc.stderr;
-  if (stderr && typeof stderr !== 'number') {
-    (async () => {
-      const reader = stderr.getReader();
-      try {
-        while (true) {
-          const { done, value } = await reader.read();
-          if (done) break;
-          const text = new TextDecoder().decode(value);
-          // cloudflared logs most output to stderr
-          if (text.includes('ERR') || text.includes('error') || text.includes('failed')) {
-            logger.warning(`[cloudflared] ${text.trim()}`);
-          }
-        }
-      } catch {
-        // Stream closed
-      }
-    })();
-  }
-}
-
-/**
- * Handle cloudflared crash and restart
- */
-function handleCloudflaredCrash(): void {
-  if (!cloudflaredSubdomain) return;
-
-  cloudflaredRestartAttempts++;
-
-  if (cloudflaredRestartAttempts > MAX_CLOUDFLARED_RESTARTS) {
-    logger.error(`cloudflared crashed ${MAX_CLOUDFLARED_RESTARTS} times, giving up`);
-    logger.dim('Check your tunnel token or network connection');
-    cloudflaredSubdomain = null;
-    return;
-  }
-
-  logger.info(`Restarting cloudflared (attempt ${cloudflaredRestartAttempts}/${MAX_CLOUDFLARED_RESTARTS})...`);
-
-  setTimeout(async () => {
-    if (cloudflaredSubdomain) {
-      await startCloudflared(cloudflaredSubdomain);
-    }
-  }, CLOUDFLARED_RESTART_DELAY);
-}
-
-/**
- * Stop cloudflared process
- */
-function stopCloudflared(): void {
-  if (cloudflaredProcess) {
-    logger.dim('Stopping cloudflared...');
-    cloudflaredProcess.kill();
-    cloudflaredProcess = null;
-    cloudflaredSubdomain = null;
-  }
-}
-
-// ============================================================================
 // Process Hosting (Serve Tunnel)
 // ============================================================================
+
+function handleCloudflaredOutput(proc: Subprocess): void {
+  const streamReader = async (stream: ReadableStream<Uint8Array> | number | undefined, level: 'warning' | 'dim') => {
+    if (!stream || typeof stream === 'number') {
+      return;
+    }
+
+    const reader = stream.getReader();
+    const decoder = new TextDecoder();
+
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) {
+          break;
+        }
+
+        const text = decoder.decode(value).trim();
+        if (!text) {
+          continue;
+        }
+
+        if (text.includes('ERR') || text.includes('error') || text.includes('failed')) {
+          if (level === 'warning') {
+            logger.warning(`[cloudflared] ${text}`);
+          } else {
+            logger.dim(`[cloudflared] ${text}`);
+          }
+        }
+      }
+    } catch {
+      // Stream closed while process exits.
+    }
+  };
+
+  void streamReader(proc.stdout, 'dim');
+  void streamReader(proc.stderr, 'warning');
+}
 
 export interface ProcessHostEntry {
   hostname: string;
@@ -961,8 +851,6 @@ function setupShutdownHandlers(
     logger.log('');
     logger.info('Shutting down...');
 
-    // Stop cloudflared if running
-    stopCloudflared();
     cleanup?.();
 
     clearRelayConfig();

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -40,7 +40,12 @@ import {
   NoIdentityError,
   SpacesError,
 } from '../types/errors.js';
-import { getServeTokenKey, listAccountSubdomains, readHostConfig, type HostConfig } from './host.js';
+import {
+  getServeTokenKey,
+  readHostConfig,
+  resolveRelaySubdomains,
+  type HostConfig,
+} from './host.js';
 import { createRelayServer } from '../relay/server.js';
 import { formatRelayFingerprint, loadOrCreateRelayIdentity } from '../relay/identity.js';
 import { deserializeIdentity, getPublicIdentity as getPublicIdentityFromPrivate } from '../lib/tmux-lite/crypto/identity.js';
@@ -191,26 +196,7 @@ async function discoverRelayCandidates(hostConfig: HostConfig | null): Promise<R
     });
   }
 
-  let accountSubdomains: string[] = [];
-  try {
-    accountSubdomains = (await listAccountSubdomains()).map((entry) => entry.subdomain);
-  } catch {
-    // Account discovery is best-effort; fallback to cached host config below.
-  }
-
-  if (accountSubdomains.length === 0) {
-    if (hostConfig?.subdomains?.length) {
-      accountSubdomains = [...hostConfig.subdomains];
-    } else if (hostConfig?.subdomain) {
-      accountSubdomains = [hostConfig.subdomain];
-    }
-  }
-
-  const deduped = [...new Set(accountSubdomains)].sort((a, b) => {
-    if (hostConfig?.subdomain === a) return -1;
-    if (hostConfig?.subdomain === b) return 1;
-    return a.localeCompare(b);
-  });
+  const deduped = await resolveRelaySubdomains(hostConfig);
 
   for (const subdomain of deduped) {
     candidates.push({
@@ -1310,16 +1296,41 @@ export async function serveStart(options: {
     } : undefined,
   });
 
+  let processHostManager: ServeProcessHostManager | null = null;
+  let processHostRefreshTimer: ReturnType<typeof setInterval> | null = null;
+
+  if (hostConfig?.subdomain) {
+    processHostManager = await startServeProcessHosting(hostConfig);
+    if (processHostManager) {
+      processHostRefreshTimer = setInterval(() => {
+        void processHostManager?.refresh();
+      }, SERVE_REFRESH_INTERVAL_MS);
+    }
+  }
+
+  const remoteSessionOptions = processHostManager
+    ? {
+        processHostDomain: processHostManager.domain,
+        onProcessesChanged: () => processHostManager?.refresh(),
+      }
+    : undefined;
+
   // Create session manager
   const sessionManager = new ClientSessionManager({
     relay: effectiveRelayUrl,
     identity,
-    remoteSessionOptions: undefined,
+    remoteSessionOptions,
     ownerUserRootId,
   });
 
   // Initialize session manager (starts tmux-lite server)
-  await sessionManager.initialize();
+  try {
+    await sessionManager.initialize();
+  } catch (error) {
+    stopServeProcessHosting(processHostManager, processHostRefreshTimer);
+    cleanupServeFiles();
+    throw error;
+  }
 
   // Event handler - update daemon state
   const eventHandler: ServeEventHandler = (event) => {
@@ -1358,6 +1369,7 @@ export async function serveStart(options: {
     );
     updateDaemonState({ relay: { url: effectiveRelayUrl, status: 'connected' } });
   } catch (error) {
+    stopServeProcessHosting(processHostManager, processHostRefreshTimer);
     cleanupServeFiles();
     throw new SpacesError(
       `Failed to connect to relay: ${error instanceof Error ? error.message : String(error)}`,
@@ -1367,14 +1379,24 @@ export async function serveStart(options: {
   }
 
   // Save relay config for reconnect/bootstrap flows
-  writeRelayConfig({
-    relayUrl: effectiveRelayUrl,
-    machineId,
-    savedAt: Date.now(),
-  });
+  try {
+    writeRelayConfig({
+      relayUrl: effectiveRelayUrl,
+      machineId,
+      savedAt: Date.now(),
+    });
+  } catch (error) {
+    stopServeProcessHosting(processHostManager, processHostRefreshTimer);
+    cleanupServeFiles();
+    throw new SpacesError(
+      `Failed to persist relay config: ${error instanceof Error ? error.message : String(error)}`,
+      'SYSTEM_ERROR',
+      2,
+    );
+  }
 
   // Set up shutdown handlers with daemon cleanup
-  setupShutdownHandlers(sessionManager, true);
+  setupShutdownHandlers(sessionManager, true, () => stopServeProcessHosting(processHostManager, processHostRefreshTimer));
 
   // Keep process alive
   await new Promise(() => {});

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -41,6 +41,7 @@ import {
   SpacesError,
 } from '../types/errors.js';
 import {
+  getTunnelTokenKey,
   getServeTokenKey,
   readHostConfig,
   resolveRelaySubdomains,
@@ -89,6 +90,7 @@ import {
 } from '../relay-client/machine-relay-client.js';
 import { deriveUnlockKey } from '../relay/unlock-kdf.js';
 import { parseRootInviteToken } from '../lib/tmux-lite/crypto/root-invites.js';
+import { isCloudflaredInstalled } from '../utils/cloudflared.js';
 
 /** Package version for daemon status */
 const PACKAGE_VERSION = '1.0.0';
@@ -418,19 +420,6 @@ async function fetchIdentityViaUnlockToken(
 // ============================================================================
 
 /**
- * Check if cloudflared is installed
- */
-async function isCloudflaredInstalled(): Promise<boolean> {
-  try {
-    const proc = spawn(['which', 'cloudflared'], { stdout: 'pipe', stderr: 'pipe' });
-    const exitCode = await proc.exited;
-    return exitCode === 0;
-  } catch {
-    return false;
-  }
-}
-
-/**
  * Start cloudflared tunnel for a subdomain
  *
  * @param subdomain - The subdomain to tunnel (e.g., 'brad' for brad.gitspace.sh)
@@ -438,7 +427,7 @@ async function isCloudflaredInstalled(): Promise<boolean> {
  */
 async function startCloudflared(subdomain: string): Promise<boolean> {
   // Get tunnel token from keychain
-  const tunnelToken = await getSecret(`TUNNEL_TOKEN_${subdomain}`);
+  const tunnelToken = await getSecret(getTunnelTokenKey(subdomain));
   if (!tunnelToken) {
     logger.warning(`No tunnel token found for ${subdomain}.gitspace.sh`);
     logger.dim('Run: gssh user host reserve ' + subdomain + ' (to get token)');
@@ -907,6 +896,25 @@ function stopServeProcessHosting(
   manager?.stop();
 }
 
+async function cleanupServeStartupFailure(
+  sessionManager: ClientSessionManager | null,
+  processHostManager: ServeProcessHostManager | null,
+  processHostRefreshTimer: ReturnType<typeof setInterval> | null,
+): Promise<void> {
+  stopServeProcessHosting(processHostManager, processHostRefreshTimer);
+  stopStatusServer();
+
+  if (sessionManager) {
+    try {
+      sessionManager.cleanup();
+    } catch {
+      // Best-effort cleanup.
+    }
+  }
+
+  cleanupServeFiles();
+}
+
 // ============================================================================
 // Relay Connection
 // ============================================================================
@@ -1273,11 +1281,15 @@ export async function serveStart(options: {
 
   // Check for gitspace.sh hosting
   const hostConfig = readHostConfig();
+  let processHostManager: ServeProcessHostManager | null = null;
+  let processHostRefreshTimer: ReturnType<typeof setInterval> | null = null;
+  let sessionManager: ClientSessionManager | null = null;
+
   let effectiveRelayUrl: string;
   try {
     effectiveRelayUrl = await resolveRelayUrlForServe(options.relay, hostConfig);
   } catch (error) {
-    cleanupServeFiles();
+    await cleanupServeStartupFailure(sessionManager, processHostManager, processHostRefreshTimer);
     throw error;
   }
 
@@ -1296,15 +1308,21 @@ export async function serveStart(options: {
     } : undefined,
   });
 
-  let processHostManager: ServeProcessHostManager | null = null;
-  let processHostRefreshTimer: ReturnType<typeof setInterval> | null = null;
-
   if (hostConfig?.subdomain) {
-    processHostManager = await startServeProcessHosting(hostConfig);
-    if (processHostManager) {
-      processHostRefreshTimer = setInterval(() => {
-        void processHostManager?.refresh();
-      }, SERVE_REFRESH_INTERVAL_MS);
+    try {
+      processHostManager = await startServeProcessHosting(hostConfig);
+      if (processHostManager) {
+        processHostRefreshTimer = setInterval(() => {
+          void processHostManager?.refresh();
+        }, SERVE_REFRESH_INTERVAL_MS);
+      }
+    } catch (error) {
+      await cleanupServeStartupFailure(sessionManager, processHostManager, processHostRefreshTimer);
+      throw new SpacesError(
+        `Failed to initialize serve process hosting: ${error instanceof Error ? error.message : String(error)}`,
+        'SYSTEM_ERROR',
+        2,
+      );
     }
   }
 
@@ -1316,7 +1334,7 @@ export async function serveStart(options: {
     : undefined;
 
   // Create session manager
-  const sessionManager = new ClientSessionManager({
+  sessionManager = new ClientSessionManager({
     relay: effectiveRelayUrl,
     identity,
     remoteSessionOptions,
@@ -1327,8 +1345,7 @@ export async function serveStart(options: {
   try {
     await sessionManager.initialize();
   } catch (error) {
-    stopServeProcessHosting(processHostManager, processHostRefreshTimer);
-    cleanupServeFiles();
+    await cleanupServeStartupFailure(sessionManager, processHostManager, processHostRefreshTimer);
     throw error;
   }
 
@@ -1369,8 +1386,7 @@ export async function serveStart(options: {
     );
     updateDaemonState({ relay: { url: effectiveRelayUrl, status: 'connected' } });
   } catch (error) {
-    stopServeProcessHosting(processHostManager, processHostRefreshTimer);
-    cleanupServeFiles();
+    await cleanupServeStartupFailure(sessionManager, processHostManager, processHostRefreshTimer);
     throw new SpacesError(
       `Failed to connect to relay: ${error instanceof Error ? error.message : String(error)}`,
       'SYSTEM_ERROR',
@@ -1386,8 +1402,7 @@ export async function serveStart(options: {
       savedAt: Date.now(),
     });
   } catch (error) {
-    stopServeProcessHosting(processHostManager, processHostRefreshTimer);
-    cleanupServeFiles();
+    await cleanupServeStartupFailure(sessionManager, processHostManager, processHostRefreshTimer);
     throw new SpacesError(
       `Failed to persist relay config: ${error instanceof Error ? error.message : String(error)}`,
       'SYSTEM_ERROR',

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -1095,6 +1095,11 @@ export async function serveStart(options: {
       }
     }
 
+    if (!options.relay) {
+      const daemonHostConfig = readHostConfig();
+      options.relay = await resolveRelayUrlForServe(undefined, daemonHostConfig);
+    }
+
     logger.log('Starting serve daemon...');
 
     // Build args for background process

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -46,8 +46,6 @@ import {
   resolveRelaySubdomains,
   type HostConfig,
 } from './host.js';
-import { createRelayServer } from '../relay/server.js';
-import { formatRelayFingerprint, loadOrCreateRelayIdentity } from '../relay/identity.js';
 import { deserializeIdentity, getPublicIdentity as getPublicIdentityFromPrivate } from '../lib/tmux-lite/crypto/identity.js';
 import { generateEphemeralKeypair, validateX25519PublicKey, x25519SharedSecret } from '../lib/tmux-lite/crypto/keyexchange.js';
 import { open } from '../lib/tmux-lite/crypto/secretbox.js';
@@ -77,7 +75,6 @@ import { buildProcessHostname, normalizeHostLabel } from '../utils/hostnames.js'
 import type { ProcessPortConfig } from '../types/processes.js';
 import {
   bindControlOwner,
-  bindControlRelayIdentity,
   ensureControlStore,
   getVaultMeta,
   setVaultMeta,
@@ -89,7 +86,7 @@ import {
 } from '../relay-client/machine-relay-client.js';
 import { deriveUnlockKey } from '../relay/unlock-kdf.js';
 import { parseRootInviteToken } from '../lib/tmux-lite/crypto/root-invites.js';
-import { isCloudflaredInstalled } from '../utils/cloudflared.js';
+import { isCloudflaredInstalled, trackCloudflaredOutput } from '../utils/cloudflared.js';
 
 /** Package version for daemon status */
 const PACKAGE_VERSION = '1.0.0';
@@ -413,44 +410,6 @@ async function fetchIdentityViaUnlockToken(
 // Process Hosting (Serve Tunnel)
 // ============================================================================
 
-function handleCloudflaredOutput(proc: Subprocess): void {
-  const streamReader = async (stream: ReadableStream<Uint8Array> | number | undefined, level: 'warning' | 'dim') => {
-    if (!stream || typeof stream === 'number') {
-      return;
-    }
-
-    const reader = stream.getReader();
-    const decoder = new TextDecoder();
-
-    try {
-      while (true) {
-        const { done, value } = await reader.read();
-        if (done) {
-          break;
-        }
-
-        const text = decoder.decode(value).trim();
-        if (!text) {
-          continue;
-        }
-
-        if (text.includes('ERR') || text.includes('error') || text.includes('failed')) {
-          if (level === 'warning') {
-            logger.warning(`[cloudflared] ${text}`);
-          } else {
-            logger.dim(`[cloudflared] ${text}`);
-          }
-        }
-      }
-    } catch {
-      // Stream closed while process exits.
-    }
-  };
-
-  void streamReader(proc.stdout, 'dim');
-  void streamReader(proc.stderr, 'warning');
-}
-
 export interface ProcessHostEntry {
   hostname: string;
   service: string;
@@ -687,7 +646,9 @@ class ServeProcessHostManager {
       stderr: 'pipe',
     });
 
-    handleCloudflaredOutput(proc);
+    trackCloudflaredOutput(proc, {
+      includeLine: (line) => line.includes('ERR') || line.includes('error') || line.includes('failed'),
+    });
 
     proc.exited.then((exitCode) => {
       if (exitCode !== 0 && this.process === proc) {

--- a/src/utils/cloudflared.ts
+++ b/src/utils/cloudflared.ts
@@ -1,5 +1,66 @@
 import { checkCommandExists } from './deps.js';
+import { logger } from './logger.js';
+
+type CloudflaredStream = 'stdout' | 'stderr';
+
+interface CloudflaredOutputProcess {
+  stdout: unknown;
+  stderr: unknown;
+}
+
+interface TrackCloudflaredOutputOptions {
+  includeLine?: (line: string, stream: CloudflaredStream) => boolean;
+}
+
+function isReadableStream(value: unknown): value is ReadableStream<Uint8Array> {
+  return typeof value === 'object' && value !== null && 'getReader' in value;
+}
 
 export async function isCloudflaredInstalled(): Promise<boolean> {
   return checkCommandExists('cloudflared');
+}
+
+export function trackCloudflaredOutput(
+  proc: CloudflaredOutputProcess,
+  options: TrackCloudflaredOutputOptions = {},
+): void {
+  const streamReader = async (stream: unknown, streamKind: CloudflaredStream) => {
+    if (!isReadableStream(stream)) {
+      return;
+    }
+
+    const reader = stream.getReader();
+    const decoder = new TextDecoder();
+
+    try {
+      while (true) {
+        const { value, done } = await reader.read();
+        if (done) {
+          break;
+        }
+
+        const text = decoder.decode(value, { stream: true }).trim();
+        if (!text) {
+          continue;
+        }
+
+        if (options.includeLine && !options.includeLine(text, streamKind)) {
+          continue;
+        }
+
+        if (streamKind === 'stderr') {
+          logger.warning(`[cloudflared] ${text}`);
+        } else {
+          logger.dim(`[cloudflared] ${text}`);
+        }
+      }
+    } catch {
+      // Ignore stream-reader errors while process exits.
+    } finally {
+      reader.releaseLock();
+    }
+  };
+
+  void streamReader(proc.stdout, 'stdout');
+  void streamReader(proc.stderr, 'stderr');
 }

--- a/src/utils/cloudflared.ts
+++ b/src/utils/cloudflared.ts
@@ -1,0 +1,5 @@
+import { checkCommandExists } from './deps.js';
+
+export async function isCloudflaredInstalled(): Promise<boolean> {
+  return checkCommandExists('cloudflared');
+}

--- a/src/utils/deps.ts
+++ b/src/utils/deps.ts
@@ -65,7 +65,8 @@ export async function checkCommandExists(command: string): Promise<boolean> {
   }
 
   try {
-    await execFileAsync('which', [command]);
+    const lookupCommand = process.platform === 'win32' ? 'where' : 'which';
+    await execFileAsync(lookupCommand, [command]);
     return true;
   } catch {
     return false;


### PR DESCRIPTION
## Summary
- make `gssh relay start` auto-bind to an account host tunnel when available (with interactive host selection when multiple subdomains exist)
- add `gssh relay stop` with runtime state tracking so relay/tunnel processes can be stopped cleanly
- make `gssh machine serve start` resolve relays automatically when `--relay` is omitted (local relay first, then account relays, with interactive chooser)
- export host helpers for account relay discovery/token hydration and update CLI/help/docs to reflect the new flow

## Validation
- `bun run typecheck`
- `bun test src/commands/__tests__/serve-messages.test.ts src/commands/__tests__/serve-process-hosting.test.ts`
- `bun test src/commands/__tests__/cloud-launch.test.ts src/commands/__tests__/cloud-lifecycle.test.ts src/commands/__tests__/cloud-relay.integration.test.ts`
- `bun test`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk: introduces new relay discovery/selection paths and PID-based process management for relay/cloudflared that can affect daemon lifecycle and user connectivity, especially across platforms (notably Windows ownership checks). Changes are mostly additive but touch core serve/relay startup flows and secret/token handling.
> 
> **Overview**
> `gssh relay start` now optionally auto-selects an account host and launches a Cloudflare tunnel when no hostname is provided, persisting runtime state for the relay+tunnel and exposing new `gssh relay stop`/`gssh relay status` commands (including `--json`).
> 
> `gssh machine serve start` no longer requires `--relay`; it discovers a running local relay first, then account relays from host config/API, and prompts to choose when multiple are available (or errors non-interactively). Host helpers were expanded to list/resolve relay-capable subdomains and to normalize/migrate tunnel-token key names; cloudflared dependency/output handling was centralized, and docs/CLI help were updated to reflect the new flows.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ad24109d1373afe12eae5865f14cb19485a036a0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic relay selection when serving without an explicit relay — chooses local or account relays and prompts if multiple.
  * New relay CLI commands: stop (graceful shutdown) and status (human/--json); start now indicates auto-bind behavior.
  * Account-based subdomain discovery, token-backed tunnel support, persistent relay/tunnel state, and richer status with public relay URL.
  * Relay discovery integrated into serve flow; checks for cloudflared and platform-aware command lookup.

* **Documentation**
  * Updated self-hosted setup docs to describe omitted --relay behavior and options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->