### PR TITLE
fix: disable kitty protocol before TUI PTY passthrough

### DIFF
--- a/src/components/SessionTerminal.tui.tsx
+++ b/src/components/SessionTerminal.tui.tsx
@@ -27,11 +27,12 @@ const COLORS = {
 };
 
 const SCROLLBACK_LIMIT = 2_000;
+const CTRL_BACKSLASH_SEQUENCE = '\x1c';
 const SHIFT_ESCAPE_SEQUENCES = new Set(['\x1b[27;2u', '\x1b[27;2;27~']);
 const SHIFT_TAB_SEQUENCES = new Set(['\x1b[Z', '\x1b[9;2u', '\x1b[27;2;9~']);
 
-function isShiftEscapeSequence(sequence: string): boolean {
-  return SHIFT_ESCAPE_SEQUENCES.has(sequence);
+function isUiModeToggleSequence(sequence: string): boolean {
+  return sequence === CTRL_BACKSLASH_SEQUENCE || SHIFT_ESCAPE_SEQUENCES.has(sequence);
 }
 
 function isShiftTabSequence(sequence: string): boolean {
@@ -93,6 +94,15 @@ export function SessionTerminal({
   const textEncoderRef = useRef(new TextEncoder());
   const [terminalMounted, setTerminalMounted] = useState(false);
   const [uiModeEnabled, setUiModeEnabled] = useState(false);
+
+  useEffect(() => {
+    const previousKittyMode = renderer.useKittyKeyboard;
+    renderer.useKittyKeyboard = false;
+
+    return () => {
+      renderer.useKittyKeyboard = previousKittyMode;
+    };
+  }, [renderer]);
 
   const scrollToCursorIfFollowing = useCallback(() => {
     const scrollBox = scrollBoxRef.current;
@@ -253,7 +263,7 @@ export function SessionTerminal({
         return false;
       }
 
-      if (isShiftEscapeSequence(sequence)) {
+      if (isUiModeToggleSequence(sequence)) {
         setUiModeEnabled((prev) => !prev);
         return true;
       }
@@ -364,8 +374,8 @@ export function SessionTerminal({
   });
 
   const modeHint = uiModeEnabled
-    ? `[UI mode] [q] ${readOnly ? 'Back' : 'Detach'}  [Shift+Esc] Shell`
-    : '[Shift+Esc] UI';
+    ? `[UI mode] [q] ${readOnly ? 'Back' : 'Detach'}  [Shift+Esc/Ctrl+\\] Shell`
+    : '[Shift+Esc/Ctrl+\\] UI';
 
   return (
     <box flexDirection="column" flexGrow={1}>


### PR DESCRIPTION
## Summary
- Disable kitty keyboard protocol while `SessionTerminal` is mounted so attached TUI sessions forward raw VT bytes to PTY instead of kitty CSI-u key encodings.
- Restore the renderer's prior kitty setting on unmount to avoid side effects outside the terminal view.
- Add `Ctrl+\\` fallback for UI-mode toggle and update the hint text, since `Shift+Esc` may not be distinguishable once kitty protocol is disabled.

## Validation
- `bun run typecheck`
- `bun test`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches terminal input handling by forcing `renderer.useKittyKeyboard = false` while `SessionTerminal` is mounted; mistakes here could break key encoding or leak renderer state despite the unmount restore.
> 
> **Overview**
> Ensures attached `SessionTerminal` PTY sessions receive *raw VT input* by temporarily disabling the renderer’s kitty keyboard protocol while the component is mounted and restoring the previous setting on unmount.
> 
> Updates UI-mode toggling to accept `Ctrl+\\` in addition to `Shift+Esc`, and adjusts the status-bar hint to reflect the new shortcut.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 27d9f9643d92958919b441f2aa9dc705f9ec3725. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Ctrl+Backslash keyboard shortcut to toggle between shell and UI modes, providing an alternative to the existing Shift+Esc shortcut.

* **UI/UX Improvements**
  * Updated UI mode indicator hints to display both available keyboard shortcuts [Shift+Esc/Ctrl+\] for improved visibility and discoverability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->