### PR TITLE
fix: remove unrequested Ctrl+\ fallback from TUI toggle

### DIFF
--- a/src/components/SessionTerminal.tui.tsx
+++ b/src/components/SessionTerminal.tui.tsx
@@ -27,12 +27,11 @@ const COLORS = {
 };
 
 const SCROLLBACK_LIMIT = 2_000;
-const CTRL_BACKSLASH_SEQUENCE = '\x1c';
 const SHIFT_ESCAPE_SEQUENCES = new Set(['\x1b[27;2u', '\x1b[27;2;27~']);
 const SHIFT_TAB_SEQUENCES = new Set(['\x1b[Z', '\x1b[9;2u', '\x1b[27;2;9~']);
 
 function isUiModeToggleSequence(sequence: string): boolean {
-  return sequence === CTRL_BACKSLASH_SEQUENCE || SHIFT_ESCAPE_SEQUENCES.has(sequence);
+  return SHIFT_ESCAPE_SEQUENCES.has(sequence);
 }
 
 function isShiftTabSequence(sequence: string): boolean {
@@ -374,8 +373,8 @@ export function SessionTerminal({
   });
 
   const modeHint = uiModeEnabled
-    ? `[UI mode] [q] ${readOnly ? 'Back' : 'Detach'}  [Shift+Esc/Ctrl+\\] Shell`
-    : '[Shift+Esc/Ctrl+\\] UI';
+    ? `[UI mode] [q] ${readOnly ? 'Back' : 'Detach'}  [Shift+Esc] Shell`
+    : '[Shift+Esc] UI';
 
   return (
     <box flexDirection="column" flexGrow={1}>


### PR DESCRIPTION
## Summary
- Remove the `Ctrl+\\` fallback that was added to TUI UI-mode toggle handling in `SessionTerminal`.
- Keep UI-mode toggle strictly on `Shift+Esc`.
- Update the mode hint text to remove `Ctrl+\\` and show only `Shift+Esc`.

## Validation
- `bun run typecheck`
- `bun test`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: limits a keyboard shortcut by removing the `Ctrl+\\` toggle path and only updates related UI hint text; behavior change is confined to TUI input handling.
> 
> **Overview**
> UI-mode toggle in `SessionTerminal.tui.tsx` is now triggered **only** by Shift+Esc sequences by removing the `Ctrl+\\` fallback.
> 
> The status bar mode hint text is updated accordingly to advertise `[Shift+Esc]` instead of `[Shift+Esc/Ctrl+\\]`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 30b5582c612452d2acab5bcfa819e4e900b9816e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Simplified UI mode toggle shortcut to use only [Shift+Esc]. Removed alternate Ctrl+\ shortcut to prevent conflicts and reduce confusion.
  * Updated on-screen hints to reflect the single keyboard shortcut for toggling UI mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->