### PR TITLE
fix: enforce VT keyboard mode in session terminal

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -41,10 +41,10 @@
         "typescript": "^5.9.3",
       },
       "optionalDependencies": {
-        "@gitspace/darwin-arm64": "0.2.0-rc.20",
-        "@gitspace/darwin-x64": "0.2.0-rc.20",
-        "@gitspace/linux-arm64": "0.2.0-rc.20",
-        "@gitspace/linux-x64": "0.2.0-rc.20",
+        "@gitspace/darwin-arm64": "0.2.0-rc.27",
+        "@gitspace/darwin-x64": "0.2.0-rc.27",
+        "@gitspace/linux-arm64": "0.2.0-rc.27",
+        "@gitspace/linux-x64": "0.2.0-rc.27",
       },
     },
   },
@@ -67,7 +67,13 @@
 
     "@fly/sprites": ["@fly/sprites@0.0.1-rc37", "", {}, "sha512-yzjJ8bsBl1XoECSols0iFvvmlqiog22ODO8F3Z+8mao44ZaMYiOVjRTuSd2g+rE0OFuj0u/ctlpPTHfVdpgWKA=="],
 
-    "@gitspace/darwin-arm64": ["@gitspace/darwin-arm64@0.2.0-rc.20", "", { "os": "darwin", "cpu": "arm64", "bin": { "gssh-darwin-arm64": "bin/gssh" } }, "sha512-bRlt6OKBsB38y+qzlmZtNRtnEKSmkxKu+hi19lYtSoPa9lR0zr+A6TiUpWLnB09B2++Xsj5aiN0KnNe/G4wk0Q=="],
+    "@gitspace/darwin-arm64": ["@gitspace/darwin-arm64@0.2.0-rc.27", "", { "os": "darwin", "cpu": "arm64", "bin": { "gssh-darwin-arm64": "bin/gssh" } }, "sha512-NOjrqO/vttvLZlzZrow3VzRXW+KRbu3IF6WWEUFkmscuuBAxwrU8KJgN052dqTFEbREYMt4AVKZO7hNMvs7NSA=="],
+
+    "@gitspace/darwin-x64": ["@gitspace/darwin-x64@0.2.0-rc.27", "", { "os": "darwin", "cpu": "x64", "bin": { "gssh-darwin-x64": "bin/gssh" } }, "sha512-bqeIqoTAOfV69K2Naxg5/oPHOCcyknMsldw2IytCjjCi3LbhNXjiBDrTu7nHAmx58MffZ0NySbuE4e6IHhiXSQ=="],
+
+    "@gitspace/linux-arm64": ["@gitspace/linux-arm64@0.2.0-rc.27", "", { "os": "linux", "cpu": "arm64", "bin": { "gssh-linux-arm64": "bin/gssh" } }, "sha512-FDoC/PFA6rY2dQ/9QLsirBQBcjaEaJeRtvv5BPOJh7+fZup+VH6jYxrX4TMg2PhIR8v1Liu6UumfdM6Cf8NdYQ=="],
+
+    "@gitspace/linux-x64": ["@gitspace/linux-x64@0.2.0-rc.27", "", { "os": "linux", "cpu": "x64", "bin": { "gssh-linux-x64": "bin/gssh" } }, "sha512-MpNr1L4tk+03VI9taKXJc/mAsBPs3LvhnKcXwVrtbE7i2LVtcwl7csd7FsaeFsXe5lio8AdvNeLKFVYyb/vkPQ=="],
 
     "@graphql-typed-document-node/core": ["@graphql-typed-document-node/core@3.2.0", "", { "peerDependencies": { "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0" } }, "sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ=="],
 

--- a/scripts/test-tui-keyboard-mode.ts
+++ b/scripts/test-tui-keyboard-mode.ts
@@ -1,0 +1,109 @@
+#!/usr/bin/env bun
+
+import { createCliRenderer } from '@opentui/core';
+import {
+  VT_KITTY_KEYBOARD_CONFIG,
+  forceDisableKittyKeyboard,
+} from '../src/tui/kitty-keyboard.js';
+
+type ProbeResult = {
+  label: string;
+  useKittyKeyboard: boolean;
+  parsedSample: {
+    name: string;
+    source: string;
+    sequence: string;
+    raw: string;
+  } | null;
+};
+
+const SAMPLE_KITTY_BACKSPACE = '\x1b[127;1u';
+
+function visible(value: string): string {
+  return JSON.stringify(value)
+    .replace(/\\u001b/g, '\\x1b')
+    .replace(/\\r/g, '\\x0d')
+    .replace(/\\n/g, '\\x0a');
+}
+
+async function probe(
+  label: string,
+  useKittyKeyboard: object | null | undefined,
+  applyWorkaround: boolean = false
+): Promise<ProbeResult> {
+  const renderer = await createCliRenderer({
+    useKittyKeyboard,
+    useAlternateScreen: false,
+    useMouse: false,
+    useConsole: false,
+    exitOnCtrlC: false,
+    targetFps: 1,
+  });
+
+  try {
+    if (applyWorkaround) {
+      forceDisableKittyKeyboard(renderer);
+    }
+
+    let parsedSample: ProbeResult['parsedSample'] = null;
+    const onKey = (key: { name: string; source: string; sequence: string; raw: string }) => {
+      if (!parsedSample) {
+        parsedSample = {
+          name: key.name,
+          source: key.source,
+          sequence: key.sequence,
+          raw: key.raw,
+        };
+      }
+    };
+
+    renderer.keyInput.on('keypress', onKey);
+    (renderer.keyInput as { processInput: (value: string) => boolean }).processInput(SAMPLE_KITTY_BACKSPACE);
+    renderer.keyInput.off('keypress', onKey);
+
+    return {
+      label,
+      useKittyKeyboard: renderer.useKittyKeyboard,
+      parsedSample,
+    };
+  } finally {
+    renderer.destroy();
+  }
+}
+
+const probes: ProbeResult[] = [];
+probes.push(await probe('default config (kitty expected)', undefined));
+probes.push(await probe('explicit null (vt intent)', null));
+probes.push(await probe('workaround path (vt config + forced disable)', VT_KITTY_KEYBOARD_CONFIG, true));
+
+process.stderr.write('\n=== TUI keyboard mode probe ===\n\n');
+for (const result of probes) {
+  process.stderr.write(`- ${result.label}\n`);
+  process.stderr.write(`  renderer.useKittyKeyboard: ${result.useKittyKeyboard}\n`);
+  if (result.parsedSample) {
+    process.stderr.write(
+      `  parsed ${visible(SAMPLE_KITTY_BACKSPACE)} -> name=${result.parsedSample.name || '<empty>'} source=${result.parsedSample.source} sequence=${visible(result.parsedSample.sequence)} raw=${visible(result.parsedSample.raw)}\n`
+    );
+  } else {
+    process.stderr.write(`  parsed ${visible(SAMPLE_KITTY_BACKSPACE)} -> <no key event>\n`);
+  }
+  process.stderr.write('\n');
+}
+
+const workaroundProbe = probes.find((item) => item.label === 'workaround path (vt config + forced disable)');
+if (!workaroundProbe) {
+  process.stderr.write('Probe failed: missing workaround probe result\n');
+  process.exit(1);
+}
+
+if (workaroundProbe.useKittyKeyboard) {
+  process.stderr.write('FAIL: workaround path still leaves kitty mode enabled.\n');
+  process.exit(1);
+}
+
+const nullProbe = probes.find((item) => item.label === 'explicit null (vt intent)');
+if (nullProbe?.useKittyKeyboard) {
+  process.stderr.write('NOTE: upstream null path still enables kitty mode (known OpenTUI behavior).\n');
+}
+
+process.stderr.write('PASS: workaround path disables kitty mode as expected.\n');

--- a/src/app.tui.tsx
+++ b/src/app.tui.tsx
@@ -101,6 +101,10 @@ import {
   getNumericInputChunk,
   normalizeInputText,
 } from './tui/input-text.js';
+import {
+  VT_KITTY_KEYBOARD_CONFIG,
+  forceDisableKittyKeyboard,
+} from './tui/kitty-keyboard.js';
 
 // Types
 import type { InboxItem } from './lib/tmux-lite/cli.js';
@@ -2410,13 +2414,19 @@ function looksLikeKittyEnterLeak(buffer: string): boolean {
   );
 }
 
-function createRendererForKeyboardMode(mode: ResolvedKeyboardMode) {
-  return createCliRenderer({
+async function createRendererForKeyboardMode(mode: ResolvedKeyboardMode) {
+  const renderer = await createCliRenderer({
     exitOnCtrlC: false,
     targetFps: 30,
     useMouse: true,
-    useKittyKeyboard: mode === 'vt' ? null : undefined,
+    useKittyKeyboard: mode === 'vt' ? VT_KITTY_KEYBOARD_CONFIG : undefined,
   });
+
+  if (mode === 'vt') {
+    forceDisableKittyKeyboard(renderer);
+  }
+
+  return renderer;
 }
 
 function KeyboardWelcomeGate({

--- a/src/components/SessionTerminal.tui.tsx
+++ b/src/components/SessionTerminal.tui.tsx
@@ -16,6 +16,10 @@ import {
   shouldBypassScrollboxKeyHandling,
   shouldConsumePageNavigationInScrollbox,
 } from './session-terminal-page-navigation.js';
+import {
+  forceDisableKittyKeyboard,
+  restoreKittyKeyboard,
+} from '../tui/kitty-keyboard.js';
 
 extend({ 'ghostty-terminal': GhosttyTerminalRenderable });
 
@@ -93,15 +97,33 @@ export function SessionTerminal({
   const textEncoderRef = useRef(new TextEncoder());
   const [terminalMounted, setTerminalMounted] = useState(false);
   const [uiModeEnabled, setUiModeEnabled] = useState(false);
+  const uiModeEnabledRef = useRef(false);
+
+  const forceDisableKeyboard = useCallback(() => {
+    forceDisableKittyKeyboard(renderer);
+  }, [renderer]);
+
+  useEffect(() => {
+    uiModeEnabledRef.current = uiModeEnabled;
+  }, [uiModeEnabled]);
 
   useEffect(() => {
     const previousKittyMode = renderer.useKittyKeyboard;
-    renderer.useKittyKeyboard = false;
+    forceDisableKeyboard();
+
+    const handleFocus = () => {
+      if (!uiModeEnabledRef.current) {
+        forceDisableKeyboard();
+      }
+    };
+
+    renderer.on('focus', handleFocus);
 
     return () => {
-      renderer.useKittyKeyboard = previousKittyMode;
+      renderer.off('focus', handleFocus);
+      restoreKittyKeyboard(renderer, previousKittyMode);
     };
-  }, [renderer]);
+  }, [forceDisableKeyboard, renderer]);
 
   const scrollToCursorIfFollowing = useCallback(() => {
     const scrollBox = scrollBoxRef.current;
@@ -263,6 +285,9 @@ export function SessionTerminal({
       }
 
       if (isUiModeToggleSequence(sequence)) {
+        if (uiModeEnabledRef.current) {
+          forceDisableKeyboard();
+        }
         setUiModeEnabled((prev) => !prev);
         return true;
       }
@@ -284,15 +309,16 @@ export function SessionTerminal({
     return () => {
       renderer.removeInputHandler(rawInputHandler);
     };
-  }, [interceptShiftTab, modalOpen, onActivity, onData, readOnly, renderer, uiModeEnabled]);
+  }, [forceDisableKeyboard, interceptShiftTab, modalOpen, onActivity, onData, readOnly, renderer, uiModeEnabled]);
 
   useEffect(() => {
     if (!modalOpen) {
       return;
     }
 
+    forceDisableKeyboard();
     setUiModeEnabled(false);
-  }, [modalOpen]);
+  }, [forceDisableKeyboard, modalOpen]);
 
   useEffect(() => {
     const handlePaste = (event: PasteEvent) => {
@@ -326,6 +352,7 @@ export function SessionTerminal({
     }
 
     if (key.shift && key.name === 'escape') {
+      forceDisableKeyboard();
       setUiModeEnabled(false);
       return;
     }

--- a/src/tui/__tests__/kitty-keyboard.opentui.test.ts
+++ b/src/tui/__tests__/kitty-keyboard.opentui.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'bun:test'
+import { createCliRenderer } from '@opentui/core'
+import {
+  VT_KITTY_KEYBOARD_CONFIG,
+  forceDisableKittyKeyboard,
+} from '../kitty-keyboard.js'
+
+const runIntegration = process.env.GSSH_RUN_TTY_KEYBOARD_TEST === '1'
+
+describe('OpenTUI kitty keyboard integration', () => {
+  const integrationIt = runIntegration ? it : it.skip
+
+  integrationIt('forces kitty mode off in workaround path', async () => {
+    const renderer = await createCliRenderer({
+      exitOnCtrlC: false,
+      targetFps: 1,
+      useMouse: false,
+      useConsole: false,
+      useAlternateScreen: false,
+      useKittyKeyboard: VT_KITTY_KEYBOARD_CONFIG,
+    })
+
+    try {
+      forceDisableKittyKeyboard(renderer, () => {})
+      expect(renderer.useKittyKeyboard).toBe(false)
+    } finally {
+      renderer.destroy()
+    }
+  })
+})

--- a/src/tui/__tests__/kitty-keyboard.test.ts
+++ b/src/tui/__tests__/kitty-keyboard.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'bun:test'
+import {
+  KITTY_KEYBOARD_DISABLE_SEQUENCE,
+  KITTY_KEYBOARD_ENABLE_SEQUENCE,
+  VT_KITTY_KEYBOARD_CONFIG,
+  forceDisableKittyKeyboard,
+  restoreKittyKeyboard,
+  type KittyKeyboardRenderer,
+} from '../kitty-keyboard.js'
+
+function createRendererMock(initialMode: boolean): KittyKeyboardRenderer & {
+  disableCalls: number
+  enableCalls: number
+} {
+  return {
+    useKittyKeyboard: initialMode,
+    disableCalls: 0,
+    enableCalls: 0,
+    disableKittyKeyboard() {
+      this.disableCalls += 1
+      this.useKittyKeyboard = false
+    },
+    enableKittyKeyboard() {
+      this.enableCalls += 1
+      this.useKittyKeyboard = true
+    },
+  }
+}
+
+describe('kitty keyboard helpers', () => {
+  it('defines VT kitty config with all options disabled', () => {
+    expect(VT_KITTY_KEYBOARD_CONFIG).toEqual({
+      disambiguate: false,
+      alternateKeys: false,
+      events: false,
+      allKeysAsEscapes: false,
+      reportText: false,
+    })
+  })
+
+  it('forceDisableKittyKeyboard disables renderer and writes disable sequence', () => {
+    const renderer = createRendererMock(true)
+    const writes: string[] = []
+
+    forceDisableKittyKeyboard(renderer, (chunk) => {
+      writes.push(chunk)
+    })
+
+    expect(renderer.useKittyKeyboard).toBe(false)
+    expect(renderer.disableCalls).toBe(1)
+    expect(renderer.enableCalls).toBe(0)
+    expect(writes).toEqual([KITTY_KEYBOARD_DISABLE_SEQUENCE])
+  })
+
+  it('restoreKittyKeyboard reenables kitty mode when previous mode was enabled', () => {
+    const renderer = createRendererMock(false)
+    const writes: string[] = []
+
+    restoreKittyKeyboard(renderer, true, (chunk) => {
+      writes.push(chunk)
+    })
+
+    expect(renderer.useKittyKeyboard).toBe(true)
+    expect(renderer.enableCalls).toBe(1)
+    expect(renderer.disableCalls).toBe(0)
+    expect(writes).toEqual([KITTY_KEYBOARD_ENABLE_SEQUENCE])
+  })
+
+  it('restoreKittyKeyboard keeps kitty mode disabled when previous mode was disabled', () => {
+    const renderer = createRendererMock(true)
+    const writes: string[] = []
+
+    restoreKittyKeyboard(renderer, false, (chunk) => {
+      writes.push(chunk)
+    })
+
+    expect(renderer.useKittyKeyboard).toBe(false)
+    expect(renderer.enableCalls).toBe(0)
+    expect(renderer.disableCalls).toBe(1)
+    expect(writes).toEqual([KITTY_KEYBOARD_DISABLE_SEQUENCE])
+  })
+})

--- a/src/tui/__tests__/opentui-keyboard-parsing.test.ts
+++ b/src/tui/__tests__/opentui-keyboard-parsing.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'bun:test'
+import { parseKeypress } from '@opentui/core'
+
+const KITTY_BACKSPACE = '\x1b[127;1u'
+
+describe('OpenTUI kitty parsing behavior', () => {
+  it('keeps raw CSI-u bytes even when kitty parsing recognizes the key', () => {
+    const parsed = parseKeypress(KITTY_BACKSPACE, { useKittyKeyboard: true })
+
+    expect(parsed).not.toBeNull()
+    expect(parsed?.source).toBe('kitty')
+    expect(parsed?.name).toBe('backspace')
+    expect(parsed?.raw).toBe(KITTY_BACKSPACE)
+    expect(parsed?.sequence).toBe(KITTY_BACKSPACE)
+  })
+
+  it('does not decode CSI-u to legacy key bytes when kitty parsing is disabled', () => {
+    const parsed = parseKeypress(KITTY_BACKSPACE, { useKittyKeyboard: false })
+
+    expect(parsed).not.toBeNull()
+    expect(parsed?.source).toBe('raw')
+    expect(parsed?.name).toBe('')
+    expect(parsed?.raw).toBe(KITTY_BACKSPACE)
+    expect(parsed?.sequence).toBe(KITTY_BACKSPACE)
+  })
+})

--- a/src/tui/kitty-keyboard.ts
+++ b/src/tui/kitty-keyboard.ts
@@ -1,0 +1,47 @@
+export const VT_KITTY_KEYBOARD_CONFIG = {
+  disambiguate: false,
+  alternateKeys: false,
+  events: false,
+  allKeysAsEscapes: false,
+  reportText: false,
+} as const;
+
+export const KITTY_KEYBOARD_DISABLE_SEQUENCE = '\x1b[>4;0m';
+export const KITTY_KEYBOARD_ENABLE_SEQUENCE = '\x1b[>4;1m';
+
+export interface KittyKeyboardRenderer {
+  useKittyKeyboard: boolean;
+  disableKittyKeyboard: () => void;
+  enableKittyKeyboard: () => void;
+}
+
+type TerminalWrite = (chunk: string) => void;
+
+function writeToStdout(chunk: string): void {
+  process.stdout.write(chunk);
+}
+
+export function forceDisableKittyKeyboard(
+  renderer: KittyKeyboardRenderer,
+  write: TerminalWrite = writeToStdout
+): void {
+  renderer.useKittyKeyboard = false;
+  renderer.disableKittyKeyboard();
+  write(KITTY_KEYBOARD_DISABLE_SEQUENCE);
+}
+
+export function restoreKittyKeyboard(
+  renderer: KittyKeyboardRenderer,
+  previousKittyMode: boolean,
+  write: TerminalWrite = writeToStdout
+): void {
+  renderer.useKittyKeyboard = previousKittyMode;
+  if (previousKittyMode) {
+    renderer.enableKittyKeyboard();
+    write(KITTY_KEYBOARD_ENABLE_SEQUENCE);
+    return;
+  }
+
+  renderer.disableKittyKeyboard();
+  write(KITTY_KEYBOARD_DISABLE_SEQUENCE);
+}

--- a/src/tui/kitty-keyboard.ts
+++ b/src/tui/kitty-keyboard.ts
@@ -6,6 +6,9 @@ export const VT_KITTY_KEYBOARD_CONFIG = {
   reportText: false,
 } as const;
 
+// These are xterm modifyOtherKeys sequences (XTMODKEYS), not kitty CSI-u
+// push/pop sequences. They match what OpenTUI's native Zig renderer sends
+// via enableKittyKeyboard()/disableKittyKeyboard() FFI calls.
 export const KITTY_KEYBOARD_DISABLE_SEQUENCE = '\x1b[>4;0m';
 export const KITTY_KEYBOARD_ENABLE_SEQUENCE = '\x1b[>4;1m';
 


### PR DESCRIPTION
## Summary
- enforce VT keyboard mode by applying an explicit all-off kitty config and force-disabling kitty after renderer creation, including focus/lifecycle re-application in the session terminal path
- remove the Ctrl+\\ fallback from UI/shell mode hints and toggle handling, keeping Shift+Esc as the only toggle path as validated on this machine
- add regression coverage and diagnostics for kitty parsing/disable behavior (`kitty-keyboard` helper tests, OpenTUI parsing test, and a local `scripts/test-tui-keyboard-mode.ts` probe)

## Testing
- bun test \"src/tui/__tests__/kitty-keyboard.test.ts\" \"src/tui/__tests__/opentui-keyboard-parsing.test.ts\"
- GSSH_RUN_TTY_KEYBOARD_TEST=1 bun test \"src/tui/__tests__/kitty-keyboard.opentui.test.ts\"
- bun run typecheck

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes low-level TUI keyboard-mode handling and renderer lifecycle hooks, which can affect input parsing and terminal state across platforms. New helper sequences and focus/toggle interactions may have edge cases in different terminals.
> 
> **Overview**
> **VT keyboard mode is now enforced more aggressively in the TUI.** Renderer creation for VT mode switches from passing `null` to using an explicit all-off `VT_KITTY_KEYBOARD_CONFIG`, then *force-disables* kitty mode after `createCliRenderer` completes.
> 
> **Session terminal input handling is hardened against kitty mode re-enabling.** `SessionTerminal` now disables kitty mode via a shared helper on mount, re-applies the disable on renderer focus and during UI-mode/modal transitions, and restores the previous kitty state on cleanup.
> 
> **Adds verification tooling and tests.** Introduces `src/tui/kitty-keyboard.ts` helpers (with unit + optional integration tests), a parsing behavior test for CSI-u, and a `scripts/test-tui-keyboard-mode.ts` probe script. Also bumps `@gitspace/*` optional binaries to `0.2.0-rc.27` in `bun.lock`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cc3183984311fa47aedc61024c25d09e5229f80f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved terminal keyboard behavior and VT-mode compatibility for a more reliable interactive UI (consistent handling across focus, UI mode, and modals).

* **Tests**
  * Added unit and integration tests covering Kitty keyboard helpers, keyboard parsing, and end-to-end keyboard mode scenarios.

* **Chores**
  * Added automation script to probe and verify TUI keyboard mode behavior during CI or local checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->