### PR TITLE
fix TUI select dialogs overflow and add search

### DIFF
--- a/src/app.tui.tsx
+++ b/src/app.tui.tsx
@@ -437,7 +437,7 @@ function App({ relayConfig, onQuit, keyboardMode }: AppProps) {
       dispatch({ type: 'SET_VIEW', view: 'terminal' });
     },
     onAttachCancelled: ({ target }) => {
-      if (target === 'workspace' && state.view === 'scripts') {
+      if (target === 'workspace') {
         return;
       }
       dispatch({ type: 'SET_VIEW', view: 'projects' });
@@ -1358,6 +1358,26 @@ function App({ relayConfig, onQuit, keyboardMode }: AppProps) {
         return;
       }
 
+      if (
+        state.view === 'scripts' &&
+        !localScriptState?.isRunning &&
+        !!localScriptState?.error &&
+        flow.flow.type === 'message' &&
+        (key.raw === 'a' || key.name === 'a')
+      ) {
+        const workspaceId = lastScriptWorkspaceIdRef.current;
+        if (!workspaceId) {
+          return;
+        }
+
+        flow.close();
+        await attachLocal({
+          workspaceId,
+          scriptPolicy: 'skip',
+        });
+        return;
+      }
+
       // Handle other modals (select, message, etc.)
       if (flow.flow.type === 'select' && flow.flow.searchable) {
         if (key.name === 'escape') {
@@ -1384,6 +1404,8 @@ function App({ relayConfig, onQuit, keyboardMode }: AppProps) {
 
       // Handle other modals (select, message, etc.)
       if (key.name === 'escape') {
+        flow.handleCancel();
+      } else if (key.raw === 'n') {
         flow.handleCancel();
       } else if (key.name === 'return') {
         await flow.handleConfirm();
@@ -2012,28 +2034,28 @@ function App({ relayConfig, onQuit, keyboardMode }: AppProps) {
   if (state.view === 'scripts') {
     const phase = localScriptState?.phase ?? 'pre';
     const isRunning = localScriptState?.isRunning ?? true;
+    const scriptHint = isRunning
+      ? '[Running scripts... c: cancel + attach anyway]'
+      : localScriptState?.error
+        ? '[←/→ or [/] Phase  [↑/↓ PgUp/PgDn] Scroll  [a] Attach anyway  [Esc/n] Back'
+        : '[←/→ or [/] Phase  [↑/↓ PgUp/PgDn] Scroll  [Esc/n] Back';
 
     return (
       <Fragment>
         <Toaster position="top-right" />
-        <ScriptTerminal
-          ref={scriptTerminalRef}
-          phase={phase}
-          workspaceName={scriptWorkspaceName}
-          isRunning={isRunning}
-          error={localScriptState?.error}
-          exitCode={localScriptState?.exitCode}
-          modalOpen={flow.isOpen}
-        />
-        {!isRunning && <FlowTUI flow={flow} />}
-        <StatusBar
-          hint={isRunning
-            ? '[Running scripts... c: cancel + attach anyway]'
-            : localScriptState?.error
-              ? '[←/→ or [/] Phase  [↑/↓ PgUp/PgDn] Scroll  [a] Attach anyway  [Esc/n] Back'
-              : '[←/→ or [/] Phase  [↑/↓ PgUp/PgDn] Scroll  [Esc/n] Back'}
-          rightHint={keyboardModeHint}
-        />
+        <box flexDirection="column" flexGrow={1} width="100%" height="100%">
+          <ScriptTerminal
+            ref={scriptTerminalRef}
+            phase={phase}
+            workspaceName={scriptWorkspaceName}
+            isRunning={isRunning}
+            error={localScriptState?.error}
+            exitCode={localScriptState?.exitCode}
+            modalOpen={flow.isOpen}
+          />
+          <StatusBar hint={scriptHint} rightHint={keyboardModeHint} />
+          {!isRunning && <FlowTUI flow={flow} />}
+        </box>
       </Fragment>
     );
   }

--- a/src/app.tui.tsx
+++ b/src/app.tui.tsx
@@ -1271,6 +1271,13 @@ function App({ relayConfig, onQuit, keyboardMode }: AppProps) {
           event.preventDefault();
           return;
         }
+
+        if (flow.flow.type === 'select' && flow.flow.searchable) {
+          const currentQuery = flow.flow.searchQuery ?? '';
+          flow.updateSelectQuery(currentQuery + text);
+          event.preventDefault();
+          return;
+        }
       }
 
       if (projectFlow.type === 'onboarding') {
@@ -1347,6 +1354,30 @@ function App({ relayConfig, onQuit, keyboardMode }: AppProps) {
           }
           const current = 'inputValue' in flow.flow ? flow.flow.inputValue || '' : '';
           flow.handleInput(current + chunk);
+        }
+        return;
+      }
+
+      // Handle other modals (select, message, etc.)
+      if (flow.flow.type === 'select' && flow.flow.searchable) {
+        if (key.name === 'escape') {
+          flow.handleCancel();
+        } else if (key.name === 'return') {
+          await flow.handleConfirm();
+        } else if (key.name === 'up') {
+          flow.moveUp();
+        } else if (key.name === 'down') {
+          flow.moveDown();
+        } else if (key.name === 'backspace') {
+          const current = flow.flow.searchQuery ?? '';
+          flow.updateSelectQuery(current.slice(0, -1));
+        } else {
+          const chunk = getKeyboardInputChunk(key);
+          if (!chunk) {
+            return;
+          }
+          const current = flow.flow.searchQuery ?? '';
+          flow.updateSelectQuery(current + chunk);
         }
         return;
       }

--- a/src/app.tui.tsx
+++ b/src/app.tui.tsx
@@ -102,6 +102,10 @@ import {
   normalizeInputText,
 } from './tui/input-text.js';
 import {
+  applySearchableSelectPaste,
+  handleSearchableSelectKey,
+} from './tui/flow-select-input.js';
+import {
   VT_KITTY_KEYBOARD_CONFIG,
   forceDisableKittyKeyboard,
 } from './tui/kitty-keyboard.js';
@@ -1252,7 +1256,14 @@ function App({ relayConfig, onQuit, keyboardMode }: AppProps) {
 
   useEffect(() => {
     const handlePaste = (event: PasteEvent) => {
-      const text = normalizeInputText(event.text ?? '');
+      const rawText = event.text ?? '';
+
+      if (flow.isOpen && applySearchableSelectPaste(flow, rawText)) {
+        event.preventDefault();
+        return;
+      }
+
+      const text = normalizeInputText(rawText);
       if (!text) {
         return;
       }
@@ -1272,12 +1283,6 @@ function App({ relayConfig, onQuit, keyboardMode }: AppProps) {
           return;
         }
 
-        if (flow.flow.type === 'select' && flow.flow.searchable) {
-          const currentQuery = flow.flow.searchQuery ?? '';
-          flow.updateSelectQuery(currentQuery + text);
-          event.preventDefault();
-          return;
-        }
       }
 
       if (projectFlow.type === 'onboarding') {
@@ -1379,26 +1384,7 @@ function App({ relayConfig, onQuit, keyboardMode }: AppProps) {
       }
 
       // Handle other modals (select, message, etc.)
-      if (flow.flow.type === 'select' && flow.flow.searchable) {
-        if (key.name === 'escape') {
-          flow.handleCancel();
-        } else if (key.name === 'return') {
-          await flow.handleConfirm();
-        } else if (key.name === 'up') {
-          flow.moveUp();
-        } else if (key.name === 'down') {
-          flow.moveDown();
-        } else if (key.name === 'backspace') {
-          const current = flow.flow.searchQuery ?? '';
-          flow.updateSelectQuery(current.slice(0, -1));
-        } else {
-          const chunk = getKeyboardInputChunk(key);
-          if (!chunk) {
-            return;
-          }
-          const current = flow.flow.searchQuery ?? '';
-          flow.updateSelectQuery(current + chunk);
-        }
+      if (await handleSearchableSelectKey(flow, key)) {
         return;
       }
 

--- a/src/app.tui.tsx
+++ b/src/app.tui.tsx
@@ -1405,8 +1405,6 @@ function App({ relayConfig, onQuit, keyboardMode }: AppProps) {
       // Handle other modals (select, message, etc.)
       if (key.name === 'escape') {
         flow.handleCancel();
-      } else if (key.raw === 'n') {
-        flow.handleCancel();
       } else if (key.name === 'return') {
         await flow.handleConfirm();
       } else if (key.name === 'up' || key.raw === 'k') {
@@ -1429,7 +1427,7 @@ function App({ relayConfig, onQuit, keyboardMode }: AppProps) {
 
     // Shift+Tab attach hotkey - check FIRST, even in terminal view
     // This allows attaching to a different session while in a terminal
-    if (key.shift && key.name === 'tab' && notifications.activeToast) {
+    if (key.shift && key.name === 'tab' && notifications.activeToast && state.view !== 'scripts') {
       // Show confirmation before switching sessions
       const sessionLabel = getSessionLabel(notifications.activeToast.sessionName);
       flow.showConfirm({

--- a/src/app.tui.tsx
+++ b/src/app.tui.tsx
@@ -1383,7 +1383,7 @@ function App({ relayConfig, onQuit, keyboardMode }: AppProps) {
         return;
       }
 
-      // Handle other modals (select, message, etc.)
+      // Handle searchable select modal input/navigation.
       if (await handleSearchableSelectKey(flow, key)) {
         return;
       }

--- a/src/app.tui.tsx
+++ b/src/app.tui.tsx
@@ -373,19 +373,21 @@ function App({ relayConfig, onQuit, keyboardMode }: AppProps) {
     };
   }, []);
 
+  const resolveLocalWorkspaceProjectName = useCallback((workspaceId: string) => {
+    const separator = workspaceId.indexOf(':');
+    if (separator > 0) {
+      return workspaceId.slice(0, separator);
+    }
+    return currentProject;
+  }, [currentProject]);
+
   const bundleRefreshAttach = useBundleRefreshAttachFlow({
     flow,
     commandError: localCommandError,
     attachSession: (params) => attachLocalSession(params),
     getBundleRefreshPlan: getLocalBundleRefreshPlan,
     applyBundleRefresh: applyLocalBundleRefresh,
-    resolveProjectName: (workspaceId) => {
-      const separator = workspaceId.indexOf(':');
-      if (separator > 0) {
-        return workspaceId.slice(0, separator);
-      }
-      return currentProject;
-    },
+    resolveProjectName: resolveLocalWorkspaceProjectName,
   });
 
   const {
@@ -396,13 +398,7 @@ function App({ relayConfig, onQuit, keyboardMode }: AppProps) {
     attachSessionWithBundleRefresh: bundleRefreshAttach.attachSessionWithBundleRefresh,
     defaultProjectName: currentProject,
     getAttachSize: getLocalAttachSize,
-    resolveProjectName: (workspaceId) => {
-      const separator = workspaceId.indexOf(':');
-      if (separator > 0) {
-        return workspaceId.slice(0, separator);
-      }
-      return currentProject;
-    },
+    resolveProjectName: resolveLocalWorkspaceProjectName,
     preflightSessionAttach: async (sessionId) => {
       const sessionInfo = localSessions.find((session) => session.id === sessionId);
       if (!sessionInfo) {
@@ -527,13 +523,7 @@ function App({ relayConfig, onQuit, keyboardMode }: AppProps) {
     flow,
     getBundleConfigState: getLocalBundleConfigState,
     applyBundleConfigUpdate: applyLocalBundleConfigUpdate,
-    resolveProjectName: (workspaceId) => {
-      const separator = workspaceId.indexOf(':');
-      if (separator > 0) {
-        return workspaceId.slice(0, separator);
-      }
-      return currentProject;
-    },
+    resolveProjectName: resolveLocalWorkspaceProjectName,
     onApplied: async () => {
       await refreshWorkspaces();
     },

--- a/src/app.tui.tsx
+++ b/src/app.tui.tsx
@@ -17,7 +17,7 @@ import { Toaster } from '@opentui-ui/toast/react';
 // Terminal components
 import { SessionTerminal } from './components/SessionTerminal.tui.js';
 import { RemoteMachineScreen } from './components/RemoteMachineScreen.tui.js';
-import { ScriptTerminal, type ScriptTerminalHandle } from './components/ScriptTerminal.tui.js';
+import { ScriptTerminal } from './components/ScriptTerminal.tui.js';
 import { ProjectOnboardingStepTUI } from './components/ProjectOnboardingStep.tui.js';
 
 // Shared components and hooks
@@ -80,6 +80,7 @@ import { useRemoteMachines, type RelayConfig } from './hooks/useRemoteMachines.t
 import { useLocalSession } from './hooks/useLocalSession.tui.js';
 import { useUserActivity } from './hooks/index.js';
 import { useBundleRefreshAttachFlow } from './session/index.js';
+import { useBundleConfigFlow } from './session/index.js';
 import { useAttachController } from './app/session/useAttachController.js';
 import { useProcessActions } from './app/session/useProcessActions.js';
 import { useWorkspaceDeleteFlow } from './app/session/useWorkspaceDeleteFlow.js';
@@ -273,7 +274,6 @@ function App({ relayConfig, onQuit, keyboardMode }: AppProps) {
 
   // Track when we're switching sessions (to prevent detach handler from navigating away)
   const sessionSwitchingRef = useRef(false);
-  const scriptTerminalRef = useRef<ScriptTerminalHandle | null>(null);
   const lastScriptWorkspaceIdRef = useRef<string | null>(null);
   const renderer = useRenderer();
 
@@ -343,6 +343,8 @@ function App({ relayConfig, onQuit, keyboardMode }: AppProps) {
     commandError: localCommandError,
     getBundleRefreshPlan: getLocalBundleRefreshPlan,
     applyBundleRefresh: applyLocalBundleRefresh,
+    getBundleConfigState: getLocalBundleConfigState,
+    applyBundleConfigUpdate: applyLocalBundleConfigUpdate,
     startProcess: startLocalProcess,
     stopProcess: stopLocalProcess,
     requestEvents: requestLocalEvents,
@@ -521,6 +523,22 @@ function App({ relayConfig, onQuit, keyboardMode }: AppProps) {
     ]);
   }, [isLocalMachineContext, requestLocalSessions, requestLocalWorkspaces]);
 
+  const bundleConfigFlow = useBundleConfigFlow({
+    flow,
+    getBundleConfigState: getLocalBundleConfigState,
+    applyBundleConfigUpdate: applyLocalBundleConfigUpdate,
+    resolveProjectName: (workspaceId) => {
+      const separator = workspaceId.indexOf(':');
+      if (separator > 0) {
+        return workspaceId.slice(0, separator);
+      }
+      return currentProject;
+    },
+    onApplied: async () => {
+      await refreshWorkspaces();
+    },
+  });
+
   // Load inbox
   const refreshInbox = useCallback(async () => {
     if (!isLocalMachineContext) {
@@ -632,6 +650,12 @@ function App({ relayConfig, onQuit, keyboardMode }: AppProps) {
       }
     });
   }, [attachLocal, localWorkspaces]);
+
+  const handleManageBundleConfig = useCallback(async ({ workspaceId }: { workspaceId: string }) => {
+    const workspace = localWorkspaces.find((item) => item.id === workspaceId);
+    const projectName = workspace?.projectName ?? currentProject;
+    await bundleConfigFlow.openBundleConfig({ workspaceId, projectName });
+  }, [bundleConfigFlow, currentProject, localWorkspaces]);
 
   useEffect(() => {
     if (!pendingProcessEditWorkspaceId) {
@@ -1080,6 +1104,7 @@ function App({ relayConfig, onQuit, keyboardMode }: AppProps) {
     onRequestSessions: () => {}, // Sessions already loaded
     onAttachSession: handleAttachSession,
     onEditProcesses: handleEditProcesses,
+    onManageBundleConfig: handleManageBundleConfig,
     onStartProcess: handleStartProcess,
     onStartProcessAttach: handleStartProcessAttach,
     onStopProcess: handleStopProcess,
@@ -1239,20 +1264,6 @@ function App({ relayConfig, onQuit, keyboardMode }: AppProps) {
     isUserActive,
     currentSessionId: localAttachedSessionId ?? undefined,
   });
-
-  useEffect(() => {
-    if (state.view !== 'scripts') {
-      return;
-    }
-
-    setLocalWriteCallback((data) => {
-      scriptTerminalRef.current?.feed(data);
-    });
-
-    return () => {
-      setLocalWriteCallback(null);
-    };
-  }, [setLocalWriteCallback, state.view]);
 
   useEffect(() => {
     const handlePaste = (event: PasteEvent) => {
@@ -1835,6 +1846,16 @@ function App({ relayConfig, onQuit, keyboardMode }: AppProps) {
           // In workspaces panel, 'n' always creates new workspace
           // Sessions are created via expand (Enter) → "+ New session" (Enter)
           lifecycleController.openCreateWorkspaceFlow(currentProject);
+        } else if (command === 'bundle') {
+          const selected = spacesBrowserProps.selectedItem;
+          const workspaceId = selected?.type === 'workspace'
+            ? selected.workspace.id
+            : selected && 'workspaceId' in selected
+              ? selected.workspaceId
+              : null;
+          if (workspaceId) {
+            await handleManageBundleConfig({ workspaceId });
+          }
         } else if (command === 'delete') {
           // Delete workspace
           const selected = spacesBrowserProps.selectedItem;
@@ -2029,13 +2050,13 @@ function App({ relayConfig, onQuit, keyboardMode }: AppProps) {
         <Toaster position="top-right" />
         <box flexDirection="column" flexGrow={1} width="100%" height="100%">
           <ScriptTerminal
-            ref={scriptTerminalRef}
             phase={phase}
             workspaceName={scriptWorkspaceName}
             isRunning={isRunning}
             error={localScriptState?.error}
             exitCode={localScriptState?.exitCode}
             modalOpen={flow.isOpen}
+            setWriteCallback={setLocalWriteCallback}
           />
           <StatusBar hint={scriptHint} rightHint={keyboardModeHint} />
           {!isRunning && <FlowTUI flow={flow} />}
@@ -2379,16 +2400,16 @@ function SettingsFlowModal({ flow }: { flow: SettingsFlowState }) {
 
 function getWorkspacesPanelHint(selectedItem: TreeItem | null | undefined): string {
   if (selectedItem?.type === 'session') {
-    return '[Tab] Switch  [Enter] Attach  [x] Kill  [n] New Workspace  [d] Delete  [,] Settings  [?] Help  [q] Quit';
+    return '[Tab] Switch  [Enter] Attach  [x] Kill  [b] Bundle  [n] New Workspace  [d] Delete  [,] Settings  [?] Help  [q] Quit';
   }
   if (selectedItem?.type === 'process') {
     if (selectedItem.status === 'running') {
       return '[Tab] Switch  [Enter] View  [x] Stop  [,] Settings  [?] Help  [q] Quit';
     }
-    return '[Tab] Switch  [Enter] Start  [,] Settings  [?] Help  [q] Quit';
+    return '[Tab] Switch  [Enter] Start  [b] Bundle  [,] Settings  [?] Help  [q] Quit';
   }
   if (selectedItem?.type === 'workspace') {
-    return '[Tab] Switch  [Enter] Expand  [n] New Workspace  [d] Delete  [,] Settings  [?] Help  [q] Quit';
+    return '[Tab] Switch  [Enter] Expand  [b] Bundle  [n] New Workspace  [d] Delete  [,] Settings  [?] Help  [q] Quit';
   }
   if (selectedItem?.type === 'process-disabled') {
     return '[Tab] Switch  [Enter] Disabled  [,] Settings  [?] Help  [q] Quit';
@@ -2397,15 +2418,18 @@ function getWorkspacesPanelHint(selectedItem: TreeItem | null | undefined): stri
     return '[Tab] Switch  [Enter] Fix Process Config  [,] Settings  [?] Help  [q] Quit';
   }
   if (selectedItem?.type === 'edit-processes') {
-    return '[Tab] Switch  [Enter] Edit Processes Config  [,] Settings  [?] Help  [q] Quit';
+    return '[Tab] Switch  [Enter] Edit Processes Config  [b] Bundle  [,] Settings  [?] Help  [q] Quit';
+  }
+  if (selectedItem?.type === 'bundle-config') {
+    return '[Tab] Switch  [Enter] Edit Bundle Config  [b] Bundle  [,] Settings  [?] Help  [q] Quit';
   }
   if (selectedItem?.type === 'events') {
-    return '[Tab] Switch  [Enter] Open Events  [,] Settings  [?] Help  [q] Quit';
+    return '[Tab] Switch  [Enter] Open Events  [b] Bundle  [,] Settings  [?] Help  [q] Quit';
   }
   if (selectedItem?.type === 'new-session') {
-    return '[Tab] Switch  [Enter] New Session  [,] Settings  [?] Help  [q] Quit';
+    return '[Tab] Switch  [Enter] New Session  [b] Bundle  [,] Settings  [?] Help  [q] Quit';
   }
-  return '[Tab] Switch  [Enter] Open  [n] New Workspace  [,] Settings  [?] Help  [q] Quit';
+  return '[Tab] Switch  [Enter] Open  [b] Bundle  [n] New Workspace  [,] Settings  [?] Help  [q] Quit';
 }
 
 // ============================================================================

--- a/src/app.tui.tsx
+++ b/src/app.tui.tsx
@@ -439,7 +439,7 @@ function App({ relayConfig, onQuit, keyboardMode }: AppProps) {
       dispatch({ type: 'SET_VIEW', view: 'terminal' });
     },
     onAttachCancelled: ({ target }) => {
-      if (target === 'workspace') {
+      if (target === 'workspace' && state.view === 'scripts') {
         return;
       }
       dispatch({ type: 'SET_VIEW', view: 'projects' });

--- a/src/app.web.tsx
+++ b/src/app.web.tsx
@@ -147,32 +147,28 @@ export default function App() {
     onError: (error) => console.error('Flow error:', error),
   });
 
+  const resolveWebWorkspaceProjectName = useCallback((workspaceId: string) => {
+    const index = workspaceId.indexOf(':');
+    if (index > 0) {
+      return workspaceId.slice(0, index);
+    }
+    return terminal.selectedProjectName;
+  }, [terminal.selectedProjectName]);
+
   const bundleRefreshAttach = useBundleRefreshAttachFlow({
     flow,
     commandError: terminal.commandError,
     attachSession: (params) => terminal.attachSession(params),
     getBundleRefreshPlan: terminal.getBundleRefreshPlan,
     applyBundleRefresh: terminal.applyBundleRefresh,
-    resolveProjectName: (workspaceId) => {
-      const index = workspaceId.indexOf(':');
-      if (index > 0) {
-        return workspaceId.slice(0, index);
-      }
-      return terminal.selectedProjectName;
-    },
+    resolveProjectName: resolveWebWorkspaceProjectName,
   });
 
   const bundleConfigFlow = useBundleConfigFlow({
     flow,
     getBundleConfigState: terminal.getBundleConfigState,
     applyBundleConfigUpdate: terminal.applyBundleConfigUpdate,
-    resolveProjectName: (workspaceId) => {
-      const index = workspaceId.indexOf(':');
-      if (index > 0) {
-        return workspaceId.slice(0, index);
-      }
-      return terminal.selectedProjectName;
-    },
+    resolveProjectName: resolveWebWorkspaceProjectName,
     onApplied: async () => {
       terminal.requestWorkspaces();
       terminal.requestSessions();
@@ -188,13 +184,7 @@ export default function App() {
     attachSessionWithBundleRefresh: bundleRefreshAttach.attachSessionWithBundleRefresh,
     defaultProjectName: terminal.selectedProjectName,
     getAttachSize: getWebAttachSize,
-    resolveProjectName: (workspaceId) => {
-      const index = workspaceId.indexOf(':');
-      if (index > 0) {
-        return workspaceId.slice(0, index);
-      }
-      return terminal.selectedProjectName;
-    },
+    resolveProjectName: resolveWebWorkspaceProjectName,
     onBeforeAttach: ({ target, params }) => {
       if (target === 'session') {
         setShowScriptTerminal(false);

--- a/src/app.web.tsx
+++ b/src/app.web.tsx
@@ -16,6 +16,7 @@ import { Toaster, toast } from "./lib/sonner.web";
 import { applyDeviceClasses, isMobileLayout, isTouchDevice } from "./utils/device.web";
 import { useUserActivity } from "./hooks/index.js";
 import { useBundleRefreshAttachFlow } from './session/useBundleRefreshAttachFlow.js';
+import { useBundleConfigFlow } from './session/useBundleConfigFlow.js';
 import { useAttachController } from './app/session/useAttachController.js';
 import { useProcessActions } from './app/session/useProcessActions.js';
 import { useWorkspaceDeleteFlow } from './app/session/useWorkspaceDeleteFlow.js';
@@ -158,6 +159,23 @@ export default function App() {
         return workspaceId.slice(0, index);
       }
       return terminal.selectedProjectName;
+    },
+  });
+
+  const bundleConfigFlow = useBundleConfigFlow({
+    flow,
+    getBundleConfigState: terminal.getBundleConfigState,
+    applyBundleConfigUpdate: terminal.applyBundleConfigUpdate,
+    resolveProjectName: (workspaceId) => {
+      const index = workspaceId.indexOf(':');
+      if (index > 0) {
+        return workspaceId.slice(0, index);
+      }
+      return terminal.selectedProjectName;
+    },
+    onApplied: async () => {
+      terminal.requestWorkspaces();
+      terminal.requestSessions();
     },
   });
 
@@ -574,6 +592,12 @@ export default function App() {
     toast.error(`Process "${params.processName}" is disabled in ${workspaceLabel} (instances: 0).`);
   }, [terminal.workspaces]);
 
+  const handleManageBundleConfig = useCallback(async ({ workspaceId }: { workspaceId: string }) => {
+    const workspace = terminal.workspaces.find((item) => item.id === workspaceId);
+    const projectName = workspace?.projectName ?? terminal.selectedProjectName;
+    await bundleConfigFlow.openBundleConfig({ workspaceId, projectName });
+  }, [bundleConfigFlow, terminal.selectedProjectName, terminal.workspaces]);
+
   // Spaces browser hook
   const spacesBrowserProps = useSpacesBrowser({
     workspaces: terminal.workspaces,
@@ -581,6 +605,7 @@ export default function App() {
     onRequestSessions: () => terminal.requestSessions(),
     onAttachSession: handleAttachSession,
     onEditProcesses: handleEditProcesses,
+    onManageBundleConfig: handleManageBundleConfig,
     onStartProcess: (params) => processActions.handleStartProcess(params),
     onStartProcessAttach: (params) => processActions.handleStartProcessAttach(params),
     onStopProcess: (params) => processActions.handleStopProcess(params),
@@ -905,6 +930,16 @@ export default function App() {
         spacesBrowserProps.activateSelected();
       } else if (command === 'new') {
         lifecycleController.openCreateMenu(selectedProjectName);
+      } else if (command === 'bundle') {
+        const selected = spacesBrowserProps.selectedItem;
+        const workspaceId = selected?.type === 'workspace'
+          ? selected.workspace.id
+          : selected && 'workspaceId' in selected
+            ? selected.workspaceId
+            : null;
+        if (workspaceId) {
+          void handleManageBundleConfig({ workspaceId });
+        }
       } else if (command === 'refresh') {
         spacesBrowserProps.refresh();
       } else if (command === 'back') {
@@ -976,6 +1011,7 @@ export default function App() {
     selectedProjectName,
     flow,
     lifecycleController,
+    handleManageBundleConfig,
     deleteWorkspaceWithPrompt,
   ]);
 

--- a/src/app/input/__tests__/sessionCommands.test.ts
+++ b/src/app/input/__tests__/sessionCommands.test.ts
@@ -36,5 +36,6 @@ describe('sessionCommands', () => {
     expect(resolveSessionBrowserCommand({ key: 'x' })).toBe('kill')
     expect(resolveSessionBrowserCommand({ key: 'd' })).toBe('delete')
     expect(resolveSessionBrowserCommand({ key: 'i' })).toBe('open-inbox')
+    expect(resolveSessionBrowserCommand({ key: 'b' })).toBe('bundle')
   })
 })

--- a/src/app/input/sessionCommands.ts
+++ b/src/app/input/sessionCommands.ts
@@ -18,6 +18,7 @@ export type SessionUiCommand =
   | 'attach'
   | 'kill'
   | 'open-inbox'
+  | 'bundle'
   | 'copy'
 
 function normalizeCommandKey(input: SessionCommandKeyInput): string | null {
@@ -90,5 +91,6 @@ export function resolveSessionBrowserCommand(input: SessionCommandKeyInput): Ses
   if (key === 'x') return 'kill'
   if (key === 'd') return 'delete'
   if (key === 'i') return 'open-inbox'
+  if (key === 'b') return 'bundle'
   return null
 }

--- a/src/app/session/__tests__/useLifecycleController.test.ts
+++ b/src/app/session/__tests__/useLifecycleController.test.ts
@@ -22,6 +22,7 @@ afterAll(() => {
 type SelectCall<T> = {
   title: string
   onSelect: (value: T) => void | Promise<void>
+  searchable?: boolean
 }
 
 type InputCall = {
@@ -55,6 +56,7 @@ describe('useLifecycleController project flow', () => {
             showSelectCalls.push({
               title: opts.title,
               onSelect: opts.onSelect as (value: 'manual' | 'github') => void | Promise<void>,
+              searchable: opts.searchable,
             })
           },
           showInput: (opts) => {
@@ -118,6 +120,7 @@ describe('useLifecycleController project flow', () => {
             showSelectCalls.push({
               title: opts.title,
               onSelect: opts.onSelect as (value: string) => void | Promise<void>,
+              searchable: opts.searchable,
             })
           },
           showInput: (opts) => {
@@ -175,6 +178,7 @@ describe('useLifecycleController project flow', () => {
             showSelectCalls.push({
               title: opts.title,
               onSelect: opts.onSelect as (value: string) => void | Promise<void>,
+              searchable: opts.searchable,
             })
           },
           showInput: (opts) => {
@@ -203,5 +207,114 @@ describe('useLifecycleController project flow', () => {
     expect(showMessage).toHaveBeenCalledTimes(1)
     expect(showInputCalls.length).toBe(1)
     expect(showInputCalls[0]?.title).toBe('Repository Remote')
+  })
+})
+
+describe('useLifecycleController workspace source flow', () => {
+  function makeIssue(id: string, identifier: string, title: string) {
+    return {
+      id,
+      identifier,
+      title,
+      description: null,
+      url: `https://linear.app/acme/issue/${identifier}`,
+      assigneeName: null,
+      stateName: 'Backlog',
+      createdAt: new Date(0).toISOString(),
+      updatedAt: new Date(0).toISOString(),
+      attachments: [],
+    }
+  }
+
+  it('opens searchable branch picker for workspace creation', async () => {
+    const showSelectCalls: Array<SelectCall<string>> = []
+    const showLoading = mock(() => {})
+    const close = mock(() => {})
+
+    const { result } = renderHook(() =>
+      useLifecycleController({
+        flow: {
+          showLoading,
+          showSelect: (opts) => {
+            showSelectCalls.push({
+              title: opts.title,
+              onSelect: opts.onSelect as (value: string) => void | Promise<void>,
+              searchable: opts.searchable,
+            })
+          },
+          showInput: () => {},
+          showConfirmTyped: () => {},
+          showMessage: () => {},
+          close,
+        },
+        listGithubRepos: async () => [],
+        listRemoteBranches: async () => ['feature/search-modal', 'fix/dialog-overflow'],
+        listLinearIssues: async () => [makeIssue('1', 'ACME-1', 'Issue one')],
+        createProject: async () => {},
+        createWorkspace: async () => {},
+        deleteProject: async () => {},
+        getProjectNames: () => ['acme'],
+        refreshProjects: async () => {},
+        refreshWorkspaces: async () => {},
+      })
+    )
+
+    result.current.openCreateWorkspaceFlow('acme')
+    expect(showSelectCalls[0]?.title).toBe('Create Workspace From')
+
+    await showSelectCalls[0]!.onSelect('branch')
+    await flushMicrotasks()
+
+    const branchPicker = showSelectCalls.find((call) => call.title === 'Select Branch')
+    expect(branchPicker).toBeDefined()
+    expect(branchPicker?.searchable).toBe(true)
+    expect(showLoading).toHaveBeenCalledTimes(1)
+    expect(close).toHaveBeenCalledTimes(1)
+  })
+
+  it('opens searchable linear picker for workspace creation', async () => {
+    const showSelectCalls: Array<SelectCall<string>> = []
+    const showLoading = mock(() => {})
+    const close = mock(() => {})
+
+    const { result } = renderHook(() =>
+      useLifecycleController({
+        flow: {
+          showLoading,
+          showSelect: (opts) => {
+            showSelectCalls.push({
+              title: opts.title,
+              onSelect: opts.onSelect as (value: string) => void | Promise<void>,
+              searchable: opts.searchable,
+            })
+          },
+          showInput: () => {},
+          showConfirmTyped: () => {},
+          showMessage: () => {},
+          close,
+        },
+        listGithubRepos: async () => [],
+        listRemoteBranches: async () => ['main'],
+        listLinearIssues: async () => [makeIssue('2', 'ACME-2', 'Search and overflow fix')],
+        createProject: async () => {},
+        createWorkspace: async () => {},
+        deleteProject: async () => {},
+        getProjectNames: () => ['acme'],
+        refreshProjects: async () => {},
+        refreshWorkspaces: async () => {},
+      })
+    )
+
+    result.current.openCreateWorkspaceFlow('acme')
+    expect(showSelectCalls[0]?.title).toBe('Create Workspace From')
+
+    await showSelectCalls[0]!.onSelect('linear')
+    await flushMicrotasks()
+
+    const linearPicker = showSelectCalls.find((call) => call.title === 'Select Linear Issue')
+    expect(linearPicker).toBeDefined()
+    expect(linearPicker?.searchable).toBe(true)
+    expect(showLoading).toHaveBeenCalledTimes(1)
+    expect(close).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/app/session/useLifecycleController.ts
+++ b/src/app/session/useLifecycleController.ts
@@ -377,6 +377,7 @@ export function useLifecycleController(
 
         flow.showSelect({
           title: 'Select Branch',
+          searchable: true,
           options: branches.map((branch) => ({ label: branch, value: branch })),
           onSelect: async (branch) => {
             const workspaceName = sanitizeForFileSystem(branch);
@@ -433,6 +434,7 @@ export function useLifecycleController(
 
         flow.showSelect({
           title: 'Select Linear Issue',
+          searchable: true,
           options: issues.map((issue) => ({
             label: buildLinearIssueLabel(issue),
             value: issue,

--- a/src/cli/commands/space.ts
+++ b/src/cli/commands/space.ts
@@ -257,4 +257,48 @@ function registerSpaceBundleCommands(space: Command): void {
         workspace: ctx.workspace,
       });
     }));
+
+  bundle
+    .command('show')
+    .description('Show current bundle values, secret set-status, and confirm status')
+    .action(withErrorHandler(async () => {
+      const ctx = requireSessionContext();
+      const { bundleShow } = await import('../../commands/bundle.js');
+      await bundleShow({
+        project: ctx.project,
+        workspace: ctx.workspace,
+      });
+    }));
+
+  bundle
+    .command('edit')
+    .description('Update bundle inputs, secrets, and confirm states')
+    .option('--input <key=value>', 'Set a non-secret input value (repeatable)', (value: string, previous: string[] = []) => {
+      previous.push(value);
+      return previous;
+    })
+    .option('--secret <key>', 'Prompt for a secret key value (repeatable)', (value: string, previous: string[] = []) => {
+      previous.push(value);
+      return previous;
+    })
+    .option('--secret-unset <key>', 'Unset a secret key value (repeatable)', (value: string, previous: string[] = []) => {
+      previous.push(value);
+      return previous;
+    })
+    .option('--confirm <id=status>', 'Set confirm status to passed|skipped (repeatable)', (value: string, previous: string[] = []) => {
+      previous.push(value);
+      return previous;
+    })
+    .action(withErrorHandler(async (options) => {
+      const ctx = requireSessionContext();
+      const { bundleEdit } = await import('../../commands/bundle.js');
+      await bundleEdit({
+        project: ctx.project,
+        workspace: ctx.workspace,
+        input: options.input,
+        secret: options.secret,
+        secretUnset: options.secretUnset,
+        confirm: options.confirm,
+      });
+    }));
 }

--- a/src/cli/commands/workspace.ts
+++ b/src/cli/commands/workspace.ts
@@ -136,7 +136,7 @@ export function registerWorkspaceCommands(parent: Command): void {
   registerWorkspaceEventsCommands(cmd);
 
   // --------------------------------------------------------------------------
-  // Bundle subcommands: gssh workspace bundle [refresh|status]
+  // Bundle subcommands: gssh workspace bundle [refresh|status|show|edit]
   // --------------------------------------------------------------------------
   registerWorkspaceBundleCommands(cmd);
 }
@@ -461,6 +461,62 @@ function registerWorkspaceBundleCommands(workspace: Command): void {
       await bundleStatus({
         project: ctx.project,
         workspace: ctx.workspace,
+      });
+    }));
+
+  // gssh workspace bundle show --project <p> --workspace <w>
+  requireProjectAndWorkspace(
+    bundle
+      .command('show')
+      .description('Show current bundle values, secret set-status, and confirm status')
+  )
+    .action(withErrorHandler(async (options) => {
+      const ctx = useExplicitContext(options);
+      const { bundleShow } = await import('../../commands/bundle.js');
+      if (!ctx.workspace) {
+        throw new SpacesError('--workspace is required for bundle show', 'USER_ERROR', 1);
+      }
+      await bundleShow({
+        project: ctx.project,
+        workspace: ctx.workspace,
+      });
+    }));
+
+  // gssh workspace bundle edit --project <p> --workspace <w>
+  requireProjectAndWorkspace(
+    bundle
+      .command('edit')
+      .description('Update bundle inputs, secrets, and confirm states')
+  )
+    .option('--input <key=value>', 'Set a non-secret input value (repeatable)', (value: string, previous: string[] = []) => {
+      previous.push(value);
+      return previous;
+    })
+    .option('--secret <key>', 'Prompt for a secret key value (repeatable)', (value: string, previous: string[] = []) => {
+      previous.push(value);
+      return previous;
+    })
+    .option('--secret-unset <key>', 'Unset a secret key value (repeatable)', (value: string, previous: string[] = []) => {
+      previous.push(value);
+      return previous;
+    })
+    .option('--confirm <id=status>', 'Set confirm status to passed|skipped (repeatable)', (value: string, previous: string[] = []) => {
+      previous.push(value);
+      return previous;
+    })
+    .action(withErrorHandler(async (options) => {
+      const ctx = useExplicitContext(options);
+      const { bundleEdit } = await import('../../commands/bundle.js');
+      if (!ctx.workspace) {
+        throw new SpacesError('--workspace is required for bundle edit', 'USER_ERROR', 1);
+      }
+      await bundleEdit({
+        project: ctx.project,
+        workspace: ctx.workspace,
+        input: options.input,
+        secret: options.secret,
+        secretUnset: options.secretUnset,
+        confirm: options.confirm,
       });
     }));
 }

--- a/src/commands/bundle.ts
+++ b/src/commands/bundle.ts
@@ -8,13 +8,17 @@ import { logger } from '../utils/logger.js';
 import { SpacesError } from '../types/errors.js';
 import { getProjectWorkspacesDir } from '../core/config.js';
 import {
+  applyBundleConfigSubmission,
   detectBundleChanges,
   formatBundleChangeDetails,
+  getBundleConfigState,
   refreshBundle,
   type BundleRefreshOptions,
 } from '../core/bundle-refresh.js';
 import { join } from 'path';
 import { existsSync } from 'fs';
+import type { BundleConfigSubmission } from '../types/bundle-config.js';
+import { promptPassword } from '../utils/prompts.js';
 
 /**
  * Options for bundle refresh command
@@ -38,6 +42,45 @@ export interface BundleStatusOptions {
   workspace: string;
 }
 
+export interface BundleShowOptions {
+  project: string;
+  workspace: string;
+}
+
+export interface BundleEditOptions {
+  project: string;
+  workspace: string;
+  input?: string[];
+  secret?: string[];
+  secretUnset?: string[];
+  confirm?: string[];
+}
+
+function resolveWorkspacePath(projectName: string, workspaceName: string): string {
+  const workspacePath = join(getProjectWorkspacesDir(projectName), workspaceName);
+  if (!existsSync(workspacePath)) {
+    throw new SpacesError(
+      `Workspace not found: ${workspacePath}`,
+      'USER_ERROR',
+      1,
+    );
+  }
+  return workspacePath;
+}
+
+function parseKeyValue(raw: string, label: string): { key: string; value: string } {
+  const index = raw.indexOf('=');
+  if (index <= 0) {
+    throw new SpacesError(`Invalid ${label} value: "${raw}" (expected key=value)`, 'USER_ERROR', 1);
+  }
+  const key = raw.slice(0, index).trim();
+  const value = raw.slice(index + 1);
+  if (!key) {
+    throw new SpacesError(`Invalid ${label} key in "${raw}"`, 'USER_ERROR', 1);
+  }
+  return { key, value };
+}
+
 /**
  * Refresh bundle onboarding for a project
  *
@@ -56,14 +99,7 @@ export async function bundleRefresh(options: BundleRefreshCommandOptions): Promi
     );
   }
 
-  const workspacePath = join(getProjectWorkspacesDir(projectName), workspaceName);
-  if (!existsSync(workspacePath)) {
-    throw new SpacesError(
-      `Workspace not found: ${workspacePath}`,
-      'USER_ERROR',
-      1,
-    );
-  }
+  const workspacePath = resolveWorkspacePath(projectName, workspaceName);
 
   logger.info(`Checking bundle for workspace: ${projectName}/${workspaceName}`);
   logger.dim(`Workspace path: ${workspacePath}`);
@@ -117,14 +153,7 @@ export async function bundleStatus(options: BundleStatusOptions): Promise<void> 
     );
   }
 
-  const workspacePath = join(getProjectWorkspacesDir(projectName), workspaceName);
-  if (!existsSync(workspacePath)) {
-    throw new SpacesError(
-      `Workspace not found: ${workspacePath}`,
-      'USER_ERROR',
-      1,
-    );
-  }
+  const workspacePath = resolveWorkspacePath(projectName, workspaceName);
 
   const changes = detectBundleChanges(projectName, workspacePath, {
     allowBaseFallback: false,
@@ -165,5 +194,173 @@ export async function bundleStatus(options: BundleStatusOptions): Promise<void> 
     logger.log('Run "gssh workspace bundle refresh --project <name> --workspace <name>" to update configuration');
   } else {
     logger.success('Bundle is up to date');
+  }
+}
+
+export async function bundleShow(options: BundleShowOptions): Promise<void> {
+  const projectName = options.project;
+  const workspaceName = options.workspace;
+
+  if (!projectName || !workspaceName) {
+    throw new SpacesError(
+      'Project and workspace are required. Use `--project <name> --workspace <name>`.',
+      'USER_ERROR',
+      1
+    );
+  }
+
+  const workspacePath = resolveWorkspacePath(projectName, workspaceName);
+  const state = await getBundleConfigState(projectName, workspacePath, `${projectName}:${workspaceName}`);
+
+  logger.bold(`\nBundle Config: ${projectName}/${workspaceName}\n`);
+
+  if (!state.hasBundle) {
+    logger.log('No bundle found for this workspace');
+    logger.dim('Bundles are defined in .gitspace/bundle.json');
+    return;
+  }
+
+  logger.log(`Bundle: ${state.bundleName ?? '(unnamed)'}`);
+  logger.log(`Version: ${state.bundleVersion ?? '1.0'}`);
+  logger.log(`Path: ${state.workspacePath}`);
+  logger.log(`Source: ${state.bundleSource === 'workspace' ? 'workspace .gitspace/bundle.json' : 'base .gitspace/bundle.json'}`);
+  logger.log('');
+
+  const steps = state.steps;
+  if (steps.length === 0) {
+    logger.dim('No onboarding steps defined in bundle.json');
+    return;
+  }
+
+  logger.log('Steps:');
+  for (const step of steps) {
+    if (step.type === 'input') {
+      const value = step.value ?? '';
+      logger.log(`  - [input] ${step.configKey}: ${value.length > 0 ? value : '(unset)'}`);
+      continue;
+    }
+
+    if (step.type === 'secret') {
+      logger.log(`  - [secret] ${step.configKey}: ${step.hasSecret ? 'set' : 'unset'}`);
+      continue;
+    }
+
+    if (step.type === 'confirm') {
+      const status = step.confirmResult?.status ?? 'pending';
+      const checked = step.confirmCheckedAt ? ` @ ${step.confirmCheckedAt}` : '';
+      logger.log(`  - [confirm] ${step.id}: ${status}${checked}`);
+      continue;
+    }
+
+    logger.log(`  - [info] ${step.id}: ${step.title}`);
+  }
+}
+
+export async function bundleEdit(options: BundleEditOptions): Promise<void> {
+  const projectName = options.project;
+  const workspaceName = options.workspace;
+
+  if (!projectName || !workspaceName) {
+    throw new SpacesError(
+      'Project and workspace are required. Use `--project <name> --workspace <name>`.',
+      'USER_ERROR',
+      1
+    );
+  }
+
+  const workspacePath = resolveWorkspacePath(projectName, workspaceName);
+  const state = await getBundleConfigState(projectName, workspacePath, `${projectName}:${workspaceName}`);
+  if (!state.hasBundle) {
+    throw new SpacesError('No bundle found for this workspace', 'USER_ERROR', 1);
+  }
+
+  const inputKeys = new Set(
+    state.steps.filter((step) => step.type === 'input' && step.configKey).map((step) => step.configKey as string)
+  );
+  const secretKeys = new Set(
+    state.steps.filter((step) => step.type === 'secret' && step.configKey).map((step) => step.configKey as string)
+  );
+  const confirmIds = new Set(state.steps.filter((step) => step.type === 'confirm').map((step) => step.id));
+
+  const inputValues: Record<string, string> = {};
+  for (const pair of options.input ?? []) {
+    const parsed = parseKeyValue(pair, '--input');
+    if (!inputKeys.has(parsed.key)) {
+      throw new SpacesError(`Input key not found in bundle: ${parsed.key}`, 'USER_ERROR', 1);
+    }
+    inputValues[parsed.key] = parsed.value;
+  }
+
+  const secretValues: Record<string, string> = {};
+  for (const keyRaw of options.secret ?? []) {
+    const key = keyRaw.trim();
+    if (!secretKeys.has(key)) {
+      throw new SpacesError(`Secret key not found in bundle: ${key}`, 'USER_ERROR', 1);
+    }
+    const value = await promptPassword(`Enter value for secret ${key}`);
+    if (value === null || value.length === 0) {
+      throw new SpacesError(`Secret entry cancelled for ${key}`, 'USER_ERROR', 1);
+    }
+    secretValues[key] = value;
+  }
+
+  const unsetSecretKeys = new Set<string>();
+  for (const keyRaw of options.secretUnset ?? []) {
+    const key = keyRaw.trim();
+    if (!secretKeys.has(key)) {
+      throw new SpacesError(`Secret key not found in bundle: ${key}`, 'USER_ERROR', 1);
+    }
+    if (secretValues[key]) {
+      throw new SpacesError(`Conflicting secret update for ${key}: cannot set and unset in same command`, 'USER_ERROR', 1);
+    }
+    unsetSecretKeys.add(key);
+    secretValues[key] = '';
+  }
+
+  const confirmResults: NonNullable<BundleConfigSubmission['confirmResults']> = {};
+  for (const pair of options.confirm ?? []) {
+    const parsed = parseKeyValue(pair, '--confirm');
+    if (!confirmIds.has(parsed.key)) {
+      throw new SpacesError(`Confirm step not found in bundle: ${parsed.key}`, 'USER_ERROR', 1);
+    }
+
+    if (parsed.value !== 'passed' && parsed.value !== 'skipped') {
+      throw new SpacesError(`Invalid confirm status for ${parsed.key}: ${parsed.value}`, 'USER_ERROR', 1);
+    }
+
+    confirmResults[parsed.key] = {
+      status: parsed.value,
+    };
+  }
+
+  if (
+    Object.keys(inputValues).length === 0 &&
+    Object.keys(secretValues).length === 0 &&
+    Object.keys(confirmResults).length === 0
+  ) {
+    throw new SpacesError('No updates provided. Use --input, --secret, or --confirm.', 'USER_ERROR', 1);
+  }
+
+  await applyBundleConfigSubmission(projectName, workspacePath, {
+    inputValues,
+    secretValues,
+    confirmResults,
+  });
+
+  logger.success('Bundle configuration updated');
+  if (Object.keys(inputValues).length > 0) {
+    logger.log(`- inputs: ${Object.keys(inputValues).join(', ')}`);
+  }
+  if (Object.keys(secretValues).length > 0) {
+    const secretSetKeys = Object.keys(secretValues).filter((key) => !unsetSecretKeys.has(key));
+    if (secretSetKeys.length > 0) {
+      logger.log(`- secrets set: ${secretSetKeys.join(', ')}`);
+    }
+    if (unsetSecretKeys.size > 0) {
+      logger.log(`- secrets unset: ${[...unsetSecretKeys].join(', ')}`);
+    }
+  }
+  if (Object.keys(confirmResults).length > 0) {
+    logger.log(`- confirms: ${Object.keys(confirmResults).join(', ')}`);
   }
 }

--- a/src/components/Flow.tsx
+++ b/src/components/Flow.tsx
@@ -494,6 +494,7 @@ export function getDefaultShortcuts(): FlowHelp['shortcuts'] {
     { key: '↑/↓ or j/k', description: 'Navigate list' },
     { key: 'Tab', description: 'Switch panel' },
     { key: 'n', description: 'New project/workspace' },
+    { key: 'b', description: 'Edit bundle config' },
     { key: 'd', description: 'Delete selected' },
     { key: 'i', description: 'Open inbox' },
     { key: 'r', description: 'Refresh' },

--- a/src/components/Flow.tsx
+++ b/src/components/Flow.tsx
@@ -465,7 +465,7 @@ export function hasInputValue(flow: FlowState): flow is FlowInput | FlowConfirmT
   return flow.type === 'input' || flow.type === 'confirm-typed' || flow.type === 'wizard';
 }
 
-function getVisibleSelectOptions(
+export function getVisibleSelectOptions(
   flow: FlowSelect
 ): Array<{ option: FlowSelect['options'][number]; index: number }> {
   const entries = flow.options.map((option, index) => ({ option, index }));

--- a/src/components/Flow.tsx
+++ b/src/components/Flow.tsx
@@ -80,6 +80,8 @@ export interface FlowSelect<T = unknown> {
   title: string;
   options: Array<{ label: string; description?: string; value: T }>;
   selectedIndex: number;
+  searchable?: boolean;
+  searchQuery?: string;
   onSelect: (value: T, index: number) => void | Promise<void>;
   onCancel?: () => void;
 }
@@ -159,6 +161,7 @@ export interface UseFlowReturn {
   handleCancel: () => void;
   handleInput: (value: string) => void;
   handleSelect: (index: number) => void;
+  updateSelectQuery: (value: string) => void;
   moveUp: () => void;
   moveDown: () => void;
   nextStep: () => void;
@@ -216,7 +219,7 @@ export function useFlow(props: UseFlowProps = {}): UseFlowReturn {
 
   // Show select
   const showSelect = useCallback(<T,>(opts: Omit<FlowSelect<T>, 'type' | 'selectedIndex'>) => {
-    setFlow({ type: 'select', ...opts, selectedIndex: 0 } as FlowSelect);
+    setFlow({ type: 'select', ...opts, selectedIndex: 0, searchQuery: '' } as FlowSelect);
   }, []);
 
   // Show wizard
@@ -255,9 +258,10 @@ export function useFlow(props: UseFlowProps = {}): UseFlowReturn {
         await flow.onSubmit(flow.inputValue);
         closeIfUnchanged();
       } else if (flow.type === 'select') {
-        const option = flow.options[flow.selectedIndex];
-        if (option) {
-          await flow.onSelect(option.value, flow.selectedIndex);
+        const visibleOptions = getVisibleSelectOptions(flow);
+        const entry = visibleOptions[flow.selectedIndex];
+        if (entry) {
+          await flow.onSelect(entry.option.value, entry.index);
           closeIfUnchanged();
         }
       } else if (flow.type === 'wizard') {
@@ -327,14 +331,33 @@ export function useFlow(props: UseFlowProps = {}): UseFlowReturn {
   // Handle selection change
   const handleSelect = useCallback((index: number) => {
     if (flow.type === 'select') {
-      const clampedIndex = Math.max(0, Math.min(index, flow.options.length - 1));
+      const visibleCount = getVisibleSelectOptions(flow).length;
+      const clampedIndex = visibleCount === 0
+        ? 0
+        : Math.max(0, Math.min(index, visibleCount - 1));
       setFlow({ ...flow, selectedIndex: clampedIndex });
     }
+  }, [flow]);
+
+  const updateSelectQuery = useCallback((value: string) => {
+    if (flow.type !== 'select' || !flow.searchable) {
+      return;
+    }
+
+    setFlow({
+      ...flow,
+      searchQuery: value,
+      selectedIndex: 0,
+    });
   }, [flow]);
 
   // Move selection up
   const moveUp = useCallback(() => {
     if (flow.type === 'select') {
+      const visibleCount = getVisibleSelectOptions(flow).length;
+      if (visibleCount === 0) {
+        return;
+      }
       setFlow({ ...flow, selectedIndex: Math.max(0, flow.selectedIndex - 1) });
     }
   }, [flow]);
@@ -342,7 +365,11 @@ export function useFlow(props: UseFlowProps = {}): UseFlowReturn {
   // Move selection down
   const moveDown = useCallback(() => {
     if (flow.type === 'select') {
-      setFlow({ ...flow, selectedIndex: Math.min(flow.options.length - 1, flow.selectedIndex + 1) });
+      const visibleCount = getVisibleSelectOptions(flow).length;
+      if (visibleCount === 0) {
+        return;
+      }
+      setFlow({ ...flow, selectedIndex: Math.min(visibleCount - 1, flow.selectedIndex + 1) });
     }
   }, [flow]);
 
@@ -397,6 +424,7 @@ export function useFlow(props: UseFlowProps = {}): UseFlowReturn {
     handleCancel,
     handleInput,
     handleSelect,
+    updateSelectQuery,
     moveUp,
     moveDown,
     nextStep,
@@ -435,6 +463,23 @@ export function isFlowWizard(flow: FlowState): flow is FlowWizard {
  */
 export function hasInputValue(flow: FlowState): flow is FlowInput | FlowConfirmTyped | FlowWizard {
   return flow.type === 'input' || flow.type === 'confirm-typed' || flow.type === 'wizard';
+}
+
+function getVisibleSelectOptions(
+  flow: FlowSelect
+): Array<{ option: FlowSelect['options'][number]; index: number }> {
+  const entries = flow.options.map((option, index) => ({ option, index }));
+  const query = flow.searchable ? flow.searchQuery?.trim().toLowerCase() : '';
+
+  if (!query) {
+    return entries;
+  }
+
+  return entries.filter(({ option }) => {
+    const label = option.label.toLowerCase();
+    const description = option.description?.toLowerCase() ?? '';
+    return label.includes(query) || description.includes(query);
+  });
 }
 
 // ============================================================================

--- a/src/components/Flow.tui.tsx
+++ b/src/components/Flow.tui.tsx
@@ -9,7 +9,11 @@ import { useKeyboard } from '@opentui/react';
 import type { ScrollBoxRenderable } from '@opentui/core';
 import { toast } from '@opentui-ui/toast';
 import { copyToClipboard } from '../utils/clipboard.js';
-import type { UseFlowReturn, FlowSelect, FlowState } from './Flow.js';
+import {
+  getVisibleSelectOptions,
+  type UseFlowReturn,
+  type FlowState,
+} from './Flow.js';
 
 // ============================================================================
 // Colors
@@ -203,7 +207,9 @@ function renderModal(state: FlowState, flow: UseFlowReturn) {
       {
         const maxWidth = getModalMaxWidth();
         const preferredWidth = state.searchable ? 96 : 72;
-        const modalWidth = Math.max(56, Math.min(maxWidth, preferredWidth));
+        const desiredMinWidth = state.searchable ? 56 : 48;
+        const safeMinWidth = Math.min(desiredMinWidth, maxWidth);
+        const modalWidth = Math.max(safeMinWidth, Math.min(maxWidth, preferredWidth));
         const filteredOptions = getVisibleSelectOptions(state);
         const selectedIndex = filteredOptions.length === 0
           ? 0
@@ -521,24 +527,7 @@ function getModalMaxWidth(): number {
   }
 
   const terminalColumns = columns > 0 ? columns : 80;
-  return Math.max(56, terminalColumns - 4);
-}
-
-function getVisibleSelectOptions(
-  state: FlowSelect
-): Array<{ option: FlowSelect['options'][number]; index: number }> {
-  const entries = state.options.map((option, index) => ({ option, index }));
-  const query = state.searchable ? state.searchQuery?.trim().toLowerCase() : '';
-
-  if (!query) {
-    return entries;
-  }
-
-  return entries.filter(({ option }) => {
-    const label = option.label.toLowerCase();
-    const description = option.description?.toLowerCase() ?? '';
-    return label.includes(query) || description.includes(query);
-  });
+  return Math.max(1, terminalColumns - 4);
 }
 
 function getOptionWindowStart(

--- a/src/components/Flow.tui.tsx
+++ b/src/components/Flow.tui.tsx
@@ -221,9 +221,10 @@ function renderModal(state: FlowState, flow: UseFlowReturn) {
         const modalHeight = Math.min(maxHeight, chromeHeight + (visibleCount * 3));
         const windowStart = getOptionWindowStart(selectedIndex, visibleCount, filteredOptions.length);
         const visibleOptions = filteredOptions.slice(windowStart, windowStart + visibleCount);
-        const maxLabelWidth = Math.max(10, modalWidth - 8);
-        const maxDescriptionWidth = Math.max(8, modalWidth - 10);
-        const searchLineWidth = Math.max(8, modalWidth - 6);
+        const maxContentWidth = Math.max(1, modalWidth - 6);
+        const maxLabelWidth = Math.max(1, Math.min(maxContentWidth, modalWidth - 8));
+        const maxDescriptionWidth = Math.max(1, Math.min(maxContentWidth, modalWidth - 10));
+        const searchLineWidth = maxContentWidth;
         const searchQuery = state.searchQuery ?? '';
         const searchDisplay = fitInputText(searchQuery, searchLineWidth);
 

--- a/src/components/Flow.tui.tsx
+++ b/src/components/Flow.tui.tsx
@@ -260,10 +260,18 @@ function renderModal(state: FlowState, flow: UseFlowReturn) {
                 visibleOptions.map((entry, offset) => {
                   const visibleIndex = windowStart + offset;
                   const isSelected = visibleIndex === selectedIndex;
-                  const labelPrefix = isSelected ? '▶ ' : '  ';
-                  const label = truncateLine(entry.option.label, maxLabelWidth - labelPrefix.length);
+                  const baseLabelPrefix = isSelected ? '▶ ' : '  ';
+                  const labelPrefix = baseLabelPrefix.slice(0, Math.max(0, maxLabelWidth));
+                  const label = truncateLine(
+                    entry.option.label,
+                    Math.max(0, maxLabelWidth - labelPrefix.length)
+                  );
+                  const descriptionIndent = '    '.slice(0, Math.max(0, maxDescriptionWidth));
                   const description = entry.option.description
-                    ? truncateLine(entry.option.description, maxDescriptionWidth)
+                    ? truncateLine(
+                        entry.option.description,
+                        Math.max(0, maxDescriptionWidth - descriptionIndent.length)
+                      )
                     : null;
 
                   return (
@@ -272,7 +280,7 @@ function renderModal(state: FlowState, flow: UseFlowReturn) {
                         {labelPrefix}{label}
                       </text>
                       <text fg={COLORS.textDim} height={1}>
-                        {description ? `    ${description}` : ' '}
+                        {description ? `${descriptionIndent}${description}` : ' '}
                       </text>
                       <text fg={COLORS.textDim} height={1}> </text>
                     </box>

--- a/src/components/Flow.tui.tsx
+++ b/src/components/Flow.tui.tsx
@@ -9,7 +9,7 @@ import { useKeyboard } from '@opentui/react';
 import type { ScrollBoxRenderable } from '@opentui/core';
 import { toast } from '@opentui-ui/toast';
 import { copyToClipboard } from '../utils/clipboard.js';
-import type { UseFlowReturn, FlowState } from './Flow.js';
+import type { UseFlowReturn, FlowSelect, FlowState } from './Flow.js';
 
 // ============================================================================
 // Colors
@@ -200,30 +200,84 @@ function renderModal(state: FlowState, flow: UseFlowReturn) {
       );
 
     case 'select':
-      return (
-        <Modal title={state.title} width={60} height={state.options.length + 8}>
-          <box flexDirection="column" flexGrow={1} overflow="scroll">
-            {state.options.map((option, idx) => {
-              const isSelected = idx === state.selectedIndex;
-              return (
-                <box key={idx} flexDirection="column" marginBottom={1}>
-                  <text fg={isSelected ? COLORS.selected : COLORS.text} height={1}>
-                    {isSelected ? '▶ ' : '  '}{option.label}
-                  </text>
-                  {option.description && (
-                    <text fg={COLORS.textDim} height={1} paddingLeft={4}>
-                      {option.description}
-                    </text>
-                  )}
+      {
+        const maxWidth = getModalMaxWidth();
+        const preferredWidth = state.searchable ? 96 : 72;
+        const modalWidth = Math.max(56, Math.min(maxWidth, preferredWidth));
+        const filteredOptions = getVisibleSelectOptions(state);
+        const selectedIndex = filteredOptions.length === 0
+          ? 0
+          : Math.max(0, Math.min(state.selectedIndex, filteredOptions.length - 1));
+        const maxHeight = getModalMaxHeight();
+        const chromeHeight = state.searchable ? 11 : 8;
+        const maxVisibleOptions = Math.max(1, Math.floor((maxHeight - chromeHeight) / 3));
+        const visibleCount = Math.max(1, Math.min(filteredOptions.length || 1, maxVisibleOptions));
+        const modalHeight = Math.min(maxHeight, chromeHeight + (visibleCount * 3));
+        const windowStart = getOptionWindowStart(selectedIndex, visibleCount, filteredOptions.length);
+        const visibleOptions = filteredOptions.slice(windowStart, windowStart + visibleCount);
+        const maxLabelWidth = Math.max(10, modalWidth - 8);
+        const maxDescriptionWidth = Math.max(8, modalWidth - 10);
+        const searchLineWidth = Math.max(8, modalWidth - 6);
+        const searchQuery = state.searchQuery ?? '';
+        const searchDisplay = fitInputText(searchQuery, searchLineWidth);
+
+        return (
+          <Modal title={state.title} width={modalWidth} height={modalHeight}>
+            {state.searchable && (
+              <>
+                <text fg={COLORS.textDim} marginBottom={1}>Search</text>
+                <box
+                  border
+                  borderStyle="single"
+                  borderColor={COLORS.inputBorder}
+                  paddingLeft={1}
+                  paddingRight={1}
+                  marginBottom={1}
+                >
+                  <text fg={COLORS.text}>{searchDisplay || ' '}</text>
                 </box>
-              );
-            })}
-          </box>
-          <text fg={COLORS.textDim} height={1} marginTop={1}>
-            [↑↓] Navigate  [Enter] Select  [Esc] Cancel
-          </text>
-        </Modal>
-      );
+              </>
+            )}
+
+            <box flexDirection="column" flexGrow={1} overflow="hidden">
+              {filteredOptions.length === 0 ? (
+                <>
+                  <text fg={COLORS.warning}>No matches for "{fitInputText(searchQuery, maxLabelWidth - 2)}"</text>
+                  <text fg={COLORS.textDim} marginTop={1}>Try a different search query.</text>
+                </>
+              ) : (
+                visibleOptions.map((entry, offset) => {
+                  const visibleIndex = windowStart + offset;
+                  const isSelected = visibleIndex === selectedIndex;
+                  const labelPrefix = isSelected ? '▶ ' : '  ';
+                  const label = truncateLine(entry.option.label, maxLabelWidth - labelPrefix.length);
+                  const description = entry.option.description
+                    ? truncateLine(entry.option.description, maxDescriptionWidth)
+                    : null;
+
+                  return (
+                    <box key={entry.index} flexDirection="column">
+                      <text fg={isSelected ? COLORS.selected : COLORS.text} height={1}>
+                        {labelPrefix}{label}
+                      </text>
+                      <text fg={COLORS.textDim} height={1}>
+                        {description ? `    ${description}` : ' '}
+                      </text>
+                      <text fg={COLORS.textDim} height={1}> </text>
+                    </box>
+                  );
+                })
+              )}
+            </box>
+
+            <text fg={COLORS.textDim} height={1} marginTop={1}>
+              {state.searchable
+                ? '[Type] Search  [Backspace] Delete  [↑/↓] Navigate  [Enter] Select  [Esc] Cancel'
+                : '[↑/↓ or j/k] Navigate  [Enter] Select  [Esc] Cancel'}
+            </text>
+          </Modal>
+        );
+      }
 
     case 'wizard':
       const step = state.steps[state.currentStep];
@@ -455,4 +509,81 @@ function getModalMaxHeight(): number {
 
   const terminalRows = rows > 0 ? rows : 24;
   return Math.max(8, terminalRows - 4);
+}
+
+function getModalMaxWidth(): number {
+  let columns = process.stdout.columns || 0;
+  if (columns <= 0) {
+    const size = (process.stdout as { getWindowSize?: () => number[] }).getWindowSize?.();
+    if (Array.isArray(size) && size.length >= 1) {
+      columns = size[0];
+    }
+  }
+
+  const terminalColumns = columns > 0 ? columns : 80;
+  return Math.max(56, terminalColumns - 4);
+}
+
+function getVisibleSelectOptions(
+  state: FlowSelect
+): Array<{ option: FlowSelect['options'][number]; index: number }> {
+  const entries = state.options.map((option, index) => ({ option, index }));
+  const query = state.searchable ? state.searchQuery?.trim().toLowerCase() : '';
+
+  if (!query) {
+    return entries;
+  }
+
+  return entries.filter(({ option }) => {
+    const label = option.label.toLowerCase();
+    const description = option.description?.toLowerCase() ?? '';
+    return label.includes(query) || description.includes(query);
+  });
+}
+
+function getOptionWindowStart(
+  selectedIndex: number,
+  visibleCount: number,
+  totalCount: number
+): number {
+  if (totalCount <= visibleCount) {
+    return 0;
+  }
+
+  const maxStart = Math.max(0, totalCount - visibleCount);
+  const centeredStart = selectedIndex - Math.floor(visibleCount / 2);
+  return Math.max(0, Math.min(centeredStart, maxStart));
+}
+
+function truncateLine(text: string, maxLength: number): string {
+  const normalized = text.replace(/\s+/g, ' ').trim();
+  if (maxLength <= 0) {
+    return '';
+  }
+
+  if (normalized.length <= maxLength) {
+    return normalized;
+  }
+
+  if (maxLength <= 3) {
+    return normalized.slice(0, maxLength);
+  }
+
+  return `${normalized.slice(0, maxLength - 3)}...`;
+}
+
+function fitInputText(text: string, maxLength: number): string {
+  if (maxLength <= 0) {
+    return '';
+  }
+
+  if (text.length <= maxLength) {
+    return text;
+  }
+
+  if (maxLength <= 3) {
+    return text.slice(-maxLength);
+  }
+
+  return `...${text.slice(-(maxLength - 3))}`;
 }

--- a/src/components/Flow.tui.tsx
+++ b/src/components/Flow.tui.tsx
@@ -249,8 +249,12 @@ function renderModal(state: FlowState, flow: UseFlowReturn) {
             <box flexDirection="column" flexGrow={1} overflow="hidden">
               {filteredOptions.length === 0 ? (
                 <>
-                  <text fg={COLORS.warning}>No matches for "{fitInputText(searchQuery, maxLabelWidth - 2)}"</text>
-                  <text fg={COLORS.textDim} marginTop={1}>Try a different search query.</text>
+                  <text fg={COLORS.warning}>
+                    {truncateLine(`No matches for "${searchQuery}"`, maxContentWidth) || 'No matches'}
+                  </text>
+                  <text fg={COLORS.textDim} marginTop={1}>
+                    {truncateLine('Try a different search query.', maxContentWidth) || 'Try another query.'}
+                  </text>
                 </>
               ) : (
                 visibleOptions.map((entry, offset) => {

--- a/src/components/RemoteMachineScreen.tui.tsx
+++ b/src/components/RemoteMachineScreen.tui.tsx
@@ -486,6 +486,13 @@ export function RemoteMachineScreen({ machine, relayUrl, identity, onBack }: Rem
         const current = 'inputValue' in flow.flow ? flow.flow.inputValue || '' : '';
         flow.handleInput(current + text);
         event.preventDefault();
+        return;
+      }
+
+      if (flow.flow.type === 'select' && flow.flow.searchable) {
+        const currentQuery = flow.flow.searchQuery ?? '';
+        flow.updateSelectQuery(currentQuery + text);
+        event.preventDefault();
       }
     };
 
@@ -532,6 +539,29 @@ export function RemoteMachineScreen({ machine, relayUrl, identity, onBack }: Rem
           }
           const current = 'inputValue' in flow.flow ? flow.flow.inputValue || '' : '';
           flow.handleInput(current + chunk);
+        }
+        return;
+      }
+
+      if (flow.flow.type === 'select' && flow.flow.searchable) {
+        if (key.name === 'escape') {
+          flow.handleCancel();
+        } else if (key.name === 'return') {
+          await flow.handleConfirm();
+        } else if (key.name === 'up' || key.raw === 'k') {
+          flow.moveUp();
+        } else if (key.name === 'down' || key.raw === 'j') {
+          flow.moveDown();
+        } else if (key.name === 'backspace') {
+          const current = flow.flow.searchQuery ?? '';
+          flow.updateSelectQuery(current.slice(0, -1));
+        } else {
+          const chunk = getKeyboardInputChunk(key);
+          if (!chunk) {
+            return;
+          }
+          const current = flow.flow.searchQuery ?? '';
+          flow.updateSelectQuery(current + chunk);
         }
         return;
       }

--- a/src/components/RemoteMachineScreen.tui.tsx
+++ b/src/components/RemoteMachineScreen.tui.tsx
@@ -104,32 +104,29 @@ export function RemoteMachineScreen({ machine, relayUrl, identity, onBack }: Rem
       cancelled = true;
     };
   }, [flow, identity]);
+
+  const resolveRemoteWorkspaceProjectName = useCallback((workspaceId: string) => {
+    const separator = workspaceId.indexOf(':');
+    if (separator > 0) {
+      return workspaceId.slice(0, separator);
+    }
+    return remote.selectedProjectName;
+  }, [remote.selectedProjectName]);
+
   const bundleRefreshAttach = useBundleRefreshAttachFlow({
     flow,
     commandError: remote.commandError ?? null,
     attachSession: (params) => remote.attachSession(params),
     getBundleRefreshPlan: remote.getBundleRefreshPlan,
     applyBundleRefresh: remote.applyBundleRefresh,
-    resolveProjectName: (workspaceId) => {
-      const separator = workspaceId.indexOf(':');
-      if (separator > 0) {
-        return workspaceId.slice(0, separator);
-      }
-      return remote.selectedProjectName;
-    },
+    resolveProjectName: resolveRemoteWorkspaceProjectName,
   });
 
   const bundleConfigFlow = useBundleConfigFlow({
     flow,
     getBundleConfigState: remote.getBundleConfigState,
     applyBundleConfigUpdate: remote.applyBundleConfigUpdate,
-    resolveProjectName: (workspaceId) => {
-      const separator = workspaceId.indexOf(':');
-      if (separator > 0) {
-        return workspaceId.slice(0, separator);
-      }
-      return remote.selectedProjectName;
-    },
+    resolveProjectName: resolveRemoteWorkspaceProjectName,
     onApplied: async () => {
       remote.requestWorkspaces();
       remote.requestSessions();
@@ -140,13 +137,7 @@ export function RemoteMachineScreen({ machine, relayUrl, identity, onBack }: Rem
     flow,
     attachSessionWithBundleRefresh: bundleRefreshAttach.attachSessionWithBundleRefresh,
     defaultProjectName: remote.selectedProjectName,
-    resolveProjectName: (workspaceId) => {
-      const separator = workspaceId.indexOf(':');
-      if (separator > 0) {
-        return workspaceId.slice(0, separator);
-      }
-      return remote.selectedProjectName;
-    },
+    resolveProjectName: resolveRemoteWorkspaceProjectName,
     onBeforeAttach: ({ target, params }) => {
       if (target === 'workspace' && params.workspaceId && !params.command) {
         lastScriptWorkspaceIdRef.current = params.workspaceId;

--- a/src/components/RemoteMachineScreen.tui.tsx
+++ b/src/components/RemoteMachineScreen.tui.tsx
@@ -17,6 +17,7 @@ import {
 import { FlowTUI } from './Flow.tui.js';
 import { useRemoteTerminal } from '../hooks/useRemoteTerminal.tui.js';
 import { useBundleRefreshAttachFlow } from '../session/index.js';
+import { useBundleConfigFlow } from '../session/index.js';
 import { useAttachController } from '../app/session/useAttachController.js';
 import { useProcessActions } from '../app/session/useProcessActions.js';
 import {
@@ -24,7 +25,7 @@ import {
   resolveSessionBrowserCommand,
 } from '../app/input/sessionCommands.js';
 import { SessionTerminal } from './SessionTerminal.tui.js';
-import { ScriptTerminal, type ScriptTerminalHandle } from './ScriptTerminal.tui.js';
+import { ScriptTerminal } from './ScriptTerminal.tui.js';
 import { getKeyboardInputChunk, normalizeInputText } from '../tui/input-text.js';
 import {
   applySearchableSelectPaste,
@@ -69,7 +70,6 @@ export function RemoteMachineScreen({ machine, relayUrl, identity, onBack }: Rem
   const [pendingProcessEditWorkspaceId, setPendingProcessEditWorkspaceId] = useState<string | null>(null);
   const pendingProcessEditWorkspacesRef = useRef<unknown[] | null>(null);
   const pendingProcessEditValidationArmedRef = useRef(false);
-  const scriptTerminalRef = useRef<ScriptTerminalHandle | null>(null);
   const lastScriptWorkspaceIdRef = useRef<string | null>(null);
   const flow = useFlow({
     onError: (error) => {
@@ -116,6 +116,23 @@ export function RemoteMachineScreen({ machine, relayUrl, identity, onBack }: Rem
         return workspaceId.slice(0, separator);
       }
       return remote.selectedProjectName;
+    },
+  });
+
+  const bundleConfigFlow = useBundleConfigFlow({
+    flow,
+    getBundleConfigState: remote.getBundleConfigState,
+    applyBundleConfigUpdate: remote.applyBundleConfigUpdate,
+    resolveProjectName: (workspaceId) => {
+      const separator = workspaceId.indexOf(':');
+      if (separator > 0) {
+        return workspaceId.slice(0, separator);
+      }
+      return remote.selectedProjectName;
+    },
+    onApplied: async () => {
+      remote.requestWorkspaces();
+      remote.requestSessions();
     },
   });
 
@@ -198,20 +215,6 @@ export function RemoteMachineScreen({ machine, relayUrl, identity, onBack }: Rem
     refreshWorkspaces: () => remote.requestWorkspaces(),
     refreshSessions: () => remote.requestSessions(),
   });
-
-  useEffect(() => {
-    if (!showScriptTerminal || remote.mode !== 'browsing') {
-      return;
-    }
-
-    remote.setWriteCallback((data) => {
-      scriptTerminalRef.current?.feed(data);
-    });
-
-    return () => {
-      remote.setWriteCallback(null);
-    };
-  }, [remote.mode, remote.setWriteCallback, showScriptTerminal]);
 
   useEffect(() => {
     if (!deviceCertificate) {
@@ -412,12 +415,19 @@ export function RemoteMachineScreen({ machine, relayUrl, identity, onBack }: Rem
     });
   }, [attachController, remote.workspaces]);
 
+  const handleManageBundleConfig = useCallback(async ({ workspaceId }: { workspaceId: string }) => {
+    const workspace = remote.workspaces.find((item) => item.id === workspaceId);
+    const projectName = workspace?.projectName ?? remote.selectedProjectName;
+    await bundleConfigFlow.openBundleConfig({ workspaceId, projectName });
+  }, [bundleConfigFlow, remote.selectedProjectName, remote.workspaces]);
+
   const spacesBrowserProps = useSpacesBrowser({
     workspaces: remote.workspaces,
     sessions: remote.sessions,
     onRequestSessions: () => remote.requestSessions(),
     onAttachSession: handleAttachSession,
     onEditProcesses: handleEditProcesses,
+    onManageBundleConfig: handleManageBundleConfig,
     onStartProcess: handleStartProcess,
     onStartProcessAttach: handleStartProcessAttach,
     onStopProcess: handleStopProcess,
@@ -668,6 +678,16 @@ export function RemoteMachineScreen({ machine, relayUrl, identity, onBack }: Rem
       spacesBrowserProps.activateSelected();
     } else if (browseCommand === 'new') {
       lifecycleController.openCreateMenu(selectedProjectName);
+    } else if (browseCommand === 'bundle') {
+      const selected = spacesBrowserProps.selectedItem;
+      const workspaceId = selected?.type === 'workspace'
+        ? selected.workspace.id
+        : selected && 'workspaceId' in selected
+          ? selected.workspaceId
+          : null;
+      if (workspaceId) {
+        await handleManageBundleConfig({ workspaceId });
+      }
     } else if (browseCommand === 'refresh') {
       spacesBrowserProps.refresh();
     } else if (browseCommand === 'open-inbox') {
@@ -755,25 +775,27 @@ export function RemoteMachineScreen({ machine, relayUrl, identity, onBack }: Rem
 
   if (showScriptTerminal && remote.status === 'established' && remote.mode === 'browsing') {
     const isRunning = remote.scriptState?.isRunning ?? true;
+    const scriptHint = isRunning
+      ? '[Running scripts... c: cancel + attach anyway]'
+      : remote.scriptState?.error
+        ? '[←/→ or [/] Phase  [↑/↓ PgUp/PgDn] Scroll  [a] Attach anyway  [Esc/n] Back'
+        : '[←/→ or [/] Phase  [↑/↓ PgUp/PgDn] Scroll  [Esc/n] Back';
+
     return (
       <Fragment>
-        <ScriptTerminal
-          ref={scriptTerminalRef}
-          phase={remote.scriptState?.phase ?? 'remove'}
-          workspaceName={scriptWorkspaceName}
-          isRunning={isRunning}
-          error={remote.scriptState?.error}
-          exitCode={remote.scriptState?.exitCode}
-          modalOpen={flow.isOpen}
-        />
-        {!isRunning && <FlowTUI flow={flow} />}
-        <StatusBar
-          hint={isRunning
-            ? '[Running scripts... c: cancel + attach anyway]'
-            : remote.scriptState?.error
-              ? '[←/→ or [/] Phase  [↑/↓ PgUp/PgDn] Scroll  [a] Attach anyway  [Esc/n] Back'
-              : '[←/→ or [/] Phase  [↑/↓ PgUp/PgDn] Scroll  [Esc/n] Back'}
-        />
+        <box flexDirection="column" flexGrow={1} width="100%" height="100%">
+          <ScriptTerminal
+            phase={remote.scriptState?.phase ?? 'remove'}
+            workspaceName={scriptWorkspaceName}
+            isRunning={isRunning}
+            error={remote.scriptState?.error}
+            exitCode={remote.scriptState?.exitCode}
+            modalOpen={flow.isOpen}
+            setWriteCallback={remote.setWriteCallback}
+          />
+          <StatusBar hint={scriptHint} />
+          {!isRunning && <FlowTUI flow={flow} />}
+        </box>
       </Fragment>
     );
   }
@@ -806,7 +828,7 @@ export function RemoteMachineScreen({ machine, relayUrl, identity, onBack }: Rem
       </box>
       <SpacesBrowserTUI {...spacesBrowserProps} focused={true} />
       <FlowTUI flow={flow} />
-      <StatusBar hint="[↑↓] Navigate  [Enter] Open/Join  [n] Create  [x] Kill  [d] Delete  [i] Inbox  [Esc] Back" />
+      <StatusBar hint="[↑↓] Navigate  [Enter] Open/Join  [n] Create  [b] Bundle  [x] Kill  [d] Delete  [i] Inbox  [Esc] Back" />
     </box>
   );
 }

--- a/src/components/RemoteMachineScreen.tui.tsx
+++ b/src/components/RemoteMachineScreen.tui.tsx
@@ -26,6 +26,10 @@ import {
 import { SessionTerminal } from './SessionTerminal.tui.js';
 import { ScriptTerminal, type ScriptTerminalHandle } from './ScriptTerminal.tui.js';
 import { getKeyboardInputChunk, normalizeInputText } from '../tui/input-text.js';
+import {
+  applySearchableSelectPaste,
+  handleSearchableSelectKey,
+} from '../tui/flow-select-input.js';
 import { useWorkspaceDeleteFlow } from '../app/session/useWorkspaceDeleteFlow.js';
 import { useLifecycleController } from '../app/session/useLifecycleController.js';
 import { buildEditProcessesCommand } from '../lib/processes/editor.js';
@@ -466,11 +470,18 @@ export function RemoteMachineScreen({ machine, relayUrl, identity, onBack }: Rem
 
   useEffect(() => {
     const handlePaste = (event: PasteEvent) => {
+      const rawText = event.text ?? '';
+
+      if (flow.isOpen && applySearchableSelectPaste(flow, rawText)) {
+        event.preventDefault();
+        return;
+      }
+
       if (!flow.isOpen) {
         return;
       }
 
-      const text = normalizeInputText(event.text ?? '');
+      const text = normalizeInputText(rawText);
       if (!text) {
         return;
       }
@@ -489,11 +500,6 @@ export function RemoteMachineScreen({ machine, relayUrl, identity, onBack }: Rem
         return;
       }
 
-      if (flow.flow.type === 'select' && flow.flow.searchable) {
-        const currentQuery = flow.flow.searchQuery ?? '';
-        flow.updateSelectQuery(currentQuery + text);
-        event.preventDefault();
-      }
     };
 
     renderer.keyInput.on('paste', handlePaste);
@@ -543,26 +549,7 @@ export function RemoteMachineScreen({ machine, relayUrl, identity, onBack }: Rem
         return;
       }
 
-      if (flow.flow.type === 'select' && flow.flow.searchable) {
-        if (key.name === 'escape') {
-          flow.handleCancel();
-        } else if (key.name === 'return') {
-          await flow.handleConfirm();
-        } else if (key.name === 'up') {
-          flow.moveUp();
-        } else if (key.name === 'down') {
-          flow.moveDown();
-        } else if (key.name === 'backspace') {
-          const current = flow.flow.searchQuery ?? '';
-          flow.updateSelectQuery(current.slice(0, -1));
-        } else {
-          const chunk = getKeyboardInputChunk(key);
-          if (!chunk) {
-            return;
-          }
-          const current = flow.flow.searchQuery ?? '';
-          flow.updateSelectQuery(current + chunk);
-        }
+      if (await handleSearchableSelectKey(flow, key)) {
         return;
       }
 

--- a/src/components/RemoteMachineScreen.tui.tsx
+++ b/src/components/RemoteMachineScreen.tui.tsx
@@ -548,9 +548,9 @@ export function RemoteMachineScreen({ machine, relayUrl, identity, onBack }: Rem
           flow.handleCancel();
         } else if (key.name === 'return') {
           await flow.handleConfirm();
-        } else if (key.name === 'up' || key.raw === 'k') {
+        } else if (key.name === 'up') {
           flow.moveUp();
-        } else if (key.name === 'down' || key.raw === 'j') {
+        } else if (key.name === 'down') {
           flow.moveDown();
         } else if (key.name === 'backspace') {
           const current = flow.flow.searchQuery ?? '';

--- a/src/components/ScriptTerminal.tui.tsx
+++ b/src/components/ScriptTerminal.tui.tsx
@@ -114,6 +114,24 @@ function getPhaseMarker(status: PhaseStatus): string {
   }
 }
 
+const PHASE_BANNER_REGEX = /==>\s*(pre|setup|select|remove)\s+scripts\.\.\./gi;
+const PHASE_BANNER_SCAN_LIMIT = 256;
+
+function findLatestPhaseBanner(text: string): ScriptPhase | null {
+  let latest: ScriptPhase | null = null;
+  PHASE_BANNER_REGEX.lastIndex = 0;
+
+  let match: RegExpExecArray | null;
+  while ((match = PHASE_BANNER_REGEX.exec(text)) !== null) {
+    const phase = match[1];
+    if (phase === 'pre' || phase === 'setup' || phase === 'select' || phase === 'remove') {
+      latest = phase;
+    }
+  }
+
+  return latest;
+}
+
 export function ScriptTerminal({
   phase,
   workspaceName,
@@ -123,283 +141,328 @@ export function ScriptTerminal({
   modalOpen = false,
   setWriteCallback,
 }: ScriptTerminalProps) {
-    const renderer = useRenderer();
+  const renderer = useRenderer();
 
-    const [phaseEntries, setPhaseEntries] = useState<PhaseTerminalState[]>(() => [
-      createPhaseEntry(phase, isRunning, error, exitCode),
-    ]);
-    const phaseEntriesRef = useRef<PhaseTerminalState[]>(phaseEntries);
-    const previousPhaseRef = useRef<ScriptPhase>(phase);
-    const [activePhaseIndex, setActivePhaseIndex] = useState(0);
-    const scrollBoxRef = useRef<ScrollBoxRenderable | null>(null);
+  const [phaseEntries, setPhaseEntries] = useState<PhaseTerminalState[]>(() => [
+    createPhaseEntry(phase, isRunning, error, exitCode),
+  ]);
+  const phaseEntriesRef = useRef<PhaseTerminalState[]>(phaseEntries);
+  const phaseBannerCarryRef = useRef('');
+  const previousPhaseRef = useRef<ScriptPhase>(phase);
+  const previousRunningRef = useRef<boolean>(isRunning);
+  const [activePhaseIndex, setActivePhaseIndex] = useState(0);
+  const scrollBoxRef = useRef<ScrollBoxRenderable | null>(null);
 
-    const activeEntry = phaseEntries[activePhaseIndex] ?? phaseEntries[phaseEntries.length - 1];
-    const activeError = activeEntry?.status === 'failed' ? activeEntry.error : undefined;
-    const showWaitingOutput = isRunning && !!activeEntry && activeEntry.outputChunks.length === 0;
+  const latestPhaseIndex = Math.max(0, phaseEntries.length - 1);
+  const displayPhaseIndex = isRunning ? latestPhaseIndex : activePhaseIndex;
+  const activeEntry = phaseEntries[displayPhaseIndex] ?? phaseEntries[latestPhaseIndex];
+  const activeError = activeEntry?.status === 'failed' ? activeEntry.error : undefined;
+  const showWaitingOutput = isRunning && !!activeEntry && activeEntry.outputChunks.length === 0;
 
-    const showErrorBanner = !!activeError && !isRunning;
-    const reservedRows = 3 + (showErrorBanner ? 1 : 0) + (showWaitingOutput ? 1 : 0);
-    const [termSize, setTermSize] = useState(() => getTerminalSize(reservedRows));
+  const showErrorBanner = !!activeError && !isRunning;
+  const reservedRows = 3 + (showErrorBanner ? 1 : 0) + (showWaitingOutput ? 1 : 0);
+  const [termSize, setTermSize] = useState(() => getTerminalSize(reservedRows));
 
-    useEffect(() => {
-      phaseEntriesRef.current = phaseEntries;
-    }, [phaseEntries]);
+  useEffect(() => {
+    phaseEntriesRef.current = phaseEntries;
+  }, [phaseEntries]);
 
-    useEffect(() => {
-      const onResize = () => {
-        setTermSize(getTerminalSize(reservedRows));
-      };
+  useEffect(() => {
+    const onResize = () => {
       setTermSize(getTerminalSize(reservedRows));
-      process.on('SIGWINCH', onResize);
-      return () => {
-        process.removeListener('SIGWINCH', onResize);
-      };
-    }, [reservedRows]);
+    };
+    setTermSize(getTerminalSize(reservedRows));
+    process.on('SIGWINCH', onResize);
+    return () => {
+      process.removeListener('SIGWINCH', onResize);
+    };
+  }, [reservedRows]);
 
-    useEffect(() => {
-      const switchedPhase = previousPhaseRef.current !== phase;
-      previousPhaseRef.current = phase;
+  useEffect(() => {
+    const switchedPhase = previousPhaseRef.current !== phase;
+    previousPhaseRef.current = phase;
 
-      setPhaseEntries((prev) => {
-        if (prev.length === 0) {
-          return [createPhaseEntry(phase, isRunning, error, exitCode)];
-        }
+    setPhaseEntries((prev) => {
+      if (prev.length === 0) {
+        return [createPhaseEntry(phase, isRunning, error, exitCode)];
+      }
 
-        const last = prev[prev.length - 1];
-        if (last.phase === phase) {
-          const next = [...prev];
-          next[next.length - 1] = {
-            ...last,
-            status: toPhaseStatus(isRunning, error),
-            error,
-            exitCode,
-          };
-          return next;
-        }
-
+      const last = prev[prev.length - 1];
+      if (last.phase === phase) {
         const next = [...prev];
-        if (next.length > 0 && next[next.length - 1]?.status === 'running') {
-          next[next.length - 1] = {
-            ...next[next.length - 1],
+        next[next.length - 1] = {
+          ...last,
+          status: toPhaseStatus(isRunning, error),
+          error,
+          exitCode,
+        };
+        return next;
+      }
+
+      const next = [...prev];
+      if (next.length > 0 && next[next.length - 1]?.status === 'running') {
+        next[next.length - 1] = {
+          ...next[next.length - 1],
+          status: 'complete',
+        };
+      }
+      next.push(createPhaseEntry(phase, isRunning, error, exitCode));
+      return next;
+    });
+
+    if (switchedPhase) {
+      setActivePhaseIndex(Math.max(0, phaseEntriesRef.current.length - 1));
+    }
+  }, [phase, isRunning, error, exitCode]);
+
+  useEffect(() => {
+    const transitionedToStopped = previousRunningRef.current && !isRunning;
+    previousRunningRef.current = isRunning;
+    if (transitionedToStopped) {
+      setActivePhaseIndex(Math.max(0, phaseEntriesRef.current.length - 1));
+    }
+  }, [isRunning]);
+
+  useEffect(() => {
+    setActivePhaseIndex((current) => {
+      const maxIndex = phaseEntries.length - 1;
+      if (maxIndex < 0) {
+        return 0;
+      }
+      if (current > maxIndex) {
+        return maxIndex;
+      }
+      if (current < 0) {
+        return 0;
+      }
+      return current;
+    });
+  }, [phaseEntries.length]);
+
+  useEffect(() => {
+    const entries = phaseEntriesRef.current;
+    for (let index = 0; index < entries.length; index += 1) {
+      if (index !== displayPhaseIndex) {
+        entries[index]!.target = null;
+      }
+    }
+  }, [displayPhaseIndex, phaseEntries.length]);
+
+  const handleMouseUp = useCallback(async () => {
+    const text = renderer.getSelection()?.getSelectedText();
+    if (!text || text.length === 0) {
+      return;
+    }
+
+    try {
+      await copyToClipboard(text);
+      toast.success('Copied to clipboard');
+    } catch {
+      toast.error('Failed to copy to clipboard');
+    }
+
+    renderer.clearSelection();
+  }, [renderer]);
+
+  useKeyboard((key) => {
+    if (modalOpen) {
+      return;
+    }
+
+    if (!isRunning && (key.name === 'left' || key.raw === '[')) {
+      setActivePhaseIndex((current) => Math.max(0, current - 1));
+      return;
+    }
+
+    if (!isRunning && (key.name === 'right' || key.raw === ']')) {
+      setActivePhaseIndex((current) => Math.min(phaseEntriesRef.current.length - 1, current + 1));
+      return;
+    }
+
+    const scrollBox = scrollBoxRef.current;
+    if (!scrollBox) {
+      return;
+    }
+
+    if (key.name === 'up' || key.raw === 'k') {
+      scrollBox.scrollBy(-1);
+      return;
+    }
+
+    if (key.name === 'down' || key.raw === 'j') {
+      scrollBox.scrollBy(1);
+      return;
+    }
+
+    if (
+      key.name === 'pageup' &&
+      shouldConsumePageNavigationInScrollbox({
+        direction: 'up',
+        scrollTop: scrollBox.scrollTop,
+        scrollHeight: scrollBox.scrollHeight,
+        viewportHeight: scrollBox.viewport.height,
+      })
+    ) {
+      scrollBox.scrollBy(-1, 'viewport');
+      return;
+    }
+
+    if (
+      key.name === 'pagedown' &&
+      shouldConsumePageNavigationInScrollbox({
+        direction: 'down',
+        scrollTop: scrollBox.scrollTop,
+        scrollHeight: scrollBox.scrollHeight,
+        viewportHeight: scrollBox.viewport.height,
+      })
+    ) {
+      scrollBox.scrollBy(1, 'viewport');
+    }
+  });
+
+  const feed = useCallback((data: Uint8Array) => {
+    const entries = phaseEntriesRef.current;
+    if (entries.length === 0) {
+      return;
+    }
+
+    const chunk = Buffer.from(data);
+    const scanWindow = `${phaseBannerCarryRef.current}${chunk.toString('utf-8')}`;
+    phaseBannerCarryRef.current = scanWindow.slice(-PHASE_BANNER_SCAN_LIMIT);
+
+    const streamPhase = findLatestPhaseBanner(scanWindow);
+    if (streamPhase) {
+      const currentEntries = phaseEntriesRef.current;
+      const lastEntry = currentEntries[currentEntries.length - 1];
+
+      if (!lastEntry || lastEntry.phase !== streamPhase) {
+        const nextEntries = [...currentEntries];
+        const currentLast = nextEntries[nextEntries.length - 1];
+        if (currentLast?.status === 'running') {
+          nextEntries[nextEntries.length - 1] = {
+            ...currentLast,
             status: 'complete',
           };
         }
-        next.push(createPhaseEntry(phase, isRunning, error, exitCode));
-        return next;
-      });
 
-      if (switchedPhase) {
-        setActivePhaseIndex(phaseEntriesRef.current.length);
+        const createdEntry = createPhaseEntry(streamPhase, true);
+        nextEntries.push(createdEntry);
+        phaseEntriesRef.current = nextEntries;
+        setPhaseEntries(nextEntries);
+        setActivePhaseIndex(nextEntries.length - 1);
       }
-    }, [phase, isRunning, error, exitCode]);
+    }
 
-    useEffect(() => {
-      setActivePhaseIndex((current) => {
-        const maxIndex = phaseEntries.length - 1;
-        if (maxIndex < 0) {
-          return 0;
-        }
-        if (current > maxIndex) {
-          return maxIndex;
-        }
-        if (current < 0) {
-          return 0;
-        }
-        return current;
-      });
-    }, [phaseEntries.length]);
+    const current = phaseEntriesRef.current[phaseEntriesRef.current.length - 1];
+    if (!current) {
+      return;
+    }
 
-    const handleMouseUp = useCallback(async () => {
-      const text = renderer.getSelection()?.getSelectedText();
-      if (!text || text.length === 0) {
-        return;
-      }
+    current.outputChunks.push(chunk);
+    current.target?.feed(chunk);
+  }, []);
 
-      try {
-        await copyToClipboard(text);
-        toast.success('Copied to clipboard');
-      } catch {
-        toast.error('Failed to copy to clipboard');
-      }
+  const setActiveTerminalRef = useCallback((el: GhosttyTerminalRenderable | null) => {
+    if (!activeEntry) {
+      return;
+    }
 
-      renderer.clearSelection();
-    }, [renderer]);
+    const justMounted = activeEntry.target === null && el !== null;
+    activeEntry.target = el;
 
-    useKeyboard((key) => {
-      if (modalOpen) {
-        return;
-      }
+    if (!justMounted || !el || activeEntry.outputChunks.length === 0) {
+      return;
+    }
 
-      if (key.name === 'left' || key.raw === '[') {
-        setActivePhaseIndex((current) => Math.max(0, current - 1));
-        return;
-      }
+    el.feed(Buffer.concat(activeEntry.outputChunks));
+  }, [activeEntry]);
 
-      if (key.name === 'right' || key.raw === ']') {
-        setActivePhaseIndex((current) => Math.min(phaseEntriesRef.current.length - 1, current + 1));
-        return;
-      }
+  useEffect(() => {
+    setWriteCallback(feed);
+    return () => {
+      setWriteCallback(null);
+    };
+  }, [feed, setWriteCallback]);
 
-      const scrollBox = scrollBoxRef.current;
-      if (!scrollBox) {
-        return;
-      }
+  const statusText = isRunning
+    ? 'Running...'
+    : error
+      ? `Failed${typeof exitCode === 'number' ? ` (exit ${exitCode})` : ''}`
+      : 'Complete';
 
-      if (key.name === 'up' || key.raw === 'k') {
-        scrollBox.scrollBy(-1);
-        return;
-      }
+  const statusColor = isRunning
+    ? COLORS.runningHint
+    : error
+      ? COLORS.error
+      : COLORS.success;
+  const waitingPhaseName = activeEntry ? PHASE_NAMES[activeEntry.phase] : 'script';
 
-      if (key.name === 'down' || key.raw === 'j') {
-        scrollBox.scrollBy(1);
-        return;
-      }
-
-      if (
-        key.name === 'pageup' &&
-        shouldConsumePageNavigationInScrollbox({
-          direction: 'up',
-          scrollTop: scrollBox.scrollTop,
-          scrollHeight: scrollBox.scrollHeight,
-          viewportHeight: scrollBox.viewport.height,
-        })
-      ) {
-        scrollBox.scrollBy(-1, 'viewport');
-        return;
-      }
-
-      if (
-        key.name === 'pagedown' &&
-        shouldConsumePageNavigationInScrollbox({
-          direction: 'down',
-          scrollTop: scrollBox.scrollTop,
-          scrollHeight: scrollBox.scrollHeight,
-          viewportHeight: scrollBox.viewport.height,
-        })
-      ) {
-        scrollBox.scrollBy(1, 'viewport');
-      }
-    });
-
-    const feed = useCallback((data: Uint8Array) => {
-      const entries = phaseEntriesRef.current;
-      if (entries.length === 0) {
-        return;
-      }
-
-      const chunk = Buffer.from(data);
-      const current = entries[entries.length - 1];
-      if (!current) {
-        return;
-      }
-
-      current.outputChunks.push(chunk);
-      current.target?.feed(chunk);
-    }, []);
-
-    const setActiveTerminalRef = useCallback((el: GhosttyTerminalRenderable | null) => {
-      const entries = phaseEntriesRef.current;
-      const current = entries[activePhaseIndex];
-      if (!current) {
-        return;
-      }
-
-      const justMounted = current.target === null && el !== null;
-      current.target = el;
-
-      if (!justMounted || !el || current.outputChunks.length === 0) {
-        return;
-      }
-
-      el.feed(Buffer.concat(current.outputChunks));
-    }, [activePhaseIndex]);
-
-    useEffect(() => {
-      setWriteCallback(feed);
-      return () => {
-        setWriteCallback(null);
-      };
-    }, [feed, setWriteCallback]);
-
-    const statusText = isRunning
-      ? 'Running...'
-      : error
-        ? `Failed${typeof exitCode === 'number' ? ` (exit ${exitCode})` : ''}`
-        : 'Complete';
-
-    const statusColor = isRunning
-      ? COLORS.runningHint
-      : error
-        ? COLORS.error
-        : COLORS.success;
-    const waitingPhaseName = activeEntry ? PHASE_NAMES[activeEntry.phase] : 'script';
-
-    const stickyToBottom = isRunning && activePhaseIndex === phaseEntries.length - 1;
-    const phaseHint = isRunning
-      ? '[c] Cancel  [mouse] Select+copy'
-      : activeError
-        ? '[[/]] Phase  [↑/↓ PgUp/PgDn] Scroll  [a] Attach anyway  [mouse] Select+copy'
-        : '[[/]] Phase  [↑/↓ PgUp/PgDn] Scroll  [mouse] Select+copy';
-    return (
-      <box flexDirection="column" flexGrow={1}>
-        <box
-          height={1}
-          width="100%"
-          backgroundColor={COLORS.statusBar}
-          flexDirection="row"
-          paddingLeft={1}
-          paddingRight={1}
-        >
-          <box flexGrow={1} flexDirection="row">
-            {phaseEntries.map((entry, index) => {
-              const isActive = index === activePhaseIndex;
-              const color = isActive ? COLORS.phaseActive : COLORS.phase;
-              return (
-                <text key={entry.id} fg={color}>
-                  {index > 0 ? ' ' : ''}[{PHASE_NAMES[entry.phase]}{getPhaseMarker(entry.status)}]
-                </text>
-              );
-            })}
-            <text fg={COLORS.textDim}> - {workspaceName}</text>
-          </box>
-          <text fg={statusColor}>{statusText}</text>
+  const stickyToBottom = isRunning && displayPhaseIndex === latestPhaseIndex;
+  const phaseHint = isRunning
+    ? '[c] Cancel  [mouse] Select+copy'
+    : activeError
+      ? '[[/]] Phase  [↑/↓ PgUp/PgDn] Scroll  [a] Attach anyway  [mouse] Select+copy'
+      : '[[/]] Phase  [↑/↓ PgUp/PgDn] Scroll  [mouse] Select+copy';
+  return (
+    <box flexDirection="column" flexGrow={1}>
+      <box
+        height={1}
+        width="100%"
+        backgroundColor={COLORS.statusBar}
+        flexDirection="row"
+        paddingLeft={1}
+        paddingRight={1}
+      >
+        <box flexGrow={1} flexDirection="row">
+          {phaseEntries.map((entry, index) => {
+            const isActive = index === displayPhaseIndex;
+            const color = isActive ? COLORS.phaseActive : COLORS.phase;
+            return (
+              <text key={entry.id} fg={color}>
+                {index > 0 ? ' ' : ''}[{PHASE_NAMES[entry.phase]}{getPhaseMarker(entry.status)}]
+              </text>
+            );
+          })}
+          <text fg={COLORS.textDim}> - {workspaceName}</text>
         </box>
-
-        <box height={1} width="100%" backgroundColor="#222222" paddingLeft={1}>
-          <text fg={COLORS.textDim}>{phaseHint}</text>
-        </box>
-
-        {showWaitingOutput && (
-          <box height={1} width="100%" backgroundColor="#1a1a1a" paddingLeft={1}>
-            <text fg={COLORS.textDim}>Waiting for {waitingPhaseName} script output...</text>
-          </box>
-        )}
-
-        <scrollbox
-          ref={(el: ScrollBoxRenderable | null) => {
-            scrollBoxRef.current = el;
-          }}
-          flexGrow={1}
-          viewportCulling={true}
-          stickyScroll={stickyToBottom}
-          stickyStart="bottom"
-          onMouseUp={handleMouseUp}
-        >
-          <ghostty-terminal
-            key={activeEntry?.id ?? 'script-terminal-empty'}
-            ref={setActiveTerminalRef}
-            persistent={true}
-            showCursor={false}
-            cols={termSize.cols}
-            rows={termSize.rows}
-          />
-        </scrollbox>
-
-        {activeError && !isRunning && (
-          <box height={1} width="100%" backgroundColor="#331111" paddingLeft={1}>
-            <text fg={COLORS.error}>{activeError}</text>
-          </box>
-        )}
+        <text fg={statusColor}>{statusText}</text>
       </box>
-    );
+
+      <box height={1} width="100%" backgroundColor="#222222" paddingLeft={1}>
+        <text fg={COLORS.textDim}>{phaseHint}</text>
+      </box>
+
+      {showWaitingOutput && (
+        <box height={1} width="100%" backgroundColor="#1a1a1a" paddingLeft={1}>
+          <text fg={COLORS.textDim}>Waiting for {waitingPhaseName} script output...</text>
+        </box>
+      )}
+
+      <scrollbox
+        ref={(el: ScrollBoxRenderable | null) => {
+          scrollBoxRef.current = el;
+        }}
+        flexGrow={1}
+        viewportCulling={true}
+        stickyScroll={stickyToBottom}
+        stickyStart="bottom"
+        onMouseUp={handleMouseUp}
+      >
+        <ghostty-terminal
+          key={activeEntry?.id ?? 'script-terminal-empty'}
+          ref={setActiveTerminalRef}
+          persistent={true}
+          showCursor={false}
+          cols={termSize.cols}
+          rows={termSize.rows}
+        />
+      </scrollbox>
+
+      {activeError && !isRunning && (
+        <box height={1} width="100%" backgroundColor="#331111" paddingLeft={1}>
+          <text fg={COLORS.error}>{activeError}</text>
+        </box>
+      )}
+    </box>
+  );
 }

--- a/src/components/ScriptTerminal.tui.tsx
+++ b/src/components/ScriptTerminal.tui.tsx
@@ -115,21 +115,24 @@ function getPhaseMarker(status: PhaseStatus): string {
 }
 
 const PHASE_BANNER_REGEX = /==>\s*(pre|setup|select|remove)\s+scripts\.\.\./gi;
-const PHASE_BANNER_SCAN_LIMIT = 256;
 
-function findLatestPhaseBanner(text: string): ScriptPhase | null {
-  let latest: ScriptPhase | null = null;
+function findPhaseBannerMatches(chunk: Buffer): Array<{ phase: ScriptPhase; byteIndex: number }> {
+  const text = chunk.toString('utf8');
+  const matches: Array<{ phase: ScriptPhase; byteIndex: number }> = [];
   PHASE_BANNER_REGEX.lastIndex = 0;
 
   let match: RegExpExecArray | null;
   while ((match = PHASE_BANNER_REGEX.exec(text)) !== null) {
     const phase = match[1];
     if (phase === 'pre' || phase === 'setup' || phase === 'select' || phase === 'remove') {
-      latest = phase;
+      matches.push({
+        phase,
+        byteIndex: Buffer.byteLength(text.slice(0, match.index), 'utf8'),
+      });
     }
   }
 
-  return latest;
+  return matches;
 }
 
 export function ScriptTerminal({
@@ -147,7 +150,6 @@ export function ScriptTerminal({
     createPhaseEntry(phase, isRunning, error, exitCode),
   ]);
   const phaseEntriesRef = useRef<PhaseTerminalState[]>(phaseEntries);
-  const phaseBannerCarryRef = useRef('');
   const previousPhaseRef = useRef<ScriptPhase>(phase);
   const previousRunningRef = useRef<boolean>(isRunning);
   const [activePhaseIndex, setActivePhaseIndex] = useState(0);
@@ -327,39 +329,62 @@ export function ScriptTerminal({
     }
 
     const chunk = Buffer.from(data);
-    const scanWindow = `${phaseBannerCarryRef.current}${chunk.toString('utf-8')}`;
-    phaseBannerCarryRef.current = scanWindow.slice(-PHASE_BANNER_SCAN_LIMIT);
+    const appendToCurrentPhase = (output: Buffer) => {
+      if (output.length === 0) {
+        return;
+      }
 
-    const streamPhase = findLatestPhaseBanner(scanWindow);
-    if (streamPhase) {
+      const current = phaseEntriesRef.current[phaseEntriesRef.current.length - 1];
+      if (!current) {
+        return;
+      }
+
+      current.outputChunks.push(output);
+      current.target?.feed(output);
+    };
+
+    const switchToPhase = (streamPhase: ScriptPhase) => {
       const currentEntries = phaseEntriesRef.current;
       const lastEntry = currentEntries[currentEntries.length - 1];
 
-      if (!lastEntry || lastEntry.phase !== streamPhase) {
-        const nextEntries = [...currentEntries];
-        const currentLast = nextEntries[nextEntries.length - 1];
-        if (currentLast?.status === 'running') {
-          nextEntries[nextEntries.length - 1] = {
-            ...currentLast,
-            status: 'complete',
-          };
-        }
-
-        const createdEntry = createPhaseEntry(streamPhase, true);
-        nextEntries.push(createdEntry);
-        phaseEntriesRef.current = nextEntries;
-        setPhaseEntries(nextEntries);
-        setActivePhaseIndex(nextEntries.length - 1);
+      if (lastEntry?.phase === streamPhase) {
+        return;
       }
-    }
 
-    const current = phaseEntriesRef.current[phaseEntriesRef.current.length - 1];
-    if (!current) {
+      const nextEntries = [...currentEntries];
+      const currentLast = nextEntries[nextEntries.length - 1];
+      if (currentLast?.status === 'running') {
+        nextEntries[nextEntries.length - 1] = {
+          ...currentLast,
+          status: 'complete',
+        };
+      }
+
+      const createdEntry = createPhaseEntry(streamPhase, true);
+      nextEntries.push(createdEntry);
+      phaseEntriesRef.current = nextEntries;
+      setPhaseEntries(nextEntries);
+      setActivePhaseIndex(nextEntries.length - 1);
+    };
+
+    const bannerMatches = findPhaseBannerMatches(chunk);
+    if (bannerMatches.length === 0) {
+      appendToCurrentPhase(chunk);
       return;
     }
 
-    current.outputChunks.push(chunk);
-    current.target?.feed(chunk);
+    let cursor = 0;
+    for (const match of bannerMatches) {
+      if (match.byteIndex > cursor) {
+        appendToCurrentPhase(chunk.subarray(cursor, match.byteIndex));
+      }
+      switchToPhase(match.phase);
+      cursor = match.byteIndex;
+    }
+
+    if (cursor < chunk.length) {
+      appendToCurrentPhase(chunk.subarray(cursor));
+    }
   }, []);
 
   const setActiveTerminalRef = useCallback((el: GhosttyTerminalRenderable | null) => {

--- a/src/components/ScriptTerminal.tui.tsx
+++ b/src/components/ScriptTerminal.tui.tsx
@@ -7,8 +7,6 @@ import {
   useRef,
   useCallback,
   useEffect,
-  useImperativeHandle,
-  forwardRef,
 } from 'react';
 import { extend, useKeyboard, useRenderer } from '@opentui/react';
 import type { ScrollBoxRenderable } from '@opentui/core';
@@ -41,10 +39,7 @@ export interface ScriptTerminalProps {
   error?: string;
   exitCode?: number;
   modalOpen?: boolean;
-}
-
-export interface ScriptTerminalHandle {
-  feed: (data: Uint8Array) => void;
+  setWriteCallback: (fn: ((data: Uint8Array) => void) | null) => void;
 }
 
 const COLORS = {
@@ -119,8 +114,15 @@ function getPhaseMarker(status: PhaseStatus): string {
   }
 }
 
-export const ScriptTerminal = forwardRef<ScriptTerminalHandle, ScriptTerminalProps>(
-  function ScriptTerminal({ phase, workspaceName, isRunning, error, exitCode, modalOpen = false }, ref) {
+export function ScriptTerminal({
+  phase,
+  workspaceName,
+  isRunning,
+  error,
+  exitCode,
+  modalOpen = false,
+  setWriteCallback,
+}: ScriptTerminalProps) {
     const renderer = useRenderer();
 
     const [phaseEntries, setPhaseEntries] = useState<PhaseTerminalState[]>(() => [
@@ -133,9 +135,10 @@ export const ScriptTerminal = forwardRef<ScriptTerminalHandle, ScriptTerminalPro
 
     const activeEntry = phaseEntries[activePhaseIndex] ?? phaseEntries[phaseEntries.length - 1];
     const activeError = activeEntry?.status === 'failed' ? activeEntry.error : undefined;
+    const showWaitingOutput = isRunning && !!activeEntry && activeEntry.outputChunks.length === 0;
 
     const showErrorBanner = !!activeError && !isRunning;
-    const reservedRows = 3 + (showErrorBanner ? 1 : 0);
+    const reservedRows = 3 + (showErrorBanner ? 1 : 0) + (showWaitingOutput ? 1 : 0);
     const [termSize, setTermSize] = useState(() => getTerminalSize(reservedRows));
 
     useEffect(() => {
@@ -311,7 +314,12 @@ export const ScriptTerminal = forwardRef<ScriptTerminalHandle, ScriptTerminalPro
       el.feed(Buffer.concat(current.outputChunks));
     }, [activePhaseIndex]);
 
-    useImperativeHandle(ref, () => ({ feed }), [feed]);
+    useEffect(() => {
+      setWriteCallback(feed);
+      return () => {
+        setWriteCallback(null);
+      };
+    }, [feed, setWriteCallback]);
 
     const statusText = isRunning
       ? 'Running...'
@@ -324,6 +332,7 @@ export const ScriptTerminal = forwardRef<ScriptTerminalHandle, ScriptTerminalPro
       : error
         ? COLORS.error
         : COLORS.success;
+    const waitingPhaseName = activeEntry ? PHASE_NAMES[activeEntry.phase] : 'script';
 
     const stickyToBottom = isRunning && activePhaseIndex === phaseEntries.length - 1;
     const phaseHint = isRunning
@@ -331,7 +340,6 @@ export const ScriptTerminal = forwardRef<ScriptTerminalHandle, ScriptTerminalPro
       : activeError
         ? '[[/]] Phase  [↑/↓ PgUp/PgDn] Scroll  [a] Attach anyway  [mouse] Select+copy'
         : '[[/]] Phase  [↑/↓ PgUp/PgDn] Scroll  [mouse] Select+copy';
-
     return (
       <box flexDirection="column" flexGrow={1}>
         <box
@@ -361,6 +369,12 @@ export const ScriptTerminal = forwardRef<ScriptTerminalHandle, ScriptTerminalPro
           <text fg={COLORS.textDim}>{phaseHint}</text>
         </box>
 
+        {showWaitingOutput && (
+          <box height={1} width="100%" backgroundColor="#1a1a1a" paddingLeft={1}>
+            <text fg={COLORS.textDim}>Waiting for {waitingPhaseName} script output...</text>
+          </box>
+        )}
+
         <scrollbox
           ref={(el: ScrollBoxRenderable | null) => {
             scrollBoxRef.current = el;
@@ -388,5 +402,4 @@ export const ScriptTerminal = forwardRef<ScriptTerminalHandle, ScriptTerminalPro
         )}
       </box>
     );
-  }
-);
+}

--- a/src/components/SpacesBrowser.tsx
+++ b/src/components/SpacesBrowser.tsx
@@ -61,6 +61,7 @@ export type TreeItem =
   | { type: 'process-disabled'; processName: string; workspaceId: string; ports?: WorkspaceProcessPort[] }
   | { type: 'process-config-error'; workspaceId: string; error: string }
   | { type: 'edit-processes'; workspaceId: string }
+  | { type: 'bundle-config'; workspaceId: string }
   | { type: 'events'; workspaceId: string }
   | { type: 'new-session'; workspaceId: string };
 
@@ -82,6 +83,7 @@ export interface UseSpacesBrowserProps {
   onProcessDisabled?: (params: { workspaceId: string; processName: string }) => void;
   onOpenEvents: (workspaceId: string) => void;
   onEditProcesses?: (params: { workspaceId: string }) => void;
+  onManageBundleConfig?: (params: { workspaceId: string }) => void;
   onRefresh: () => void | Promise<void>;
   /** Called to refresh sessions after workspace refresh (full refresh by default). */
   onRefreshSessions?: () => void | Promise<void>;
@@ -122,6 +124,7 @@ export interface UseSpacesBrowserReturn {
   refresh: () => Promise<void>;
   openEvents: (workspaceId: string) => void;
   editProcesses: (params: { workspaceId: string }) => void;
+  manageBundleConfig: (params: { workspaceId: string }) => void;
   back: () => void;
 }
 
@@ -283,6 +286,12 @@ function buildTree(
           workspaceId: ws.id,
         });
 
+        // Manage bundle config action
+        items.push({
+          type: 'bundle-config',
+          workspaceId: ws.id,
+        });
+
         // Events action
         items.push({
           type: 'events',
@@ -325,6 +334,7 @@ export function useSpacesBrowser(props: UseSpacesBrowserProps): UseSpacesBrowser
     onProcessDisabled,
     onOpenEvents,
     onEditProcesses,
+    onManageBundleConfig,
     onRefresh,
     onRefreshSessions,
     onBack,
@@ -445,12 +455,14 @@ export function useSpacesBrowser(props: UseSpacesBrowserProps): UseSpacesBrowser
       onEditProcesses?.({ workspaceId: item.workspaceId });
     } else if (item.type === 'edit-processes') {
       onEditProcesses?.({ workspaceId: item.workspaceId });
+    } else if (item.type === 'bundle-config') {
+      onManageBundleConfig?.({ workspaceId: item.workspaceId });
     } else if (item.type === 'events') {
       onOpenEvents(item.workspaceId);
     } else if (item.type === 'new-session') {
       await onAttachSession({ workspaceId: item.workspaceId });
     }
-  }, [toggleWorkspace, onAttachSession, onStartProcessAttach, findSessionForProcess, onProcessDisabled, onEditProcesses, onOpenEvents]);
+  }, [toggleWorkspace, onAttachSession, onStartProcessAttach, findSessionForProcess, onProcessDisabled, onEditProcesses, onManageBundleConfig, onOpenEvents]);
 
   const activateSelected = useCallback(async () => {
     await activateItem(selectedItem);
@@ -522,6 +534,7 @@ export function useSpacesBrowser(props: UseSpacesBrowserProps): UseSpacesBrowser
     refresh,
     openEvents: (workspaceId) => onOpenEvents(workspaceId),
     editProcesses: (params) => onEditProcesses?.(params),
+    manageBundleConfig: (params) => onManageBundleConfig?.(params),
     back,
   };
 }

--- a/src/components/SpacesBrowser.tui.tsx
+++ b/src/components/SpacesBrowser.tui.tsx
@@ -62,13 +62,16 @@ function getSpacesBrowserHint(selectedItem: TreeItem | null | undefined): string
   if (selectedItem?.type === 'edit-processes') {
     return '[↑↓] Navigate  [Enter] Edit Processes Config  [r] Refresh  [q] Back';
   }
+  if (selectedItem?.type === 'bundle-config') {
+    return '[↑↓] Navigate  [Enter] Edit Bundle Config  [b] Bundle  [r] Refresh  [q] Back';
+  }
   if (selectedItem?.type === 'events') {
     return '[↑↓] Navigate  [Enter] Open Events  [r] Refresh  [q] Back';
   }
   if (selectedItem?.type === 'new-session') {
     return '[↑↓] Navigate  [Enter] New Session  [r] Refresh  [q] Back';
   }
-  return '[↑↓] Navigate  [Enter] Select  [n] New  [r] Refresh  [q] Back';
+  return '[↑↓] Navigate  [Enter] Select  [n] New  [b] Bundle  [r] Refresh  [q] Back';
 }
 
 // ============================================================================
@@ -212,6 +215,16 @@ export function SpacesBrowserTUI(props: SpacesBrowserTUIProps) {
             return (
               <text key={`edit-processes-${item.workspaceId}`} fg={textColor} height={1}>
                 {prefix}   ⚙ Edit Processes Config
+              </text>
+            );
+          }
+
+          if (item.type === 'bundle-config') {
+            const textColor = isSelected ? COLORS.selected : '#58A6FF';
+            const prefix = isSelected ? '>' : ' ';
+            return (
+              <text key={`bundle-config-${item.workspaceId}`} fg={textColor} height={1}>
+                {prefix}   ◇ Edit Bundle Config
               </text>
             );
           }

--- a/src/components/SpacesBrowser.web.tsx
+++ b/src/components/SpacesBrowser.web.tsx
@@ -229,6 +229,24 @@ export function SpacesBrowserWeb(props: SpacesBrowserWebProps) {
             );
           }
 
+          if (item.type === 'bundle-config') {
+            return (
+              <div
+                key={`bundle-config-${item.workspaceId}`}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  void activateIndex(index);
+                }}
+                className={`
+                  pl-10 sm:pl-12 pr-4 py-3 cursor-pointer border-b border-[#30363d] min-h-[48px] flex items-center
+                  ${isSelected ? 'bg-[#21262d] border-l-4 border-l-[#58a6ff]' : 'hover:bg-[#161b22] active:bg-[#21262d]'}
+                `}
+              >
+                <span className="text-[#58a6ff]">◇ Edit Bundle Config</span>
+              </div>
+            );
+          }
+
           if (item.type === 'events') {
             return (
               <div
@@ -319,6 +337,7 @@ function Footer() {
         <span>Enter Select</span>
         <span>n New</span>
         <span>x Kill</span>
+        <span>b Bundle</span>
         <span>d Delete</span>
         <span>r Refresh</span>
         <span>Esc Back</span>

--- a/src/components/__tests__/Flow.test.ts
+++ b/src/components/__tests__/Flow.test.ts
@@ -1,0 +1,99 @@
+import { afterAll, beforeAll, describe, expect, it, mock } from 'bun:test';
+import { act, renderHook } from '@testing-library/react';
+import { Window } from 'happy-dom';
+import { useFlow } from '../Flow.js';
+
+const domWindow = new Window();
+const originalWindow = globalThis.window;
+const originalDocument = globalThis.document;
+
+beforeAll(() => {
+  // @ts-expect-error test DOM setup
+  globalThis.window = domWindow;
+  // @ts-expect-error test DOM setup
+  globalThis.document = domWindow.document;
+});
+
+afterAll(() => {
+  globalThis.window = originalWindow;
+  globalThis.document = originalDocument;
+});
+
+describe('useFlow searchable select', () => {
+  it('filters options and confirms using the filtered selection', async () => {
+    const onSelect = mock(async () => {});
+    const { result } = renderHook(() => useFlow());
+
+    act(() => {
+      result.current.showSelect({
+        title: 'Create Workspace From',
+        searchable: true,
+        options: [
+          { label: 'GitHub Branch', value: 'branch' },
+          { label: 'Linear Issue', value: 'linear' },
+          { label: 'Manual Name', value: 'manual' },
+        ],
+        onSelect,
+      });
+    });
+
+    act(() => {
+      result.current.updateSelectQuery('lin');
+    });
+
+    expect(result.current.flow.type).toBe('select');
+    if (result.current.flow.type === 'select') {
+      expect(result.current.flow.searchQuery).toBe('lin');
+      expect(result.current.flow.selectedIndex).toBe(0);
+    }
+
+    await act(async () => {
+      await result.current.handleConfirm();
+    });
+
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    expect(onSelect).toHaveBeenCalledWith('linear', 1);
+  });
+
+  it('clamps navigation to filtered result count', () => {
+    const { result } = renderHook(() => useFlow());
+
+    act(() => {
+      result.current.showSelect({
+        title: 'Select Branch',
+        searchable: true,
+        options: [
+          { label: 'alpha', value: 'alpha' },
+          { label: 'beta', value: 'beta' },
+          { label: 'gamma', value: 'gamma' },
+        ],
+        onSelect: () => {},
+      });
+    });
+
+    act(() => {
+      result.current.updateSelectQuery('ga');
+    });
+
+    act(() => {
+      result.current.moveDown();
+    });
+
+    expect(result.current.flow.type).toBe('select');
+    if (result.current.flow.type === 'select') {
+      expect(result.current.flow.selectedIndex).toBe(0);
+    }
+
+    act(() => {
+      result.current.updateSelectQuery('');
+    });
+
+    act(() => {
+      result.current.moveDown();
+    });
+
+    if (result.current.flow.type === 'select') {
+      expect(result.current.flow.selectedIndex).toBe(1);
+    }
+  });
+});

--- a/src/components/__tests__/ScriptTerminal.tui.test.tsx
+++ b/src/components/__tests__/ScriptTerminal.tui.test.tsx
@@ -1,0 +1,200 @@
+import { afterEach, describe, expect, it } from 'bun:test';
+import { act } from '@testing-library/react';
+import { testRender } from '@opentui/react/test-utils';
+import { useCallback, useEffect, useState, type ReactElement } from 'react';
+import { ScriptTerminal } from '../ScriptTerminal.tui.js';
+
+type ScriptPhase = 'pre' | 'setup' | 'select' | 'remove';
+
+interface HarnessState {
+  phase: ScriptPhase;
+  isRunning: boolean;
+  error?: string;
+  exitCode?: number;
+  modalOpen?: boolean;
+}
+
+interface HarnessControls {
+  update: (patch: Partial<HarnessState>) => void;
+  getWriter: () => ((data: Uint8Array) => void) | null;
+  feedText: (text: string) => void;
+}
+
+function createHarness(initial: HarnessState): {
+  Component: () => ReactElement;
+  controls: HarnessControls;
+} {
+  let writer: ((data: Uint8Array) => void) | null = null;
+  let updateState: ((patch: Partial<HarnessState>) => void) | null = null;
+
+  const controls: HarnessControls = {
+    update: (patch) => {
+      updateState?.(patch);
+    },
+    getWriter: () => writer,
+    feedText: (text) => {
+      writer?.(new TextEncoder().encode(text));
+    },
+  };
+
+  function Component(): ReactElement {
+    const [state, setState] = useState<HarnessState>(initial);
+    const handleWriteCallback = useCallback((fn: ((data: Uint8Array) => void) | null) => {
+      writer = fn;
+    }, []);
+
+    useEffect(() => {
+      updateState = (patch) => {
+        setState((prev) => ({ ...prev, ...patch }));
+      };
+
+      return () => {
+        updateState = null;
+      };
+    }, []);
+
+    return (
+      <ScriptTerminal
+        phase={state.phase}
+        workspaceName="alpha-ws"
+        isRunning={state.isRunning}
+        error={state.error}
+        exitCode={state.exitCode}
+        modalOpen={state.modalOpen}
+        setWriteCallback={handleWriteCallback}
+      />
+    ) as ReactElement;
+  }
+
+  return { Component, controls };
+}
+
+async function renderAndFlush(renderOnce: () => Promise<void>): Promise<void> {
+  await renderOnce();
+  await Bun.sleep(0);
+  await renderOnce();
+}
+
+let destroyRenderer: (() => void) | null = null;
+
+afterEach(() => {
+  if (destroyRenderer) {
+    destroyRenderer();
+    destroyRenderer = null;
+  }
+});
+
+describe('ScriptTerminal TUI', () => {
+  it('renders live script output while running', async () => {
+    const { Component, controls } = createHarness({
+      phase: 'pre',
+      isRunning: true,
+    });
+
+    const { renderer, renderOnce, captureCharFrame } = await testRender(<Component />, {
+      width: 90,
+      height: 24,
+    });
+    destroyRenderer = () => renderer.destroy();
+
+    await renderAndFlush(renderOnce);
+    expect(controls.getWriter()).toBeDefined();
+    expect(captureCharFrame()).toContain('Waiting for Pre script output...');
+
+    await act(async () => {
+      controls.feedText('pre-live-output\n');
+    });
+
+    await renderAndFlush(renderOnce);
+    expect(captureCharFrame()).toContain('pre-live-output');
+  });
+
+  it('keeps showing current running phase output even after manual phase navigation', async () => {
+    const { Component, controls } = createHarness({
+      phase: 'pre',
+      isRunning: true,
+    });
+
+    const { renderer, renderOnce, captureCharFrame, mockInput } = await testRender(<Component />, {
+      width: 90,
+      height: 24,
+    });
+    destroyRenderer = () => renderer.destroy();
+
+    await renderAndFlush(renderOnce);
+
+    await act(async () => {
+      controls.feedText('pre-start\n');
+    });
+    await renderAndFlush(renderOnce);
+    expect(captureCharFrame()).toContain('pre-start');
+
+    await act(async () => {
+      controls.update({ phase: 'setup', isRunning: true });
+    });
+    await renderAndFlush(renderOnce);
+    expect(captureCharFrame()).toContain('[Setup ...]');
+    expect(captureCharFrame()).toContain('Waiting for Setup script output...');
+
+    await act(async () => {
+      controls.feedText('setup-live-1\n');
+    });
+    await renderAndFlush(renderOnce);
+    expect(captureCharFrame()).toContain('setup-live-1');
+
+    await act(async () => {
+      mockInput.pressArrow('left');
+    });
+    await renderAndFlush(renderOnce);
+
+    await act(async () => {
+      controls.feedText('setup-live-2\n');
+    });
+    await renderAndFlush(renderOnce);
+    expect(captureCharFrame()).toContain('setup-live-2');
+  });
+
+  it('keeps phase output segregated when phase banner arrives before prop phase update', async () => {
+    const { Component, controls } = createHarness({
+      phase: 'pre',
+      isRunning: true,
+    });
+
+    const { renderer, renderOnce, captureCharFrame, mockInput } = await testRender(<Component />, {
+      width: 90,
+      height: 24,
+    });
+    destroyRenderer = () => renderer.destroy();
+
+    await renderAndFlush(renderOnce);
+
+    await act(async () => {
+      controls.feedText('pre-only\n');
+      controls.feedText('\r\n==> setup scripts...\r\nsetup-only\n');
+    });
+    await renderAndFlush(renderOnce);
+    expect(captureCharFrame()).toContain('[Setup ...]');
+
+    await act(async () => {
+      controls.update({ phase: 'setup', isRunning: false });
+    });
+    await renderAndFlush(renderOnce);
+
+    const setupFrame = captureCharFrame();
+    expect(setupFrame).toContain('setup-only');
+
+    await act(async () => {
+      mockInput.pressArrow('left');
+    });
+    await renderAndFlush(renderOnce);
+    const preFrame = captureCharFrame();
+    expect(preFrame).toContain('pre-only');
+    expect(preFrame).not.toContain('setup-only');
+
+    await act(async () => {
+      mockInput.pressArrow('right');
+    });
+    await renderAndFlush(renderOnce);
+    expect(captureCharFrame()).toContain('setup-only');
+  });
+});

--- a/src/components/__tests__/ScriptTerminal.tui.test.tsx
+++ b/src/components/__tests__/ScriptTerminal.tui.test.tsx
@@ -197,4 +197,41 @@ describe('ScriptTerminal TUI', () => {
     await renderAndFlush(renderOnce);
     expect(captureCharFrame()).toContain('setup-only');
   });
+
+  it('keeps pre-banner text in the previous phase when mixed in one chunk', async () => {
+    const { Component, controls } = createHarness({
+      phase: 'pre',
+      isRunning: true,
+    });
+
+    const { renderer, renderOnce, captureCharFrame, mockInput } = await testRender(<Component />, {
+      width: 90,
+      height: 24,
+    });
+    destroyRenderer = () => renderer.destroy();
+
+    await renderAndFlush(renderOnce);
+
+    await act(async () => {
+      controls.feedText('pre-before-banner\r\n==> setup scripts...\r\nsetup-after-banner\n');
+    });
+    await renderAndFlush(renderOnce);
+
+    expect(captureCharFrame()).toContain('[Setup ...]');
+    expect(captureCharFrame()).toContain('setup-after-banner');
+    expect(captureCharFrame()).not.toContain('pre-before-banner');
+
+    await act(async () => {
+      controls.update({ phase: 'setup', isRunning: false });
+    });
+    await renderAndFlush(renderOnce);
+
+    await act(async () => {
+      mockInput.pressArrow('left');
+    });
+    await renderAndFlush(renderOnce);
+    const preFrame = captureCharFrame();
+    expect(preFrame).toContain('pre-before-banner');
+    expect(preFrame).not.toContain('setup-after-banner');
+  });
 });

--- a/src/components/__tests__/SpacesBrowser.test.ts
+++ b/src/components/__tests__/SpacesBrowser.test.ts
@@ -114,6 +114,7 @@ describe('useSpacesBrowser tree building', () => {
     expect(types).toContain('workspace');
     expect(types).toContain('session');
     expect(types).toContain('events');
+    expect(types).toContain('bundle-config');
     expect(types).toContain('new-session');
   });
 
@@ -327,6 +328,23 @@ describe('useSpacesBrowser activateSelected', () => {
     await act(async () => { await result.current.activateSelected(); });
 
     expect(onEditProcesses).toHaveBeenCalledWith({ workspaceId: 'ws-1' });
+  });
+
+  it('calls onManageBundleConfig when bundle-config item is activated', async () => {
+    const ws = makeWorkspace();
+    const onManageBundleConfig = mock(() => {});
+    const props = makeProps({ workspaces: [ws], onManageBundleConfig });
+    const { result } = renderHook(() => useSpacesBrowser(props));
+
+    act(() => { result.current.toggleWorkspace('ws-1'); });
+
+    const manageIndex = result.current.items.findIndex((item) => item.type === 'bundle-config');
+    expect(manageIndex).toBeGreaterThanOrEqual(0);
+    act(() => { result.current.selectIndex(manageIndex); });
+
+    await act(async () => { await result.current.activateSelected(); });
+
+    expect(onManageBundleConfig).toHaveBeenCalledWith({ workspaceId: 'ws-1' });
   });
 
   it('edit-processes item appears before events item in expanded workspace', () => {

--- a/src/components/__tests__/SpacesBrowser.tui.test.tsx
+++ b/src/components/__tests__/SpacesBrowser.tui.test.tsx
@@ -38,6 +38,7 @@ function makeTuiProps(overrides: Partial<UseSpacesBrowserReturn> = {}): UseSpace
     refresh: mock(async () => {}),
     openEvents: mock(() => {}),
     editProcesses: mock(() => {}),
+    manageBundleConfig: mock(() => {}),
     back: mock(() => {}),
     ...overrides,
   };

--- a/src/core/__tests__/bundle-refresh.test.ts
+++ b/src/core/__tests__/bundle-refresh.test.ts
@@ -57,6 +57,13 @@ describe('bundle-refresh', () => {
       setProjectSecret: async (_projectName: string, key: string, value: string) => {
         savedSecrets[key] = value;
       },
+      deleteProjectSecret: async (_projectName: string, key: string) => {
+        if (!(key in savedSecrets)) {
+          return false;
+        }
+        delete savedSecrets[key];
+        return true;
+      },
       getProjectSecret: async (_projectName: string, key: string) => {
         return savedSecrets[key] ?? null;
       },
@@ -562,6 +569,39 @@ describe('bundle-refresh', () => {
       expect(plan.hasChanged).toBe(false);
       expect(plan.steps.map((step) => step.id)).toContain('pulumi-token');
       expect(plan.details).toContain('Missing required secrets: PULUMI_ACCESS_TOKEN.');
+    });
+
+    it('allows clearing persisted bundle secret values via empty submission value', async () => {
+      const bundleDir = join(testBaseDir, '.gitspace');
+      mkdirSync(bundleDir, { recursive: true });
+      const bundle = {
+        version: '1.0' as const,
+        name: 'Unset Secret Bundle',
+        onboarding: [
+          {
+            id: 'token',
+            type: 'secret' as const,
+            title: 'API token',
+            description: 'Secret token',
+            configKey: 'API_TOKEN',
+          },
+        ],
+      };
+      writeFileSync(join(bundleDir, 'bundle.json'), JSON.stringify(bundle));
+
+      const workspacePath = join(testDir, 'workspaces', 'feature-unset-secret');
+      mkdirSync(workspacePath, { recursive: true });
+
+      savedSecrets.API_TOKEN = 'existing-secret';
+      mockProjectConfig.bundleSecretKeys = ['API_TOKEN'];
+
+      const { applyBundleConfigSubmission } = await import('../bundle-refresh');
+      await applyBundleConfigSubmission('test-project', workspacePath, {
+        secretValues: { API_TOKEN: '' },
+      });
+
+      expect(savedSecrets.API_TOKEN).toBeUndefined();
+      expect(mockProjectConfig.bundleSecretKeys ?? []).not.toContain('API_TOKEN');
     });
   });
 });

--- a/src/core/bundle-refresh.ts
+++ b/src/core/bundle-refresh.ts
@@ -16,7 +16,7 @@ import {
   updateProjectConfig,
 } from './config.js';
 import { runOnboarding, KEEP_EXISTING_SECRET, type OnboardingOptions } from '../utils/onboarding.js';
-import { getProjectSecret, getProjectSecrets, setProjectSecret } from '../utils/secrets.js';
+import { deleteProjectSecret, getProjectSecret, getProjectSecrets, setProjectSecret } from '../utils/secrets.js';
 import { checkCommandExists } from '../utils/deps.js';
 import { SpacesError } from '../types/errors.js';
 import type {
@@ -36,6 +36,11 @@ import type {
   BundleRefreshStep,
   BundleRefreshSubmission,
 } from '../types/bundle-refresh.js';
+import type {
+  BundleConfigState,
+  BundleConfigStep,
+  BundleConfigSubmission,
+} from '../types/bundle-config.js';
 
 const BUNDLE_FILENAME = 'bundle.json';
 const BASE_SCOPE = '__base__';
@@ -649,6 +654,37 @@ function buildPendingRequirementsSummary(steps: BundleRefreshStep[]): string[] {
   return lines;
 }
 
+async function resolveConfirmResult(
+  step: ConfirmStep,
+  confirmHistory: Record<string, BundleConfirmHistoryEntry>
+): Promise<{ result?: ConfirmStepResult; checkedAt?: string }> {
+  const fingerprint = getConfirmStepFingerprint(step);
+  const history = confirmHistory[fingerprint];
+  if (history) {
+    return {
+      result: {
+        status: history.status,
+        checkCommand: history.checkCommand,
+      },
+      checkedAt: history.checkedAt,
+    };
+  }
+
+  if (step.checkCommand) {
+    const exists = await checkCommandExists(step.checkCommand);
+    if (exists) {
+      return {
+        result: {
+          status: 'passed',
+          checkCommand: step.checkCommand,
+        },
+      };
+    }
+  }
+
+  return {};
+}
+
 export async function getBundleRefreshPlan(
   projectName: string,
   workspacePath: string,
@@ -859,6 +895,186 @@ export async function applyBundleRefreshSubmission(
     }
 
     const result = allConfirmResults[step.id];
+    if (!result) {
+      continue;
+    }
+
+    const fingerprint = getConfirmStepFingerprint(step);
+    historyNext[fingerprint] = {
+      fingerprint,
+      stepId: step.id,
+      checkCommand: step.checkCommand,
+      status: result.status,
+      scope,
+      bundleHash,
+      checkedAt: new Date().toISOString(),
+    };
+  }
+
+  updateProjectConfig(projectName, {
+    bundleValues: Object.keys(newValues).length > 0 ? newValues : undefined,
+    bundleSecretKeys: secretKeys.size > 0 ? uniqueSorted([...secretKeys]) : undefined,
+    bundleWorkspaceState: stateApplied.bundleWorkspaceState,
+    bundleConfirmHistory: Object.keys(historyNext).length > 0 ? historyNext : undefined,
+  });
+}
+
+export async function getBundleConfigState(
+  projectName: string,
+  workspacePath: string,
+  workspaceId?: string
+): Promise<BundleConfigState> {
+  const workspaceName = resolveWorkspaceNameFromPath(workspacePath);
+  const resolvedWorkspaceId = workspaceId ?? `${projectName}:${workspaceName}`;
+  const changes = detectBundleChanges(projectName, workspacePath);
+  const details = formatBundleChangeDetails(changes);
+
+  const emptyState: BundleConfigState = {
+    projectName,
+    workspaceId: resolvedWorkspaceId,
+    workspaceName,
+    workspacePath: resolve(workspacePath),
+    hasBundle: false,
+    scope: changes.scope,
+    bundleSource: changes.bundleSource,
+    currentHash: changes.currentHash,
+    details,
+    steps: [],
+  };
+
+  if (!changes.hasBundle || !changes.currentBundle) {
+    return emptyState;
+  }
+
+  const config = readProjectConfig(projectName);
+  const inputValues = config.bundleValues || {};
+  const confirmHistory = config.bundleConfirmHistory || {};
+  const secretStepKeys = (changes.currentBundle.onboarding || [])
+    .filter((step): step is SecretStep => step.type === 'secret')
+    .map((step) => step.configKey);
+  const existingSecrets = await getProjectSecrets(projectName, secretStepKeys);
+  const steps: BundleConfigStep[] = [];
+
+  for (const step of changes.currentBundle.onboarding || []) {
+    if (step.type === 'input') {
+      steps.push({
+        id: step.id,
+        type: step.type,
+        title: step.title,
+        description: step.description,
+        required: step.required,
+        configKey: step.configKey,
+        defaultValue: step.defaultValue,
+        validationPattern: step.validationPattern,
+        validationMessage: step.validationMessage,
+        value: inputValues[step.configKey],
+      });
+      continue;
+    }
+
+    if (step.type === 'secret') {
+      steps.push({
+        id: step.id,
+        type: step.type,
+        title: step.title,
+        description: step.description,
+        required: step.required,
+        configKey: step.configKey,
+        validationPattern: step.validationPattern,
+        validationMessage: step.validationMessage,
+        hasSecret: Object.prototype.hasOwnProperty.call(existingSecrets, step.configKey),
+      });
+      continue;
+    }
+
+    if (step.type === 'confirm') {
+      const resolved = await resolveConfirmResult(step, confirmHistory);
+      steps.push({
+        id: step.id,
+        type: step.type,
+        title: step.title,
+        description: step.description,
+        required: step.required,
+        checkCommand: step.checkCommand,
+        installUrl: step.installUrl,
+        confirmPrompt: step.confirmPrompt,
+        confirmResult: resolved.result,
+        confirmCheckedAt: resolved.checkedAt,
+      });
+      continue;
+    }
+
+    steps.push({
+      id: step.id,
+      type: step.type,
+      title: step.title,
+      description: step.description,
+      required: step.required,
+    });
+  }
+
+  return {
+    ...emptyState,
+    hasBundle: true,
+    bundleName: changes.currentBundle.name,
+    bundleVersion: changes.currentBundle.version,
+    steps,
+  };
+}
+
+export async function applyBundleConfigSubmission(
+  projectName: string,
+  workspacePath: string,
+  submission: BundleConfigSubmission
+): Promise<void> {
+  const changes = detectBundleChanges(projectName, workspacePath);
+  if (!changes.hasBundle || !changes.currentBundle || !changes.currentHash) {
+    throw new SpacesError(changes.parseError || 'No bundle found for workspace', 'USER_ERROR', 1);
+  }
+
+  const scope = changes.scope || BASE_SCOPE;
+  const bundle = changes.currentBundle;
+  const bundleHash = changes.currentHash;
+  const config = readProjectConfig(projectName);
+  const confirmHistory = config.bundleConfirmHistory || {};
+  const stateApplied = applyWorkspaceState(config, scope, bundleHash, bundle);
+
+  const inputValues = submission.inputValues || {};
+  const secretValues = submission.secretValues || {};
+  const confirmResults = submission.confirmResults || {};
+
+  const newValues: Record<string, string> = {
+    ...(config.bundleValues || {}),
+    ...inputValues,
+  };
+
+  const secretKeys = new Set<string>(stateApplied.mergedSecretKeys);
+
+  for (const [key, value] of Object.entries(secretValues)) {
+    if (value === '') {
+      await deleteProjectSecret(projectName, key);
+      secretKeys.delete(key);
+      continue;
+    }
+
+    if (!value || value === KEEP_EXISTING_SECRET) {
+      continue;
+    }
+
+    await setProjectSecret(projectName, key, value);
+    secretKeys.add(key);
+  }
+
+  const historyNext: Record<string, BundleConfirmHistoryEntry> = {
+    ...confirmHistory,
+  };
+
+  for (const step of bundle.onboarding || []) {
+    if (step.type !== 'confirm') {
+      continue;
+    }
+
+    const result = confirmResults[step.id];
     if (!result) {
       continue;
     }

--- a/src/hooks/__tests__/useLocalSession.tui.test.ts
+++ b/src/hooks/__tests__/useLocalSession.tui.test.ts
@@ -12,6 +12,7 @@ import type {
 } from '../../session/index.js'
 import type { NotificationConfig } from '../../notifications/types.js'
 import type { BundleRefreshPlan, BundleRefreshSubmission } from '../../types/bundle-refresh.js'
+import type { BundleConfigState, BundleConfigSubmission } from '../../types/bundle-config.js'
 import { SpacesError } from '../../types/errors.js'
 import {
   useLocalSession,
@@ -136,6 +137,27 @@ class FakeLocalBackend implements SessionBackend {
     _projectName: string,
     _workspaceId: string,
     _submission: BundleRefreshSubmission
+  ): Promise<void> {}
+
+  async getBundleConfigState(
+    _projectName: string,
+    workspaceId: string
+  ): Promise<BundleConfigState> {
+    return {
+      projectName: 'project',
+      workspaceId,
+      workspaceName: workspaceId,
+      workspacePath: `/tmp/${workspaceId}`,
+      hasBundle: true,
+      details: 'bundle state',
+      steps: [],
+    }
+  }
+
+  async applyBundleConfigUpdate(
+    _projectName: string,
+    _workspaceId: string,
+    _submission: BundleConfigSubmission
   ): Promise<void> {}
 
   async requestInbox(): Promise<void> {}

--- a/src/hooks/useLocalSession.tui.ts
+++ b/src/hooks/useLocalSession.tui.ts
@@ -14,6 +14,7 @@ import {
 import type { NotificationConfig } from '../notifications/types.js';
 import type { WideEventFilter } from '../types/events.js';
 import type { SessionLinearIssueSummary } from '../types/lifecycle.js';
+import type { BundleConfigState, BundleConfigSubmission } from '../types/bundle-config.js';
 import { createBunLocalSessionBackend } from '../app/session/createSessionBackend.bun.js';
 import { logger } from '../utils/logger.js';
 import { SpacesError } from '../types/errors.js';
@@ -372,6 +373,34 @@ export function useLocalSession(options: UseLocalSessionOptions = {}) {
     }, { strict: true });
   }, [backendKey, runWithBackend]);
 
+  const getBundleConfigState = useCallback(async (
+    projectName: string,
+    workspaceId: string
+  ): Promise<BundleConfigState> => {
+    let stateResult: BundleConfigState | null = null;
+    await runWithBackend(async (sessionEngine) => {
+      stateResult = await sessionEngine.getBundleConfigState(backendKey, projectName, workspaceId);
+    }, { strict: true });
+
+    if (!stateResult) {
+      throw new SpacesError('Bundle config state unavailable', 'SYSTEM_ERROR', 2);
+    }
+
+    return stateResult;
+  }, [backendKey, runWithBackend]);
+
+  const applyBundleConfigUpdate = useCallback(async (
+    projectName: string,
+    workspaceId: string,
+    submission: BundleConfigSubmission
+  ) => {
+    await runWithBackend(async (sessionEngine) => {
+      await sessionEngine.applyBundleConfigUpdate(backendKey, projectName, workspaceId, submission);
+      await sessionEngine.listWorkspaces(backendKey);
+      await sessionEngine.listSessions(backendKey, workspaceId);
+    }, { strict: true });
+  }, [backendKey, runWithBackend]);
+
   const send = useCallback((data: Uint8Array) => {
     const backend = backendRef.current;
     if (!enabled || !backend?.writePtyData) {
@@ -469,6 +498,8 @@ export function useLocalSession(options: UseLocalSessionOptions = {}) {
     deleteWorkspace,
     getBundleRefreshPlan,
     applyBundleRefresh,
+    getBundleConfigState,
+    applyBundleConfigUpdate,
     startProcess,
     stopProcess,
     requestEvents,

--- a/src/lib/remote-session/__tests__/protocol.test.ts
+++ b/src/lib/remote-session/__tests__/protocol.test.ts
@@ -241,14 +241,16 @@ describe('ClientToMachineMessage type coverage', () => {
     { type: 'update_notification_config', config: { enabled: true, minCommandDurationMs: 10000, types: { exit: true, idle: true, bell: true, title: true, osc: true }, toast: { enabled: true, holdWhenIdleMs: 15000 } } },
     { type: 'get_bundle_refresh_plan', projectName: 'p1', workspaceId: 'w1' },
     { type: 'apply_bundle_refresh', projectName: 'p1', workspaceId: 'w1', submission: { inputValues: {}, secretValues: {}, confirmResults: {} } },
+    { type: 'get_bundle_config_state', projectName: 'p1', workspaceId: 'w1' },
+    { type: 'apply_bundle_config_update', projectName: 'p1', workspaceId: 'w1', submission: { inputValues: {}, secretValues: {}, confirmResults: {} } },
     { type: 'get_events', workspacePath: '/tmp' },
     { type: 'start_process', workspaceId: 'w1', processName: 'web' },
     { type: 'stop_process', workspaceId: 'w1', processName: 'web' },
   ];
 
-  it('should include all 22 client message types', () => {
+  it('should include all 24 client message types', () => {
     const types = new Set(clientMessages.map(m => m.type));
-    expect(types.size).toBe(22);
+    expect(types.size).toBe(24);
   });
 
   it('should all parse successfully via round-trip', () => {
@@ -290,14 +292,16 @@ describe('MachineToClientMessage type coverage', () => {
     { type: 'script_output', phase: 'setup', data: '' },
     { type: 'bundle_refresh_plan', plan: { projectName: 'p1', workspaceId: 'w1', workspaceName: 'w1', workspacePath: '/tmp', hasBundle: false, hasChanged: false, details: '', steps: [], autoConfirmResults: {} } },
     { type: 'bundle_refresh_applied', projectName: 'p1', workspaceId: 'w1' },
+    { type: 'bundle_config_state', state: { projectName: 'p1', workspaceId: 'w1', workspaceName: 'w1', workspacePath: '/tmp', hasBundle: false, details: '', steps: [] } },
+    { type: 'bundle_config_updated', projectName: 'p1', workspaceId: 'w1' },
     { type: 'events_list', workspaceId: 'w1', events: [], liveEventIds: [] },
     { type: 'process_started', workspaceId: 'w1', processName: 'web' },
     { type: 'process_stopped', workspaceId: 'w1', processName: 'web' },
   ];
 
-  it('should include all 26 machine message types', () => {
+  it('should include all 28 machine message types', () => {
     const types = new Set(machineMessages.map(m => m.type));
-    expect(types.size).toBe(26);
+    expect(types.size).toBe(28);
   });
 
   it('should all parse successfully via round-trip', () => {

--- a/src/lib/remote-session/protocol.ts
+++ b/src/lib/remote-session/protocol.ts
@@ -23,6 +23,10 @@ export type {
   BundleRefreshSubmission,
 } from "../../types/bundle-refresh.js";
 export type {
+  BundleConfigState,
+  BundleConfigSubmission,
+} from '../../types/bundle-config.js';
+export type {
   SessionLinearIssueSummary,
   WorkspaceSource,
 } from "../../types/lifecycle.js";
@@ -196,6 +200,21 @@ export interface ApplyBundleRefreshRequest {
   projectName: string;
   workspaceId: string;
   submission: import("../../types/bundle-refresh.js").BundleRefreshSubmission;
+}
+
+/** Request ad hoc bundle configuration state for a workspace */
+export interface GetBundleConfigStateRequest {
+  type: 'get_bundle_config_state';
+  projectName: string;
+  workspaceId: string;
+}
+
+/** Apply ad hoc bundle configuration updates for a workspace */
+export interface ApplyBundleConfigUpdateRequest {
+  type: 'apply_bundle_config_update';
+  projectName: string;
+  workspaceId: string;
+  submission: import('../../types/bundle-config.js').BundleConfigSubmission;
 }
 
 /**
@@ -412,6 +431,19 @@ export interface BundleRefreshAppliedResponse {
   workspaceId: string;
 }
 
+/** Bundle configuration state response */
+export interface BundleConfigStateResponse {
+  type: 'bundle_config_state';
+  state: import('../../types/bundle-config.js').BundleConfigState;
+}
+
+/** Bundle configuration update applied successfully */
+export interface BundleConfigUpdatedResponse {
+  type: 'bundle_config_updated';
+  projectName: string;
+  workspaceId: string;
+}
+
 /** Review operation response — carries either a result or an error */
 export interface ReviewResponse {
   type: "review_response";
@@ -475,6 +507,8 @@ export type ClientToMachineMessage =
   | UpdateNotificationConfigRequest
   | GetBundleRefreshPlanRequest
   | ApplyBundleRefreshRequest
+  | GetBundleConfigStateRequest
+  | ApplyBundleConfigUpdateRequest
   | ReviewRequest
   | GetEventsRequest
   | StartProcessRequest
@@ -505,6 +539,8 @@ export type MachineToClientMessage =
   | ScriptOutputResponse
   | BundleRefreshPlanResponse
   | BundleRefreshAppliedResponse
+  | BundleConfigStateResponse
+  | BundleConfigUpdatedResponse
   | ReviewResponse
   | EventsListResponse
   | ProcessStartedResponse
@@ -555,6 +591,8 @@ export function isBrowseMessage(msg: RemoteSessionMessage): msg is
   | CreateProjectRequest
   | CreateWorkspaceRequest
   | DeleteProjectRequest
+  | GetBundleConfigStateRequest
+  | ApplyBundleConfigUpdateRequest
   | GetEventsRequest {
   return [
     "list_workspaces",
@@ -567,6 +605,8 @@ export function isBrowseMessage(msg: RemoteSessionMessage): msg is
     "create_project",
     "create_workspace",
     "delete_project",
+    'get_bundle_config_state',
+    'apply_bundle_config_update',
     "get_events",
   ].includes(msg.type);
 }

--- a/src/lib/remote-session/session-handler.ts
+++ b/src/lib/remote-session/session-handler.ts
@@ -50,6 +50,8 @@ import { getNotificationConfig, updateNotificationConfig } from "../../core/conf
 import {
   getBundleRefreshPlan,
   applyBundleRefreshSubmission,
+  getBundleConfigState,
+  applyBundleConfigSubmission,
 } from '../../core/bundle-refresh.js';
 import { buildSessionName } from '../../session/session-name.js';
 import { buildWorkspaceSessionHooks } from '../../session/workspace-shell-hooks.js';
@@ -424,6 +426,43 @@ export class RemoteSessionHandler {
         );
         break;
 
+      case 'get_bundle_config_state':
+        if (!canManage(session.accessType)) {
+          await this.sendError(
+            session,
+            sendResponse,
+            'PERMISSION_DENIED',
+            'Requires full access to inspect bundle configuration'
+          );
+          return;
+        }
+        await this.handleGetBundleConfigState(
+          session,
+          msg.projectName,
+          msg.workspaceId,
+          sendResponse
+        );
+        break;
+
+      case 'apply_bundle_config_update':
+        if (!canManage(session.accessType)) {
+          await this.sendError(
+            session,
+            sendResponse,
+            'PERMISSION_DENIED',
+            'Requires full access to update bundle configuration'
+          );
+          return;
+        }
+        await this.handleApplyBundleConfigUpdate(
+          session,
+          msg.projectName,
+          msg.workspaceId,
+          msg.submission,
+          sendResponse
+        );
+        break;
+
       case 'review_request':
         await this.handleReviewRequest(
           session,
@@ -701,6 +740,14 @@ export class RemoteSessionHandler {
             },
             onPhaseStart: (phase) => {
               currentPhase = phase;
+              const banner = Buffer.from(`\r\n==> ${phase} scripts...\r\n`);
+              void this.sendMessage(session, sendResponse, {
+                type: 'script_output',
+                phase,
+                data: banner.toString('base64'),
+              }).catch((error) => {
+                logger.debug(`[remote-session] Failed to send script phase banner: ${error instanceof Error ? error.message : String(error)}`);
+              });
             },
           }).finally(() => {
             const pending = this.pendingAttachRuns.get(session.connectionId);
@@ -1229,6 +1276,46 @@ export class RemoteSessionHandler {
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Failed to apply bundle refresh';
       await this.sendError(session, sendResponse, 'BUNDLE_REFRESH_APPLY_FAILED', message);
+    }
+  }
+
+  private async handleGetBundleConfigState(
+    session: RemoteClientSession,
+    projectName: string,
+    workspaceId: string,
+    sendResponse: (data: Uint8Array) => void
+  ): Promise<void> {
+    try {
+      const workspace = await this.resolveWorkspace(projectName, workspaceId);
+      const state = await getBundleConfigState(projectName, workspace.path, `${projectName}:${workspace.id}`);
+      await this.sendMessage(session, sendResponse, {
+        type: 'bundle_config_state',
+        state,
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Failed to load bundle configuration state';
+      await this.sendError(session, sendResponse, 'BUNDLE_CONFIG_STATE_FAILED', message);
+    }
+  }
+
+  private async handleApplyBundleConfigUpdate(
+    session: RemoteClientSession,
+    projectName: string,
+    workspaceId: string,
+    submission: import('../../types/bundle-config.js').BundleConfigSubmission,
+    sendResponse: (data: Uint8Array) => void
+  ): Promise<void> {
+    try {
+      const workspace = await this.resolveWorkspace(projectName, workspaceId);
+      await applyBundleConfigSubmission(projectName, workspace.path, submission);
+      await this.sendMessage(session, sendResponse, {
+        type: 'bundle_config_updated',
+        projectName,
+        workspaceId: `${projectName}:${workspace.id}`,
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Failed to apply bundle configuration update';
+      await this.sendError(session, sendResponse, 'BUNDLE_CONFIG_UPDATE_FAILED', message);
     }
   }
 

--- a/src/session/__tests__/backend-manager.test.ts
+++ b/src/session/__tests__/backend-manager.test.ts
@@ -11,6 +11,7 @@ import type {
 } from '../backend';
 import type { BackendEvent } from '../events';
 import type { BundleRefreshPlan, BundleRefreshSubmission } from '../../types/bundle-refresh';
+import type { BundleConfigState, BundleConfigSubmission } from '../../types/bundle-config';
 
 class FakeBackend implements SessionBackend {
   readonly descriptor: BackendDescriptor;
@@ -70,6 +71,14 @@ class FakeBackend implements SessionBackend {
     _projectName: string,
     _workspaceId: string,
     _submission: BundleRefreshSubmission
+  ): Promise<void> {}
+  async getBundleConfigState(_projectName: string, _workspaceId: string): Promise<BundleConfigState> {
+    throw new Error('not implemented');
+  }
+  async applyBundleConfigUpdate(
+    _projectName: string,
+    _workspaceId: string,
+    _submission: BundleConfigSubmission
   ): Promise<void> {}
   async requestInbox(): Promise<void> {}
   async clearInbox(_id?: string): Promise<void> {}

--- a/src/session/__tests__/local-session-backend.test.ts
+++ b/src/session/__tests__/local-session-backend.test.ts
@@ -189,6 +189,15 @@ describe('LocalSessionBackend', () => {
       viewOnly: false,
     });
 
+    const scriptStreamChunks = events
+      .filter((event): event is Extract<BackendEvent, { type: 'script_output' }> =>
+        event.type === 'script_output' && !event.done && event.data.length > 0
+      )
+      .map((event) => new TextDecoder().decode(event.data));
+
+    expect(scriptStreamChunks.some((chunk) => chunk.includes('==> pre scripts...'))).toBe(true);
+    expect(scriptStreamChunks.some((chunk) => chunk.includes('==> setup scripts...'))).toBe(true);
+
     expect(events).toContainEqual({
       type: 'script_output',
       phase: 'setup',

--- a/src/session/__tests__/local-session-backend.test.ts
+++ b/src/session/__tests__/local-session-backend.test.ts
@@ -73,6 +73,8 @@ describe('LocalSessionBackend', () => {
         options.onOutput?.(Buffer.from('pre-output'));
         options.onPhaseStart?.('setup');
         options.onOutput?.(Buffer.from('setup-output'));
+        options.onPhaseStart?.('select');
+        options.onOutput?.(Buffer.from('select-output'));
         return { success: true };
       },
       getInbox: async () => [
@@ -195,12 +197,18 @@ describe('LocalSessionBackend', () => {
       )
       .map((event) => new TextDecoder().decode(event.data));
 
-    expect(scriptStreamChunks.some((chunk) => chunk.includes('==> pre scripts...'))).toBe(true);
-    expect(scriptStreamChunks.some((chunk) => chunk.includes('==> setup scripts...'))).toBe(true);
+    expect(scriptStreamChunks).toEqual([
+      '\r\n==> pre scripts...\r\n',
+      'pre-output',
+      '\r\n==> setup scripts...\r\n',
+      'setup-output',
+      '\r\n==> select scripts...\r\n',
+      'select-output',
+    ]);
 
     expect(events).toContainEqual({
       type: 'script_output',
-      phase: 'setup',
+      phase: 'select',
       data: new Uint8Array(0),
       done: true,
     });

--- a/src/session/__tests__/remote-session-backend.test.ts
+++ b/src/session/__tests__/remote-session-backend.test.ts
@@ -339,6 +339,102 @@ describe('RemoteSessionBackend', () => {
     expect(output).toEqual(['snapshot-before-handler', 'live-after-handler']);
   });
 
+  it('preserves script phase banner and output ordering during running scripts', async () => {
+    const socket = createFakeSocket();
+    const events: BackendEvent[] = [];
+    const ptyChunks: string[] = [];
+
+    const backend = new RemoteSessionBackend({
+      descriptor: {
+        key: buildRemoteBackendKey('wss://relay.test/ws', 'machine-1'),
+        kind: 'remote',
+        label: 'Machine 1',
+        relayUrl: 'wss://relay.test/ws',
+        machineId: 'machine-1',
+      },
+      socket,
+      socketAdapter,
+      identity,
+      machineId: 'machine-1',
+      deviceCertificate: 'test-device-cert',
+      signer: (message) => ({ ...message, signature: { sig: 'x' } }),
+      crypto: cryptoAdapter,
+      handshake: handshakeAdapter,
+    });
+
+    backend.onEvent((event) => events.push(event));
+    backend.setPtyOutputHandler((data) => {
+      ptyChunks.push(new TextDecoder().decode(data));
+    });
+
+    await connectAndHandshake(backend, socket);
+
+    socket.handlers?.onMessage(
+      makeRelayDataPayload(cryptoAdapter, {
+        type: 'script_output',
+        phase: 'pre',
+        data: cryptoAdapter.encodeBase64(new TextEncoder().encode('==> pre scripts...\n')),
+      })
+    );
+
+    socket.handlers?.onMessage(
+      makeRelayDataPayload(cryptoAdapter, {
+        type: 'script_output',
+        phase: 'setup',
+        data: cryptoAdapter.encodeBase64(new TextEncoder().encode('==> setup scripts...\n')),
+      })
+    );
+
+    socket.handlers?.onMessage(
+      makeRelayDataPayload(cryptoAdapter, {
+        type: 'script_output',
+        phase: 'setup',
+        data: cryptoAdapter.encodeBase64(new TextEncoder().encode('installing deps\n')),
+      })
+    );
+
+    socket.handlers?.onMessage(
+      makeRelayDataPayload(cryptoAdapter, {
+        type: 'script_output',
+        phase: 'select',
+        data: cryptoAdapter.encodeBase64(new TextEncoder().encode('==> select scripts...\n')),
+      })
+    );
+
+    socket.handlers?.onMessage(
+      makeRelayDataPayload(cryptoAdapter, {
+        type: 'script_output',
+        phase: 'select',
+        data: cryptoAdapter.encodeBase64(new TextEncoder().encode('opening shell\n')),
+      })
+    );
+    await Bun.sleep(0);
+
+    expect(ptyChunks).toEqual([
+      '==> pre scripts...\n',
+      '==> setup scripts...\n',
+      'installing deps\n',
+      '==> select scripts...\n',
+      'opening shell\n',
+    ]);
+
+    const scriptEvents = events.filter(
+      (event): event is Extract<BackendEvent, { type: 'script_output' }> => event.type === 'script_output'
+    );
+    const chunks = scriptEvents.map((event) => ({
+      phase: event.phase,
+      text: new TextDecoder().decode(event.data),
+    }));
+
+    expect(chunks).toEqual([
+      { phase: 'pre', text: '==> pre scripts...\n' },
+      { phase: 'setup', text: '==> setup scripts...\n' },
+      { phase: 'setup', text: 'installing deps\n' },
+      { phase: 'select', text: '==> select scripts...\n' },
+      { phase: 'select', text: 'opening shell\n' },
+    ]);
+  });
+
   it('re-buffers PTY output after callback is cleared and flushes on re-register', async () => {
     const socket = createFakeSocket();
     const callbackOneOutput: string[] = [];

--- a/src/session/__tests__/useRemoteSessionClient.test.ts
+++ b/src/session/__tests__/useRemoteSessionClient.test.ts
@@ -15,6 +15,7 @@ import { buildRemoteBackendKey } from '../backend-key.js'
 import type { RemoteSessionPtyBackend } from '../useRemoteSessionClient.js'
 import { useRemoteSessionClient } from '../useRemoteSessionClient.js'
 import type { BundleRefreshPlan, BundleRefreshSubmission } from '../../types/bundle-refresh.js'
+import type { BundleConfigState, BundleConfigSubmission } from '../../types/bundle-config.js'
 
 const domWindow = new Window()
 const originalWindow = globalThis.window
@@ -54,6 +55,8 @@ class FakeRemoteBackend implements RemoteSessionPtyBackend {
   updateNotificationConfigCalls: NotificationConfig[] = []
   bundlePlanCalls: Array<{ projectName: string; workspaceId: string }> = []
   bundleApplyCalls: Array<{ projectName: string; workspaceId: string; submission: BundleRefreshSubmission }> = []
+  bundleConfigStateCalls: Array<{ projectName: string; workspaceId: string }> = []
+  bundleConfigUpdateCalls: Array<{ projectName: string; workspaceId: string; submission: BundleConfigSubmission }> = []
   ptyWrites: Uint8Array[] = []
   ptyResizes: Array<{ cols: number; rows: number }> = []
 
@@ -173,6 +176,27 @@ class FakeRemoteBackend implements RemoteSessionPtyBackend {
     submission: BundleRefreshSubmission
   ): Promise<void> {
     this.bundleApplyCalls.push({ projectName, workspaceId, submission })
+  }
+
+  async getBundleConfigState(projectName: string, workspaceId: string): Promise<BundleConfigState> {
+    this.bundleConfigStateCalls.push({ projectName, workspaceId })
+    return {
+      projectName,
+      workspaceId,
+      workspaceName: workspaceId,
+      workspacePath: `/tmp/${workspaceId}`,
+      hasBundle: true,
+      details: 'bundle state',
+      steps: [],
+    }
+  }
+
+  async applyBundleConfigUpdate(
+    projectName: string,
+    workspaceId: string,
+    submission: BundleConfigSubmission
+  ): Promise<void> {
+    this.bundleConfigUpdateCalls.push({ projectName, workspaceId, submission })
   }
 
   async clearInbox(id?: string): Promise<void> {

--- a/src/session/backend.ts
+++ b/src/session/backend.ts
@@ -4,6 +4,10 @@ import type {
   BundleRefreshPlan,
   BundleRefreshSubmission,
 } from '../types/bundle-refresh.js';
+import type {
+  BundleConfigState,
+  BundleConfigSubmission,
+} from '../types/bundle-config.js';
 import type { ReviewOperation, ReviewResult } from '../types/review.js';
 import type { WideEventFilter } from '../types/events.js';
 import type { SessionLinearIssueSummary, WorkspaceSource } from '../types/lifecycle.js';
@@ -105,6 +109,12 @@ export interface SessionBackend {
     projectName: string,
     workspaceId: string,
     submission: BundleRefreshSubmission
+  ): Promise<void>;
+  getBundleConfigState(projectName: string, workspaceId: string): Promise<BundleConfigState>;
+  applyBundleConfigUpdate(
+    projectName: string,
+    workspaceId: string,
+    submission: BundleConfigSubmission
   ): Promise<void>;
 
   requestInbox(): Promise<void>;

--- a/src/session/backends/local-session-backend.ts
+++ b/src/session/backends/local-session-backend.ts
@@ -41,6 +41,8 @@ import {
 import {
   getBundleRefreshPlan as getBundleRefreshPlanCore,
   applyBundleRefreshSubmission,
+  getBundleConfigState as getBundleConfigStateCore,
+  applyBundleConfigSubmission,
 } from '../../core/bundle-refresh.js';
 import { createBufferedSocketWriter } from '../../utils/bun-socket-writer.js';
 import { findUtf8Boundary } from '../../utils/utf8.js';
@@ -63,6 +65,7 @@ import type {
 import type { BackendEvent } from '../events.js';
 import type { NotificationConfig } from '../../notifications/types.js';
 import type { BundleRefreshPlan, BundleRefreshSubmission } from '../../types/bundle-refresh.js';
+import type { BundleConfigState, BundleConfigSubmission } from '../../types/bundle-config.js';
 import type { ReviewOperation, ReviewResult } from '../../types/review.js';
 import { executeLocalReviewOperation } from '../../core/review-executor.js';
 import type { WideEventFilter } from '../../types/events.js';
@@ -109,6 +112,8 @@ export interface LocalSessionBackendDependencies {
   prepareWorkspaceForSession: typeof prepareWorkspaceForSession;
   getBundleRefreshPlanCore: typeof getBundleRefreshPlanCore;
   applyBundleRefreshSubmission: typeof applyBundleRefreshSubmission;
+  getBundleConfigStateCore: typeof getBundleConfigStateCore;
+  applyBundleConfigSubmission: typeof applyBundleConfigSubmission;
   connectSessionSocket: (
     socketPath: string,
     handlers: LocalSessionSocketHandlers
@@ -357,6 +362,8 @@ function buildDeps(
     prepareWorkspaceForSession,
     getBundleRefreshPlanCore,
     applyBundleRefreshSubmission,
+    getBundleConfigStateCore,
+    applyBundleConfigSubmission,
     connectSessionSocket,
     ...overrides,
   };
@@ -624,6 +631,13 @@ export class LocalSessionBackend implements SessionBackend {
           },
           onPhaseStart: (phase) => {
             currentPhase = phase;
+            const banner = Buffer.from(`\r\n==> ${phase} scripts...\r\n`);
+            this.emitPtyData(banner);
+            this.emit({
+              type: 'script_output',
+              phase,
+              data: banner,
+            });
           },
         }).finally(() => {
           if (this.pendingAttachAbortController === attachAbortController) {
@@ -825,6 +839,20 @@ export class LocalSessionBackend implements SessionBackend {
   ): Promise<void> {
     const workspace = await this.resolveWorkspace(projectName, workspaceId);
     await this.deps.applyBundleRefreshSubmission(projectName, workspace.path, submission);
+  }
+
+  async getBundleConfigState(projectName: string, workspaceId: string): Promise<BundleConfigState> {
+    const workspace = await this.resolveWorkspace(projectName, workspaceId);
+    return this.deps.getBundleConfigStateCore(projectName, workspace.path, workspace.id);
+  }
+
+  async applyBundleConfigUpdate(
+    projectName: string,
+    workspaceId: string,
+    submission: BundleConfigSubmission
+  ): Promise<void> {
+    const workspace = await this.resolveWorkspace(projectName, workspaceId);
+    await this.deps.applyBundleConfigSubmission(projectName, workspace.path, submission);
   }
 
   async sendReviewRequest(operation: ReviewOperation): Promise<ReviewResult> {

--- a/src/session/backends/remote-session-backend.ts
+++ b/src/session/backends/remote-session-backend.ts
@@ -1,5 +1,6 @@
 import type { Identity, SessionKeys } from '../../types/identity.js';
 import {
+  type ApplyBundleConfigUpdateRequest,
   parseRemoteMessage,
   type ApplyBundleRefreshRequest,
   type AttachSessionRequest,
@@ -7,6 +8,8 @@ import {
   type CreateWorkspaceRequest,
   type DeleteProjectRequest,
   type BundleRefreshAppliedResponse,
+  type BundleConfigUpdatedResponse,
+  type BundleConfigStateResponse,
   type BundleRefreshPlanResponse,
   type CancelPendingAttachRequest,
   type ClearInboxRequest,
@@ -17,6 +20,7 @@ import {
   type GetEventsRequest,
   type GetInboxRequest,
   type GetBundleRefreshPlanRequest,
+  type GetBundleConfigStateRequest,
   type GetNotificationConfigRequest,
   type KillSessionRequest,
   type ListLinearIssuesRequest,
@@ -41,6 +45,7 @@ import {
   type WorkspaceCreatedResponse,
 } from '../../lib/remote-session/protocol.js';
 import type { BundleRefreshPlan, BundleRefreshSubmission } from '../../types/bundle-refresh.js';
+import type { BundleConfigState, BundleConfigSubmission } from '../../types/bundle-config.js';
 import type { ReviewOperation, ReviewResult } from '../../types/review.js';
 import type { WideEvent, WideEventFilter } from '../../types/events.js';
 import type { SessionLinearIssueSummary } from '../../types/lifecycle.js';
@@ -200,6 +205,8 @@ const MACHINE_TO_CLIENT_TYPES = new Set<string>([
   'script_output',
   'bundle_refresh_plan',
   'bundle_refresh_applied',
+  'bundle_config_state',
+  'bundle_config_updated',
   'review_response',
   'events_list',
   'process_started',
@@ -344,6 +351,20 @@ export class RemoteSessionBackend<TSocket, THandshakeState, TServerHello, TServe
       }
     | null = null;
   private pendingBundleRefreshApply:
+    | {
+        resolve: () => void;
+        reject: (error: Error) => void;
+        timeout: ReturnType<typeof setTimeout>;
+      }
+    | null = null;
+  private pendingBundleConfigState:
+    | {
+        resolve: (state: BundleConfigState) => void;
+        reject: (error: Error) => void;
+        timeout: ReturnType<typeof setTimeout>;
+      }
+    | null = null;
+  private pendingBundleConfigUpdate:
     | {
         resolve: () => void;
         reject: (error: Error) => void;
@@ -911,6 +932,77 @@ export class RemoteSessionBackend<TSocket, THandshakeState, TServerHello, TServe
     });
   }
 
+  async getBundleConfigState(projectName: string, workspaceId: string): Promise<BundleConfigState> {
+    if (this.pendingBundleConfigState) {
+      throw new Error('Bundle config state request already in progress');
+    }
+
+    const command: GetBundleConfigStateRequest = {
+      type: 'get_bundle_config_state',
+      projectName,
+      workspaceId,
+    };
+
+    return new Promise<BundleConfigState>((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        if (!this.pendingBundleConfigState) {
+          return;
+        }
+        this.pendingBundleConfigState = null;
+        reject(new Error('Timed out waiting for bundle config state'));
+      }, 15000);
+
+      this.pendingBundleConfigState = { resolve, reject, timeout };
+      void this.sendCommand(command).catch((error) => {
+        const pending = this.pendingBundleConfigState;
+        if (!pending) {
+          return;
+        }
+        clearTimeout(pending.timeout);
+        this.pendingBundleConfigState = null;
+        reject(error instanceof Error ? error : new Error(String(error)));
+      });
+    });
+  }
+
+  async applyBundleConfigUpdate(
+    projectName: string,
+    workspaceId: string,
+    submission: BundleConfigSubmission
+  ): Promise<void> {
+    if (this.pendingBundleConfigUpdate) {
+      throw new Error('Bundle config update request already in progress');
+    }
+
+    const command: ApplyBundleConfigUpdateRequest = {
+      type: 'apply_bundle_config_update',
+      projectName,
+      workspaceId,
+      submission,
+    };
+
+    return new Promise<void>((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        if (!this.pendingBundleConfigUpdate) {
+          return;
+        }
+        this.pendingBundleConfigUpdate = null;
+        reject(new Error('Timed out applying bundle config update'));
+      }, 15000);
+
+      this.pendingBundleConfigUpdate = { resolve, reject, timeout };
+      void this.sendCommand(command).catch((error) => {
+        const pending = this.pendingBundleConfigUpdate;
+        if (!pending) {
+          return;
+        }
+        clearTimeout(pending.timeout);
+        this.pendingBundleConfigUpdate = null;
+        reject(error instanceof Error ? error : new Error(String(error)));
+      });
+    });
+  }
+
   async requestInbox(): Promise<void> {
     const command: GetInboxRequest = { type: 'get_inbox' };
     await this.sendCommand(command);
@@ -1372,6 +1464,14 @@ export class RemoteSessionBackend<TSocket, THandshakeState, TServerHello, TServe
         this.resolveBundleRefreshApply(message);
         return;
       }
+      case 'bundle_config_state': {
+        this.resolveBundleConfigState(message);
+        return;
+      }
+      case 'bundle_config_updated': {
+        this.resolveBundleConfigUpdate(message);
+        return;
+      }
       case 'review_response': {
         this.resolveReviewRequest(message);
         return;
@@ -1736,6 +1836,28 @@ export class RemoteSessionBackend<TSocket, THandshakeState, TServerHello, TServe
     pending.resolve();
   }
 
+  private resolveBundleConfigState(message: BundleConfigStateResponse): void {
+    const pending = this.pendingBundleConfigState;
+    if (!pending) {
+      return;
+    }
+
+    clearTimeout(pending.timeout);
+    this.pendingBundleConfigState = null;
+    pending.resolve(message.state);
+  }
+
+  private resolveBundleConfigUpdate(_message: BundleConfigUpdatedResponse): void {
+    const pending = this.pendingBundleConfigUpdate;
+    if (!pending) {
+      return;
+    }
+
+    clearTimeout(pending.timeout);
+    this.pendingBundleConfigUpdate = null;
+    pending.resolve();
+  }
+
   private rejectPendingBundleRefreshRequests(message: string): void {
     const error = new Error(message);
 
@@ -1749,6 +1871,18 @@ export class RemoteSessionBackend<TSocket, THandshakeState, TServerHello, TServe
       clearTimeout(this.pendingBundleRefreshApply.timeout);
       this.pendingBundleRefreshApply.reject(error);
       this.pendingBundleRefreshApply = null;
+    }
+
+    if (this.pendingBundleConfigState) {
+      clearTimeout(this.pendingBundleConfigState.timeout);
+      this.pendingBundleConfigState.reject(error);
+      this.pendingBundleConfigState = null;
+    }
+
+    if (this.pendingBundleConfigUpdate) {
+      clearTimeout(this.pendingBundleConfigUpdate.timeout);
+      this.pendingBundleConfigUpdate.reject(error);
+      this.pendingBundleConfigUpdate = null;
     }
   }
 

--- a/src/session/index.ts
+++ b/src/session/index.ts
@@ -81,6 +81,15 @@ export {
 } from './useBundleRefreshAttachFlow.js';
 
 export type {
+  UseBundleConfigFlowOptions,
+  UseBundleConfigFlowResult,
+} from './useBundleConfigFlow.js';
+
+export {
+  useBundleConfigFlow,
+} from './useBundleConfigFlow.js';
+
+export type {
   RemoteSessionSocketHandlers,
   RemoteSessionSocketAdapter,
   RemoteSessionCryptoAdapter,

--- a/src/session/useBundleConfigFlow.ts
+++ b/src/session/useBundleConfigFlow.ts
@@ -1,0 +1,298 @@
+import { useCallback } from 'react';
+import type { UseFlowReturn, FlowWizardStep } from '../components/Flow.js';
+import type { ConfirmStepResult } from '../types/bundle.js';
+import type { BundleConfigState, BundleConfigStep, BundleConfigSubmission } from '../types/bundle-config.js';
+
+const MAX_VALIDATION_PATTERN_LENGTH = 256;
+const MAX_VALIDATION_INPUT_LENGTH = 512;
+const UNSET_SECRET_TOKEN = '-';
+
+function parseProjectNameFromWorkspaceId(workspaceId: string): string | null {
+  const separatorIndex = workspaceId.indexOf(':');
+  if (separatorIndex <= 0) {
+    return null;
+  }
+  return workspaceId.slice(0, separatorIndex) || null;
+}
+
+function toErrorMessage(error: unknown, fallback: string): string {
+  if (error instanceof Error && error.message) {
+    return error.message;
+  }
+
+  if (typeof error === 'string' && error.length > 0) {
+    return error;
+  }
+
+  return fallback;
+}
+
+function isLikelySafeValidationPattern(pattern: string): boolean {
+  if (pattern.length > MAX_VALIDATION_PATTERN_LENGTH) {
+    return false;
+  }
+
+  if (/\(\?<?[=!]/.test(pattern) || /\\[1-9]/.test(pattern)) {
+    return false;
+  }
+
+  if (/\((?:[^()\\]|\\.)*[+*](?:[^()\\]|\\.)*\)[+*{]/.test(pattern)) {
+    return false;
+  }
+
+  return true;
+}
+
+function buildSafeValidationRegex(pattern?: string): RegExp | null {
+  if (!pattern || !isLikelySafeValidationPattern(pattern)) {
+    return null;
+  }
+
+  try {
+    return new RegExp(pattern);
+  } catch {
+    return null;
+  }
+}
+
+function buildValidation(step: BundleConfigStep): ((value: string) => string | null) | undefined {
+  if (step.type !== 'input' && step.type !== 'secret') {
+    return undefined;
+  }
+
+  const validationRegex = buildSafeValidationRegex(step.validationPattern);
+
+  return (value: string): string | null => {
+    const trimmed = value.trim();
+    const required = step.required !== false;
+    const allowsUnset = step.type === 'secret' && step.hasSecret;
+
+    if (required && trimmed.length === 0 && !allowsUnset) {
+      return 'This field is required';
+    }
+
+    if (trimmed.length > MAX_VALIDATION_INPUT_LENGTH) {
+      return `Value must be ${MAX_VALIDATION_INPUT_LENGTH} characters or fewer`;
+    }
+
+    if (validationRegex && trimmed.length > 0 && trimmed !== UNSET_SECRET_TOKEN && !validationRegex.test(trimmed)) {
+      return step.validationMessage || `Value must match pattern: ${step.validationPattern}`;
+    }
+
+    return null;
+  };
+}
+
+function toWizardStep(step: BundleConfigStep): FlowWizardStep {
+  if (step.type === 'confirm') {
+    const status = step.confirmResult?.status ?? 'pending';
+    const checkedAt = step.confirmCheckedAt ? `\nLast checked: ${step.confirmCheckedAt}` : '';
+    return {
+      id: step.id,
+      type: 'confirm',
+      title: step.title,
+      description: `${step.description}\nCurrent status: ${status}${checkedAt}\n\nPress Enter to keep this status.`,
+      checkCommand: step.checkCommand,
+      checkStatus: status === 'passed' ? 'found' : 'missing',
+      installUrl: step.installUrl,
+    };
+  }
+
+  if (step.type === 'secret') {
+    const suffix = step.hasSecret
+      ? '\n\nSecret is currently set. Leave blank to keep it, or enter - to unset it.'
+      : '';
+    return {
+      id: step.id,
+      type: 'secret',
+      title: step.title,
+      description: `${step.description}${suffix}`,
+      validation: buildValidation(step),
+      defaultValue: '',
+    };
+  }
+
+  if (step.type === 'input') {
+    return {
+      id: step.id,
+      type: 'input',
+      title: step.title,
+      description: step.description,
+      validation: buildValidation(step),
+      defaultValue: step.value ?? step.defaultValue ?? '',
+    };
+  }
+
+  return {
+    id: step.id,
+    type: 'info',
+    title: step.title,
+    description: step.description,
+  };
+}
+
+function runWizard(
+  flow: Pick<UseFlowReturn, 'showWizard'>,
+  state: BundleConfigState
+): Promise<Record<string, string> | null> {
+  return new Promise<Record<string, string> | null>((resolve) => {
+    flow.showWizard({
+      title: `Bundle Config - ${state.workspaceName}`,
+      steps: state.steps.map(toWizardStep),
+      onComplete: async (values) => {
+        resolve(values);
+      },
+      onCancel: () => {
+        resolve(null);
+      },
+    });
+  });
+}
+
+function buildSubmission(
+  state: BundleConfigState,
+  values: Record<string, string>
+): BundleConfigSubmission {
+  const inputValues: Record<string, string> = {};
+  const secretValues: Record<string, string> = {};
+  const confirmResults: Record<string, ConfirmStepResult> = {};
+
+  for (const step of state.steps) {
+    if (step.type === 'input' && step.configKey) {
+      const value = (values[step.id] ?? '').trim();
+      inputValues[step.configKey] = value;
+      continue;
+    }
+
+    if (step.type === 'secret' && step.configKey) {
+      const value = (values[step.id] ?? '').trim();
+      if (value.length === 0) {
+        continue;
+      }
+      if (value === UNSET_SECRET_TOKEN) {
+        secretValues[step.configKey] = '';
+        continue;
+      }
+      secretValues[step.configKey] = value;
+      continue;
+    }
+
+    if (step.type === 'confirm') {
+      if (step.confirmResult) {
+        confirmResults[step.id] = {
+          status: step.confirmResult.status,
+          checkCommand: step.checkCommand,
+        };
+      }
+    }
+  }
+
+  return {
+    inputValues,
+    secretValues,
+    confirmResults,
+  };
+}
+
+export interface UseBundleConfigFlowOptions {
+  flow: Pick<UseFlowReturn, 'showLoading' | 'showMessage' | 'showWizard' | 'close'>;
+  getBundleConfigState: (projectName: string, workspaceId: string) => Promise<BundleConfigState>;
+  applyBundleConfigUpdate: (
+    projectName: string,
+    workspaceId: string,
+    submission: BundleConfigSubmission
+  ) => Promise<void>;
+  resolveProjectName?: (workspaceId: string) => string | null;
+  onApplied?: () => Promise<void> | void;
+}
+
+export interface UseBundleConfigFlowResult {
+  openBundleConfig: (params: { workspaceId: string; projectName?: string | null }) => Promise<boolean>;
+}
+
+export function useBundleConfigFlow(
+  options: UseBundleConfigFlowOptions
+): UseBundleConfigFlowResult {
+  const openBundleConfig = useCallback(async (
+    params: { workspaceId: string; projectName?: string | null }
+  ): Promise<boolean> => {
+    const projectName =
+      params.projectName ??
+      options.resolveProjectName?.(params.workspaceId) ??
+      parseProjectNameFromWorkspaceId(params.workspaceId);
+
+    if (!projectName) {
+      options.flow.showMessage({
+        title: 'Bundle Config Unavailable',
+        message: `Could not resolve project for workspace ${params.workspaceId}.`,
+        variant: 'error',
+      });
+      return false;
+    }
+
+    try {
+      options.flow.showLoading({
+        title: 'Bundle Config',
+        message: 'Loading current bundle configuration...',
+      });
+
+      const state = await options.getBundleConfigState(projectName, params.workspaceId);
+
+      if (!state.hasBundle) {
+        options.flow.showMessage({
+          title: 'No Bundle',
+          message: 'No bundle is configured for this workspace.',
+          variant: 'info',
+        });
+        return false;
+      }
+
+      if (state.steps.length === 0) {
+        options.flow.showMessage({
+          title: 'Bundle Config',
+          message: 'This bundle has no editable onboarding steps.',
+          variant: 'info',
+        });
+        return false;
+      }
+
+      const values = await runWizard(options.flow, state);
+      if (!values) {
+        options.flow.showMessage({
+          title: 'Bundle Config Cancelled',
+          message: 'No changes were applied.',
+          variant: 'warning',
+        });
+        return false;
+      }
+
+      options.flow.showLoading({
+        title: 'Bundle Config',
+        message: 'Applying bundle configuration updates...',
+      });
+
+      await options.applyBundleConfigUpdate(
+        projectName,
+        params.workspaceId,
+        buildSubmission(state, values)
+      );
+
+      await options.onApplied?.();
+      options.flow.showMessage({
+        title: 'Bundle Config Updated',
+        message: `Saved bundle configuration for ${state.workspaceName}.`,
+        variant: 'success',
+      });
+      return true;
+    } catch (error) {
+      options.flow.showMessage({
+        title: 'Bundle Config Failed',
+        message: toErrorMessage(error, 'Failed to update bundle configuration.'),
+        variant: 'error',
+      });
+      return false;
+    }
+  }, [options]);
+
+  return { openBundleConfig };
+}

--- a/src/session/useBundleConfigFlow.ts
+++ b/src/session/useBundleConfigFlow.ts
@@ -213,16 +213,24 @@ export interface UseBundleConfigFlowResult {
 export function useBundleConfigFlow(
   options: UseBundleConfigFlowOptions
 ): UseBundleConfigFlowResult {
+  const {
+    flow,
+    getBundleConfigState,
+    applyBundleConfigUpdate,
+    resolveProjectName,
+    onApplied,
+  } = options;
+
   const openBundleConfig = useCallback(async (
     params: { workspaceId: string; projectName?: string | null }
   ): Promise<boolean> => {
     const projectName =
       params.projectName ??
-      options.resolveProjectName?.(params.workspaceId) ??
+      resolveProjectName?.(params.workspaceId) ??
       parseProjectNameFromWorkspaceId(params.workspaceId);
 
     if (!projectName) {
-      options.flow.showMessage({
+      flow.showMessage({
         title: 'Bundle Config Unavailable',
         message: `Could not resolve project for workspace ${params.workspaceId}.`,
         variant: 'error',
@@ -231,15 +239,15 @@ export function useBundleConfigFlow(
     }
 
     try {
-      options.flow.showLoading({
+      flow.showLoading({
         title: 'Bundle Config',
         message: 'Loading current bundle configuration...',
       });
 
-      const state = await options.getBundleConfigState(projectName, params.workspaceId);
+      const state = await getBundleConfigState(projectName, params.workspaceId);
 
       if (!state.hasBundle) {
-        options.flow.showMessage({
+        flow.showMessage({
           title: 'No Bundle',
           message: 'No bundle is configured for this workspace.',
           variant: 'info',
@@ -248,7 +256,7 @@ export function useBundleConfigFlow(
       }
 
       if (state.steps.length === 0) {
-        options.flow.showMessage({
+        flow.showMessage({
           title: 'Bundle Config',
           message: 'This bundle has no editable onboarding steps.',
           variant: 'info',
@@ -256,9 +264,9 @@ export function useBundleConfigFlow(
         return false;
       }
 
-      const values = await runWizard(options.flow, state);
+      const values = await runWizard(flow, state);
       if (!values) {
-        options.flow.showMessage({
+        flow.showMessage({
           title: 'Bundle Config Cancelled',
           message: 'No changes were applied.',
           variant: 'warning',
@@ -266,33 +274,33 @@ export function useBundleConfigFlow(
         return false;
       }
 
-      options.flow.showLoading({
+      flow.showLoading({
         title: 'Bundle Config',
         message: 'Applying bundle configuration updates...',
       });
 
-      await options.applyBundleConfigUpdate(
+      await applyBundleConfigUpdate(
         projectName,
         params.workspaceId,
         buildSubmission(state, values)
       );
 
-      await options.onApplied?.();
-      options.flow.showMessage({
+      await onApplied?.();
+      flow.showMessage({
         title: 'Bundle Config Updated',
         message: `Saved bundle configuration for ${state.workspaceName}.`,
         variant: 'success',
       });
       return true;
     } catch (error) {
-      options.flow.showMessage({
+      flow.showMessage({
         title: 'Bundle Config Failed',
         message: toErrorMessage(error, 'Failed to update bundle configuration.'),
         variant: 'error',
       });
       return false;
     }
-  }, [options]);
+  }, [applyBundleConfigUpdate, flow, getBundleConfigState, onApplied, resolveProjectName]);
 
   return { openBundleConfig };
 }

--- a/src/session/useBundleRefreshAttachFlow.ts
+++ b/src/session/useBundleRefreshAttachFlow.ts
@@ -451,10 +451,7 @@ export function useBundleRefreshAttachFlow(
       const currentOptions = optionsRef.current;
       currentOptions.flow.showMessage({
         title: 'Workspace Script Failed',
-        message:
-          `${message}\n\n` +
-          'Press Enter/Esc to close this dialog and inspect script output.\n' +
-          'Press a to retry attach anyway (skip scripts).',
+        message: `${message}\n\nClose this dialog to inspect script output.`,
         variant: 'error',
       });
       lastHandledAttemptRef.current = pending.attemptId;

--- a/src/session/useBundleRefreshAttachFlow.ts
+++ b/src/session/useBundleRefreshAttachFlow.ts
@@ -451,7 +451,10 @@ export function useBundleRefreshAttachFlow(
       const currentOptions = optionsRef.current;
       currentOptions.flow.showMessage({
         title: 'Workspace Script Failed',
-        message,
+        message:
+          `${message}\n\n` +
+          'Press Enter/Esc to close this dialog and inspect script output.\n' +
+          'Press a to retry attach anyway (skip scripts).',
         variant: 'error',
       });
       lastHandledAttemptRef.current = pending.attemptId;

--- a/src/session/useRemoteSessionClient.ts
+++ b/src/session/useRemoteSessionClient.ts
@@ -20,6 +20,10 @@ import type {
   BundleRefreshPlan,
   BundleRefreshSubmission,
 } from '../types/bundle-refresh.js';
+import type {
+  BundleConfigState,
+  BundleConfigSubmission,
+} from '../types/bundle-config.js';
 import type { ReviewOperation, ReviewResult } from '../types/review.js';
 import { SpacesError } from '../types/errors.js';
 import type { WideEvent, SavedEventFilter, WideEventFilter } from '../types/events.js';
@@ -87,6 +91,12 @@ export interface UseRemoteSessionClientReturn<ConnectParams> {
     projectName: string,
     workspaceId: string,
     submission: BundleRefreshSubmission
+  ) => Promise<void>;
+  getBundleConfigState: (projectName: string, workspaceId: string) => Promise<BundleConfigState>;
+  applyBundleConfigUpdate: (
+    projectName: string,
+    workspaceId: string,
+    submission: BundleConfigSubmission
   ) => Promise<void>;
 
   send: (data: Uint8Array) => void;
@@ -344,6 +354,34 @@ export function useRemoteSessionClient<ConnectParams>(
     [engine]
   );
 
+  const getBundleConfigState = useCallback(
+    async (projectName: string, workspaceId: string): Promise<BundleConfigState> => {
+      const backendKey = activeBackendKeyRef.current;
+      if (!backendKey) {
+        throw new Error('No active backend connection');
+      }
+
+      return engine.getBundleConfigState(backendKey, projectName, workspaceId);
+    },
+    [engine]
+  );
+
+  const applyBundleConfigUpdate = useCallback(
+    async (
+      projectName: string,
+      workspaceId: string,
+      submission: BundleConfigSubmission
+    ): Promise<void> => {
+      const backendKey = activeBackendKeyRef.current;
+      if (!backendKey) {
+        throw new Error('No active backend connection');
+      }
+
+      await engine.applyBundleConfigUpdate(backendKey, projectName, workspaceId, submission);
+    },
+    [engine]
+  );
+
   const send = useCallback((data: Uint8Array) => {
     const backend = backendRef.current;
     if (!backend || !backend.writePtyData) {
@@ -472,6 +510,8 @@ export function useRemoteSessionClient<ConnectParams>(
     deleteWorkspace,
     getBundleRefreshPlan,
     applyBundleRefresh,
+    getBundleConfigState,
+    applyBundleConfigUpdate,
 
     send,
     resize,

--- a/src/session/useSessionEngine.ts
+++ b/src/session/useSessionEngine.ts
@@ -13,6 +13,10 @@ import type {
   BundleRefreshPlan,
   BundleRefreshSubmission,
 } from '../types/bundle-refresh.js';
+import type {
+  BundleConfigState,
+  BundleConfigSubmission,
+} from '../types/bundle-config.js';
 import type { ReviewOperation, ReviewResult } from '../types/review.js';
 import type { ScriptPhase } from '../types/script-phase.js';
 import type { WideEventFilter } from '../types/events.js';
@@ -395,6 +399,34 @@ export function useSessionEngine() {
     );
   }, [withBackend]);
 
+  const getBundleConfigState = useCallback(async (
+    backendKey: BackendKey,
+    projectName: string,
+    workspaceId: string
+  ): Promise<BundleConfigState> => {
+    let stateResult: BundleConfigState | null = null;
+    await withBackend(backendKey, async (backend) => {
+      stateResult = await backend.getBundleConfigState(projectName, workspaceId);
+    });
+
+    if (!stateResult) {
+      throw new SpacesError('Bundle config state was not returned by backend', 'SYSTEM_ERROR', 2);
+    }
+
+    return stateResult;
+  }, [withBackend]);
+
+  const applyBundleConfigUpdate = useCallback(async (
+    backendKey: BackendKey,
+    projectName: string,
+    workspaceId: string,
+    submission: BundleConfigSubmission
+  ) => {
+    await withBackend(backendKey, (backend) =>
+      backend.applyBundleConfigUpdate(projectName, workspaceId, submission)
+    );
+  }, [withBackend]);
+
   const requestInbox = useCallback(async (backendKey: BackendKey) => {
     await withBackend(backendKey, (backend) => backend.requestInbox());
   }, [withBackend]);
@@ -488,6 +520,8 @@ export function useSessionEngine() {
     deleteWorkspace,
     getBundleRefreshPlan,
     applyBundleRefresh,
+    getBundleConfigState,
+    applyBundleConfigUpdate,
 
     requestInbox,
     clearInbox,
@@ -522,6 +556,8 @@ export function useSessionEngine() {
     deleteWorkspace,
     getBundleRefreshPlan,
     applyBundleRefresh,
+    getBundleConfigState,
+    applyBundleConfigUpdate,
     requestInbox,
     clearInbox,
     markInboxRead,

--- a/src/tui/__tests__/flow-select-input.test.ts
+++ b/src/tui/__tests__/flow-select-input.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it, mock } from 'bun:test'
+import { applySearchableSelectPaste, handleSearchableSelectKey } from '../flow-select-input.js'
+
+function createFlow(overrides: Partial<{ type: string; searchable: boolean; searchQuery: string }> = {}) {
+  const flowState = {
+    type: overrides.type ?? 'select',
+    searchable: overrides.searchable ?? true,
+    searchQuery: overrides.searchQuery ?? '',
+  }
+
+  const flowApi = {
+    flow: flowState,
+    handleCancel: mock(() => {}),
+    handleConfirm: mock(async () => {}),
+    moveUp: mock(() => {}),
+    moveDown: mock(() => {}),
+    updateSelectQuery: mock((value: string) => {
+      flowState.searchQuery = value
+    }),
+  }
+
+  return flowApi
+}
+
+describe('searchable select input helpers', () => {
+  it('applies normalized pasted text to searchable select query', () => {
+    const flow = createFlow({ searchQuery: 'fea' })
+
+    const handled = applySearchableSelectPaste(flow, 't\nure')
+
+    expect(handled).toBe(true)
+    expect(flow.flow.searchQuery).toBe('feature')
+    expect(flow.updateSelectQuery).toHaveBeenCalledWith('feature')
+  })
+
+  it('treats j/k as text input for searchable selects', async () => {
+    const flow = createFlow({ searchQuery: 'fix-' })
+
+    const handled = await handleSearchableSelectKey(flow, { raw: 'j' })
+
+    expect(handled).toBe(true)
+    expect(flow.flow.searchQuery).toBe('fix-j')
+    expect(flow.moveDown).toHaveBeenCalledTimes(0)
+  })
+
+  it('uses arrow keys for navigation in searchable selects', async () => {
+    const flow = createFlow()
+
+    const handled = await handleSearchableSelectKey(flow, { name: 'down' })
+
+    expect(handled).toBe(true)
+    expect(flow.moveDown).toHaveBeenCalledTimes(1)
+    expect(flow.updateSelectQuery).toHaveBeenCalledTimes(0)
+  })
+
+  it('returns false when flow is not a searchable select', async () => {
+    const flow = createFlow({ type: 'message', searchable: false })
+
+    const pasteHandled = applySearchableSelectPaste(flow, 'abc')
+    const keyHandled = await handleSearchableSelectKey(flow, { raw: 'x' })
+
+    expect(pasteHandled).toBe(false)
+    expect(keyHandled).toBe(false)
+    expect(flow.updateSelectQuery).toHaveBeenCalledTimes(0)
+  })
+})

--- a/src/tui/flow-select-input.ts
+++ b/src/tui/flow-select-input.ts
@@ -1,0 +1,78 @@
+import { getKeyboardInputChunk, normalizeInputText, type KeyboardLikeInput } from './input-text.js'
+
+interface SearchableSelectState {
+  type: string
+  searchable?: boolean
+  searchQuery?: string
+}
+
+export interface SearchableSelectFlowApi {
+  flow: SearchableSelectState
+  handleCancel: () => void
+  handleConfirm: () => void | Promise<void>
+  moveUp: () => void
+  moveDown: () => void
+  updateSelectQuery: (value: string) => void
+}
+
+function isSearchableSelectOpen(flow: SearchableSelectFlowApi): boolean {
+  return flow.flow.type === 'select' && flow.flow.searchable === true
+}
+
+export function applySearchableSelectPaste(flow: SearchableSelectFlowApi, text: string): boolean {
+  if (!isSearchableSelectOpen(flow)) {
+    return false
+  }
+
+  const chunk = normalizeInputText(text)
+  if (!chunk) {
+    return false
+  }
+
+  const current = flow.flow.searchQuery ?? ''
+  flow.updateSelectQuery(current + chunk)
+  return true
+}
+
+export async function handleSearchableSelectKey(
+  flow: SearchableSelectFlowApi,
+  key: KeyboardLikeInput
+): Promise<boolean> {
+  if (!isSearchableSelectOpen(flow)) {
+    return false
+  }
+
+  if (key.name === 'escape') {
+    flow.handleCancel()
+    return true
+  }
+
+  if (key.name === 'return') {
+    await flow.handleConfirm()
+    return true
+  }
+
+  if (key.name === 'up') {
+    flow.moveUp()
+    return true
+  }
+
+  if (key.name === 'down') {
+    flow.moveDown()
+    return true
+  }
+
+  if (key.name === 'backspace') {
+    const current = flow.flow.searchQuery ?? ''
+    flow.updateSelectQuery(current.slice(0, -1))
+    return true
+  }
+
+  const chunk = getKeyboardInputChunk(key)
+  if (chunk) {
+    const current = flow.flow.searchQuery ?? ''
+    flow.updateSelectQuery(current + chunk)
+  }
+
+  return true
+}

--- a/src/tui/input-text.ts
+++ b/src/tui/input-text.ts
@@ -1,4 +1,5 @@
-interface KeyboardLikeInput {
+export interface KeyboardLikeInput {
+  name?: string | null;
   raw?: string;
   ctrl?: boolean;
   meta?: boolean;

--- a/src/types/bundle-config.ts
+++ b/src/types/bundle-config.ts
@@ -1,0 +1,41 @@
+import type { ConfirmStepResult, OnboardingStepType } from './bundle.js';
+
+export interface BundleConfigStep {
+  id: string;
+  type: OnboardingStepType;
+  title: string;
+  description: string;
+  required?: boolean;
+  configKey?: string;
+  defaultValue?: string;
+  validationPattern?: string;
+  validationMessage?: string;
+  checkCommand?: string;
+  installUrl?: string;
+  confirmPrompt?: string;
+  value?: string;
+  hasSecret?: boolean;
+  confirmResult?: ConfirmStepResult;
+  confirmCheckedAt?: string;
+}
+
+export interface BundleConfigState {
+  projectName: string;
+  workspaceId: string;
+  workspaceName: string;
+  workspacePath: string;
+  hasBundle: boolean;
+  scope?: string;
+  bundleSource?: 'workspace' | 'base';
+  currentHash?: string;
+  details: string;
+  bundleName?: string;
+  bundleVersion?: string;
+  steps: BundleConfigStep[];
+}
+
+export interface BundleConfigSubmission {
+  inputValues?: Record<string, string>;
+  secretValues?: Record<string, string>;
+  confirmResults?: Record<string, ConfirmStepResult>;
+}

--- a/src/utils/__tests__/run-workspace-scripts.test.ts
+++ b/src/utils/__tests__/run-workspace-scripts.test.ts
@@ -193,6 +193,42 @@ describe('runWorkspaceScripts', () => {
       expect(hasSetupBeenRun(workspacePath)).toBe(true);
     });
 
+    it('reports pre, setup, and select phases in order on first run', async () => {
+      const phases: string[] = [];
+      const chunks: string[] = [];
+
+      const preScript = join(preScriptsDir, '01-pre.sh');
+      writeFileSync(preScript, '#!/bin/bash\necho "pre-phase"');
+      chmodSync(preScript, 0o755);
+
+      const setupScript = join(setupScriptsDir, '01-setup.sh');
+      writeFileSync(setupScript, '#!/bin/bash\necho "setup-phase"');
+      chmodSync(setupScript, 0o755);
+
+      const selectScript = join(selectScriptsDir, '01-select.sh');
+      writeFileSync(selectScript, '#!/bin/bash\necho "select-phase"');
+      chmodSync(selectScript, 0o755);
+
+      const result = await runWorkspaceScripts({
+        projectName: 'test-project',
+        workspacePath,
+        workspaceName: 'test-workspace',
+        repository: 'owner/repo',
+        onPhaseStart: (phase) => {
+          phases.push(phase);
+        },
+        onOutput: (data) => {
+          chunks.push(data.toString());
+        },
+      });
+
+      expect(result.success).toBe(true);
+      expect(phases).toEqual(['pre', 'setup', 'select']);
+      expect(chunks.join('')).toContain('pre-phase');
+      expect(chunks.join('')).toContain('setup-phase');
+      expect(chunks.join('')).toContain('select-phase');
+    });
+
     it('should return pre phase error when pre script fails', async () => {
       // Create failing pre script
       const preScript = join(preScriptsDir, '01-fail.sh');
@@ -327,6 +363,27 @@ describe('runWorkspaceScripts', () => {
       expect(output.trim()).toBe('select');
     });
 
+    it('reports only the select phase for an existing workspace', async () => {
+      const phases: string[] = [];
+
+      const selectScript = join(selectScriptsDir, '01-select.sh');
+      writeFileSync(selectScript, '#!/bin/bash\necho "select-only"');
+      chmodSync(selectScript, 0o755);
+
+      const result = await runWorkspaceScripts({
+        projectName: 'test-project',
+        workspacePath,
+        workspaceName: 'test-workspace',
+        repository: 'owner/repo',
+        onPhaseStart: (phase) => {
+          phases.push(phase);
+        },
+      });
+
+      expect(result.success).toBe(true);
+      expect(phases).toEqual(['select']);
+    });
+
     it('should return select phase error when select script fails', async () => {
       // Create failing select script
       const selectScript = join(selectScriptsDir, '01-fail.sh');
@@ -401,6 +458,32 @@ describe('runWorkspaceScripts', () => {
 
       expect(result.success).toBe(true);
       expect(existsSync(outputFile)).toBe(false);
+    });
+
+    it('does not report any phases when scriptPolicy is skip', async () => {
+      const phases: string[] = [];
+
+      const setupScript = join(setupScriptsDir, '01-setup.sh');
+      writeFileSync(setupScript, '#!/bin/bash\necho "setup"');
+      chmodSync(setupScript, 0o755);
+
+      const selectScript = join(selectScriptsDir, '01-select.sh');
+      writeFileSync(selectScript, '#!/bin/bash\necho "select"');
+      chmodSync(selectScript, 0o755);
+
+      const result = await runWorkspaceScripts({
+        projectName: 'test-project',
+        workspacePath,
+        workspaceName: 'test-workspace',
+        repository: 'owner/repo',
+        scriptPolicy: 'skip',
+        onPhaseStart: (phase) => {
+          phases.push(phase);
+        },
+      });
+
+      expect(result.success).toBe(true);
+      expect(phases).toEqual([]);
     });
   });
 });


### PR DESCRIPTION
## Summary
- make TUI `Flow` select dialogs scroll-safe by clamping modal height and rendering a bounded option viewport
- add type-to-search support for selectable dialogs and enable it for "Select Branch" and "Select Linear Issue"
- improve option row spacing in select dialogs so labels and descriptions no longer overlap, and add tests for searchable selection behavior

## Verification
- bun run typecheck
- bun test src/components/__tests__/Flow.test.ts src/app/session/__tests__/useLifecycleController.test.ts

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new bundle config read/update flows (including secret set/unset) and extends the remote-session protocol/backends, which could affect workspace configuration correctness and permissions if buggy.
> 
> **Overview**
> **Searchable select modals:** `Flow` select dialogs now support type-to-search filtering, clamped sizing, and correct confirm/navigation against filtered results, with TUI keyboard/paste handling wired via `flow-select-input` and tests added.
> 
> **Bundle config management:** Adds a new `useBundleConfigFlow` wizard to view/edit bundle inputs, secrets (including unset), and confirm statuses; exposes it in Spaces Browser via a new `bundle-config` action and `[b] Bundle` shortcut across TUI/web/remote screens.
> 
> **Backend/CLI support:** Introduces `bundle show`/`bundle edit` CLI commands, adds `getBundleConfigState`/`applyBundleConfigUpdate` to session backends and remote protocol/handler, and tweaks script output streaming to include phase banners plus a clearer script-failure message.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0aaddc2539b861a320031e89380e8a0faa52bd7f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Selection modals are now searchable with live filtering, paginated display, and full keyboard & paste support; script view layout updated with a dynamic hint for running state and errors.

* **Bug Fixes**
  * Keyboard and paste input now reliably update searchable selects; navigation and selection honor filtered results and hotkeys are suppressed in script mode.

* **Tests**
  * Added unit tests for searchable select filtering, navigation, and selection.

* **UX**
  * Error dialog now suggests closing it to inspect script output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->