### PR TITLE
Harden cloud identity recovery and relay trust flows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ temp/
 
 # Cloudflare
 .wrangler/
+worker/.mf-build/
 
 # GitSpace marker files
 gitspace.lock

--- a/docs/issues/01-host-sync-diagnostics-after-login.md
+++ b/docs/issues/01-host-sync-diagnostics-after-login.md
@@ -1,0 +1,45 @@
+# [P0] Host Sync Diagnostics After Login
+
+Status: implemented.
+
+## Problem
+
+`gssh user auth login` can succeed while host sync fails silently. Users then expect hosted relay/tunnel flows to work but discover missing setup later.
+
+Current pain point: host sync currently ignores many failures in best-effort mode.
+
+## Goal
+
+After login, show an explicit hosted readiness summary:
+
+- active reserved subdomain present/missing
+- tunnel token present/missing
+- serve tunnel token present/missing
+- exact fix command for each missing item
+
+## Scope
+
+- Make `syncHostConfig()` return structured diagnostics (not silent catch-all).
+- Surface diagnostics in `authLogin()` output.
+- Add optional `gssh user host doctor` for explicit checks.
+
+## Proposed implementation
+
+- `src/commands/host.ts`
+  - Return `{ ok, warnings[], checks{} }` from sync path.
+  - Keep compatibility for callers that only need side effects.
+- `src/commands/auth.ts`
+  - Print concise post-login readiness state.
+- `src/cli/commands/user.ts` (optional)
+  - Add `user host doctor` command.
+
+## Acceptance criteria
+
+- [x] Login output clearly states whether hosted relay is ready.
+- [x] Missing host token/subdomain states are visible and actionable.
+- [x] No silent failures for token/subdomain fetch in normal login flow.
+
+## Tests
+
+- Unit tests for sync result classification.
+- Command tests for post-login output in success/degraded/fail states.

--- a/docs/issues/02-hosted-relay-startup-deterministic.md
+++ b/docs/issues/02-hosted-relay-startup-deterministic.md
@@ -1,0 +1,53 @@
+# [P0] Deterministic Hosted Relay Startup
+
+Status: implemented.
+
+## Problem
+
+`gssh relay start` can attempt hosted startup and then silently degrade to local-only relay behavior when hosted prerequisites fail.
+
+That breaks onboarding expectations and makes docs hard to trust.
+
+## Goal
+
+When users choose hosted mode, startup must be deterministic:
+
+- either return a public relay URL (`wss://<subdomain>.gitspace.sh/ws`)
+- or fail fast with actionable errors
+
+## Scope
+
+- Add explicit startup mode:
+  - `--mode hosted` (strict)
+  - `--mode auto` (backward-compatible behavior)
+  - `--mode local` (no hosted assumptions)
+- In hosted mode, fail on:
+  - missing subdomain
+  - missing/failed tunnel token fetch
+  - missing `cloudflared`
+
+## Proposed implementation
+
+- `src/cli/commands/relay.ts`
+  - Add `--mode` option and help text.
+- `src/commands/relay.ts`
+  - Refactor startup path by mode.
+  - Keep fallback only for `auto` mode.
+  - Standardize printed endpoint for websocket usage.
+
+## Acceptance criteria
+
+- [x] `gssh relay start --mode hosted` never silently downgrades.
+- [x] Hosted success prints public URL.
+- [x] Hosted failure prints exact remediation commands.
+- [x] `--mode local` works without hosted checks.
+
+## Tests
+
+- Startup tests for hosted/auto/local mode matrix.
+- Multi-subdomain selection tests for deterministic behavior.
+
+## Follow-up
+
+- Relay owner binding no longer pre-marks the vault as initialized.
+- First unlock now repairs legacy incomplete vault metadata created by the earlier startup bug.

--- a/docs/issues/03-external-relay-identity-pinning-for-cloud-bootstrap.md
+++ b/docs/issues/03-external-relay-identity-pinning-for-cloud-bootstrap.md
@@ -1,0 +1,40 @@
+# [P0] External Relay Identity Pinning for Cloud Bootstrap
+
+Status: implemented.
+
+## Problem
+
+Cloud bootstrap assumes relay identity data is available in control metadata or local relay identity files. In dedicated-relay topology, the control machine may not have local relay identity material.
+
+Result: cloud launch can fail or become ambiguous.
+
+## Goal
+
+Persist and enforce trusted relay identity metadata for cloud bootstrap in external-relay setups.
+
+## Scope
+
+- Persist relay identity (`relayIdentityId`, signing pubkey, fingerprint) after trust verification when `machine serve start` connects to relay.
+- Ensure cloud launch resolves relay identity from pinned control metadata first.
+- Fail closed on relay identity mismatch.
+
+## Proposed implementation
+
+- `src/commands/serve.ts`
+  - Persist trusted relay metadata after successful trust flow.
+-  - Persist a cloud-reachable relay URL separately from the last relay URL used for local reconnects.
+- `src/relay/control/store.ts`
+  - Reuse `bindControlRelayIdentity()` mismatch checks.
+- `src/commands/cloud.ts`
+  - Prefer pinned control metadata plus a cloud-reachable relay URL, and fail closed when only a local/private relay URL is saved.
+
+## Acceptance criteria
+
+- [x] Dedicated relay machine + separate control machine can run `gssh cloud launch`.
+- [x] Pinned relay mismatch blocks launch with explicit error.
+- [x] Cloud launch no longer depends on local relay private identity on control machine.
+
+## Tests
+
+- Integration test: external relay + control node + cloud launch.
+- Regression test: pinned relay mismatch fail path.

--- a/docs/issues/04-cloudflared-preflight-and-install-ux.md
+++ b/docs/issues/04-cloudflared-preflight-and-install-ux.md
@@ -1,0 +1,36 @@
+# [P0] Cloudflared Preflight and Install UX
+
+## Problem
+
+Hosted relay and hosted serve flows require `cloudflared`, but checks happen late and install guidance is inconsistent.
+
+## Goal
+
+Fail early and clearly when `cloudflared` is missing, with platform-aware install instructions.
+
+## Scope
+
+- Add preflight helper command (`gssh doctor relay` or `gssh deps cloudflared`).
+- Run preflight automatically in hosted relay/serve startup paths.
+- Improve install instructions for macOS and Linux.
+
+## Proposed implementation
+
+- `src/utils/cloudflared.ts`
+  - Add `getCloudflaredInstallHint()` helper.
+- `src/commands/relay.ts`
+  - Preflight in hosted mode before startup.
+- `src/commands/serve.ts`
+  - Preflight for hosted tunnel path.
+- CLI command registration for explicit doctor/deps command.
+
+## Acceptance criteria
+
+- [ ] Missing `cloudflared` is reported before startup attempts.
+- [ ] Error message includes install guidance for current platform.
+- [ ] Hosted path does not continue past failed preflight.
+
+## Tests
+
+- Unit tests for install hint resolution by platform.
+- Command tests for preflight failure output and exit behavior.

--- a/docs/issues/05-client-relay-trust-verification-and-pinning.md
+++ b/docs/issues/05-client-relay-trust-verification-and-pinning.md
@@ -1,0 +1,37 @@
+# [P0] Client Relay Trust Verification and Pinning
+
+Status: implemented.
+
+## Problem
+
+Client flows (`client connect`, `client machines list`) need explicit relay identity verification parity with serve/enroll trust flows.
+
+## Goal
+
+Require relay trust on client side (TOFU or explicit pubkey) and reject key mismatch by default.
+
+## Scope
+
+- Add client relay identity verification flow.
+- Integrate with trusted relay store.
+- Add optional `--relay-pubkey` override for explicit trust.
+
+## Proposed implementation
+
+- `src/commands/connect.ts`
+  - Verify relay identity before sending authorization messages.
+- `src/session/backends/remote-session-backend.ts`
+  - Ensure relay identity handshake event is available to client command path.
+- Trusted relay utilities in `src/core/`.
+
+## Acceptance criteria
+
+- [x] Unknown relay requires explicit trust confirmation or pubkey.
+- [x] Relay key mismatch fails connection by default.
+- [x] Client list/connect have consistent trust behavior.
+
+## Tests
+
+- [x] TOFU accept/reject tests.
+- [x] Key rotation mismatch tests.
+- [x] Explicit pubkey mode tests.

--- a/docs/issues/06-cloud-bootstrap-token-hardening.md
+++ b/docs/issues/06-cloud-bootstrap-token-hardening.md
@@ -1,0 +1,43 @@
+# [P0] Cloud Bootstrap Token Hardening
+
+Status: partially implemented.
+
+## Problem
+
+Cloud bootstrap unlock/claim flow needs stronger guarantees against replay/race/incorrect claimant scenarios.
+
+## Goal
+
+Tighten bootstrap security with explicit identity binding and strict token/state invariants.
+
+## Scope
+
+- Bind unlock grants to expected machine identity where possible.
+- Enforce single-use + strict expiry + irreversible state transitions.
+- Reject stale/replayed unlock requests reliably.
+
+## Proposed implementation
+
+- `src/relay/server.ts`
+  - Harden unlock grant checks and machine binding assertions.
+- `src/relay/control/store.ts`
+  - Strengthen token state machine and consumed semantics.
+- `src/cloud/bootstrap-entry.ts`
+  - Keep bootstrap client behavior aligned with stricter server checks.
+
+## Acceptance criteria
+
+- [x] Replay of consumed token is rejected.
+- [x] Wrong claimant machine cannot complete bootstrap.
+- [ ] Race attempts do not produce split/ambiguous ownership of bootstrap path.
+
+## Tests
+
+- [x] Unlock token replay tests.
+- [ ] Concurrent claim race tests.
+- [x] Expired token rejection tests.
+
+## Notes
+
+- Store-side state invariants are stricter now (`pending` / `vm_created` / `unlock_granted` transitions, workspace status checks, machine key/id consistency checks).
+- A broader concurrent-claim regression harness is still worth adding before calling this fully complete.

--- a/docs/issues/07-cloud-connect-ux-workspace-to-machine.md
+++ b/docs/issues/07-cloud-connect-ux-workspace-to-machine.md
@@ -1,0 +1,37 @@
+# [P1] Cloud Connect UX: Workspace to Machine Resolution
+
+Status: implemented.
+
+## Problem
+
+`cloud list` is workspace-centric, while `client connect` requires machine ID. Users must manually map workspace to machine.
+
+## Goal
+
+Allow direct connect from cloud workspace identity.
+
+## Scope
+
+- Add `gssh cloud connect <workspace-id>` (or equivalent resolver command).
+- Improve `cloud list` output with machine mapping and suggested connect command.
+- Handle non-ready states (`bootstrapping`, `error`, `destroyed`) with clear errors.
+
+## Proposed implementation
+
+- `src/cli/commands/cloud.ts`
+  - Add `connect` subcommand.
+- `src/commands/cloud.ts`
+  - Resolve workspace -> machine ID and delegate to remote connect.
+- `src/commands/connect.ts`
+  - Reuse existing connect path.
+
+## Acceptance criteria
+
+- [x] Users can connect via workspace ID directly.
+- [x] Ready-state validation prevents confusing connect failures.
+- [x] `cloud list` presents enough info to connect without cross-referencing.
+
+## Tests
+
+- [x] Command tests for connect by workspace ID.
+- [x] Error-path tests for non-ready workspace states.

--- a/docs/issues/08-cloud-launch-machine-first-repo-optional.md
+++ b/docs/issues/08-cloud-launch-machine-first-repo-optional.md
@@ -2,24 +2,27 @@
 
 ## Problem
 
-`gssh cloud launch` currently requires `--repo` and `--branch`, but cloud runtime is machine-centric and repo/branch are mostly launch metadata.
+`gssh cloud launch` currently treats `--repo` / `--branch` like required launch inputs, but cloud runtime is machine-centric and repo/branch are only optional metadata.
 
 ## Goal
 
-Support cloud machine launch without repo binding, while preserving optional repo/branch metadata.
+Support cloud machine launch without repo or branch metadata, while preserving optional repo/branch metadata when explicitly provided.
 
 ## Scope
 
-- Make `--repo` optional in CLI.
+- Make both `--repo` and `--branch` optional in CLI.
 - Make launch options and provider contract accept missing repo/branch.
+- Reject `--branch` when `--repo` is omitted.
 - Keep metadata display in `cloud list` when provided.
 
 ## Proposed implementation
 
 - `src/cli/commands/cloud.ts`
   - Change `--repo` from required to optional.
+  - Remove the implicit default for `--branch` and treat it as optional metadata.
 - `src/commands/cloud.ts`
-  - Make `repo` optional in launch options.
+  - Make `repo` and `branch` optional in launch options.
+  - Only accept `branch` when `repo` is present.
 - `src/relay/control/sprites-provider.ts`
   - Align provider input contract with optional repo/branch.
 - tests in `src/commands/__tests__/cloud-launch.test.ts`.
@@ -27,10 +30,12 @@ Support cloud machine launch without repo binding, while preserving optional rep
 ## Acceptance criteria
 
 - [ ] `gssh cloud launch` works without `--repo`.
+- [ ] `gssh cloud launch --repo owner/repo` works without `--branch`.
 - [ ] Existing repo/branch launch still works unchanged.
+- [ ] `gssh cloud launch --branch main` fails unless `--repo` is also provided.
 - [ ] `cloud list` includes repo/branch only when present.
 
 ## Tests
 
-- Launch tests for with/without repo.
+- Launch tests for machine-first, repo-only, and repo+branch flows.
 - Backward compatibility tests for existing command patterns.

--- a/docs/issues/08-cloud-launch-machine-first-repo-optional.md
+++ b/docs/issues/08-cloud-launch-machine-first-repo-optional.md
@@ -1,0 +1,36 @@
+# [P1] Cloud Launch Should Be Machine-First (Repo Optional)
+
+## Problem
+
+`gssh cloud launch` currently requires `--repo` and `--branch`, but cloud runtime is machine-centric and repo/branch are mostly launch metadata.
+
+## Goal
+
+Support cloud machine launch without repo binding, while preserving optional repo/branch metadata.
+
+## Scope
+
+- Make `--repo` optional in CLI.
+- Make launch options and provider contract accept missing repo/branch.
+- Keep metadata display in `cloud list` when provided.
+
+## Proposed implementation
+
+- `src/cli/commands/cloud.ts`
+  - Change `--repo` from required to optional.
+- `src/commands/cloud.ts`
+  - Make `repo` optional in launch options.
+- `src/relay/control/sprites-provider.ts`
+  - Align provider input contract with optional repo/branch.
+- tests in `src/commands/__tests__/cloud-launch.test.ts`.
+
+## Acceptance criteria
+
+- [ ] `gssh cloud launch` works without `--repo`.
+- [ ] Existing repo/branch launch still works unchanged.
+- [ ] `cloud list` includes repo/branch only when present.
+
+## Tests
+
+- Launch tests for with/without repo.
+- Backward compatibility tests for existing command patterns.

--- a/docs/issues/09-noninteractive-golden-path.md
+++ b/docs/issues/09-noninteractive-golden-path.md
@@ -1,0 +1,34 @@
+# [P1] Non-Interactive Golden Path
+
+## Problem
+
+Prompt-heavy identity/trust/connect paths make automation difficult, even for users who want a deterministic script-based setup.
+
+## Goal
+
+Provide a realistic unattended setup path for hosted relay + machine attach + client connect list.
+
+## Scope
+
+- Normalize `--yes` behavior across auth/serve/connect/invite/enroll flows.
+- Add `--password-stdin` where missing.
+- Add `--non-interactive` fail-fast mode with explicit missing-input errors.
+
+## Proposed implementation
+
+- `src/commands/auth.ts`
+- `src/commands/connect.ts`
+- `src/commands/invite.ts`
+- `src/commands/machine-enroll.ts`
+- corresponding CLI command definitions
+
+## Acceptance criteria
+
+- [ ] End-to-end setup possible without interactive prompts.
+- [ ] Commands fail fast with explicit missing-input diagnostics in non-interactive mode.
+- [ ] Docs include both interactive and automation sequences.
+
+## Tests
+
+- Command tests for non-interactive failure/success branches.
+- Scripted end-to-end smoke test in CI (or local integration harness).

--- a/docs/issues/README.md
+++ b/docs/issues/README.md
@@ -1,0 +1,39 @@
+# Polish Issues: Final Backlog
+
+These issues capture the final polish pass needed to make the three-chapter GitSpace journey feel reliable and elegant in practice.
+
+## Priority order
+
+P0:
+
+1. `01-host-sync-diagnostics-after-login.md`
+2. `02-hosted-relay-startup-deterministic.md`
+3. `03-external-relay-identity-pinning-for-cloud-bootstrap.md`
+4. `04-cloudflared-preflight-and-install-ux.md`
+5. `05-client-relay-trust-verification-and-pinning.md`
+6. `06-cloud-bootstrap-token-hardening.md`
+
+P1:
+
+7. `07-cloud-connect-ux-workspace-to-machine.md`
+8. `08-cloud-launch-machine-first-repo-optional.md`
+9. `09-noninteractive-golden-path.md`
+
+## Release gate (minimum)
+
+Before calling the polish phase complete:
+
+- [x] hosted relay startup is deterministic and never silently downgrades
+- [x] host readiness diagnostics are visible after login
+- [x] external-relay cloud bootstrap works with pinned relay identity and a cloud-reachable relay URL
+- [x] client relay trust path is explicit and key mismatch is rejected
+- [ ] cloud bootstrap token path has full race/replay protections
+
+## Current status
+
+- Done: `01`, `02`, `03`, `05`, `07`
+- In progress: `06`
+- Remaining: `04`, `08`, `09`
+- Follow-up fixes landed after the initial backlog writeup:
+  - cloud flows now fail closed when only a local/private relay URL is saved
+  - relay owner binding no longer leaves the vault in a broken "initialized" state

--- a/src/cli/commands/__tests__/client.test.ts
+++ b/src/cli/commands/__tests__/client.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, mock, test } from 'bun:test';
 import { Command } from 'commander';
 
 const mockListRemoteMachines = mock(
-  async (_options: { relay?: string; relayPubkey?: string; yes?: boolean; json?: boolean }) => {
+  async (_options: { relay?: string; relayPubkey?: string; yes?: boolean; json?: boolean; passwordStdin?: boolean }) => {
     return;
   },
 );
@@ -10,7 +10,7 @@ const mockListRemoteMachines = mock(
 const mockConnectToRemote = mock(
   async (
     _target?: string,
-    _options?: { relay?: string; machine?: string; relayPubkey?: string; yes?: boolean },
+    _options?: { relay?: string; machine?: string; relayPubkey?: string; yes?: boolean; passwordStdin?: boolean },
   ) => {
     return;
   },
@@ -64,6 +64,7 @@ describe('registerClientCommands', () => {
         '--relay-pubkey',
         'relay-pubkey-b64',
         '--yes',
+        '--password-stdin',
         '--json',
       ],
       { from: 'user' },
@@ -74,6 +75,7 @@ describe('registerClientCommands', () => {
       relay: 'wss://relay.test/ws',
       relayPubkey: 'relay-pubkey-b64',
       yes: true,
+      passwordStdin: true,
       json: true,
     });
   });
@@ -91,6 +93,7 @@ describe('registerClientCommands', () => {
         '--relay-pubkey',
         'relay-pubkey-b64',
         '--yes',
+        '--password-stdin',
       ],
       { from: 'user' },
     );
@@ -100,6 +103,7 @@ describe('registerClientCommands', () => {
       relay: 'wss://relay.test/ws',
       relayPubkey: 'relay-pubkey-b64',
       yes: true,
+      passwordStdin: true,
     });
   });
 
@@ -117,6 +121,7 @@ describe('registerClientCommands', () => {
         '--relay-pubkey',
         'local-pubkey-b64',
         '--yes',
+        '--password-stdin',
       ],
       { from: 'user' },
     );
@@ -127,6 +132,7 @@ describe('registerClientCommands', () => {
       relay: 'ws://127.0.0.1:4480/ws',
       relayPubkey: 'local-pubkey-b64',
       yes: true,
+      passwordStdin: true,
     });
   });
 

--- a/src/cli/commands/__tests__/client.test.ts
+++ b/src/cli/commands/__tests__/client.test.ts
@@ -1,0 +1,150 @@
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
+import { Command } from 'commander';
+
+const mockListRemoteMachines = mock(
+  async (_options: { relay?: string; relayPubkey?: string; yes?: boolean; json?: boolean }) => {
+    return;
+  },
+);
+
+const mockConnectToRemote = mock(
+  async (
+    _target?: string,
+    _options?: { relay?: string; machine?: string; relayPubkey?: string; yes?: boolean },
+  ) => {
+    return;
+  },
+);
+
+mock.module('../../../commands/connect.js', () => ({
+  listRemoteMachines: mockListRemoteMachines,
+  connectToRemote: mockConnectToRemote,
+}));
+
+mock.module('../../error.js', () => ({
+  withErrorHandler: <T extends unknown[]>(handler: (...args: T) => Promise<void>) => handler,
+}));
+
+const { registerClientCommands } = await import('../client.js');
+
+function makeProgram(): Command {
+  const program = new Command();
+  program.name('gssh');
+  registerClientCommands(program);
+  return program;
+}
+
+function enableExitOverrideRecursively(command: Command): void {
+  command.exitOverride();
+  command.configureOutput({
+    writeErr: () => undefined,
+  });
+
+  for (const subcommand of command.commands) {
+    enableExitOverrideRecursively(subcommand);
+  }
+}
+
+describe('registerClientCommands', () => {
+  beforeEach(() => {
+    mockListRemoteMachines.mockReset();
+    mockConnectToRemote.mockReset();
+  });
+
+  test('wires client machines list options to listRemoteMachines', async () => {
+    const program = makeProgram();
+
+    await program.parseAsync(
+      [
+        'client',
+        'machines',
+        'list',
+        '--relay',
+        'wss://relay.test/ws',
+        '--relay-pubkey',
+        'relay-pubkey-b64',
+        '--yes',
+        '--json',
+      ],
+      { from: 'user' },
+    );
+
+    expect(mockListRemoteMachines).toHaveBeenCalledTimes(1);
+    expect(mockListRemoteMachines).toHaveBeenCalledWith({
+      relay: 'wss://relay.test/ws',
+      relayPubkey: 'relay-pubkey-b64',
+      yes: true,
+      json: true,
+    });
+  });
+
+  test('wires client connect target and trust flags to connectToRemote', async () => {
+    const program = makeProgram();
+
+    await program.parseAsync(
+      [
+        'client',
+        'connect',
+        'machine-123',
+        '--relay',
+        'wss://relay.test/ws',
+        '--relay-pubkey',
+        'relay-pubkey-b64',
+        '--yes',
+      ],
+      { from: 'user' },
+    );
+
+    expect(mockConnectToRemote).toHaveBeenCalledTimes(1);
+    expect(mockConnectToRemote).toHaveBeenCalledWith('machine-123', {
+      relay: 'wss://relay.test/ws',
+      relayPubkey: 'relay-pubkey-b64',
+      yes: true,
+    });
+  });
+
+  test('wires client connect --machine direct mode without target', async () => {
+    const program = makeProgram();
+
+    await program.parseAsync(
+      [
+        'client',
+        'connect',
+        '--machine',
+        'machine-abc',
+        '--relay',
+        'ws://127.0.0.1:4480/ws',
+        '--relay-pubkey',
+        'local-pubkey-b64',
+        '--yes',
+      ],
+      { from: 'user' },
+    );
+
+    expect(mockConnectToRemote).toHaveBeenCalledTimes(1);
+    expect(mockConnectToRemote).toHaveBeenCalledWith(undefined, {
+      machine: 'machine-abc',
+      relay: 'ws://127.0.0.1:4480/ws',
+      relayPubkey: 'local-pubkey-b64',
+      yes: true,
+    });
+  });
+
+  test('requires --relay for client machines list', async () => {
+    const program = makeProgram();
+    enableExitOverrideRecursively(program);
+
+    await expect(
+      program.parseAsync(
+        [
+          'client',
+          'machines',
+          'list',
+        ],
+        { from: 'user' },
+      ),
+    ).rejects.toThrow(/required option '--relay <url>' not specified/i);
+
+    expect(mockListRemoteMachines).not.toHaveBeenCalled();
+  });
+});

--- a/src/cli/commands/client.ts
+++ b/src/cli/commands/client.ts
@@ -24,6 +24,7 @@ export function registerClientCommands(parent: Command): void {
     .requiredOption('--relay <url>', 'Relay URL')
     .option('--relay-pubkey <pubkey>', 'Relay public key for explicit trust (base64)')
     .option('-y, --yes', 'Auto-confirm prompts')
+    .option('--password-stdin', 'Read password from stdin')
     .option('--json', 'Output in JSON format')
     .action(withErrorHandler(async (options) => {
       const { listRemoteMachines } = await import('../../commands/connect.js');
@@ -39,6 +40,7 @@ export function registerClientCommands(parent: Command): void {
     .option('--relay-pubkey <pubkey>', 'Relay public key for explicit trust (base64)')
     .option('--machine <id>', 'Machine ID for direct mode')
     .option('-y, --yes', 'Auto-confirm prompts')
+    .option('--password-stdin', 'Read password from stdin')
     .action(withErrorHandler(async (target, options) => {
       const { connectToRemote } = await import('../../commands/connect.js');
       await connectToRemote(target, options);

--- a/src/cli/commands/client.ts
+++ b/src/cli/commands/client.ts
@@ -22,6 +22,8 @@ export function registerClientCommands(parent: Command): void {
     .command('list')
     .description('List machines you can access')
     .requiredOption('--relay <url>', 'Relay URL')
+    .option('--relay-pubkey <pubkey>', 'Relay public key for explicit trust (base64)')
+    .option('-y, --yes', 'Auto-confirm prompts')
     .option('--json', 'Output in JSON format')
     .action(withErrorHandler(async (options) => {
       const { listRemoteMachines } = await import('../../commands/connect.js');
@@ -34,7 +36,9 @@ export function registerClientCommands(parent: Command): void {
     .description('Connect to a machine as the owner identity')
     .argument('[target]', 'Machine ID')
     .option('--relay <url>', 'Override relay URL')
+    .option('--relay-pubkey <pubkey>', 'Relay public key for explicit trust (base64)')
     .option('--machine <id>', 'Machine ID for direct mode')
+    .option('-y, --yes', 'Auto-confirm prompts')
     .action(withErrorHandler(async (target, options) => {
       const { connectToRemote } = await import('../../commands/connect.js');
       await connectToRemote(target, options);

--- a/src/cli/commands/cloud.ts
+++ b/src/cli/commands/cloud.ts
@@ -49,10 +49,10 @@ export function registerCloudCommands(parent: Command): void {
   cmd
     .command('launch')
     .description('Launch a new cloud agent workspace')
-    .requiredOption('--repo <owner/repo>', 'GitHub repository (e.g. myorg/myrepo)')
-    .option('--branch <branch>', 'Branch to check out', 'main')
+    .option('--repo <owner/repo>', 'GitHub repository metadata (optional)')
+    .option('--branch <branch>', 'Branch metadata (optional; requires --repo)')
     .option('--image <image>', 'Docker image override for the agent VM')
-    .action(withErrorHandler(async (options: { repo: string; branch?: string; image?: string }) => {
+    .action(withErrorHandler(async (options: { repo?: string; branch?: string; image?: string }) => {
       const { cloudLaunch } = await import('../../commands/cloud.js');
       await cloudLaunch({
         repo: options.repo,

--- a/src/cli/commands/cloud.ts
+++ b/src/cli/commands/cloud.ts
@@ -90,4 +90,16 @@ export function registerCloudCommands(parent: Command): void {
       const { cloudDestroy } = await import('../../commands/cloud.js');
       await cloudDestroy(workspaceId);
     }));
+
+  // gssh cloud connect <workspaceId>
+  cmd
+    .command('connect')
+    .description('Connect to a cloud workspace by workspace ID')
+    .argument('<workspaceId>', 'Cloud workspace ID')
+    .option('--relay <url>', 'Override relay URL')
+    .option('-y, --yes', 'Auto-confirm prompts')
+    .action(withErrorHandler(async (workspaceId: string, options: { relay?: string; yes?: boolean }) => {
+      const { cloudConnect } = await import('../../commands/cloud.js');
+      await cloudConnect(workspaceId, options);
+    }));
 }

--- a/src/cli/commands/cloud.ts
+++ b/src/cli/commands/cloud.ts
@@ -97,9 +97,10 @@ export function registerCloudCommands(parent: Command): void {
     .description('Connect to a cloud workspace by workspace ID')
     .argument('<workspaceId>', 'Cloud workspace ID')
     .option('--relay <url>', 'Override relay URL')
+    .option('--relay-pubkey <pubkey>', 'Relay public key for explicit trust (base64)')
     .option('-y, --yes', 'Auto-confirm prompts')
     .option('--password-stdin', 'Read password from stdin')
-    .action(withErrorHandler(async (workspaceId: string, options: { relay?: string; yes?: boolean; passwordStdin?: boolean }) => {
+    .action(withErrorHandler(async (workspaceId: string, options: { relay?: string; relayPubkey?: string; yes?: boolean; passwordStdin?: boolean }) => {
       const { cloudConnect } = await import('../../commands/cloud.js');
       await cloudConnect(workspaceId, options);
     }));

--- a/src/cli/commands/cloud.ts
+++ b/src/cli/commands/cloud.ts
@@ -98,7 +98,8 @@ export function registerCloudCommands(parent: Command): void {
     .argument('<workspaceId>', 'Cloud workspace ID')
     .option('--relay <url>', 'Override relay URL')
     .option('-y, --yes', 'Auto-confirm prompts')
-    .action(withErrorHandler(async (workspaceId: string, options: { relay?: string; yes?: boolean }) => {
+    .option('--password-stdin', 'Read password from stdin')
+    .action(withErrorHandler(async (workspaceId: string, options: { relay?: string; yes?: boolean; passwordStdin?: boolean }) => {
       const { cloudConnect } = await import('../../commands/cloud.js');
       await cloudConnect(workspaceId, options);
     }));

--- a/src/cli/commands/machine.ts
+++ b/src/cli/commands/machine.ts
@@ -58,6 +58,7 @@ function registerMachineServeCommands(machine: Command): void {
     .option('--unlock-token <token>', 'One-time token to request unlock grant from relay')
     .option('--workspace-id <id>', 'Cloud workspace id for unlock-token flow')
     .option('--ignore-keychain-and-skip-secrets', 'Skip keychain preload and skip secret-dependent scripts')
+    .option('-y, --yes', 'Auto-confirm prompts')
     .option('--password-stdin', 'Read password from stdin')
     .option('--foreground', "Run in foreground (don't daemonize)")
     .action(withErrorHandler(async (options) => {

--- a/src/cli/commands/machine.ts
+++ b/src/cli/commands/machine.ts
@@ -60,7 +60,6 @@ function registerMachineServeCommands(machine: Command): void {
     .option('--ignore-keychain-and-skip-secrets', 'Skip keychain preload and skip secret-dependent scripts')
     .option('-y, --yes', 'Auto-confirm prompts')
     .option('--password-stdin', 'Read password from stdin')
-    .option('--skip-relay-trust-verification', 'Internal: skip foreground relay trust verification')
     .option('--foreground', "Run in foreground (don't daemonize)")
     .action(withErrorHandler(async (options) => {
       const { serveStart } = await import('../../commands/serve.js');

--- a/src/cli/commands/machine.ts
+++ b/src/cli/commands/machine.ts
@@ -60,6 +60,7 @@ function registerMachineServeCommands(machine: Command): void {
     .option('--ignore-keychain-and-skip-secrets', 'Skip keychain preload and skip secret-dependent scripts')
     .option('-y, --yes', 'Auto-confirm prompts')
     .option('--password-stdin', 'Read password from stdin')
+    .option('--skip-relay-trust-verification', 'Internal: skip foreground relay trust verification')
     .option('--foreground', "Run in foreground (don't daemonize)")
     .action(withErrorHandler(async (options) => {
       const { serveStart } = await import('../../commands/serve.js');

--- a/src/cli/commands/relay.ts
+++ b/src/cli/commands/relay.ts
@@ -3,11 +3,10 @@
  */
 
 import type { Command } from 'commander';
+import type { RelayStartMode } from '../../commands/relay.js';
 import { withErrorHandler } from '../error.js';
 import { SpacesError } from '../../types/errors.js';
 import { logger } from '../../utils/logger.js';
-
-type RelayStartMode = 'auto' | 'hosted' | 'local';
 
 function parseRelayPort(rawPort: string): number {
   if (!/^\d+$/.test(rawPort)) {

--- a/src/cli/commands/relay.ts
+++ b/src/cli/commands/relay.ts
@@ -6,6 +6,8 @@ import type { Command } from 'commander';
 import { withErrorHandler } from '../error.js';
 import { SpacesError } from '../../types/errors.js';
 
+type RelayStartMode = 'auto' | 'hosted' | 'local';
+
 function parseRelayPort(rawPort: string): number {
   if (!/^\d+$/.test(rawPort)) {
     throw new SpacesError('Port must be an integer between 1 and 65535.', 'USER_ERROR', 1);
@@ -19,6 +21,19 @@ function parseRelayPort(rawPort: string): number {
   return port;
 }
 
+function parseRelayStartMode(rawMode: string): RelayStartMode {
+  const normalized = rawMode.trim().toLowerCase();
+  if (normalized === 'auto' || normalized === 'hosted' || normalized === 'local') {
+    return normalized;
+  }
+
+  throw new SpacesError(
+    'Invalid relay mode. Expected one of: auto, hosted, local.',
+    'USER_ERROR',
+    1,
+  );
+}
+
 export function registerRelayCommands(parent: Command): void {
   const cmd = parent
     .command('relay')
@@ -30,14 +45,18 @@ export function registerRelayCommands(parent: Command): void {
     .option('--port <port>', 'Port to listen on', '4480')
     .option('--bind <address>', 'Address to bind to', '0.0.0.0')
     .option('--hostname <host>', 'Only serve requests for this domain (optional)')
+    .option('--mode <mode>', 'Startup mode: auto, hosted, local', 'auto')
     .option('--label <label>', 'Human-readable label for this relay')
+    .option('-y, --yes', 'Auto-confirm prompts')
     .action(withErrorHandler(async (options) => {
       const { startRelay } = await import('../../commands/relay.js');
       await startRelay({
         port: parseRelayPort(options.port),
         bind: options.bind,
         hostname: options.hostname,
+        mode: parseRelayStartMode(options.mode),
         label: options.label,
+        yes: options.yes,
       });
     }, { skipSetupCheck: true }));
 

--- a/src/cli/commands/relay.ts
+++ b/src/cli/commands/relay.ts
@@ -5,6 +5,7 @@
 import type { Command } from 'commander';
 import { withErrorHandler } from '../error.js';
 import { SpacesError } from '../../types/errors.js';
+import { logger } from '../../utils/logger.js';
 
 type RelayStartMode = 'auto' | 'hosted' | 'local';
 
@@ -27,6 +28,7 @@ function parseRelayStartMode(rawMode: string): RelayStartMode {
     return normalized;
   }
 
+  logger.error(`Invalid relay start mode: ${rawMode}`);
   throw new SpacesError(
     'Invalid relay mode. Expected one of: auto, hosted, local.',
     'USER_ERROR',

--- a/src/cli/commands/user.ts
+++ b/src/cli/commands/user.ts
@@ -147,6 +147,7 @@ function registerAuthCommands(user: Command): void {
     .command('login')
     .description('Login with GitHub')
     .option('-y, --yes', 'Auto-confirm prompts')
+    .option('--password-stdin', 'Read local identity password from stdin')
     .action(withErrorHandler(async (options) => {
       const { authLogin } = await import('../../commands/auth.js');
       await authLogin(options);

--- a/src/cli/commands/user.ts
+++ b/src/cli/commands/user.ts
@@ -57,6 +57,8 @@ function registerIdentityCommands(user: Command): void {
   identity
     .command('recover')
     .description('Recover identity from 24-word mnemonic')
+    .option('--cloud', 'Recover from GitSpace cloud backup (requires login)')
+    .option('-y, --yes', 'Auto-confirm prompts')
     .option('--force', 'Overwrite existing identity')
     .action(withErrorHandler(async (options) => {
       const { recoverIdentity } = await import('../../commands/identity.js');
@@ -91,6 +93,45 @@ function registerIdentityCommands(user: Command): void {
       const { removeIdentity } = await import('../../commands/identity.js');
       await removeIdentity(options);
     }));
+
+  const backup = identity
+    .command('backup')
+    .description('Manage optional encrypted cloud backup of your user identity');
+
+  backup
+    .command('enable')
+    .description('Enable/update encrypted cloud backup for your identity')
+    .option('-y, --yes', 'Auto-confirm prompts')
+    .action(withErrorHandler(async (options) => {
+      const { enableIdentityBackup } = await import('../../commands/identity.js');
+      await enableIdentityBackup(options);
+    }));
+
+  backup
+    .command('status')
+    .description('Show cloud backup status for your identity')
+    .action(withErrorHandler(async () => {
+      const { showIdentityBackupStatus } = await import('../../commands/identity.js');
+      await showIdentityBackupStatus();
+    }));
+
+  backup
+    .command('disable')
+    .description('Disable and remove encrypted cloud backup for your identity')
+    .option('-y, --yes', 'Auto-confirm prompts')
+    .action(withErrorHandler(async (options) => {
+      const { disableIdentityBackup } = await import('../../commands/identity.js');
+      await disableIdentityBackup(options);
+    }));
+
+  backup
+    .command('rotate-password')
+    .description('Rotate the password used to encrypt cloud identity backup')
+    .option('-y, --yes', 'Auto-confirm prompts')
+    .action(withErrorHandler(async (options) => {
+      const { rotateIdentityBackupPassword } = await import('../../commands/identity.js');
+      await rotateIdentityBackupPassword(options);
+    }));
 }
 
 // ============================================================================
@@ -105,9 +146,10 @@ function registerAuthCommands(user: Command): void {
   auth
     .command('login')
     .description('Login with GitHub')
-    .action(withErrorHandler(async () => {
+    .option('-y, --yes', 'Auto-confirm prompts')
+    .action(withErrorHandler(async (options) => {
       const { authLogin } = await import('../../commands/auth.js');
-      await authLogin();
+      await authLogin(options);
     }));
 
   auth
@@ -178,6 +220,14 @@ function registerHostCommands(user: Command): void {
     .action(withErrorHandler(async () => {
       const { hostStatus } = await import('../../commands/host.js');
       await hostStatus();
+    }, { skipSetupCheck: true }));
+
+  host
+    .command('doctor')
+    .description('Check hosted relay readiness and remediation steps')
+    .action(withErrorHandler(async () => {
+      const { hostDoctor } = await import('../../commands/host.js');
+      await hostDoctor();
     }, { skipSetupCheck: true }));
 }
 

--- a/src/commands/__tests__/cloud-connect-password-stdin.integration.test.ts
+++ b/src/commands/__tests__/cloud-connect-password-stdin.integration.test.ts
@@ -147,7 +147,7 @@ describe('cloud connect password-stdin integration', () => {
             "import { bindControlRelayIdentity } from './src/relay/control/store.js';",
             `writeRelayConfig({ relayUrl: ${JSON.stringify(relayUrl)}, cloudRelayUrl: ${JSON.stringify(relayUrl)}, machineId: 'machine-ready', savedAt: Date.now() });`,
             `bindControlRelayIdentity({ relayIdentityId: 'relay-integration', relaySigningPublicKey: ${JSON.stringify(relayPublicKey)}, relayFingerprint: 'integration-relay-fingerprint' });`,
-            `await cloudConnect('ws-test', { relay: ${JSON.stringify(relayUrl)}, yes: true, passwordStdin: true });`,
+            `await cloudConnect('ws-test', { yes: true, passwordStdin: true }, { resolveRelayUrl: () => ${JSON.stringify(relayUrl)} });`,
           ].join(' '),
         ],
         cwd: process.cwd(),

--- a/src/commands/__tests__/cloud-connect-password-stdin.integration.test.ts
+++ b/src/commands/__tests__/cloud-connect-password-stdin.integration.test.ts
@@ -147,7 +147,7 @@ describe('cloud connect password-stdin integration', () => {
             "import { bindControlRelayIdentity } from './src/relay/control/store.js';",
             `writeRelayConfig({ relayUrl: ${JSON.stringify(relayUrl)}, cloudRelayUrl: ${JSON.stringify(relayUrl)}, machineId: 'machine-ready', savedAt: Date.now() });`,
             `bindControlRelayIdentity({ relayIdentityId: 'relay-integration', relaySigningPublicKey: ${JSON.stringify(relayPublicKey)}, relayFingerprint: 'integration-relay-fingerprint' });`,
-            `await cloudConnect('ws-test', { yes: true, passwordStdin: true }, { resolveRelayUrl: () => ${JSON.stringify(relayUrl)} });`,
+            `await cloudConnect('ws-test', { yes: true, passwordStdin: true }, { resolveRelayUrl: () => ${JSON.stringify(relayUrl)}, allowUnsafeRelayUrl: true });`,
           ].join(' '),
         ],
         cwd: process.cwd(),

--- a/src/commands/__tests__/cloud-connect-password-stdin.integration.test.ts
+++ b/src/commands/__tests__/cloud-connect-password-stdin.integration.test.ts
@@ -144,8 +144,10 @@ describe('cloud connect password-stdin integration', () => {
           [
             "import { writeRelayConfig } from './src/core/identity.js';",
             "import { cloudConnect } from './src/commands/cloud.js';",
+            "import { bindControlRelayIdentity } from './src/relay/control/store.js';",
             `writeRelayConfig({ relayUrl: ${JSON.stringify(relayUrl)}, cloudRelayUrl: ${JSON.stringify(relayUrl)}, machineId: 'machine-ready', savedAt: Date.now() });`,
-            "await cloudConnect('ws-test', { yes: true, passwordStdin: true });",
+            `bindControlRelayIdentity({ relayIdentityId: 'relay-integration', relaySigningPublicKey: ${JSON.stringify(relayPublicKey)}, relayFingerprint: 'integration-relay-fingerprint' });`,
+            `await cloudConnect('ws-test', { relay: ${JSON.stringify(relayUrl)}, yes: true, passwordStdin: true });`,
           ].join(' '),
         ],
         cwd: process.cwd(),

--- a/src/commands/__tests__/cloud-connect-password-stdin.integration.test.ts
+++ b/src/commands/__tests__/cloud-connect-password-stdin.integration.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, test } from 'bun:test';
+import { existsSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const TEST_PASSWORD = 'correct horse battery staple';
+
+function makeTestEnv(testDir: string): Record<string, string> {
+  return {
+    ...process.env,
+    HOME: testDir,
+    GITSPACE_CONTROL_DIR: join(testDir, '.relay', 'control'),
+    GSSH_ENABLE_TEST_SECRETS_BACKEND: '1',
+    GSSH_TEST_RUNTIME: '1',
+    GSSH_TEST_SECRETS_FILE: join(testDir, 'test-secrets.json'),
+    TEST_PASSWORD,
+  } as Record<string, string>;
+}
+
+async function waitForProcess(
+  subprocess: any,
+  timeoutMs = 10000,
+): Promise<{ exitCode: number; stdout: string; stderr: string }> {
+  const timeout = setTimeout(() => {
+    subprocess.kill();
+  }, timeoutMs);
+
+  try {
+    const [exitCode, stdout, stderr] = await Promise.all([
+      subprocess.exited,
+      new Response(subprocess.stdout).text(),
+      new Response(subprocess.stderr).text(),
+    ]);
+    return { exitCode, stdout, stderr };
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+describe('cloud connect password-stdin integration', () => {
+  test('cloud connect fails fast when no relay is configured', async () => {
+    const testDir = mkdtempSync(join(tmpdir(), 'gssh-cloud-connect-missing-relay-'));
+    const env = makeTestEnv(testDir);
+
+    try {
+      const subprocess = Bun.spawn({
+        cmd: [
+          'bun',
+          '-e',
+          [
+            "import { ensureControlStore, upsertCloudWorkspace } from './src/relay/control/store.js';",
+            "import { cloudConnect } from './src/commands/cloud.js';",
+            'ensureControlStore();',
+            "upsertCloudWorkspace({ id: 'ws-test', provider: 'sprites', providerWorkspaceId: 'sprite-test', machineId: 'machine-ready', machinePublicKey: 'machine-pub-test', repo: 'owner/repo', branch: 'main', status: 'ready' });",
+            "await cloudConnect('ws-test');",
+          ].join(' '),
+        ],
+        cwd: process.cwd(),
+        env,
+        stdout: 'pipe',
+        stderr: 'pipe',
+      });
+
+      const result = await waitForProcess(subprocess);
+      const output = `${result.stdout}\n${result.stderr}`;
+
+      expect(result.exitCode).not.toBe(0);
+      expect(output).toContain('No cloud-reachable relay URL is saved');
+      expect(output).not.toContain('Connect to this machine?');
+    } finally {
+      if (existsSync(testDir)) {
+        rmSync(testDir, { recursive: true, force: true });
+      }
+    }
+  });
+
+  test('cloud connect runs non-interactively with --password-stdin', async () => {
+    const testDir = mkdtempSync(join(tmpdir(), 'gssh-cloud-connect-password-stdin-'));
+    const env = makeTestEnv(testDir);
+
+    const relayPublicKey = Buffer.from('integration-relay-public-key').toString('base64');
+    const relayServer = Bun.serve({
+      port: 0,
+      hostname: '127.0.0.1',
+      fetch(request, server) {
+        const url = new URL(request.url);
+        if (url.pathname === '/health') {
+          return new Response(
+            JSON.stringify({
+              relayPublicKey,
+              relayLabel: 'integration-relay',
+            }),
+            { headers: { 'content-type': 'application/json' } },
+          );
+        }
+
+        if (url.pathname === '/ws') {
+          if (server.upgrade(request)) {
+            return undefined;
+          }
+          return new Response('upgrade failed', { status: 500 });
+        }
+
+        return new Response('not found', { status: 404 });
+      },
+      websocket: {
+        open(ws) {
+          ws.close(1011, 'integration test close');
+        },
+        message() {},
+      },
+    });
+
+    try {
+      const seedState = Bun.spawn({
+        cmd: [
+          'bun',
+          '-e',
+          [
+            "import { generateAndSaveKeypair } from './src/core/identity.js';",
+            "import { initFromMnemonic } from './src/core/user-identity.js';",
+            "import { ensureControlStore, upsertCloudWorkspace } from './src/relay/control/store.js';",
+            "import { generateMnemonic } from './src/lib/tmux-lite/crypto/user-identity.js';",
+            'ensureControlStore();',
+            "upsertCloudWorkspace({ id: 'ws-test', provider: 'sprites', providerWorkspaceId: 'sprite-test', machineId: 'machine-ready', machinePublicKey: 'machine-pub-test', repo: 'owner/repo', branch: 'main', status: 'ready' });",
+            "await generateAndSaveKeypair(process.env.TEST_PASSWORD ?? '', 'integration-device', true);",
+            'await initFromMnemonic(generateMnemonic(), true);',
+          ].join(' '),
+        ],
+        cwd: process.cwd(),
+        env,
+        stdout: 'pipe',
+        stderr: 'pipe',
+      });
+
+      const seedResult = await waitForProcess(seedState);
+      expect(seedResult.exitCode).toBe(0);
+
+      const relayUrl = `ws://127.0.0.1:${relayServer.port}/ws`;
+      const connectProcess = Bun.spawn({
+        cmd: [
+          'bun',
+          '-e',
+          [
+            "import { writeRelayConfig } from './src/core/identity.js';",
+            "import { cloudConnect } from './src/commands/cloud.js';",
+            `writeRelayConfig({ relayUrl: ${JSON.stringify(relayUrl)}, cloudRelayUrl: ${JSON.stringify(relayUrl)}, machineId: 'machine-ready', savedAt: Date.now() });`,
+            "await cloudConnect('ws-test', { yes: true, passwordStdin: true });",
+          ].join(' '),
+        ],
+        cwd: process.cwd(),
+        env,
+        stdin: 'pipe',
+        stdout: 'pipe',
+        stderr: 'pipe',
+      });
+
+      connectProcess.stdin.write(`${TEST_PASSWORD}\n`);
+      connectProcess.stdin.end();
+
+      const result = await waitForProcess(connectProcess);
+      const output = `${result.stdout}\n${result.stderr}`;
+
+      expect(result.exitCode).not.toBe(0);
+      expect(output).toContain('Connecting to cloud workspace ws-test via machine machine-ready');
+      expect(output).toContain('Connecting to relay...');
+      expect(output).toContain('Connection failed:');
+      expect(output).not.toContain('Connect to this machine?');
+      expect(output).not.toContain('Trust this relay?');
+      expect(output).not.toContain('Enter password to unlock identity:');
+    } finally {
+      relayServer.stop(true);
+      if (existsSync(testDir)) {
+        rmSync(testDir, { recursive: true, force: true });
+      }
+    }
+  });
+});

--- a/src/commands/__tests__/cloud-connect-recovery-password-stdin.integration.test.ts
+++ b/src/commands/__tests__/cloud-connect-recovery-password-stdin.integration.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, test } from 'bun:test';
+import { existsSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+function makeTestEnv(testDir: string): Record<string, string> {
+  return {
+    ...process.env,
+    HOME: testDir,
+    GITSPACE_CONTROL_DIR: join(testDir, '.relay', 'control'),
+    GSSH_ENABLE_TEST_SECRETS_BACKEND: '1',
+    GSSH_TEST_RUNTIME: '1',
+    GSSH_TEST_SECRETS_FILE: join(testDir, 'test-secrets.json'),
+  } as Record<string, string>;
+}
+
+async function waitForProcess(
+  subprocess: any,
+  timeoutMs = 10000,
+): Promise<{ exitCode: number; stdout: string; stderr: string }> {
+  const timeout = setTimeout(() => {
+    subprocess.kill();
+  }, timeoutMs);
+
+  try {
+    const [exitCode, stdout, stderr] = await Promise.all([
+      subprocess.exited,
+      new Response(subprocess.stdout).text(),
+      new Response(subprocess.stderr).text(),
+    ]);
+    return { exitCode, stdout, stderr };
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+describe('cloud connect recovery with password-stdin', () => {
+  test('fails before reading device password when root recovery needs an interactive terminal', async () => {
+    const testDir = mkdtempSync(join(tmpdir(), 'gssh-cloud-connect-recovery-password-stdin-'));
+    const env = makeTestEnv(testDir);
+
+    const relayPublicKey = Buffer.from('integration-relay-public-key').toString('base64');
+    const relayServer = Bun.serve({
+      port: 0,
+      hostname: '127.0.0.1',
+      fetch(request, server) {
+        const url = new URL(request.url);
+        if (url.pathname === '/health') {
+          return new Response(
+            JSON.stringify({
+              relayPublicKey,
+              relayLabel: 'integration-relay',
+            }),
+            { headers: { 'content-type': 'application/json' } },
+          );
+        }
+
+        if (url.pathname === '/ws') {
+          if (server.upgrade(request)) {
+            return undefined;
+          }
+          return new Response('upgrade failed', { status: 500 });
+        }
+
+        return new Response('not found', { status: 404 });
+      },
+      websocket: {
+        open(ws) {
+          ws.close(1011, 'integration test close');
+        },
+        message() {},
+      },
+    });
+
+    try {
+      const seedState = Bun.spawn({
+        cmd: [
+          'bun',
+          '-e',
+          [
+            "import { generateAndSaveKeypair, writeRelayConfig } from './src/core/identity.js';",
+            "import { ensureControlStore, upsertCloudWorkspace, bindControlRelayIdentity } from './src/relay/control/store.js';",
+            "import { setSecret } from './src/utils/secrets.js';",
+            'ensureControlStore();',
+            "upsertCloudWorkspace({ id: 'ws-test', provider: 'sprites', providerWorkspaceId: 'sprite-test', machineId: 'machine-ready', machinePublicKey: 'machine-pub-test', repo: 'owner/repo', branch: 'main', status: 'ready' });",
+            `writeRelayConfig({ relayUrl: ${JSON.stringify(`ws://127.0.0.1:${relayServer.port}/ws`)}, cloudRelayUrl: ${JSON.stringify(`ws://127.0.0.1:${relayServer.port}/ws`)}, machineId: 'machine-ready', savedAt: Date.now() });`,
+            `bindControlRelayIdentity({ relayIdentityId: 'relay-integration', relaySigningPublicKey: ${JSON.stringify(relayPublicKey)}, relayFingerprint: 'integration-relay-fingerprint' });`,
+            "await setSecret('GITSPACE_TOKEN', 'test-token');",
+            "await generateAndSaveKeypair('device-password', 'integration-device', true);",
+          ].join(' '),
+        ],
+        cwd: process.cwd(),
+        env,
+        stdout: 'pipe',
+        stderr: 'pipe',
+      });
+
+      const seedResult = await waitForProcess(seedState);
+      expect(seedResult.exitCode).toBe(0);
+
+      const relayUrl = `ws://127.0.0.1:${relayServer.port}/ws`;
+      const connectProcess = Bun.spawn({
+        cmd: [
+          'bun',
+          '-e',
+          [
+            "import { cloudConnect } from './src/commands/cloud.js';",
+            `await cloudConnect('ws-test', { relay: ${JSON.stringify(relayUrl)}, yes: true, passwordStdin: true });`,
+          ].join(' '),
+        ],
+        cwd: process.cwd(),
+        env,
+        stdin: 'pipe',
+        stdout: 'pipe',
+        stderr: 'pipe',
+      });
+
+      const result = await waitForProcess(connectProcess);
+      const output = `${result.stdout}\n${result.stderr}`;
+
+      expect(result.exitCode).not.toBe(0);
+      expect(output).toContain('requires an interactive terminal');
+      expect(output).not.toContain('Timeout reading password from stdin');
+      expect(output).not.toContain('Enter password to unlock identity:');
+    } finally {
+      relayServer.stop(true);
+      if (existsSync(testDir)) {
+        rmSync(testDir, { recursive: true, force: true });
+      }
+    }
+  });
+});

--- a/src/commands/__tests__/cloud-connect-recovery-password-stdin.integration.test.ts
+++ b/src/commands/__tests__/cloud-connect-recovery-password-stdin.integration.test.ts
@@ -105,7 +105,7 @@ describe('cloud connect recovery with password-stdin', () => {
           '-e',
           [
             "import { cloudConnect } from './src/commands/cloud.js';",
-            `await cloudConnect('ws-test', { yes: true, passwordStdin: true }, { resolveRelayUrl: () => ${JSON.stringify(relayUrl)} });`,
+            `await cloudConnect('ws-test', { yes: true, passwordStdin: true }, { resolveRelayUrl: () => ${JSON.stringify(relayUrl)}, allowUnsafeRelayUrl: true });`,
           ].join(' '),
         ],
         cwd: process.cwd(),

--- a/src/commands/__tests__/cloud-connect-recovery-password-stdin.integration.test.ts
+++ b/src/commands/__tests__/cloud-connect-recovery-password-stdin.integration.test.ts
@@ -105,7 +105,7 @@ describe('cloud connect recovery with password-stdin', () => {
           '-e',
           [
             "import { cloudConnect } from './src/commands/cloud.js';",
-            `await cloudConnect('ws-test', { relay: ${JSON.stringify(relayUrl)}, yes: true, passwordStdin: true });`,
+            `await cloudConnect('ws-test', { yes: true, passwordStdin: true }, { resolveRelayUrl: () => ${JSON.stringify(relayUrl)} });`,
           ].join(' '),
         ],
         cwd: process.cwd(),

--- a/src/commands/__tests__/cloud-connect.test.ts
+++ b/src/commands/__tests__/cloud-connect.test.ts
@@ -1,39 +1,48 @@
-import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { describe, expect, test } from 'bun:test';
 import { existsSync, mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { cloudConnect } from '../cloud.js';
-import { writeRelayConfig } from '../../core/identity.js';
 import { ensureControlStore, upsertCloudWorkspace } from '../../relay/control/store.js';
 
-let originalHome: string | undefined;
-let originalControlDir: string | undefined;
-let testDir: string;
+let envLock: Promise<void> = Promise.resolve();
 
-function setupEnv() {
-  originalHome = process.env.HOME;
-  originalControlDir = process.env.GITSPACE_CONTROL_DIR;
-  testDir = mkdtempSync(join(tmpdir(), 'gssh-cloud-connect-'));
-  process.env.HOME = testDir;
-  process.env.GITSPACE_CONTROL_DIR = join(testDir, '.relay', 'control');
-  ensureControlStore();
-}
+async function withIsolatedEnv(run: () => Promise<void>): Promise<void> {
+  const previous = envLock;
+  let release!: () => void;
+  envLock = new Promise<void>((resolve) => {
+    release = resolve;
+  });
 
-function teardownEnv() {
-  if (originalHome === undefined) {
-    delete process.env.HOME;
-  } else {
-    process.env.HOME = originalHome;
-  }
+  await previous;
 
-  if (originalControlDir === undefined) {
-    delete process.env.GITSPACE_CONTROL_DIR;
-  } else {
-    process.env.GITSPACE_CONTROL_DIR = originalControlDir;
-  }
+  const originalHome = process.env.HOME;
+  const originalControlDir = process.env.GITSPACE_CONTROL_DIR;
+  const testDir = mkdtempSync(join(tmpdir(), 'gssh-cloud-connect-'));
 
-  if (testDir && existsSync(testDir)) {
-    rmSync(testDir, { recursive: true, force: true });
+  try {
+    process.env.HOME = testDir;
+    process.env.GITSPACE_CONTROL_DIR = join(testDir, '.relay', 'control');
+    ensureControlStore();
+    await run();
+  } finally {
+    if (originalHome === undefined) {
+      delete process.env.HOME;
+    } else {
+      process.env.HOME = originalHome;
+    }
+
+    if (originalControlDir === undefined) {
+      delete process.env.GITSPACE_CONTROL_DIR;
+    } else {
+      process.env.GITSPACE_CONTROL_DIR = originalControlDir;
+    }
+
+    if (existsSync(testDir)) {
+      rmSync(testDir, { recursive: true, force: true });
+    }
+
+    release();
   }
 }
 
@@ -50,118 +59,64 @@ function seedWorkspace(status: 'ready' | 'hibernated' | 'bootstrapping' | 'error
   });
 }
 
-function seedRelayConfig(args: { relayUrl: string; cloudRelayUrl?: string }) {
-  writeRelayConfig({
-    relayUrl: args.relayUrl,
-    cloudRelayUrl: args.cloudRelayUrl,
-    machineId: 'machine-configured',
-    savedAt: Date.now(),
-  });
-}
-
 describe('cloudConnect', () => {
-  beforeEach(setupEnv);
-  afterEach(teardownEnv);
-
   test('throws when workspace has no machine id', async () => {
-    seedWorkspace('ready');
+    await withIsolatedEnv(async () => {
+      seedWorkspace('ready');
 
-    await expect(
-      cloudConnect('ws-test', { relay: 'wss://relay.test/ws' })
-    ).rejects.toThrow(/does not have an attached machine identity/i);
+      await expect(
+        cloudConnect('ws-test', { relay: 'wss://relay.test/ws' })
+      ).rejects.toThrow(/does not have an attached machine identity/i);
+    });
   });
 
   test('throws when workspace is hibernated', async () => {
-    seedWorkspace('hibernated', 'machine-hib');
+    await withIsolatedEnv(async () => {
+      seedWorkspace('hibernated', 'machine-hib');
 
-    await expect(
-      cloudConnect('ws-test', { relay: 'wss://relay.test/ws' })
-    ).rejects.toThrow(/is hibernated/i);
+      await expect(
+        cloudConnect('ws-test', { relay: 'wss://relay.test/ws' })
+      ).rejects.toThrow(/is hibernated/i);
+    });
   });
 
   test('throws when workspace is bootstrapping', async () => {
-    seedWorkspace('bootstrapping', 'machine-boot');
+    await withIsolatedEnv(async () => {
+      seedWorkspace('bootstrapping', 'machine-boot');
 
-    await expect(
-      cloudConnect('ws-test', { relay: 'wss://relay.test/ws' })
-    ).rejects.toThrow(/currently 'bootstrapping'/i);
-  });
-
-  test('throws when relay is missing and no cloud-reachable config exists', async () => {
-    seedWorkspace('ready', 'machine-ready');
-
-    await expect(
-      cloudConnect('ws-test')
-    ).rejects.toThrow(/No cloud-reachable relay URL is saved/i);
-  });
-
-  test('prefers saved cloud relay URL over local relay URL', async () => {
-    seedWorkspace('ready', 'machine-ready');
-    seedRelayConfig({
-      relayUrl: 'ws://127.0.0.1:4480/ws',
-      cloudRelayUrl: 'wss://relay.public.test/ws',
-    });
-
-    let calledOptions: { relay?: string; yes?: boolean } | undefined;
-    await cloudConnect(
-      'ws-test',
-      { yes: true },
-      {
-        connectToRemote: async (_target, options) => {
-          calledOptions = { relay: options?.relay, yes: options?.yes };
-        },
-      },
-    );
-
-    expect(calledOptions).toEqual({
-      relay: 'wss://relay.public.test/ws',
-      yes: true,
-    });
-  });
-
-  test('falls back to legacy saved relay URL when it is cloud reachable', async () => {
-    seedWorkspace('ready', 'machine-ready');
-    seedRelayConfig({
-      relayUrl: 'wss://relay.legacy.test/ws',
-    });
-
-    let calledOptions: { relay?: string; yes?: boolean } | undefined;
-    await cloudConnect(
-      'ws-test',
-      { yes: true },
-      {
-        connectToRemote: async (_target, options) => {
-          calledOptions = { relay: options?.relay, yes: options?.yes };
-        },
-      },
-    );
-
-    expect(calledOptions).toEqual({
-      relay: 'wss://relay.legacy.test/ws',
-      yes: true,
+      await expect(
+        cloudConnect('ws-test', { relay: 'wss://relay.test/ws' })
+      ).rejects.toThrow(/currently 'bootstrapping'/i);
     });
   });
 
   test('delegates to connectToRemote when workspace is ready', async () => {
-    seedWorkspace('ready', 'machine-ready');
+    await withIsolatedEnv(async () => {
+      seedWorkspace('ready', 'machine-ready');
 
-    let calledTarget: string | undefined;
-    let calledOptions: { relay?: string; yes?: boolean } | undefined;
-    await cloudConnect(
-      'ws-test',
-      { relay: 'wss://relay.test/ws', yes: true },
-      {
-        connectToRemote: async (target, options) => {
-          calledTarget = target;
-          calledOptions = { relay: options?.relay, yes: options?.yes };
+      let calledTarget: string | undefined;
+      let calledOptions: { relay?: string; yes?: boolean; passwordStdin?: boolean } | undefined;
+      await cloudConnect(
+        'ws-test',
+        { relay: 'wss://relay.test/ws', yes: true, passwordStdin: true },
+        {
+          connectToRemote: async (target, options) => {
+            calledTarget = target;
+            calledOptions = {
+              relay: options?.relay,
+              yes: options?.yes,
+              passwordStdin: options?.passwordStdin,
+            };
+          },
         },
-      },
-    );
+      );
 
-    expect(calledTarget).toBe('machine-ready');
-    expect(calledOptions).toEqual({
-      relay: 'wss://relay.test/ws',
-      yes: true,
+      expect(calledTarget).toBe('machine-ready');
+      expect(calledOptions).toEqual({
+        relay: 'wss://relay.test/ws',
+        yes: true,
+        passwordStdin: true,
+      });
     });
   });
 });

--- a/src/commands/__tests__/cloud-connect.test.ts
+++ b/src/commands/__tests__/cloud-connect.test.ts
@@ -3,7 +3,7 @@ import { existsSync, mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { cloudConnect } from '../cloud.js';
-import { ensureControlStore, upsertCloudWorkspace } from '../../relay/control/store.js';
+import { bindControlRelayIdentity, ensureControlStore, upsertCloudWorkspace } from '../../relay/control/store.js';
 
 let envLock: Promise<void> = Promise.resolve();
 
@@ -93,9 +93,14 @@ describe('cloudConnect', () => {
   test('delegates to connectToRemote when workspace is ready', async () => {
     await withIsolatedEnv(async () => {
       seedWorkspace('ready', 'machine-ready');
+      bindControlRelayIdentity({
+        relayIdentityId: 'relay-cloud-connect-test',
+        relaySigningPublicKey: 'relay-pubkey-b64',
+        relayFingerprint: 'relay-fingerprint-test',
+      });
 
       let calledTarget: string | undefined;
-      let calledOptions: { relay?: string; yes?: boolean; passwordStdin?: boolean } | undefined;
+      let calledOptions: { relay?: string; relayPubkey?: string; yes?: boolean; passwordStdin?: boolean } | undefined;
       await cloudConnect(
         'ws-test',
         { relay: 'wss://relay.test/ws', yes: true, passwordStdin: true },
@@ -104,6 +109,7 @@ describe('cloudConnect', () => {
             calledTarget = target;
             calledOptions = {
               relay: options?.relay,
+              relayPubkey: options?.relayPubkey,
               yes: options?.yes,
               passwordStdin: options?.passwordStdin,
             };
@@ -114,6 +120,7 @@ describe('cloudConnect', () => {
       expect(calledTarget).toBe('machine-ready');
       expect(calledOptions).toEqual({
         relay: 'wss://relay.test/ws',
+        relayPubkey: 'relay-pubkey-b64',
         yes: true,
         passwordStdin: true,
       });

--- a/src/commands/__tests__/cloud-connect.test.ts
+++ b/src/commands/__tests__/cloud-connect.test.ts
@@ -3,6 +3,7 @@ import { existsSync, mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { cloudConnect } from '../cloud.js';
+import { addTrustedRelay } from '../../core/trusted-relays.js';
 import { bindControlRelayIdentity, ensureControlStore, upsertCloudWorkspace } from '../../relay/control/store.js';
 
 let envLock: Promise<void> = Promise.resolve();
@@ -199,6 +200,22 @@ describe('cloudConnect', () => {
       await expect(
         cloudConnect('ws-test', { relay: '   ' }, { resolveRelayUrl: () => 'wss://relay.test/ws' })
       ).rejects.toThrow(/relay identity is not pinned yet/i);
+    });
+  });
+
+  test('fails when saved relay trust does not match pinned relay metadata', async () => {
+    await withIsolatedEnv(async () => {
+      seedWorkspace('ready', 'machine-ready');
+      bindControlRelayIdentity({
+        relayIdentityId: 'relay-cloud-connect-test',
+        relaySigningPublicKey: 'relay-pubkey-b64',
+        relayFingerprint: 'relay-fingerprint-test',
+      });
+      addTrustedRelay('wss://relay.test/ws', 'different-relay-pubkey', 'other-relay');
+
+      await expect(
+        cloudConnect('ws-test', {}, { resolveRelayUrl: () => 'wss://relay.test/ws' })
+      ).rejects.toThrow(/pinned relay metadata does not match the saved relay url/i);
     });
   });
 

--- a/src/commands/__tests__/cloud-connect.test.ts
+++ b/src/commands/__tests__/cloud-connect.test.ts
@@ -128,7 +128,7 @@ describe('cloudConnect', () => {
     });
   });
 
-  test('does not force pinned relay pubkey for explicit relay overrides', async () => {
+  test('reuses pinned relay pubkey for explicit relay overrides by default', async () => {
     await withIsolatedEnv(async () => {
       seedWorkspace('ready', 'machine-ready');
       bindControlRelayIdentity({
@@ -155,7 +155,7 @@ describe('cloudConnect', () => {
 
       expect(calledOptions).toEqual({
         relay: 'wss://override.test/ws',
-        relayPubkey: undefined,
+        relayPubkey: 'relay-pubkey-b64',
         yes: true,
         passwordStdin: true,
       });
@@ -201,32 +201,13 @@ describe('cloudConnect', () => {
     });
   });
 
-  test('allows explicit relay overrides without pinned relay identity metadata', async () => {
+  test('requires explicit relay overrides to provide a relay pubkey when no pin exists', async () => {
     await withIsolatedEnv(async () => {
       seedWorkspace('ready', 'machine-ready');
 
-      let calledOptions: { relay?: string; relayPubkey?: string; yes?: boolean; passwordStdin?: boolean } | undefined;
-      await cloudConnect(
-        'ws-test',
-        { relay: 'wss://override.test/ws', yes: true },
-        {
-          connectToRemote: async (_target, options) => {
-            calledOptions = {
-              relay: options?.relay,
-              relayPubkey: options?.relayPubkey,
-              yes: options?.yes,
-              passwordStdin: options?.passwordStdin,
-            };
-          },
-        },
-      );
-
-      expect(calledOptions).toEqual({
-        relay: 'wss://override.test/ws',
-        relayPubkey: undefined,
-        yes: true,
-        passwordStdin: undefined,
-      });
+      await expect(
+        cloudConnect('ws-test', { relay: 'wss://override.test/ws', yes: true })
+      ).rejects.toThrow(/relay identity is not pinned yet for this cloud workspace/i);
     });
   });
 

--- a/src/commands/__tests__/cloud-connect.test.ts
+++ b/src/commands/__tests__/cloud-connect.test.ts
@@ -126,4 +126,14 @@ describe('cloudConnect', () => {
       });
     });
   });
+
+  test('throws when relay identity metadata is not pinned', async () => {
+    await withIsolatedEnv(async () => {
+      seedWorkspace('ready', 'machine-ready');
+
+      await expect(
+        cloudConnect('ws-test', { relay: 'wss://relay.test/ws' })
+      ).rejects.toThrow(/relay identity is not pinned yet/i);
+    });
+  });
 });

--- a/src/commands/__tests__/cloud-connect.test.ts
+++ b/src/commands/__tests__/cloud-connect.test.ts
@@ -3,6 +3,7 @@ import { existsSync, mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { cloudConnect } from '../cloud.js';
+import { writeRelayConfig } from '../../core/identity.js';
 import { ensureControlStore, upsertCloudWorkspace } from '../../relay/control/store.js';
 
 let originalHome: string | undefined;
@@ -49,6 +50,15 @@ function seedWorkspace(status: 'ready' | 'hibernated' | 'bootstrapping' | 'error
   });
 }
 
+function seedRelayConfig(args: { relayUrl: string; cloudRelayUrl?: string }) {
+  writeRelayConfig({
+    relayUrl: args.relayUrl,
+    cloudRelayUrl: args.cloudRelayUrl,
+    machineId: 'machine-configured',
+    savedAt: Date.now(),
+  });
+}
+
 describe('cloudConnect', () => {
   beforeEach(setupEnv);
   afterEach(teardownEnv);
@@ -77,16 +87,59 @@ describe('cloudConnect', () => {
     ).rejects.toThrow(/currently 'bootstrapping'/i);
   });
 
-  test('throws when relay is missing and no local config exists', async () => {
+  test('throws when relay is missing and no cloud-reachable config exists', async () => {
     seedWorkspace('ready', 'machine-ready');
 
     await expect(
-      cloudConnect('ws-test', {}, {
-        resolveRelayUrl: () => {
-          throw new Error('Relay URL is required. Pass --relay <url> or start machine serve once to save relay config.');
+      cloudConnect('ws-test')
+    ).rejects.toThrow(/No cloud-reachable relay URL is saved/i);
+  });
+
+  test('prefers saved cloud relay URL over local relay URL', async () => {
+    seedWorkspace('ready', 'machine-ready');
+    seedRelayConfig({
+      relayUrl: 'ws://127.0.0.1:4480/ws',
+      cloudRelayUrl: 'wss://relay.public.test/ws',
+    });
+
+    let calledOptions: { relay?: string; yes?: boolean } | undefined;
+    await cloudConnect(
+      'ws-test',
+      { yes: true },
+      {
+        connectToRemote: async (_target, options) => {
+          calledOptions = { relay: options?.relay, yes: options?.yes };
         },
-      })
-    ).rejects.toThrow(/Relay URL is required/i);
+      },
+    );
+
+    expect(calledOptions).toEqual({
+      relay: 'wss://relay.public.test/ws',
+      yes: true,
+    });
+  });
+
+  test('falls back to legacy saved relay URL when it is cloud reachable', async () => {
+    seedWorkspace('ready', 'machine-ready');
+    seedRelayConfig({
+      relayUrl: 'wss://relay.legacy.test/ws',
+    });
+
+    let calledOptions: { relay?: string; yes?: boolean } | undefined;
+    await cloudConnect(
+      'ws-test',
+      { yes: true },
+      {
+        connectToRemote: async (_target, options) => {
+          calledOptions = { relay: options?.relay, yes: options?.yes };
+        },
+      },
+    );
+
+    expect(calledOptions).toEqual({
+      relay: 'wss://relay.legacy.test/ws',
+      yes: true,
+    });
   });
 
   test('delegates to connectToRemote when workspace is ready', async () => {

--- a/src/commands/__tests__/cloud-connect.test.ts
+++ b/src/commands/__tests__/cloud-connect.test.ts
@@ -1,0 +1,114 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { existsSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { cloudConnect } from '../cloud.js';
+import { ensureControlStore, upsertCloudWorkspace } from '../../relay/control/store.js';
+
+let originalHome: string | undefined;
+let originalControlDir: string | undefined;
+let testDir: string;
+
+function setupEnv() {
+  originalHome = process.env.HOME;
+  originalControlDir = process.env.GITSPACE_CONTROL_DIR;
+  testDir = mkdtempSync(join(tmpdir(), 'gssh-cloud-connect-'));
+  process.env.HOME = testDir;
+  process.env.GITSPACE_CONTROL_DIR = join(testDir, '.relay', 'control');
+  ensureControlStore();
+}
+
+function teardownEnv() {
+  if (originalHome === undefined) {
+    delete process.env.HOME;
+  } else {
+    process.env.HOME = originalHome;
+  }
+
+  if (originalControlDir === undefined) {
+    delete process.env.GITSPACE_CONTROL_DIR;
+  } else {
+    process.env.GITSPACE_CONTROL_DIR = originalControlDir;
+  }
+
+  if (testDir && existsSync(testDir)) {
+    rmSync(testDir, { recursive: true, force: true });
+  }
+}
+
+function seedWorkspace(status: 'ready' | 'hibernated' | 'bootstrapping' | 'error' | 'destroyed', machineId?: string) {
+  upsertCloudWorkspace({
+    id: 'ws-test',
+    provider: 'sprites',
+    providerWorkspaceId: 'sprite-test',
+    machineId,
+    machinePublicKey: machineId ? 'machine-pub-test' : undefined,
+    repo: 'owner/repo',
+    branch: 'main',
+    status,
+  });
+}
+
+describe('cloudConnect', () => {
+  beforeEach(setupEnv);
+  afterEach(teardownEnv);
+
+  test('throws when workspace has no machine id', async () => {
+    seedWorkspace('ready');
+
+    await expect(
+      cloudConnect('ws-test', { relay: 'wss://relay.test/ws' })
+    ).rejects.toThrow(/does not have an attached machine identity/i);
+  });
+
+  test('throws when workspace is hibernated', async () => {
+    seedWorkspace('hibernated', 'machine-hib');
+
+    await expect(
+      cloudConnect('ws-test', { relay: 'wss://relay.test/ws' })
+    ).rejects.toThrow(/is hibernated/i);
+  });
+
+  test('throws when workspace is bootstrapping', async () => {
+    seedWorkspace('bootstrapping', 'machine-boot');
+
+    await expect(
+      cloudConnect('ws-test', { relay: 'wss://relay.test/ws' })
+    ).rejects.toThrow(/currently 'bootstrapping'/i);
+  });
+
+  test('throws when relay is missing and no local config exists', async () => {
+    seedWorkspace('ready', 'machine-ready');
+
+    await expect(
+      cloudConnect('ws-test', {}, {
+        resolveRelayUrl: () => {
+          throw new Error('Relay URL is required. Pass --relay <url> or start machine serve once to save relay config.');
+        },
+      })
+    ).rejects.toThrow(/Relay URL is required/i);
+  });
+
+  test('delegates to connectToRemote when workspace is ready', async () => {
+    seedWorkspace('ready', 'machine-ready');
+
+    let calledTarget: string | undefined;
+    let calledOptions: { relay?: string; yes?: boolean } | undefined;
+    await cloudConnect(
+      'ws-test',
+      { relay: 'wss://relay.test/ws', yes: true },
+      {
+        connectToRemote: async (target, options) => {
+          calledTarget = target;
+          calledOptions = { relay: options?.relay, yes: options?.yes };
+        },
+      },
+    );
+
+    expect(calledTarget).toBe('machine-ready');
+    expect(calledOptions).toEqual({
+      relay: 'wss://relay.test/ws',
+      yes: true,
+    });
+  });
+});

--- a/src/commands/__tests__/cloud-connect.test.ts
+++ b/src/commands/__tests__/cloud-connect.test.ts
@@ -229,4 +229,14 @@ describe('cloudConnect', () => {
       });
     });
   });
+
+  test('treats whitespace relay overrides as absent and still requires pinned relay metadata', async () => {
+    await withIsolatedEnv(async () => {
+      seedWorkspace('ready', 'machine-ready');
+
+      await expect(
+        cloudConnect('ws-test', { relay: '   ' }, { resolveRelayUrl: () => 'wss://relay.test/ws' })
+      ).rejects.toThrow(/relay identity is not pinned yet/i);
+    });
+  });
 });

--- a/src/commands/__tests__/cloud-connect.test.ts
+++ b/src/commands/__tests__/cloud-connect.test.ts
@@ -90,7 +90,7 @@ describe('cloudConnect', () => {
     });
   });
 
-  test('delegates to connectToRemote when workspace is ready', async () => {
+  test('delegates pinned relay pubkey when using saved relay selection', async () => {
     await withIsolatedEnv(async () => {
       seedWorkspace('ready', 'machine-ready');
       bindControlRelayIdentity({
@@ -103,8 +103,9 @@ describe('cloudConnect', () => {
       let calledOptions: { relay?: string; relayPubkey?: string; yes?: boolean; passwordStdin?: boolean } | undefined;
       await cloudConnect(
         'ws-test',
-        { relay: 'wss://relay.test/ws', yes: true, passwordStdin: true },
+        { yes: true, passwordStdin: true },
         {
+          resolveRelayUrl: () => 'wss://relay.test/ws',
           connectToRemote: async (target, options) => {
             calledTarget = target;
             calledOptions = {
@@ -127,13 +128,105 @@ describe('cloudConnect', () => {
     });
   });
 
-  test('throws when relay identity metadata is not pinned', async () => {
+  test('does not force pinned relay pubkey for explicit relay overrides', async () => {
+    await withIsolatedEnv(async () => {
+      seedWorkspace('ready', 'machine-ready');
+      bindControlRelayIdentity({
+        relayIdentityId: 'relay-cloud-connect-test',
+        relaySigningPublicKey: 'relay-pubkey-b64',
+        relayFingerprint: 'relay-fingerprint-test',
+      });
+
+      let calledOptions: { relay?: string; relayPubkey?: string; yes?: boolean; passwordStdin?: boolean } | undefined;
+      await cloudConnect(
+        'ws-test',
+        { relay: 'wss://override.test/ws', yes: true, passwordStdin: true },
+        {
+          connectToRemote: async (_target, options) => {
+            calledOptions = {
+              relay: options?.relay,
+              relayPubkey: options?.relayPubkey,
+              yes: options?.yes,
+              passwordStdin: options?.passwordStdin,
+            };
+          },
+        },
+      );
+
+      expect(calledOptions).toEqual({
+        relay: 'wss://override.test/ws',
+        relayPubkey: undefined,
+        yes: true,
+        passwordStdin: true,
+      });
+    });
+  });
+
+  test('passes explicit relay pubkey for relay overrides', async () => {
+    await withIsolatedEnv(async () => {
+      seedWorkspace('ready', 'machine-ready');
+
+      let calledOptions: { relay?: string; relayPubkey?: string; yes?: boolean; passwordStdin?: boolean } | undefined;
+      await cloudConnect(
+        'ws-test',
+        { relay: 'wss://override.test/ws', relayPubkey: 'override-pubkey-b64', yes: true, passwordStdin: true },
+        {
+          connectToRemote: async (_target, options) => {
+            calledOptions = {
+              relay: options?.relay,
+              relayPubkey: options?.relayPubkey,
+              yes: options?.yes,
+              passwordStdin: options?.passwordStdin,
+            };
+          },
+        },
+      );
+
+      expect(calledOptions).toEqual({
+        relay: 'wss://override.test/ws',
+        relayPubkey: 'override-pubkey-b64',
+        yes: true,
+        passwordStdin: true,
+      });
+    });
+  });
+
+  test('throws when saved relay selection has no pinned relay identity metadata', async () => {
     await withIsolatedEnv(async () => {
       seedWorkspace('ready', 'machine-ready');
 
       await expect(
-        cloudConnect('ws-test', { relay: 'wss://relay.test/ws' })
+        cloudConnect('ws-test', {}, { resolveRelayUrl: () => 'wss://relay.test/ws' })
       ).rejects.toThrow(/relay identity is not pinned yet/i);
+    });
+  });
+
+  test('allows explicit relay overrides without pinned relay identity metadata', async () => {
+    await withIsolatedEnv(async () => {
+      seedWorkspace('ready', 'machine-ready');
+
+      let calledOptions: { relay?: string; relayPubkey?: string; yes?: boolean; passwordStdin?: boolean } | undefined;
+      await cloudConnect(
+        'ws-test',
+        { relay: 'wss://override.test/ws', yes: true },
+        {
+          connectToRemote: async (_target, options) => {
+            calledOptions = {
+              relay: options?.relay,
+              relayPubkey: options?.relayPubkey,
+              yes: options?.yes,
+              passwordStdin: options?.passwordStdin,
+            };
+          },
+        },
+      );
+
+      expect(calledOptions).toEqual({
+        relay: 'wss://override.test/ws',
+        relayPubkey: undefined,
+        yes: true,
+        passwordStdin: undefined,
+      });
     });
   });
 });

--- a/src/commands/__tests__/cloud-connect.test.ts
+++ b/src/commands/__tests__/cloud-connect.test.ts
@@ -249,4 +249,23 @@ describe('cloudConnect', () => {
       ).rejects.toThrow(/cloud-reachable relay url/i);
     });
   });
+
+  test('rejects unexpected workspace statuses by default', async () => {
+    await withIsolatedEnv(async () => {
+      upsertCloudWorkspace({
+        id: 'ws-test',
+        provider: 'sprites',
+        providerWorkspaceId: 'sprite-test',
+        machineId: 'machine-ready',
+        machinePublicKey: 'machine-pub-test',
+        repo: 'owner/repo',
+        branch: 'main',
+        status: 'mystery' as never,
+      } as never);
+
+      await expect(
+        cloudConnect('ws-test', {}, { resolveRelayUrl: () => 'wss://relay.test/ws' })
+      ).rejects.toThrow(/currently 'mystery'/i);
+    });
+  });
 });

--- a/src/commands/__tests__/cloud-connect.test.ts
+++ b/src/commands/__tests__/cloud-connect.test.ts
@@ -250,6 +250,16 @@ describe('cloudConnect', () => {
     });
   });
 
+  test('validates resolved relay URLs unless explicitly allowed for tests', async () => {
+    await withIsolatedEnv(async () => {
+      seedWorkspace('ready', 'machine-ready');
+
+      await expect(
+        cloudConnect('ws-test', {}, { resolveRelayUrl: () => 'ws://127.0.0.1:4480/ws' })
+      ).rejects.toThrow(/cloud-reachable relay url/i);
+    });
+  });
+
   test('rejects unexpected workspace statuses by default', async () => {
     await withIsolatedEnv(async () => {
       upsertCloudWorkspace({

--- a/src/commands/__tests__/cloud-connect.test.ts
+++ b/src/commands/__tests__/cloud-connect.test.ts
@@ -239,4 +239,14 @@ describe('cloudConnect', () => {
       ).rejects.toThrow(/relay identity is not pinned yet/i);
     });
   });
+
+  test('rejects explicit relay overrides that are not cloud-reachable', async () => {
+    await withIsolatedEnv(async () => {
+      seedWorkspace('ready', 'machine-ready');
+
+      await expect(
+        cloudConnect('ws-test', { relay: 'ws://127.0.0.1:4480/ws' })
+      ).rejects.toThrow(/cloud-reachable relay url/i);
+    });
+  });
 });

--- a/src/commands/__tests__/cloud-connect.test.ts
+++ b/src/commands/__tests__/cloud-connect.test.ts
@@ -128,7 +128,7 @@ describe('cloudConnect', () => {
     });
   });
 
-  test('reuses pinned relay pubkey for explicit relay overrides by default', async () => {
+  test('requires explicit relay pubkey for explicit relay overrides', async () => {
     await withIsolatedEnv(async () => {
       seedWorkspace('ready', 'machine-ready');
       bindControlRelayIdentity({
@@ -137,28 +137,9 @@ describe('cloudConnect', () => {
         relayFingerprint: 'relay-fingerprint-test',
       });
 
-      let calledOptions: { relay?: string; relayPubkey?: string; yes?: boolean; passwordStdin?: boolean } | undefined;
-      await cloudConnect(
-        'ws-test',
-        { relay: 'wss://override.test/ws', yes: true, passwordStdin: true },
-        {
-          connectToRemote: async (_target, options) => {
-            calledOptions = {
-              relay: options?.relay,
-              relayPubkey: options?.relayPubkey,
-              yes: options?.yes,
-              passwordStdin: options?.passwordStdin,
-            };
-          },
-        },
-      );
-
-      expect(calledOptions).toEqual({
-        relay: 'wss://override.test/ws',
-        relayPubkey: 'relay-pubkey-b64',
-        yes: true,
-        passwordStdin: true,
-      });
+      await expect(
+        cloudConnect('ws-test', { relay: 'wss://override.test/ws', yes: true, passwordStdin: true })
+      ).rejects.toThrow(/explicit relay overrides require `--relay-pubkey/i);
     });
   });
 
@@ -207,7 +188,7 @@ describe('cloudConnect', () => {
 
       await expect(
         cloudConnect('ws-test', { relay: 'wss://override.test/ws', yes: true })
-      ).rejects.toThrow(/relay identity is not pinned yet for this cloud workspace/i);
+      ).rejects.toThrow(/explicit relay overrides require `--relay-pubkey/i);
     });
   });
 

--- a/src/commands/__tests__/cloud-launch.test.ts
+++ b/src/commands/__tests__/cloud-launch.test.ts
@@ -233,6 +233,27 @@ describe('cloudLaunch', () => {
     expect(env.GSSH_RELAY_URL).toBe('wss://relay.legacy.test/ws');
   });
 
+  test('ignores invalid saved cloud relay URL and falls back to public relay URL', async () => {
+    const execCalls: Array<{ id: string; opts: Record<string, unknown> }> = [];
+    mockExecImpl = async (id, opts) => {
+      execCalls.push({ id, opts });
+      return { exitCode: 0, stdout: 'ok', stderr: '' };
+    };
+
+    seedSavedRelayConfig({
+      relayUrl: 'wss://relay.legacy.test/ws',
+      cloudRelayUrl: 'ws://127.0.0.1:4480/ws',
+    });
+
+    await cloudLaunch(
+      { repo: 'owner/repo', branch: 'main' },
+      makeDeps({ relayInfo: undefined }),
+    );
+
+    const env = execCalls[0]?.opts.env as Record<string, string>;
+    expect(env.GSSH_RELAY_URL).toBe('wss://relay.legacy.test/ws');
+  });
+
   test('fails when only a local relay URL is saved', async () => {
     seedSavedRelayConfig({
       relayUrl: 'ws://127.0.0.1:4480/ws',

--- a/src/commands/__tests__/cloud-launch.test.ts
+++ b/src/commands/__tests__/cloud-launch.test.ts
@@ -5,12 +5,15 @@ import { join } from 'node:path';
 import type { CloudLaunchDependencies, CloudLaunchProvider } from '../cloud.js';
 import { cloudLaunch } from '../cloud.js';
 import { writeRelayConfig } from '../../core/identity.js';
+import { addTrustedRelay } from '../../core/trusted-relays.js';
 import {
   bindControlRelayIdentity,
   bindControlOwner,
   ensureControlStore,
   getCloudWorkspace,
   listCloudEvents,
+  readControlMeta,
+  writeControlMeta,
 } from '../../relay/control/store.js';
 
 const TEST_OWNER_ID = 'owner-launch-test-001';
@@ -311,6 +314,60 @@ describe('cloudLaunch', () => {
         makeDeps({ relayInfo: undefined }),
       ),
     ).rejects.toThrow(/No cloud-reachable relay URL found/i);
+  });
+
+  test('recovers relay metadata from trusted relay store when control metadata is missing', async () => {
+    const execCalls: Array<{ id: string; opts: Record<string, unknown> }> = [];
+    mockExecImpl = async (id, opts) => {
+      execCalls.push({ id, opts });
+      return { exitCode: 0, stdout: 'ok', stderr: '' };
+    };
+
+    writeRelayConfig({
+      relayUrl: 'wss://relay.test/ws',
+      cloudRelayUrl: 'wss://relay.test/ws',
+      machineId: 'machine-saved-relay',
+      savedAt: Date.now(),
+    });
+    addTrustedRelay('wss://relay.test/ws', TEST_RELAY_INFO.relaySigningPublicKey, 'trusted-relay');
+    writeControlMeta({
+      ...readControlMeta(),
+      relayIdentityId: undefined,
+      relaySigningPublicKey: undefined,
+      relayFingerprint: undefined,
+    });
+
+    await cloudLaunch(
+      { repo: 'owner/repo', branch: 'main' },
+      makeDeps({ relayInfo: undefined }),
+    );
+
+    const env = execCalls[0]?.opts.env as Record<string, string>;
+    expect(env.GSSH_RELAY_URL).toBe('wss://relay.test/ws');
+    expect(env.GSSH_RELAY_PUBKEY).toBe(TEST_RELAY_INFO.relaySigningPublicKey);
+    expect(readControlMeta().relaySigningPublicKey).toBe(TEST_RELAY_INFO.relaySigningPublicKey);
+  });
+
+  test('fails closed when relay metadata is missing and relay is not trusted', async () => {
+    writeRelayConfig({
+      relayUrl: 'wss://relay.test/ws',
+      cloudRelayUrl: 'wss://relay.test/ws',
+      machineId: 'machine-saved-relay',
+      savedAt: Date.now(),
+    });
+    writeControlMeta({
+      ...readControlMeta(),
+      relayIdentityId: undefined,
+      relaySigningPublicKey: undefined,
+      relayFingerprint: undefined,
+    });
+
+    await expect(
+      cloudLaunch(
+        { repo: 'owner/repo', branch: 'main' },
+        makeDeps({ relayInfo: undefined }),
+      ),
+    ).rejects.toThrow(/Relay identity is not pinned yet/i);
   });
 
   test('leaves workspace in error state when VM creation fails', async () => {

--- a/src/commands/__tests__/cloud-launch.test.ts
+++ b/src/commands/__tests__/cloud-launch.test.ts
@@ -138,6 +138,52 @@ describe('cloudLaunch', () => {
     expect(ws?.status).toBe('bootstrapping');
   });
 
+  test('creates machine-first workspace without repo or branch metadata', async () => {
+    let createdWorkspaceId: string | null = null;
+    let createOptions: Record<string, unknown> | null = null;
+    mockCreateWorkspaceImpl = async (opts) => {
+      createdWorkspaceId = opts.name as string;
+      createOptions = opts;
+      return { providerWorkspaceId: 'sprite-machine-first', rawState: 'running' };
+    };
+
+    await cloudLaunch({}, makeDeps());
+
+    expect(createOptions).not.toBeNull();
+    const resolvedCreateOptions = createOptions!;
+    expect(resolvedCreateOptions.repo).toBeUndefined();
+    expect(resolvedCreateOptions.branch).toBeUndefined();
+    const ws = getCloudWorkspace(createdWorkspaceId!);
+    expect(ws?.repo).toBeUndefined();
+    expect(ws?.branch).toBeUndefined();
+    const launchEvent = listCloudEvents({ workspaceId: createdWorkspaceId! }).find((event) => event.eventType === 'launch_started');
+    expect(launchEvent?.message).toMatch(/machine-first workspace/i);
+  });
+
+  test('keeps repo metadata when branch is omitted', async () => {
+    let createdWorkspaceId: string | null = null;
+    let createOptions: Record<string, unknown> | null = null;
+    mockCreateWorkspaceImpl = async (opts) => {
+      createdWorkspaceId = opts.name as string;
+      createOptions = opts;
+      return { providerWorkspaceId: 'sprite-repo-only', rawState: 'running' };
+    };
+
+    await cloudLaunch({ repo: 'owner/repo' }, makeDeps());
+
+    expect(createOptions).not.toBeNull();
+    const resolvedCreateOptions = createOptions!;
+    expect(resolvedCreateOptions.repo).toBe('owner/repo');
+    expect(resolvedCreateOptions.branch).toBeUndefined();
+    const ws = getCloudWorkspace(createdWorkspaceId!);
+    expect(ws?.repo).toBe('owner/repo');
+    expect(ws?.branch).toBeUndefined();
+  });
+
+  test('rejects branch metadata without repo metadata', async () => {
+    await expect(cloudLaunch({ branch: 'main' }, makeDeps())).rejects.toThrow(/--branch.*requires.*--repo/i);
+  });
+
   test('logs launch_started and vm_created events on success', async () => {
     let capturedId: string | null = null;
     mockCreateWorkspaceImpl = async (opts) => {

--- a/src/commands/__tests__/cloud-launch.test.ts
+++ b/src/commands/__tests__/cloud-launch.test.ts
@@ -370,6 +370,21 @@ describe('cloudLaunch', () => {
     ).rejects.toThrow(/Relay identity is not pinned yet/i);
   });
 
+  test('fails when saved relay URL trust does not match pinned control metadata', async () => {
+    seedSavedRelayConfig({
+      relayUrl: 'wss://relay.test/ws',
+      cloudRelayUrl: 'wss://relay.test/ws',
+    });
+    addTrustedRelay('wss://relay.test/ws', Buffer.from('different-relay-key').toString('base64'), 'other-relay');
+
+    await expect(
+      cloudLaunch(
+        { repo: 'owner/repo', branch: 'main' },
+        makeDeps({ relayInfo: undefined }),
+      ),
+    ).rejects.toThrow(/Pinned relay metadata does not match the saved relay URL/i);
+  });
+
   test('leaves workspace in error state when VM creation fails', async () => {
     let capturedId: string | null = null;
     mockCreateWorkspaceImpl = async (opts) => {

--- a/src/commands/__tests__/cloud-launch.test.ts
+++ b/src/commands/__tests__/cloud-launch.test.ts
@@ -4,7 +4,9 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import type { CloudLaunchDependencies, CloudLaunchProvider } from '../cloud.js';
 import { cloudLaunch } from '../cloud.js';
+import { writeRelayConfig } from '../../core/identity.js';
 import {
+  bindControlRelayIdentity,
   bindControlOwner,
   ensureControlStore,
   getCloudWorkspace,
@@ -80,6 +82,21 @@ function setup() {
   mockCreateWorkspaceImpl = async () => ({ providerWorkspaceId: 'sprite-123', rawState: 'running' });
   mockExecImpl = async () => ({ exitCode: 0, stdout: 'started', stderr: '' });
   mockWriteImpl = async (_id, opts) => ({ path: String(opts.path ?? '/tmp/bootstrap.mjs'), size: 1, mode: '0644' });
+}
+
+function seedSavedRelayConfig(args: { relayUrl: string; cloudRelayUrl?: string }) {
+  bindControlRelayIdentity({
+    relayIdentityId: 'relay-cloud-launch-test',
+    relaySigningPublicKey: TEST_RELAY_INFO.relaySigningPublicKey,
+    relayFingerprint: TEST_RELAY_INFO.relayFingerprint,
+  });
+
+  writeRelayConfig({
+    relayUrl: args.relayUrl,
+    cloudRelayUrl: args.cloudRelayUrl,
+    machineId: 'machine-saved-relay',
+    savedAt: Date.now(),
+  });
 }
 
 function teardown() {
@@ -173,6 +190,60 @@ describe('cloudLaunch', () => {
     await expect(
       cloudLaunch({ repo: 'owner/repo', branch: 'main' }, makeDeps({ token: '' }))
     ).rejects.toThrow(/sprites token/i);
+  });
+
+  test('prefers saved cloud relay URL over local relay URL', async () => {
+    const execCalls: Array<{ id: string; opts: Record<string, unknown> }> = [];
+    mockExecImpl = async (id, opts) => {
+      execCalls.push({ id, opts });
+      return { exitCode: 0, stdout: 'ok', stderr: '' };
+    };
+
+    seedSavedRelayConfig({
+      relayUrl: 'ws://127.0.0.1:4480/ws',
+      cloudRelayUrl: 'wss://relay.public.test/ws',
+    });
+
+    await cloudLaunch(
+      { repo: 'owner/repo', branch: 'main' },
+      makeDeps({ relayInfo: undefined }),
+    );
+
+    const env = execCalls[0]?.opts.env as Record<string, string>;
+    expect(env.GSSH_RELAY_URL).toBe('wss://relay.public.test/ws');
+  });
+
+  test('falls back to legacy saved relay URL when it is already cloud reachable', async () => {
+    const execCalls: Array<{ id: string; opts: Record<string, unknown> }> = [];
+    mockExecImpl = async (id, opts) => {
+      execCalls.push({ id, opts });
+      return { exitCode: 0, stdout: 'ok', stderr: '' };
+    };
+
+    seedSavedRelayConfig({
+      relayUrl: 'wss://relay.legacy.test/ws',
+    });
+
+    await cloudLaunch(
+      { repo: 'owner/repo', branch: 'main' },
+      makeDeps({ relayInfo: undefined }),
+    );
+
+    const env = execCalls[0]?.opts.env as Record<string, string>;
+    expect(env.GSSH_RELAY_URL).toBe('wss://relay.legacy.test/ws');
+  });
+
+  test('fails when only a local relay URL is saved', async () => {
+    seedSavedRelayConfig({
+      relayUrl: 'ws://127.0.0.1:4480/ws',
+    });
+
+    await expect(
+      cloudLaunch(
+        { repo: 'owner/repo', branch: 'main' },
+        makeDeps({ relayInfo: undefined }),
+      ),
+    ).rejects.toThrow(/No cloud-reachable relay URL found/i);
   });
 
   test('leaves workspace in error state when VM creation fails', async () => {

--- a/src/commands/__tests__/cloud-lifecycle.test.ts
+++ b/src/commands/__tests__/cloud-lifecycle.test.ts
@@ -17,8 +17,10 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import type { CloudLifecycleDependencies, CloudLifecycleProvider } from '../cloud.js';
 import { cloudDestroy, cloudResume, cloudStop } from '../cloud.js';
+import { writeRelayConfig } from '../../core/identity.js';
 import {
   bindControlOwner,
+  bindControlRelayIdentity,
   ensureControlStore,
   getCloudWorkspace,
   listCloudEvents,
@@ -83,6 +85,21 @@ function setup() {
   process.env.GITSPACE_CONTROL_DIR = join(testDir, '.relay', 'control');
   ensureControlStore();
   bindControlOwner(OWNER_ID);
+}
+
+function seedSavedRelayConfig(args: { relayUrl: string; cloudRelayUrl?: string }) {
+  bindControlRelayIdentity({
+    relayIdentityId: 'relay-cloud-lifecycle-test',
+    relaySigningPublicKey: TEST_RELAY_INFO.relaySigningPublicKey,
+    relayFingerprint: TEST_RELAY_INFO.relayFingerprint,
+  });
+
+  writeRelayConfig({
+    relayUrl: args.relayUrl,
+    cloudRelayUrl: args.cloudRelayUrl,
+    machineId: 'machine-cloud-lifecycle',
+    savedAt: Date.now(),
+  });
 }
 
 function teardown() {
@@ -223,6 +240,29 @@ describe('cloudResume', () => {
     expect(execCalls[0].options.env?.GSSH_WORKSPACE_ID).toBe('ws-r1');
     expect(execCalls[0].options.env?.GSSH_RELAY_URL).toContain('wss://');
     expect(execCalls[0].options.env?.GSSH_RELAY_PUBKEY?.length).toBeGreaterThan(5);
+  });
+
+  test('prefers saved cloud relay URL during resume bootstrap', async () => {
+    const execCalls: Array<{ id: string; options: { command: string[]; env?: Record<string, string>; dir?: string } }> = [];
+    const provider = makeMockProvider({
+      exec: async (id, options) => {
+        execCalls.push({ id, options });
+        return { exitCode: 0, stdout: 'started', stderr: '' };
+      },
+    });
+
+    seedSavedRelayConfig({
+      relayUrl: 'ws://127.0.0.1:4480/ws',
+      cloudRelayUrl: 'wss://relay.public.test/ws',
+    });
+
+    await seedWorkspaceWithIdentity('ws-r-cloud', 'hibernated');
+    await cloudResume('ws-r-cloud', provider, {
+      ...lifecycleDeps,
+      relayInfo: undefined,
+    });
+
+    expect(execCalls[0]?.options.env?.GSSH_RELAY_URL).toBe('wss://relay.public.test/ws');
   });
 
   test('logs resume_exec_succeeded after bootstrap exec success', async () => {

--- a/src/commands/__tests__/cloud-lifecycle.test.ts
+++ b/src/commands/__tests__/cloud-lifecycle.test.ts
@@ -18,13 +18,16 @@ import { join } from 'node:path';
 import type { CloudLifecycleDependencies, CloudLifecycleProvider } from '../cloud.js';
 import { cloudDestroy, cloudResume, cloudStop } from '../cloud.js';
 import { writeRelayConfig } from '../../core/identity.js';
+import { addTrustedRelay } from '../../core/trusted-relays.js';
 import {
   bindControlOwner,
   bindControlRelayIdentity,
   ensureControlStore,
   getCloudWorkspace,
   listCloudEvents,
+  readControlMeta,
   upsertCloudWorkspace,
+  writeControlMeta,
 } from '../../relay/control/store.js';
 import type { CloudWorkspaceStatus } from '../../relay/control/types.js';
 
@@ -263,6 +266,40 @@ describe('cloudResume', () => {
     });
 
     expect(execCalls[0]?.options.env?.GSSH_RELAY_URL).toBe('wss://relay.public.test/ws');
+  });
+
+  test('recovers relay metadata from trusted relay store during resume', async () => {
+    const execCalls: Array<{ id: string; options: { command: string[]; env?: Record<string, string>; dir?: string } }> = [];
+    const provider = makeMockProvider({
+      exec: async (id, options) => {
+        execCalls.push({ id, options });
+        return { exitCode: 0, stdout: 'started', stderr: '' };
+      },
+    });
+
+    writeRelayConfig({
+      relayUrl: 'wss://relay.test/ws',
+      cloudRelayUrl: 'wss://relay.test/ws',
+      machineId: 'machine-cloud-lifecycle',
+      savedAt: Date.now(),
+    });
+    addTrustedRelay('wss://relay.test/ws', TEST_RELAY_INFO.relaySigningPublicKey, 'trusted-relay');
+    writeControlMeta({
+      ...readControlMeta(),
+      relayIdentityId: undefined,
+      relaySigningPublicKey: undefined,
+      relayFingerprint: undefined,
+    });
+
+    await seedWorkspaceWithIdentity('ws-r-trusted', 'hibernated');
+    await cloudResume('ws-r-trusted', provider, {
+      ...lifecycleDeps,
+      relayInfo: undefined,
+    });
+
+    expect(execCalls[0]?.options.env?.GSSH_RELAY_URL).toBe('wss://relay.test/ws');
+    expect(execCalls[0]?.options.env?.GSSH_RELAY_PUBKEY).toBe(TEST_RELAY_INFO.relaySigningPublicKey);
+    expect(readControlMeta().relaySigningPublicKey).toBe(TEST_RELAY_INFO.relaySigningPublicKey);
   });
 
   test('logs resume_exec_succeeded after bootstrap exec success', async () => {

--- a/src/commands/__tests__/connect-command-trust.test.ts
+++ b/src/commands/__tests__/connect-command-trust.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
 import { existsSync, mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { generateAndSaveKeypair } from '../../core/identity.js';
 import { addTrustedRelay, getTrustedRelay } from '../../core/trusted-relays.js';
 
 let promptConfirmQueue: boolean[] = [];
@@ -92,42 +93,18 @@ describe('connect command relay trust flow', () => {
     }
   });
 
-  test('connectToRemote rejects unknown relay with --yes unless relay key is pinned', async () => {
+  test('connectToRemote auto-trusts IPv4-mapped localhost relays', async () => {
     const relayPubkey = Buffer.from('relay-unknown-pubkey').toString('base64');
     const server = startRelayHealthServer(relayPubkey);
     const relayUrl = `ws://[::ffff:127.0.0.1]:${server.port}/ws`;
 
     try {
-      await expect(
-        connectToRemote('machine-test', {
-          relay: relayUrl,
-          yes: true,
-        })
-      ).rejects.toThrow(/interactive approval or --relay-pubkey/i);
+      await connectToRemote('machine-test', {
+        relay: relayUrl,
+        yes: true,
+      });
 
-      expect(getTrustedRelay(relayUrl)).toBeNull();
-    } finally {
-      server.stop(true);
-    }
-  });
-
-  test('connectToRemote aborts when user declines unknown relay trust', async () => {
-    const relayPubkey = Buffer.from('relay-decline-pubkey').toString('base64');
-    const server = startRelayHealthServer(relayPubkey);
-    const relayUrl = `ws://[::ffff:127.0.0.1]:${server.port}/ws`;
-
-    // First confirm: connect to machine => yes
-    // Second confirm: trust unknown relay => no
-    promptConfirmQueue = [true, false];
-
-    try {
-      await expect(
-        connectToRemote('machine-test', {
-          relay: relayUrl,
-        }),
-      ).rejects.toThrow(/Relay not trusted/i);
-
-      expect(getTrustedRelay(relayUrl)).toBeNull();
+      expect(getTrustedRelay(relayUrl)?.publicKey).toBe(relayPubkey);
     } finally {
       server.stop(true);
     }
@@ -171,6 +148,27 @@ describe('connect command relay trust flow', () => {
           yes: true,
         }),
       ).rejects.toThrow(/relay identity mismatch/i);
+    } finally {
+      server.stop(true);
+    }
+  });
+
+  test('listRemoteMachines fails cleanly when identity unlock password is wrong', async () => {
+    const relayPubkey = Buffer.from('relay-list-invalid-password').toString('base64');
+    const server = startRelayHealthServer(relayPubkey);
+    const relayUrl = `ws://127.0.0.1:${server.port}/ws`;
+
+    await generateAndSaveKeypair('correct-password', 'test-host');
+    promptPasswordValue = 'wrong-password';
+
+    try {
+      await expect(
+        listRemoteMachines({
+          relay: relayUrl,
+          relayPubkey,
+          yes: true,
+        }),
+      ).rejects.toThrow(/invalid password|failed to unlock identity/i);
     } finally {
       server.stop(true);
     }

--- a/src/commands/__tests__/connect-command-trust.test.ts
+++ b/src/commands/__tests__/connect-command-trust.test.ts
@@ -21,6 +21,10 @@ mock.module('../../utils/prompts.js', () => ({
   selectOne: async () => null,
 }));
 
+mock.module('../identity-recovery.js', () => ({
+  ensureUserRootIdentityWithRecovery: async () => ({ id: 'user-root-test' }),
+}));
+
 const { connectToRemote, listRemoteMachines } = await import('../connect.js');
 
 let originalHome: string | undefined;

--- a/src/commands/__tests__/connect-command-trust.test.ts
+++ b/src/commands/__tests__/connect-command-trust.test.ts
@@ -1,0 +1,182 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import { existsSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { addTrustedRelay, getTrustedRelay } from '../../core/trusted-relays.js';
+
+let promptConfirmQueue: boolean[] = [];
+let promptPasswordValue: string | null = null;
+
+mock.module('../../utils/prompts.js', () => ({
+  promptPassword: async () => promptPasswordValue,
+  promptConfirm: async () => {
+    if (promptConfirmQueue.length === 0) {
+      return true;
+    }
+
+    return promptConfirmQueue.shift() ?? true;
+  },
+  promptInput: async () => '',
+  selectOne: async () => null,
+}));
+
+const { connectToRemote, listRemoteMachines } = await import('../connect.js');
+
+let originalHome: string | undefined;
+let testDir: string;
+
+function setupEnv() {
+  originalHome = process.env.HOME;
+  testDir = mkdtempSync(join(tmpdir(), 'gssh-connect-command-trust-'));
+  process.env.HOME = testDir;
+
+  promptConfirmQueue = [];
+  promptPasswordValue = null;
+}
+
+function teardownEnv() {
+  if (originalHome === undefined) {
+    delete process.env.HOME;
+  } else {
+    process.env.HOME = originalHome;
+  }
+
+  if (testDir && existsSync(testDir)) {
+    rmSync(testDir, { recursive: true, force: true });
+  }
+}
+
+function startRelayHealthServer(relayPublicKey: string) {
+  return Bun.serve({
+    port: 0,
+    hostname: '0.0.0.0',
+    fetch: (request) => {
+      const url = new URL(request.url);
+      if (url.pathname !== '/health') {
+        return new Response('Not found', { status: 404 });
+      }
+
+      return new Response(
+        JSON.stringify({
+          relayPublicKey,
+          relayLabel: 'test-relay',
+        }),
+        { headers: { 'content-type': 'application/json' } },
+      );
+    },
+  });
+}
+
+describe('connect command relay trust flow', () => {
+  beforeEach(setupEnv);
+  afterEach(teardownEnv);
+
+  test('connectToRemote rejects when --relay-pubkey mismatches health identity', async () => {
+    const actualRelayPubkey = Buffer.from('relay-actual-pubkey').toString('base64');
+    const expectedRelayPubkey = Buffer.from('relay-expected-pubkey').toString('base64');
+    const server = startRelayHealthServer(actualRelayPubkey);
+    const relayUrl = `ws://127.0.0.1:${server.port}/ws`;
+
+    try {
+      await expect(
+        connectToRemote('machine-test', {
+          relay: relayUrl,
+          relayPubkey: expectedRelayPubkey,
+          yes: true,
+        }),
+      ).rejects.toThrow(/does not match --relay-pubkey/i);
+
+      expect(getTrustedRelay(relayUrl)).toBeNull();
+    } finally {
+      server.stop(true);
+    }
+  });
+
+  test('connectToRemote trusts unknown relay with --yes before password cancel', async () => {
+    const relayPubkey = Buffer.from('relay-unknown-pubkey').toString('base64');
+    const server = startRelayHealthServer(relayPubkey);
+    const relayUrl = `ws://[::ffff:127.0.0.1]:${server.port}/ws`;
+
+    // No local keypair in temp HOME => command asks to create one.
+    // Return null to simulate user cancelling password prompt after trust step.
+    promptPasswordValue = null;
+
+    try {
+      await connectToRemote('machine-test', {
+        relay: relayUrl,
+        yes: true,
+      });
+
+      const trusted = getTrustedRelay(relayUrl);
+      expect(trusted).not.toBeNull();
+      expect(trusted?.publicKey).toBe(relayPubkey);
+    } finally {
+      server.stop(true);
+    }
+  });
+
+  test('connectToRemote aborts when user declines unknown relay trust', async () => {
+    const relayPubkey = Buffer.from('relay-decline-pubkey').toString('base64');
+    const server = startRelayHealthServer(relayPubkey);
+    const relayUrl = `ws://[::ffff:127.0.0.1]:${server.port}/ws`;
+
+    // First confirm: connect to machine => yes
+    // Second confirm: trust unknown relay => no
+    promptConfirmQueue = [true, false];
+
+    try {
+      await expect(
+        connectToRemote('machine-test', {
+          relay: relayUrl,
+        }),
+      ).rejects.toThrow(/Relay not trusted/i);
+
+      expect(getTrustedRelay(relayUrl)).toBeNull();
+    } finally {
+      server.stop(true);
+    }
+  });
+
+  test('listRemoteMachines trusts relay via explicit --relay-pubkey', async () => {
+    const relayPubkey = Buffer.from('relay-list-explicit-pubkey').toString('base64');
+    const server = startRelayHealthServer(relayPubkey);
+    const relayUrl = `ws://127.0.0.1:${server.port}/ws`;
+
+    // Stop before opening directory socket.
+    promptPasswordValue = null;
+
+    try {
+      await listRemoteMachines({
+        relay: relayUrl,
+        relayPubkey: relayPubkey,
+        yes: true,
+      });
+
+      const trusted = getTrustedRelay(relayUrl);
+      expect(trusted).not.toBeNull();
+      expect(trusted?.publicKey).toBe(relayPubkey);
+    } finally {
+      server.stop(true);
+    }
+  });
+
+  test('listRemoteMachines rejects relay key mismatch against trusted entry', async () => {
+    const trustedPubkey = Buffer.from('relay-trusted-pubkey').toString('base64');
+    const newPubkey = Buffer.from('relay-new-pubkey').toString('base64');
+    const server = startRelayHealthServer(newPubkey);
+    const relayUrl = `ws://127.0.0.1:${server.port}/ws`;
+
+    addTrustedRelay(relayUrl, trustedPubkey, 'existing-relay');
+
+    try {
+      await expect(
+        listRemoteMachines({
+          relay: relayUrl,
+          yes: true,
+        }),
+      ).rejects.toThrow(/relay identity mismatch/i);
+    } finally {
+      server.stop(true);
+    }
+  });
+});

--- a/src/commands/__tests__/connect-command-trust.test.ts
+++ b/src/commands/__tests__/connect-command-trust.test.ts
@@ -92,24 +92,20 @@ describe('connect command relay trust flow', () => {
     }
   });
 
-  test('connectToRemote trusts unknown relay with --yes before password cancel', async () => {
+  test('connectToRemote rejects unknown relay with --yes unless relay key is pinned', async () => {
     const relayPubkey = Buffer.from('relay-unknown-pubkey').toString('base64');
     const server = startRelayHealthServer(relayPubkey);
     const relayUrl = `ws://[::ffff:127.0.0.1]:${server.port}/ws`;
 
-    // No local keypair in temp HOME => command asks to create one.
-    // Return null to simulate user cancelling password prompt after trust step.
-    promptPasswordValue = null;
-
     try {
-      await connectToRemote('machine-test', {
-        relay: relayUrl,
-        yes: true,
-      });
+      await expect(
+        connectToRemote('machine-test', {
+          relay: relayUrl,
+          yes: true,
+        })
+      ).rejects.toThrow(/interactive approval or --relay-pubkey/i);
 
-      const trusted = getTrustedRelay(relayUrl);
-      expect(trusted).not.toBeNull();
-      expect(trusted?.publicKey).toBe(relayPubkey);
+      expect(getTrustedRelay(relayUrl)).toBeNull();
     } finally {
       server.stop(true);
     }

--- a/src/commands/__tests__/connect-relay-trust.test.ts
+++ b/src/commands/__tests__/connect-relay-trust.test.ts
@@ -1,0 +1,188 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { existsSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  computeRelayFingerprint,
+  getTrustedRelay,
+  addTrustedRelay,
+} from '../../core/trusted-relays.js';
+import {
+  fetchRelayIdentity,
+  verifyClientRelayTrust,
+  type RelayIdentityProbe,
+} from '../connect.js';
+
+let originalHome: string | undefined;
+let testDir: string;
+
+function setupEnv() {
+  originalHome = process.env.HOME;
+  testDir = mkdtempSync(join(tmpdir(), 'gssh-connect-relay-trust-'));
+  process.env.HOME = testDir;
+}
+
+function teardownEnv() {
+  if (originalHome === undefined) {
+    delete process.env.HOME;
+  } else {
+    process.env.HOME = originalHome;
+  }
+
+  if (testDir && existsSync(testDir)) {
+    rmSync(testDir, { recursive: true, force: true });
+  }
+}
+
+function makeProbe(publicKey: string, label?: string): RelayIdentityProbe {
+  return {
+    publicKey,
+    fingerprint: computeRelayFingerprint(publicKey),
+    label,
+  };
+}
+
+describe('fetchRelayIdentity', () => {
+  beforeEach(setupEnv);
+  afterEach(teardownEnv);
+
+  test('reads relay identity from health endpoint', async () => {
+    const relayPublicKey = Buffer.from('relay-public-key-1').toString('base64');
+    const relayFingerprint = 'abcd:1234';
+
+    const server = Bun.serve({
+      port: 0,
+      hostname: '127.0.0.1',
+      fetch: () => {
+        return new Response(
+          JSON.stringify({
+            relayPublicKey,
+            relayFingerprint,
+            relayLabel: 'test-relay',
+          }),
+          { headers: { 'content-type': 'application/json' } },
+        );
+      },
+    });
+
+    try {
+      const relay = await fetchRelayIdentity(`ws://127.0.0.1:${server.port}/ws`);
+      expect(relay).toEqual({
+        publicKey: relayPublicKey,
+        fingerprint: relayFingerprint,
+        label: 'test-relay',
+      });
+    } finally {
+      server.stop(true);
+    }
+  });
+
+  test('computes fingerprint when health response omits it', async () => {
+    const relayPublicKey = Buffer.from('relay-public-key-2').toString('base64');
+
+    const server = Bun.serve({
+      port: 0,
+      hostname: '127.0.0.1',
+      fetch: () => {
+        return new Response(
+          JSON.stringify({ relayPublicKey }),
+          { headers: { 'content-type': 'application/json' } },
+        );
+      },
+    });
+
+    try {
+      const relay = await fetchRelayIdentity(`ws://127.0.0.1:${server.port}/ws`);
+      expect(relay.publicKey).toBe(relayPublicKey);
+      expect(relay.fingerprint).toBe(computeRelayFingerprint(relayPublicKey));
+    } finally {
+      server.stop(true);
+    }
+  });
+
+  test('throws when health endpoint does not provide relay public key', async () => {
+    const server = Bun.serve({
+      port: 0,
+      hostname: '127.0.0.1',
+      fetch: () => {
+        return new Response(JSON.stringify({ ok: true }), {
+          headers: { 'content-type': 'application/json' },
+        });
+      },
+    });
+
+    try {
+      await expect(
+        fetchRelayIdentity(`ws://127.0.0.1:${server.port}/ws`),
+      ).rejects.toThrow(/did not provide relayPublicKey/i);
+    } finally {
+      server.stop(true);
+    }
+  });
+});
+
+describe('verifyClientRelayTrust', () => {
+  beforeEach(setupEnv);
+  afterEach(teardownEnv);
+
+  test('trusts relay when explicit --relay-pubkey matches', async () => {
+    const relayUrl = 'wss://relay-explicit.example.test/ws';
+    const relayPublicKey = Buffer.from('relay-pub-match').toString('base64');
+
+    await verifyClientRelayTrust(relayUrl, makeProbe(relayPublicKey, 'example'), {
+      relayPubkey: relayPublicKey,
+    });
+
+    const trusted = getTrustedRelay(relayUrl);
+    expect(trusted).not.toBeNull();
+    expect(trusted?.publicKey).toBe(relayPublicKey);
+  });
+
+  test('rejects relay when explicit --relay-pubkey mismatches', async () => {
+    const relayUrl = 'wss://relay-explicit-mismatch.example.test/ws';
+    const expectedPublicKey = Buffer.from('expected-key').toString('base64');
+    const actualPublicKey = Buffer.from('actual-key').toString('base64');
+
+    await expect(
+      verifyClientRelayTrust(relayUrl, makeProbe(actualPublicKey), {
+        relayPubkey: expectedPublicKey,
+      }),
+    ).rejects.toThrow(/does not match --relay-pubkey/i);
+
+    expect(getTrustedRelay(relayUrl)).toBeNull();
+  });
+
+  test('auto-trusts localhost relay', async () => {
+    const relayUrl = 'ws://127.0.0.1:4480/ws';
+    const relayPublicKey = Buffer.from('localhost-key').toString('base64');
+
+    await verifyClientRelayTrust(relayUrl, makeProbe(relayPublicKey));
+
+    const trusted = getTrustedRelay(relayUrl);
+    expect(trusted).not.toBeNull();
+    expect(trusted?.publicKey).toBe(relayPublicKey);
+  });
+
+  test('rejects trusted relay key mismatch', async () => {
+    const relayUrl = 'wss://relay-known-mismatch.example.test/ws';
+    const originalKey = Buffer.from('original-key').toString('base64');
+    const unexpectedKey = Buffer.from('unexpected-key').toString('base64');
+
+    addTrustedRelay(relayUrl, originalKey, 'relay-one');
+
+    await expect(
+      verifyClientRelayTrust(relayUrl, makeProbe(unexpectedKey), { yes: true }),
+    ).rejects.toThrow(/relay identity mismatch/i);
+  });
+
+  test('trusts unknown relay non-interactively with --yes', async () => {
+    const relayUrl = 'wss://relay-yes.example.test/ws';
+    const relayPublicKey = Buffer.from('new-key').toString('base64');
+
+    await verifyClientRelayTrust(relayUrl, makeProbe(relayPublicKey), { yes: true });
+
+    const trusted = getTrustedRelay(relayUrl);
+    expect(trusted).not.toBeNull();
+    expect(trusted?.publicKey).toBe(relayPublicKey);
+  });
+});

--- a/src/commands/__tests__/connect-relay-trust.test.ts
+++ b/src/commands/__tests__/connect-relay-trust.test.ts
@@ -48,7 +48,7 @@ describe('fetchRelayIdentity', () => {
 
   test('reads relay identity from health endpoint', async () => {
     const relayPublicKey = Buffer.from('relay-public-key-1').toString('base64');
-    const relayFingerprint = 'abcd:1234';
+    const relayFingerprint = computeRelayFingerprint(relayPublicKey);
 
     const server = Bun.serve({
       port: 0,
@@ -175,14 +175,38 @@ describe('verifyClientRelayTrust', () => {
     ).rejects.toThrow(/relay identity mismatch/i);
   });
 
-  test('trusts unknown relay non-interactively with --yes', async () => {
+  test('rejects inconsistent fingerprint metadata from health endpoint', async () => {
+    const relayPublicKey = Buffer.from('relay-public-key-3').toString('base64');
+
+    const server = Bun.serve({
+      port: 0,
+      hostname: '127.0.0.1',
+      fetch: () => {
+        return new Response(
+          JSON.stringify({
+            relayPublicKey,
+            relayFingerprint: 'wrong:fingerprint',
+          }),
+          { headers: { 'content-type': 'application/json' } },
+        );
+      },
+    });
+
+    try {
+      await expect(fetchRelayIdentity(`ws://127.0.0.1:${server.port}/ws`)).rejects.toThrow(/inconsistent identity metadata/i);
+    } finally {
+      server.stop(true);
+    }
+  });
+
+  test('rejects unknown relay non-interactively with --yes', async () => {
     const relayUrl = 'wss://relay-yes.example.test/ws';
     const relayPublicKey = Buffer.from('new-key').toString('base64');
 
-    await verifyClientRelayTrust(relayUrl, makeProbe(relayPublicKey), { yes: true });
+    await expect(
+      verifyClientRelayTrust(relayUrl, makeProbe(relayPublicKey), { yes: true })
+    ).rejects.toThrow(/interactive approval or --relay-pubkey/i);
 
-    const trusted = getTrustedRelay(relayUrl);
-    expect(trusted).not.toBeNull();
-    expect(trusted?.publicKey).toBe(relayPublicKey);
+    expect(getTrustedRelay(relayUrl)).toBeNull();
   });
 });

--- a/src/commands/__tests__/device-identity-password.test.ts
+++ b/src/commands/__tests__/device-identity-password.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, describe, expect, mock, test } from 'bun:test';
+
+describe('device identity password context', () => {
+  afterEach(() => {
+    mock.restore();
+  });
+
+  test('shares one password-stdin read across repeated calls with the same context', async () => {
+    const promptPasswordMock = mock(async () => null as string | null);
+    const promptConfirmMock = mock(async () => true);
+    const keypairExistsMock = mock(() => true);
+    const generateAndSaveKeypairMock = mock(async () => undefined);
+    const readPasswordFromStdinMock = mock(async () => 'stdin-password');
+
+    mock.module('../../utils/prompts.js', () => ({
+      promptPassword: promptPasswordMock,
+      promptConfirm: promptConfirmMock,
+    }));
+
+    mock.module('../../core/identity.js', () => ({
+      keypairExists: keypairExistsMock,
+      generateAndSaveKeypair: generateAndSaveKeypairMock,
+    }));
+
+    mock.module('../../utils/password-stdin.js', () => ({
+      readPasswordFromStdin: readPasswordFromStdinMock,
+    }));
+
+    const {
+      createDeviceIdentityPasswordContext,
+      ensureDeviceIdentityPassword,
+    } = await import(`../device-identity-password.js?test=${Date.now()}`);
+
+    const devicePasswordContext = createDeviceIdentityPasswordContext({ passwordStdin: true });
+
+    const [firstPassword, secondPassword] = await Promise.all([
+      ensureDeviceIdentityPassword({}, devicePasswordContext),
+      ensureDeviceIdentityPassword({}, devicePasswordContext),
+    ]);
+
+    expect(firstPassword).toBe('stdin-password');
+    expect(secondPassword).toBe('stdin-password');
+    expect(readPasswordFromStdinMock).toHaveBeenCalledTimes(1);
+    expect(promptPasswordMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/commands/__tests__/identity-recovery.test.ts
+++ b/src/commands/__tests__/identity-recovery.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, describe, expect, mock, test } from 'bun:test';
+
+describe('ensureUserRootIdentityWithRecovery', () => {
+  afterEach(() => {
+    mock.restore();
+  });
+
+  test('skips auth login side effects when login is disallowed and recovery may be skipped', async () => {
+    const promptConfirmMock = mock(async () => true);
+    const promptPasswordMock = mock(async () => 'unused');
+    const getSecretMock = mock(async () => null as string | null);
+    const loadUserRootIdentityMock = mock(async () => null);
+    const authLoginMock = mock(async () => undefined);
+    const recoverUserRootFromCloudBackupMock = mock(async () => null);
+
+    mock.module('../../utils/prompts.js', () => ({
+      promptConfirm: promptConfirmMock,
+      promptPassword: promptPasswordMock,
+    }));
+
+    mock.module('../../utils/secrets.js', () => ({
+      getSecret: getSecretMock,
+    }));
+
+    mock.module('../../core/user-identity.js', () => ({
+      loadUserRootIdentity: loadUserRootIdentityMock,
+    }));
+
+    mock.module('../../core/identity-backup.js', () => ({
+      recoverUserRootFromCloudBackup: recoverUserRootFromCloudBackupMock,
+    }));
+
+    mock.module('../auth.js', () => ({
+      authLogin: authLoginMock,
+    }));
+
+    const { ensureUserRootIdentityWithRecovery } = await import(`../identity-recovery.js?test=${Date.now()}`);
+
+    const result = await ensureUserRootIdentityWithRecovery({
+      context: 'relay startup owner binding',
+      yes: true,
+      allowSkip: true,
+      allowAuthLogin: false,
+    });
+
+    expect(result).toBeNull();
+    expect(authLoginMock).not.toHaveBeenCalled();
+    expect(recoverUserRootFromCloudBackupMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/commands/__tests__/relay-owner-repair.test.ts
+++ b/src/commands/__tests__/relay-owner-repair.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, test } from 'bun:test';
+import { existsSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { ensureControlStore, setVaultMeta, upsertVaultMachine } from '../../relay/control/store.js';
+import { assertRelayOwnerRepairIsSafe } from '../relay.js';
+
+let envLock: Promise<void> = Promise.resolve();
+
+async function withIsolatedEnv(run: () => Promise<void>): Promise<void> {
+  const previous = envLock;
+  let release!: () => void;
+  envLock = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+
+  await previous;
+
+  const originalHome = process.env.HOME;
+  const originalControlDir = process.env.GITSPACE_CONTROL_DIR;
+  const testDir = mkdtempSync(join(tmpdir(), 'gssh-relay-owner-repair-'));
+
+  try {
+    process.env.HOME = testDir;
+    process.env.GITSPACE_CONTROL_DIR = join(testDir, '.relay', 'control');
+    ensureControlStore();
+    setVaultMeta('vault_initialized', '1');
+    await run();
+  } finally {
+    if (originalHome === undefined) {
+      delete process.env.HOME;
+    } else {
+      process.env.HOME = originalHome;
+    }
+
+    if (originalControlDir === undefined) {
+      delete process.env.GITSPACE_CONTROL_DIR;
+    } else {
+      process.env.GITSPACE_CONTROL_DIR = originalControlDir;
+    }
+
+    if (existsSync(testDir)) {
+      rmSync(testDir, { recursive: true, force: true });
+    }
+
+    release();
+  }
+}
+
+describe('assertRelayOwnerRepairIsSafe', () => {
+  test('allows repair when there are no persisted machine registrations', async () => {
+    await withIsolatedEnv(async () => {
+      expect(() => assertRelayOwnerRepairIsSafe('owner-a')).not.toThrow();
+    });
+  });
+
+  test('allows repair when all persisted machine registrations belong to the same owner', async () => {
+    await withIsolatedEnv(async () => {
+      upsertVaultMachine({
+        machineId: 'machine-a',
+        ownerUserRootId: 'owner-a',
+        signingKey: 'signing-a',
+        keyExchangeKey: 'kex-a',
+      });
+
+      expect(() => assertRelayOwnerRepairIsSafe('owner-a')).not.toThrow();
+    });
+  });
+
+  test('rejects repair when persisted machine registrations belong to a different owner', async () => {
+    await withIsolatedEnv(async () => {
+      upsertVaultMachine({
+        machineId: 'machine-a',
+        ownerUserRootId: 'owner-b',
+        signingKey: 'signing-a',
+        keyExchangeKey: 'kex-a',
+      });
+
+      expect(() => assertRelayOwnerRepairIsSafe('owner-a')).toThrow(/persisted machine registrations belong to a different owner/i);
+    });
+  });
+});

--- a/src/commands/__tests__/relay-owner-repair.test.ts
+++ b/src/commands/__tests__/relay-owner-repair.test.ts
@@ -2,12 +2,15 @@ import { describe, expect, test } from 'bun:test';
 import { existsSync, mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { ensureControlStore, setVaultMeta, upsertVaultMachine } from '../../relay/control/store.js';
-import { assertRelayOwnerRepairIsSafe } from '../relay.js';
+import { ensureControlStore, getVaultMeta, setVaultMeta, upsertVaultMachine } from '../../relay/control/store.js';
+import { assertRelayOwnerRepairIsSafe, bindRelayOwnerForStartup } from '../relay.js';
 
 let envLock: Promise<void> = Promise.resolve();
 
-async function withIsolatedEnv(run: () => Promise<void>): Promise<void> {
+async function withIsolatedEnv(
+  run: () => Promise<void>,
+  options: { initializeVault?: boolean } = {},
+): Promise<void> {
   const previous = envLock;
   let release!: () => void;
   envLock = new Promise<void>((resolve) => {
@@ -24,7 +27,9 @@ async function withIsolatedEnv(run: () => Promise<void>): Promise<void> {
     process.env.HOME = testDir;
     process.env.GITSPACE_CONTROL_DIR = join(testDir, '.relay', 'control');
     ensureControlStore();
-    setVaultMeta('vault_initialized', '1');
+    if (options.initializeVault !== false) {
+      setVaultMeta('vault_initialized', '1');
+    }
     await run();
   } finally {
     if (originalHome === undefined) {
@@ -78,5 +83,35 @@ describe('assertRelayOwnerRepairIsSafe', () => {
 
       expect(() => assertRelayOwnerRepairIsSafe('owner-a')).toThrow(/persisted machine registrations belong to a different owner/i);
     });
+  });
+});
+
+describe('bindRelayOwnerForStartup', () => {
+  test('preserves existing vault initialization metadata while repairing the owner binding', async () => {
+    await withIsolatedEnv(async () => {
+      const result = bindRelayOwnerForStartup('owner-a');
+
+      expect(result).toEqual({
+        repairedOwnerBinding: true,
+        missingVaultInitialization: false,
+      });
+      expect(getVaultMeta('owner_user_root_id')).toBe('owner-a');
+      expect(getVaultMeta('vault_initialized')).toBe('1');
+    });
+  });
+
+  test('leaves vault initialization unset when startup binds an owner before first unlock', async () => {
+    await withIsolatedEnv(async () => {
+      const result = bindRelayOwnerForStartup('owner-a');
+
+      expect(result).toEqual({
+        repairedOwnerBinding: true,
+        missingVaultInitialization: true,
+      });
+      expect(getVaultMeta('owner_user_root_id')).toBe('owner-a');
+      expect(getVaultMeta('vault_initialized')).toBeUndefined();
+      expect(getVaultMeta('vault_salt')).toBeUndefined();
+      expect(getVaultMeta('vault_key_check')).toBeUndefined();
+    }, { initializeVault: false });
   });
 });

--- a/src/commands/__tests__/serve-process-hosting.test.ts
+++ b/src/commands/__tests__/serve-process-hosting.test.ts
@@ -5,6 +5,7 @@
 import { describe, expect, test } from "bun:test";
 import {
   buildServeIngressConfig,
+  resolveCloudRelayUrlForConfig,
   type ProcessHostEntry,
 } from "../serve";
 import { buildProcessHostname, normalizeHostLabel } from "../../utils/hostnames";
@@ -59,5 +60,12 @@ describe("process hosting helpers", () => {
     expect(config).toContain("hostname: tcp.api-1.alpha.brad.serve.gitspace.sh");
     expect(config).toContain("service: tcp://127.0.0.1:9000");
     expect(config).toContain("service: http_status:404");
+  });
+
+  test("resolveCloudRelayUrlForConfig derives hosted relay url for 0.0.0.0 binds", () => {
+    expect(resolveCloudRelayUrlForConfig('ws://0.0.0.0:4480/ws', {
+      subdomain: 'brad',
+      createdAt: Date.now(),
+    })).toBe('wss://brad.gitspace.sh/ws');
   });
 });

--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -86,11 +86,9 @@ export async function authLogin(
     showHostSyncSummary?: boolean;
   } = {},
 ): Promise<void> {
-  let passwordForIdentity: string | null = null;
-
   // Load identity (requires password for signing)
   logger.info('Loading identity...');
-  passwordForIdentity = passwordForIdentity ?? await ensureDeviceIdentityPassword({
+  const passwordForIdentity = await ensureDeviceIdentityPassword({
     yes: options.yes,
     passwordStdin: options.passwordStdin,
   }, options.devicePasswordContext);
@@ -99,11 +97,9 @@ export async function authLogin(
     return;
   }
 
-  const resolvedPasswordForIdentity = passwordForIdentity;
-
   let identity;
   try {
-    identity = await loadKeypair(resolvedPasswordForIdentity);
+    identity = await loadKeypair(passwordForIdentity);
   } catch (error) {
     if (error instanceof SpacesError) {
       throw error;

--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -16,7 +16,10 @@ import { promptPassword } from '../utils/prompts.js';
 import { logger } from '../utils/logger.js';
 import { SpacesError } from '../types/errors.js';
 import { printHostSyncReport, syncHostConfig } from './host.js';
-import { ensureDeviceIdentityPassword } from './device-identity-password.js';
+import {
+  ensureDeviceIdentityPassword,
+  type DeviceIdentityPasswordContext,
+} from './device-identity-password.js';
 
 // API Configuration
 const API_BASE = process.env.GITSPACE_API_URL || 'https://api.gitspace.sh';
@@ -76,6 +79,7 @@ interface GitspaceAuthResponse {
  */
 export async function authLogin(
   options: {
+    devicePasswordContext?: DeviceIdentityPasswordContext;
     passwordStdin?: boolean;
     yes?: boolean;
     interactiveHostSync?: boolean;
@@ -89,7 +93,7 @@ export async function authLogin(
   passwordForIdentity = passwordForIdentity ?? await ensureDeviceIdentityPassword({
     yes: options.yes,
     passwordStdin: options.passwordStdin,
-  });
+  }, options.devicePasswordContext);
   if (!passwordForIdentity) {
     logger.info('Cancelled');
     return;

--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -12,11 +12,11 @@ import {
   getPublicKeyWithoutPassword,
 } from '../core/identity.js';
 import { sign, serializeIdentity } from '../lib/tmux-lite/crypto/identity.js';
-import { promptPassword } from '../utils/prompts.js';
 import { logger } from '../utils/logger.js';
 import { SpacesError } from '../types/errors.js';
 import { printHostSyncReport, syncHostConfig } from './host.js';
 import {
+  createDeviceIdentityPasswordContext,
   ensureDeviceIdentityPassword,
   type DeviceIdentityPasswordContext,
 } from './device-identity-password.js';
@@ -86,12 +86,12 @@ export async function authLogin(
     showHostSyncSummary?: boolean;
   } = {},
 ): Promise<void> {
+  const devicePasswordContext = options.devicePasswordContext
+    ?? createDeviceIdentityPasswordContext({ passwordStdin: options.passwordStdin });
+
   // Load identity (requires password for signing)
   logger.info('Loading identity...');
-  const passwordForIdentity = await ensureDeviceIdentityPassword({
-    yes: options.yes,
-    passwordStdin: options.passwordStdin,
-  }, options.devicePasswordContext);
+  const passwordForIdentity = await ensureDeviceIdentityPassword({ yes: options.yes }, devicePasswordContext);
   if (!passwordForIdentity) {
     logger.info('Cancelled');
     return;

--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -83,28 +83,13 @@ export async function authLogin(
 ): Promise<void> {
   let passwordForIdentity: string | null = null;
 
-  const requireIdentityPassword = (context: string): never => {
-    throw new SpacesError(
-      `A local identity password is required for ${context} and could not be collected non-interactively.`,
-      'USER_ERROR',
-      1,
-    );
-  };
-
-  const requireCollectedPassword = (value: string | null, context: string): string => {
-    if (value === null || value.length === 0) {
-      requireIdentityPassword(context);
-    }
-
-    return value as string;
-  };
-
   // Load identity (requires password for signing)
   logger.info('Loading identity...');
-  passwordForIdentity = requireCollectedPassword(
-    passwordForIdentity ?? await ensureDeviceIdentityPassword({ yes: options.yes }),
-    'identity unlock',
-  );
+  passwordForIdentity = passwordForIdentity ?? await ensureDeviceIdentityPassword({ yes: options.yes });
+  if (!passwordForIdentity) {
+    logger.info('Cancelled');
+    return;
+  }
 
   const resolvedPasswordForIdentity = passwordForIdentity;
 

--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -92,6 +92,14 @@ export async function authLogin(
     );
   };
 
+  const requireCollectedPassword = (value: string | null, context: string): string => {
+    if (value === null || value.length === 0) {
+      requireIdentityPassword(context);
+    }
+
+    return value as string;
+  };
+
   if (!keypairExists()) {
     const shouldCreate = options.yes || await promptConfirm(
       'No local device identity found. Create one now?',
@@ -102,17 +110,15 @@ export async function authLogin(
       throw new NoIdentityError();
     }
 
-    const createPassword = await promptPassword('Create password for local device identity:');
-    if (createPassword === null || createPassword.length === 0) {
-      requireIdentityPassword('device identity creation');
-    }
-    const resolvedCreatePassword = createPassword ?? requireIdentityPassword('device identity creation');
+    const resolvedCreatePassword = requireCollectedPassword(
+      await promptPassword('Create password for local device identity:'),
+      'device identity creation',
+    );
 
-    const confirmPassword = await promptPassword('Confirm local identity password:');
-    if (confirmPassword === null || confirmPassword.length === 0) {
-      requireIdentityPassword('device identity confirmation');
-    }
-    const resolvedConfirmPassword = confirmPassword ?? requireIdentityPassword('device identity confirmation');
+    const resolvedConfirmPassword = requireCollectedPassword(
+      await promptPassword('Confirm local identity password:'),
+      'device identity confirmation',
+    );
 
     if (resolvedCreatePassword !== resolvedConfirmPassword) {
       throw new SpacesError('Password confirmation does not match.', 'USER_ERROR', 1);
@@ -126,14 +132,13 @@ export async function authLogin(
   // Load identity (requires password for signing)
   logger.info('Loading identity...');
   if (!passwordForIdentity) {
-    const password = await promptPassword('Enter identity password:');
-    if (!password) {
-      requireIdentityPassword('identity unlock');
-    }
-    passwordForIdentity = password;
+    passwordForIdentity = requireCollectedPassword(
+      await promptPassword('Enter identity password:'),
+      'identity unlock',
+    );
   }
 
-  const resolvedPasswordForIdentity = passwordForIdentity!;
+  const resolvedPasswordForIdentity = passwordForIdentity;
 
   let identity;
   try {

--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -76,6 +76,7 @@ interface GitspaceAuthResponse {
  */
 export async function authLogin(
   options: {
+    passwordStdin?: boolean;
     yes?: boolean;
     interactiveHostSync?: boolean;
     showHostSyncSummary?: boolean;
@@ -85,7 +86,10 @@ export async function authLogin(
 
   // Load identity (requires password for signing)
   logger.info('Loading identity...');
-  passwordForIdentity = passwordForIdentity ?? await ensureDeviceIdentityPassword({ yes: options.yes });
+  passwordForIdentity = passwordForIdentity ?? await ensureDeviceIdentityPassword({
+    yes: options.yes,
+    passwordStdin: options.passwordStdin,
+  });
   if (!passwordForIdentity) {
     logger.info('Cancelled');
     return;

--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -103,17 +103,16 @@ export async function authLogin(
     }
 
     const createPassword = await promptPassword('Create password for local device identity:');
-    if (!createPassword) {
+    if (createPassword === null || createPassword.length === 0) {
       requireIdentityPassword('device identity creation');
     }
+    const resolvedCreatePassword = createPassword ?? requireIdentityPassword('device identity creation');
 
     const confirmPassword = await promptPassword('Confirm local identity password:');
-    if (!confirmPassword) {
+    if (confirmPassword === null || confirmPassword.length === 0) {
       requireIdentityPassword('device identity confirmation');
     }
-
-    const resolvedCreatePassword = createPassword!;
-    const resolvedConfirmPassword = confirmPassword!;
+    const resolvedConfirmPassword = confirmPassword ?? requireIdentityPassword('device identity confirmation');
 
     if (resolvedCreatePassword !== resolvedConfirmPassword) {
       throw new SpacesError('Password confirmation does not match.', 'USER_ERROR', 1);

--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -111,8 +111,10 @@ export async function authLogin(
     if (!confirmPassword) {
       requireIdentityPassword('device identity confirmation');
     }
-    const resolvedCreatePassword = createPassword ?? requireIdentityPassword('device identity creation');
-    const resolvedConfirmPassword = confirmPassword ?? requireIdentityPassword('device identity confirmation');
+
+    const resolvedCreatePassword = createPassword!;
+    const resolvedConfirmPassword = confirmPassword!;
+
     if (resolvedCreatePassword !== resolvedConfirmPassword) {
       throw new SpacesError('Password confirmation does not match.', 'USER_ERROR', 1);
     }
@@ -129,12 +131,14 @@ export async function authLogin(
     if (!password) {
       requireIdentityPassword('identity unlock');
     }
-    passwordForIdentity = password ?? requireIdentityPassword('identity unlock');
+    passwordForIdentity = password;
   }
+
+  const resolvedPasswordForIdentity = passwordForIdentity!;
 
   let identity;
   try {
-    identity = await loadKeypair(passwordForIdentity);
+    identity = await loadKeypair(resolvedPasswordForIdentity);
   } catch (error) {
     if (error instanceof SpacesError) {
       throw error;

--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -7,12 +7,17 @@
 import open from 'open';
 import os from 'os';
 import { getSecret, setSecret, deleteSecret } from '../utils/secrets.js';
-import { loadKeypair, keypairExists, getPublicKeyWithoutPassword } from '../core/identity.js';
+import {
+  loadKeypair,
+  keypairExists,
+  getPublicKeyWithoutPassword,
+  generateAndSaveKeypair,
+} from '../core/identity.js';
 import { sign, serializeIdentity } from '../lib/tmux-lite/crypto/identity.js';
-import { promptPassword } from '../utils/prompts.js';
+import { promptConfirm, promptPassword } from '../utils/prompts.js';
 import { logger } from '../utils/logger.js';
 import { NoIdentityError, SpacesError } from '../types/errors.js';
-import { syncHostConfig } from './host.js';
+import { printHostSyncReport, syncHostConfig } from './host.js';
 
 // API Configuration
 const API_BASE = process.env.GITSPACE_API_URL || 'https://api.gitspace.sh';
@@ -70,23 +75,55 @@ interface GitspaceAuthResponse {
 /**
  * Login to gitspace.sh using GitHub Device Flow
  */
-export async function authLogin(): Promise<void> {
-  // Check if identity exists
+export async function authLogin(
+  options: {
+    yes?: boolean;
+    interactiveHostSync?: boolean;
+    showHostSyncSummary?: boolean;
+  } = {},
+): Promise<void> {
+  let passwordForIdentity: string | null = null;
+
   if (!keypairExists()) {
-    throw new NoIdentityError();
+    const shouldCreate = options.yes || await promptConfirm(
+      'No local device identity found. Create one now?',
+      true,
+    );
+
+    if (!shouldCreate) {
+      throw new NoIdentityError();
+    }
+
+    const createPassword = await promptPassword('Create password for local device identity:');
+    if (!createPassword) {
+      logger.info('Cancelled');
+      return;
+    }
+
+    const confirmPassword = await promptPassword('Confirm local identity password:');
+    if (createPassword !== confirmPassword) {
+      throw new SpacesError('Password confirmation does not match.', 'USER_ERROR', 1);
+    }
+
+    await generateAndSaveKeypair(createPassword, os.hostname());
+    passwordForIdentity = createPassword;
+    logger.success('Created local device identity');
   }
 
   // Load identity (requires password for signing)
   logger.info('Loading identity...');
-  const password = await promptPassword('Enter identity password:');
-  if (!password) {
-    logger.info('Cancelled');
-    return;
+  if (!passwordForIdentity) {
+    const password = await promptPassword('Enter identity password:');
+    if (!password) {
+      logger.info('Cancelled');
+      return;
+    }
+    passwordForIdentity = password;
   }
 
   let identity;
   try {
-    identity = await loadKeypair(password);
+    identity = await loadKeypair(passwordForIdentity);
   } catch (error) {
     if (error instanceof SpacesError) {
       throw error;
@@ -198,7 +235,11 @@ export async function authLogin(): Promise<void> {
 
   // Step 6: Sync host config (fetches existing subdomains from API)
   // Interactive mode will prompt user to select primary or reserve a subdomain
-  await syncHostConfig(true);
+  const hostSyncReport = await syncHostConfig(options.interactiveHostSync ?? true);
+  if (options.showHostSyncSummary ?? true) {
+    logger.log('');
+    printHostSyncReport(hostSyncReport, 'Hosted relay readiness');
+  }
 }
 
 // ============================================================================

--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -84,6 +84,14 @@ export async function authLogin(
 ): Promise<void> {
   let passwordForIdentity: string | null = null;
 
+  const requireIdentityPassword = (context: string): never => {
+    throw new SpacesError(
+      `A local identity password is required for ${context} and could not be collected non-interactively.`,
+      'USER_ERROR',
+      1,
+    );
+  };
+
   if (!keypairExists()) {
     const shouldCreate = options.yes || await promptConfirm(
       'No local device identity found. Create one now?',
@@ -96,17 +104,21 @@ export async function authLogin(
 
     const createPassword = await promptPassword('Create password for local device identity:');
     if (!createPassword) {
-      logger.info('Cancelled');
-      return;
+      requireIdentityPassword('device identity creation');
     }
 
     const confirmPassword = await promptPassword('Confirm local identity password:');
-    if (createPassword !== confirmPassword) {
+    if (!confirmPassword) {
+      requireIdentityPassword('device identity confirmation');
+    }
+    const resolvedCreatePassword = createPassword ?? requireIdentityPassword('device identity creation');
+    const resolvedConfirmPassword = confirmPassword ?? requireIdentityPassword('device identity confirmation');
+    if (resolvedCreatePassword !== resolvedConfirmPassword) {
       throw new SpacesError('Password confirmation does not match.', 'USER_ERROR', 1);
     }
 
-    await generateAndSaveKeypair(createPassword, os.hostname());
-    passwordForIdentity = createPassword;
+    await generateAndSaveKeypair(resolvedCreatePassword, os.hostname());
+    passwordForIdentity = resolvedCreatePassword;
     logger.success('Created local device identity');
   }
 
@@ -115,10 +127,9 @@ export async function authLogin(
   if (!passwordForIdentity) {
     const password = await promptPassword('Enter identity password:');
     if (!password) {
-      logger.info('Cancelled');
-      return;
+      requireIdentityPassword('identity unlock');
     }
-    passwordForIdentity = password;
+    passwordForIdentity = password ?? requireIdentityPassword('identity unlock');
   }
 
   let identity;

--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -9,15 +9,14 @@ import os from 'os';
 import { getSecret, setSecret, deleteSecret } from '../utils/secrets.js';
 import {
   loadKeypair,
-  keypairExists,
   getPublicKeyWithoutPassword,
-  generateAndSaveKeypair,
 } from '../core/identity.js';
 import { sign, serializeIdentity } from '../lib/tmux-lite/crypto/identity.js';
-import { promptConfirm, promptPassword } from '../utils/prompts.js';
+import { promptPassword } from '../utils/prompts.js';
 import { logger } from '../utils/logger.js';
-import { NoIdentityError, SpacesError } from '../types/errors.js';
+import { SpacesError } from '../types/errors.js';
 import { printHostSyncReport, syncHostConfig } from './host.js';
+import { ensureDeviceIdentityPassword } from './device-identity-password.js';
 
 // API Configuration
 const API_BASE = process.env.GITSPACE_API_URL || 'https://api.gitspace.sh';
@@ -100,43 +99,12 @@ export async function authLogin(
     return value as string;
   };
 
-  if (!keypairExists()) {
-    const shouldCreate = options.yes || await promptConfirm(
-      'No local device identity found. Create one now?',
-      true,
-    );
-
-    if (!shouldCreate) {
-      throw new NoIdentityError();
-    }
-
-    const resolvedCreatePassword = requireCollectedPassword(
-      await promptPassword('Create password for local device identity:'),
-      'device identity creation',
-    );
-
-    const resolvedConfirmPassword = requireCollectedPassword(
-      await promptPassword('Confirm local identity password:'),
-      'device identity confirmation',
-    );
-
-    if (resolvedCreatePassword !== resolvedConfirmPassword) {
-      throw new SpacesError('Password confirmation does not match.', 'USER_ERROR', 1);
-    }
-
-    await generateAndSaveKeypair(resolvedCreatePassword, os.hostname());
-    passwordForIdentity = resolvedCreatePassword;
-    logger.success('Created local device identity');
-  }
-
   // Load identity (requires password for signing)
   logger.info('Loading identity...');
-  if (!passwordForIdentity) {
-    passwordForIdentity = requireCollectedPassword(
-      await promptPassword('Enter identity password:'),
-      'identity unlock',
-    );
-  }
+  passwordForIdentity = requireCollectedPassword(
+    passwordForIdentity ?? await ensureDeviceIdentityPassword({ yes: options.yes }),
+    'identity unlock',
+  );
 
   const resolvedPasswordForIdentity = passwordForIdentity;
 

--- a/src/commands/cloud.ts
+++ b/src/commands/cloud.ts
@@ -81,7 +81,7 @@ interface CloudEnrollmentInvite {
   expiresAt: string;
 }
 
-async function resolveCloudBootstrapRelayInfo(ownerIdentityId: string): Promise<CloudBootstrapRelayInfo> {
+function resolveCloudBootstrapRelayInfo(ownerIdentityId: string): CloudBootstrapRelayInfo {
   const relayUrl = getSavedCloudRelayUrl();
 
   if (!relayUrl) {
@@ -402,7 +402,7 @@ export async function cloudLaunch(
   }
 
   // 4. Resolve relay bootstrap info and generate a local workspace ID
-  const relayInfo = dependencies.relayInfo ?? await resolveCloudBootstrapRelayInfo(identityId);
+  const relayInfo = dependencies.relayInfo ?? resolveCloudBootstrapRelayInfo(identityId);
   const workspaceId = dependencies.workspaceId ?? `ws-${randomUUID().slice(0, 8)}`;
   const appId = `gssh-${identityId.slice(0, 12)}`;
   const workspaceIdentity = dependencies.workspaceIdentity ?? await ensureWorkspaceIdentity(workspaceId);
@@ -873,7 +873,7 @@ export async function cloudResume(
   const identityId = dependencies.identityId ?? await requireLocalIdentityId();
   const provider = injectedProvider ?? await makeSpritesProvider(identityId);
   const ws = requireWorkspace(workspaceId);
-  const relayInfo = dependencies.relayInfo ?? await resolveCloudBootstrapRelayInfo(identityId);
+  const relayInfo = dependencies.relayInfo ?? resolveCloudBootstrapRelayInfo(identityId);
 
   const storedIdentity = dependencies.workspaceIdentity ?? await getWorkspaceIdentity(workspaceId);
   if (!storedIdentity) {

--- a/src/commands/cloud.ts
+++ b/src/commands/cloud.ts
@@ -976,31 +976,31 @@ export async function cloudConnect(
     );
   }
 
-  if (workspace.status === 'hibernated') {
-    throw new SpacesError(
-      `Workspace '${workspaceId}' is hibernated. Resume it first:\n  gssh cloud resume ${workspaceId}`,
-      'USER_ERROR',
-      1,
-    );
-  }
+  if (workspace.status !== 'ready') {
+    if (workspace.status === 'hibernated') {
+      throw new SpacesError(
+        `Workspace '${workspaceId}' is hibernated. Resume it first:\n  gssh cloud resume ${workspaceId}`,
+        'USER_ERROR',
+        1,
+      );
+    }
 
-  if (workspace.status === 'destroyed') {
-    throw new SpacesError(
-      `Workspace '${workspaceId}' is destroyed and cannot be connected.`,
-      'USER_ERROR',
-      1,
-    );
-  }
+    if (workspace.status === 'destroyed') {
+      throw new SpacesError(
+        `Workspace '${workspaceId}' is destroyed and cannot be connected.`,
+        'USER_ERROR',
+        1,
+      );
+    }
 
-  if (workspace.status === 'error') {
-    throw new SpacesError(
-      `Workspace '${workspaceId}' is in error state. Inspect with:\n  gssh cloud list`,
-      'USER_ERROR',
-      1,
-    );
-  }
+    if (workspace.status === 'error') {
+      throw new SpacesError(
+        `Workspace '${workspaceId}' is in error state. Inspect with:\n  gssh cloud list`,
+        'USER_ERROR',
+        1,
+      );
+    }
 
-  if (workspace.status === 'provisioning' || workspace.status === 'bootstrapping' || workspace.status === 'offline') {
     throw new SpacesError(
       `Workspace '${workspaceId}' is currently '${workspace.status}'. Wait until it is ready, then retry.`,
       'USER_ERROR',

--- a/src/commands/cloud.ts
+++ b/src/commands/cloud.ts
@@ -304,7 +304,7 @@ export async function cloudSetupClear(): Promise<void> {
 }
 
 export interface CloudLaunchOptions {
-  repo: string;
+  repo?: string;
   branch?: string;
   image?: string;
 }
@@ -312,8 +312,8 @@ export interface CloudLaunchOptions {
 export interface CloudLaunchProvider {
   createWorkspace(options: {
     name: string;
-    repo: string;
-    branch: string;
+    repo?: string;
+    branch?: string;
     image?: string;
     env: Record<string, string>;
   }): Promise<{ providerWorkspaceId: string; rawState: string }>;
@@ -347,7 +347,13 @@ export async function cloudLaunch(
   options: CloudLaunchOptions,
   dependencies: CloudLaunchDependencies = {}
 ): Promise<void> {
-  const { repo, branch = 'main', image } = options;
+  const repo = options.repo?.trim() || undefined;
+  const branch = options.branch?.trim() || undefined;
+  const { image } = options;
+
+  if (branch && !repo) {
+    throw new SpacesError('`--branch` requires `--repo` for cloud launch metadata.', 'USER_ERROR', 1);
+  }
 
   // 1. Require identity
   const identityId = dependencies.identityId ?? await requireLocalIdentityId();
@@ -377,8 +383,12 @@ export async function cloudLaunch(
   logger.bold('Launching Cloud Workspace');
   logger.log('');
   logger.log(`  Workspace:  ${workspaceId}`);
-  logger.log(`  Repo:       ${repo}`);
-  logger.log(`  Branch:     ${branch}`);
+  if (repo) {
+    logger.log(`  Repo:       ${repo}`);
+  }
+  if (branch) {
+    logger.log(`  Branch:     ${branch}`);
+  }
   logger.log('');
 
   // 5. Create workspace record (bootstrapping state)
@@ -419,17 +429,19 @@ export async function cloudLaunch(
   logCloudEvent({
     workspaceId,
     eventType: 'launch_started',
-    message: `Launching workspace for ${repo}@${branch}`,
+    message: repo
+      ? `Launching workspace for ${repo}${branch ? `@${branch}` : ''}`
+      : 'Launching machine-first workspace',
     metadata: {
       identityId,
-      repo,
-      branch,
       relayUrl: relayInfo.relayUrl,
       relayFingerprint: relayInfo.relayFingerprint,
       bootstrapTokenId: bootstrap.tokenId,
       bootstrapExpiresAt: bootstrap.expiresAt,
       enrollmentInviteId: enrollmentInvite.inviteId,
       enrollmentInviteExpiresAt: enrollmentInvite.expiresAt,
+      ...(repo ? { repo } : {}),
+      ...(branch ? { branch } : {}),
     },
   });
 

--- a/src/commands/cloud.ts
+++ b/src/commands/cloud.ts
@@ -999,10 +999,11 @@ export async function cloudConnect(
     );
   }
 
-  const relayUrl = (dependencies.resolveRelayUrl ?? resolveRelayUrlForCloudConnect)(options.relay);
+  const explicitRelay = options.relay?.trim() || undefined;
+  const relayUrl = (dependencies.resolveRelayUrl ?? resolveRelayUrlForCloudConnect)(explicitRelay);
   const pinnedRelayPubkey = readControlMeta().relaySigningPublicKey;
-  const relayPubkey = options.relay ? options.relayPubkey : (options.relayPubkey ?? pinnedRelayPubkey);
-  if (!relayPubkey && !options.relay) {
+  const relayPubkey = explicitRelay ? options.relayPubkey : (options.relayPubkey ?? pinnedRelayPubkey);
+  if (!relayPubkey && !explicitRelay) {
     throw new SpacesError(
       'Relay identity is not pinned yet. Start `gssh machine serve start` against your target relay once to pin relay identity metadata before connecting cloud workspaces.',
       'USER_ERROR',

--- a/src/commands/cloud.ts
+++ b/src/commands/cloud.ts
@@ -990,6 +990,13 @@ export async function cloudConnect(
 
   const relayUrl = (dependencies.resolveRelayUrl ?? resolveRelayUrlForCloudConnect)(options.relay);
   const relayPubkey = readControlMeta().relaySigningPublicKey;
+  if (!relayPubkey) {
+    throw new SpacesError(
+      'Relay identity is not pinned yet. Start `gssh machine serve start` against your target relay once to pin relay identity metadata before connecting cloud workspaces.',
+      'USER_ERROR',
+      1,
+    );
+  }
   const connectToRemote = dependencies.connectToRemote
     ?? (await import('./connect.js')).connectToRemote;
 

--- a/src/commands/cloud.ts
+++ b/src/commands/cloud.ts
@@ -1019,10 +1019,12 @@ export async function cloudConnect(
     );
   }
   const pinnedRelayPubkey = readControlMeta().relaySigningPublicKey;
-  const relayPubkey = explicitRelay ? options.relayPubkey : (options.relayPubkey ?? pinnedRelayPubkey);
-  if (!relayPubkey && !explicitRelay) {
+  const relayPubkey = options.relayPubkey ?? pinnedRelayPubkey;
+  if (!relayPubkey) {
     throw new SpacesError(
-      'Relay identity is not pinned yet. Start `gssh machine serve start` against your target relay once to pin relay identity metadata before connecting cloud workspaces.',
+      explicitRelay
+        ? 'Relay identity is not pinned yet for this cloud workspace. Pass `--relay-pubkey <pubkey>` or start `gssh machine serve start` against your target relay once to pin relay identity metadata before connecting cloud workspaces.'
+        : 'Relay identity is not pinned yet. Start `gssh machine serve start` against your target relay once to pin relay identity metadata before connecting cloud workspaces.',
       'USER_ERROR',
       1,
     );

--- a/src/commands/cloud.ts
+++ b/src/commands/cloud.ts
@@ -5,6 +5,7 @@ import { logger } from '../utils/logger.js';
 import { SpacesError } from '../types/errors.js';
 import { promptInput } from '../utils/prompts.js';
 import { readRelayConfig } from '../core/identity.js';
+import { isCloudReachableRelayUrl } from '../core/trusted-relays.js';
 import { loadUserRootIdentity } from '../core/user-identity.js';
 import {
   queryControlMeta,
@@ -12,7 +13,6 @@ import {
   sendAssertOwnerCommand,
   sendListCloudWorkspacesCommand,
 } from '../serve/daemon.js';
-import { readHostConfig } from './host.js';
 import {
   clearSpritesToken,
   getSpritesToken,
@@ -20,7 +20,6 @@ import {
 } from '../relay/control/provider-config.js';
 import {
   assertControlOwner,
-  bindControlRelayIdentity,
   createCloudBootstrapToken,
   createCloudUnlockToken,
   getCloudWorkspace,
@@ -31,12 +30,28 @@ import {
   updateCloudWorkspaceStatus,
   upsertCloudWorkspace,
 } from '../relay/control/store.js';
-import { formatRelayFingerprint, getRelayPublicIdentity } from '../relay/identity.js';
 import { SpritesProvider } from '../relay/control/sprites-provider.js';
 import { getCloudBootstrapBundleSource, CLOUD_BOOTSTRAP_BUNDLE_FILENAME } from '../cloud/bootstrap-bundle.generated.js';
 import { ensureWorkspaceIdentity, getWorkspaceIdentity } from '../relay/control/workspace-identity.js';
 import { createRootInviteToken, parseRootInviteToken } from '../lib/tmux-lite/crypto/root-invites.js';
 import { registerRootInvite } from '../relay/auth/store.js';
+
+function getSavedCloudRelayUrl(): string | null {
+  const relayConfig = readRelayConfig();
+  if (!relayConfig) {
+    return null;
+  }
+
+  if (relayConfig.cloudRelayUrl?.trim()) {
+    return relayConfig.cloudRelayUrl.trim();
+  }
+
+  if (isCloudReachableRelayUrl(relayConfig.relayUrl)) {
+    return relayConfig.relayUrl;
+  }
+
+  return null;
+}
 
 async function requireLocalIdentityId(): Promise<string> {
   const userRoot = await loadUserRootIdentity();
@@ -64,17 +79,11 @@ interface CloudEnrollmentInvite {
 }
 
 function resolveCloudBootstrapRelayInfo(ownerIdentityId: string): CloudBootstrapRelayInfo {
-  const hostConfig = readHostConfig();
-  const relayConfig = readRelayConfig();
-
-  // Prefer the last relay URL actually used by serve; fallback to hosted account
-  // subdomain only when no explicit relay config is available.
-  const relayUrl = relayConfig?.relayUrl
-    ?? (hostConfig?.subdomain ? `wss://${hostConfig.subdomain}.gitspace.sh/ws` : undefined);
+  const relayUrl = getSavedCloudRelayUrl();
 
   if (!relayUrl) {
     throw new SpacesError(
-      'No relay URL found for cloud bootstrap. Start `gssh machine serve start` once (or configure hosting) before launching cloud workspaces.',
+      'No cloud-reachable relay URL found for cloud bootstrap. Start `gssh machine serve start` once against your target hosted or external relay before launching cloud workspaces.',
       'USER_ERROR',
       1
     );
@@ -93,30 +102,14 @@ function resolveCloudBootstrapRelayInfo(ownerIdentityId: string): CloudBootstrap
     };
   }
 
-  const relayPublicIdentity = getRelayPublicIdentity();
-  if (!relayPublicIdentity) {
-    throw new SpacesError(
-      'Relay identity is not pinned yet. Start `gssh machine serve start` against your target relay once to pin relay identity metadata before launching cloud workspaces.',
-      'USER_ERROR',
-      1
-    );
-  }
-
-  const relayFingerprint = formatRelayFingerprint(relayPublicIdentity.signingPublicKey);
-  bindControlRelayIdentity({
-    relayIdentityId: relayPublicIdentity.id,
-    relaySigningPublicKey: relayPublicIdentity.signingPublicKey,
-    relayFingerprint,
-  });
-
-  // Keep owner assertion strict whenever we bind relay metadata from launch path.
+  // Keep owner assertion strict whenever we bootstrap cloud flows from control metadata.
   assertControlOwner(ownerIdentityId);
 
-  return {
-    relayUrl,
-    relaySigningPublicKey: relayPublicIdentity.signingPublicKey,
-    relayFingerprint,
-  };
+  throw new SpacesError(
+    'Relay identity is not pinned yet. Start `gssh machine serve start` against your target relay once to pin relay identity metadata before launching cloud workspaces.',
+    'USER_ERROR',
+    1
+  );
 }
 
 async function createCloudEnrollmentInvite(
@@ -601,18 +594,13 @@ function resolveRelayUrlForCloudConnect(explicitRelay?: string): string {
     return explicitRelay.trim();
   }
 
-  const relayConfig = readRelayConfig();
-  if (relayConfig?.relayUrl) {
-    return relayConfig.relayUrl;
-  }
-
-  const hostConfig = readHostConfig();
-  if (hostConfig?.subdomain) {
-    return `wss://${hostConfig.subdomain}.gitspace.sh/ws`;
+  const relayUrl = getSavedCloudRelayUrl();
+  if (relayUrl) {
+    return relayUrl;
   }
 
   throw new SpacesError(
-    'Relay URL is required. Pass --relay <url> or start machine serve once to save relay config.',
+    'No cloud-reachable relay URL is saved. Pass --relay <url> or start `gssh machine serve start` once against your target hosted or external relay.',
     'USER_ERROR',
     1,
   );

--- a/src/commands/cloud.ts
+++ b/src/commands/cloud.ts
@@ -98,6 +98,15 @@ async function resolveCloudBootstrapRelayInfo(ownerIdentityId: string): Promise<
     controlMeta.relaySigningPublicKey &&
     controlMeta.relayFingerprint
   ) {
+    const trustedRelay = getTrustedRelay(relayUrl);
+    if (trustedRelay && trustedRelay.publicKey !== controlMeta.relaySigningPublicKey) {
+      throw new SpacesError(
+        'Pinned relay metadata does not match the saved relay URL. Start `gssh machine serve start` against your target relay once to re-pin relay identity metadata before launching cloud workspaces.',
+        'USER_ERROR',
+        1,
+      );
+    }
+
     return {
       relayUrl,
       relaySigningPublicKey: controlMeta.relaySigningPublicKey,
@@ -1036,6 +1045,14 @@ export async function cloudConnect(
     );
   }
   const pinnedRelayPubkey = readControlMeta().relaySigningPublicKey;
+  if (explicitRelay && !options.relayPubkey) {
+    throw new SpacesError(
+      'Explicit relay overrides require `--relay-pubkey <pubkey>` so the override relay can be trusted explicitly.',
+      'USER_ERROR',
+      1,
+    );
+  }
+
   const relayPubkey = options.relayPubkey ?? pinnedRelayPubkey;
   if (!relayPubkey) {
     throw new SpacesError(

--- a/src/commands/cloud.ts
+++ b/src/commands/cloud.ts
@@ -5,7 +5,7 @@ import { logger } from '../utils/logger.js';
 import { SpacesError } from '../types/errors.js';
 import { promptInput } from '../utils/prompts.js';
 import { readRelayConfig } from '../core/identity.js';
-import { isCloudReachableRelayUrl } from '../core/trusted-relays.js';
+import { getTrustedRelay, isCloudReachableRelayUrl } from '../core/trusted-relays.js';
 import { loadUserRootIdentity } from '../core/user-identity.js';
 import {
   queryControlMeta,
@@ -37,7 +37,6 @@ import { ensureWorkspaceIdentity, getWorkspaceIdentity } from '../relay/control/
 import { createRootInviteToken, parseRootInviteToken } from '../lib/tmux-lite/crypto/root-invites.js';
 import { registerRootInvite } from '../relay/auth/store.js';
 import { computeIdentityId } from '../relay/identity.js';
-import { fetchRelayIdentity } from './connect.js';
 
 function getSavedCloudRelayUrl(): string | null {
   const relayConfig = readRelayConfig();
@@ -109,19 +108,26 @@ async function resolveCloudBootstrapRelayInfo(ownerIdentityId: string): Promise<
   // Keep owner assertion strict whenever we bootstrap cloud flows from control metadata.
   assertControlOwner(ownerIdentityId);
 
-  const relayIdentity = await fetchRelayIdentity(relayUrl);
+  const trustedRelay = getTrustedRelay(relayUrl);
+  if (!trustedRelay) {
+    throw new SpacesError(
+      'Relay identity is not pinned yet. Start `gssh machine serve start` against your target relay once to pin relay identity metadata before launching cloud workspaces.',
+      'USER_ERROR',
+      1,
+    );
+  }
+
   bindControlRelayIdentity({
-    relayIdentityId: computeIdentityId(relayIdentity.publicKey),
-    relaySigningPublicKey: relayIdentity.publicKey,
-    relayFingerprint: relayIdentity.fingerprint,
+    relayIdentityId: computeIdentityId(trustedRelay.publicKey),
+    relaySigningPublicKey: trustedRelay.publicKey,
+    relayFingerprint: trustedRelay.fingerprint,
   });
 
   return {
     relayUrl,
-    relaySigningPublicKey: relayIdentity.publicKey,
-    relayFingerprint: relayIdentity.fingerprint,
+    relaySigningPublicKey: trustedRelay.publicKey,
+    relayFingerprint: trustedRelay.fingerprint,
   };
-
 }
 
 async function createCloudEnrollmentInvite(

--- a/src/commands/cloud.ts
+++ b/src/commands/cloud.ts
@@ -603,7 +603,16 @@ function requireWorkspace(workspaceId: string) {
 
 function resolveRelayUrlForCloudConnect(explicitRelay?: string): string {
   if (explicitRelay?.trim()) {
-    return explicitRelay.trim();
+    const relayUrl = explicitRelay.trim();
+    if (!isCloudReachableRelayUrl(relayUrl)) {
+      throw new SpacesError(
+        'Cloud connect requires a cloud-reachable relay URL. Pass a hosted or public relay with --relay <url>.',
+        'USER_ERROR',
+        1,
+      );
+    }
+
+    return relayUrl;
   }
 
   const relayUrl = getSavedCloudRelayUrl();

--- a/src/commands/cloud.ts
+++ b/src/commands/cloud.ts
@@ -81,6 +81,17 @@ interface CloudEnrollmentInvite {
   expiresAt: string;
 }
 
+function assertPinnedRelayMatchesSavedRelayUrl(relayUrl: string, pinnedRelayPublicKey: string): void {
+  const trustedRelay = getTrustedRelay(relayUrl);
+  if (trustedRelay && trustedRelay.publicKey !== pinnedRelayPublicKey) {
+    throw new SpacesError(
+      'Pinned relay metadata does not match the saved relay URL. Start `gssh machine serve start` against your target relay once to re-pin relay identity metadata before launching cloud workspaces.',
+      'USER_ERROR',
+      1,
+    );
+  }
+}
+
 function resolveCloudBootstrapRelayInfo(ownerIdentityId: string): CloudBootstrapRelayInfo {
   const relayUrl = getSavedCloudRelayUrl();
 
@@ -98,14 +109,7 @@ function resolveCloudBootstrapRelayInfo(ownerIdentityId: string): CloudBootstrap
     controlMeta.relaySigningPublicKey &&
     controlMeta.relayFingerprint
   ) {
-    const trustedRelay = getTrustedRelay(relayUrl);
-    if (trustedRelay && trustedRelay.publicKey !== controlMeta.relaySigningPublicKey) {
-      throw new SpacesError(
-        'Pinned relay metadata does not match the saved relay URL. Start `gssh machine serve start` against your target relay once to re-pin relay identity metadata before launching cloud workspaces.',
-        'USER_ERROR',
-        1,
-      );
-    }
+    assertPinnedRelayMatchesSavedRelayUrl(relayUrl, controlMeta.relaySigningPublicKey);
 
     return {
       relayUrl,
@@ -1044,7 +1048,12 @@ export async function cloudConnect(
       1,
     );
   }
+
   const pinnedRelayPubkey = readControlMeta().relaySigningPublicKey;
+  if (!explicitRelay && pinnedRelayPubkey) {
+    assertPinnedRelayMatchesSavedRelayUrl(relayUrl, pinnedRelayPubkey);
+  }
+
   if (explicitRelay && !options.relayPubkey) {
     throw new SpacesError(
       'Explicit relay overrides require `--relay-pubkey <pubkey>` so the override relay can be trusted explicitly.',
@@ -1053,12 +1062,12 @@ export async function cloudConnect(
     );
   }
 
-  const relayPubkey = options.relayPubkey ?? pinnedRelayPubkey;
+  const relayPubkey = explicitRelay
+    ? options.relayPubkey
+    : options.relayPubkey ?? pinnedRelayPubkey;
   if (!relayPubkey) {
     throw new SpacesError(
-      explicitRelay
-        ? 'Relay identity is not pinned yet for this cloud workspace. Pass `--relay-pubkey <pubkey>` or start `gssh machine serve start` against your target relay once to pin relay identity metadata before connecting cloud workspaces.'
-        : 'Relay identity is not pinned yet. Start `gssh machine serve start` against your target relay once to pin relay identity metadata before connecting cloud workspaces.',
+      'Relay identity is not pinned yet. Start `gssh machine serve start` against your target relay once to pin relay identity metadata before connecting cloud workspaces.',
       'USER_ERROR',
       1,
     );

--- a/src/commands/cloud.ts
+++ b/src/commands/cloud.ts
@@ -948,7 +948,7 @@ export async function cloudDestroy(
 
 export async function cloudConnect(
   workspaceId: string,
-  options: { relay?: string; yes?: boolean; passwordStdin?: boolean } = {},
+  options: { relay?: string; relayPubkey?: string; yes?: boolean; passwordStdin?: boolean } = {},
   dependencies: {
     resolveRelayUrl?: (explicitRelay?: string) => string;
     connectToRemote?: (
@@ -1000,8 +1000,9 @@ export async function cloudConnect(
   }
 
   const relayUrl = (dependencies.resolveRelayUrl ?? resolveRelayUrlForCloudConnect)(options.relay);
-  const relayPubkey = readControlMeta().relaySigningPublicKey;
-  if (!relayPubkey) {
+  const pinnedRelayPubkey = readControlMeta().relaySigningPublicKey;
+  const relayPubkey = options.relay ? options.relayPubkey : (options.relayPubkey ?? pinnedRelayPubkey);
+  if (!relayPubkey && !options.relay) {
     throw new SpacesError(
       'Relay identity is not pinned yet. Start `gssh machine serve start` against your target relay once to pin relay identity metadata before connecting cloud workspaces.',
       'USER_ERROR',

--- a/src/commands/cloud.ts
+++ b/src/commands/cloud.ts
@@ -42,8 +42,9 @@ function getSavedCloudRelayUrl(): string | null {
     return null;
   }
 
-  if (relayConfig.cloudRelayUrl?.trim()) {
-    return relayConfig.cloudRelayUrl.trim();
+  const cloudRelayUrl = relayConfig.cloudRelayUrl?.trim();
+  if (cloudRelayUrl && isCloudReachableRelayUrl(cloudRelayUrl)) {
+    return cloudRelayUrl;
   }
 
   if (isCloudReachableRelayUrl(relayConfig.relayUrl)) {
@@ -988,12 +989,14 @@ export async function cloudConnect(
   }
 
   const relayUrl = (dependencies.resolveRelayUrl ?? resolveRelayUrlForCloudConnect)(options.relay);
+  const relayPubkey = readControlMeta().relaySigningPublicKey;
   const connectToRemote = dependencies.connectToRemote
     ?? (await import('./connect.js')).connectToRemote;
 
   logger.info(`Connecting to cloud workspace ${workspaceId} via machine ${workspace.machineId}...`);
   await connectToRemote(workspace.machineId, {
     relay: relayUrl,
+    relayPubkey,
     yes: options.yes,
     passwordStdin: options.passwordStdin,
   });

--- a/src/commands/cloud.ts
+++ b/src/commands/cloud.ts
@@ -960,6 +960,7 @@ export async function cloudConnect(
   options: { relay?: string; relayPubkey?: string; yes?: boolean; passwordStdin?: boolean } = {},
   dependencies: {
     resolveRelayUrl?: (explicitRelay?: string) => string;
+    allowUnsafeRelayUrl?: boolean;
     connectToRemote?: (
       target?: string,
       options?: { relay?: string; machine?: string; relayPubkey?: string; yes?: boolean; passwordStdin?: boolean },
@@ -1010,6 +1011,13 @@ export async function cloudConnect(
 
   const explicitRelay = options.relay?.trim() || undefined;
   const relayUrl = (dependencies.resolveRelayUrl ?? resolveRelayUrlForCloudConnect)(explicitRelay);
+  if (!dependencies.allowUnsafeRelayUrl && !isCloudReachableRelayUrl(relayUrl)) {
+    throw new SpacesError(
+      'Cloud connect requires a cloud-reachable relay URL. Pass a hosted or public relay with --relay <url>.',
+      'USER_ERROR',
+      1,
+    );
+  }
   const pinnedRelayPubkey = readControlMeta().relaySigningPublicKey;
   const relayPubkey = explicitRelay ? options.relayPubkey : (options.relayPubkey ?? pinnedRelayPubkey);
   if (!relayPubkey && !explicitRelay) {

--- a/src/commands/cloud.ts
+++ b/src/commands/cloud.ts
@@ -350,6 +350,10 @@ export async function cloudLaunch(
   const repo = options.repo?.trim() || undefined;
   const branch = options.branch?.trim() || undefined;
   const { image } = options;
+  const workspaceMetadata = {
+    ...(repo ? { repo } : {}),
+    ...(branch ? { branch } : {}),
+  };
 
   if (branch && !repo) {
     throw new SpacesError('`--branch` requires `--repo` for cloud launch metadata.', 'USER_ERROR', 1);
@@ -398,8 +402,7 @@ export async function cloudLaunch(
     providerWorkspaceId: '',  // filled in after API call
     machineId: workspaceIdentity.id,
     machinePublicKey: workspaceIdentity.signingPublicKey,
-    repo,
-    branch,
+    ...workspaceMetadata,
     status: 'bootstrapping',
   });
 
@@ -440,8 +443,7 @@ export async function cloudLaunch(
       bootstrapExpiresAt: bootstrap.expiresAt,
       enrollmentInviteId: enrollmentInvite.inviteId,
       enrollmentInviteExpiresAt: enrollmentInvite.expiresAt,
-      ...(repo ? { repo } : {}),
-      ...(branch ? { branch } : {}),
+      ...workspaceMetadata,
     },
   });
 
@@ -453,8 +455,7 @@ export async function cloudLaunch(
     logger.dim('  Creating Sprites VM...');
     providerResult = await provider.createWorkspace({
       name: workspaceId,
-      repo,
-      branch,
+      ...workspaceMetadata,
       image,
       env: {
         GSSH_BOOTSTRAP_TOKEN: bootstrap.token,
@@ -474,8 +475,7 @@ export async function cloudLaunch(
       providerWorkspaceId: '',
       machineId: workspaceIdentity.id,
       machinePublicKey: workspaceIdentity.signingPublicKey,
-      repo,
-      branch,
+      ...workspaceMetadata,
       status: 'error',
       error: msg,
     });
@@ -490,8 +490,7 @@ export async function cloudLaunch(
     providerWorkspaceId: providerResult.providerWorkspaceId,
     machineId: workspaceIdentity.id,
     machinePublicKey: workspaceIdentity.signingPublicKey,
-    repo,
-    branch,
+    ...workspaceMetadata,
     status: 'bootstrapping',
   });
 

--- a/src/commands/cloud.ts
+++ b/src/commands/cloud.ts
@@ -20,6 +20,7 @@ import {
 } from '../relay/control/provider-config.js';
 import {
   assertControlOwner,
+  bindControlRelayIdentity,
   createCloudBootstrapToken,
   createCloudUnlockToken,
   getCloudWorkspace,
@@ -35,6 +36,8 @@ import { getCloudBootstrapBundleSource, CLOUD_BOOTSTRAP_BUNDLE_FILENAME } from '
 import { ensureWorkspaceIdentity, getWorkspaceIdentity } from '../relay/control/workspace-identity.js';
 import { createRootInviteToken, parseRootInviteToken } from '../lib/tmux-lite/crypto/root-invites.js';
 import { registerRootInvite } from '../relay/auth/store.js';
+import { computeIdentityId } from '../relay/identity.js';
+import { fetchRelayIdentity } from './connect.js';
 
 function getSavedCloudRelayUrl(): string | null {
   const relayConfig = readRelayConfig();
@@ -79,7 +82,7 @@ interface CloudEnrollmentInvite {
   expiresAt: string;
 }
 
-function resolveCloudBootstrapRelayInfo(ownerIdentityId: string): CloudBootstrapRelayInfo {
+async function resolveCloudBootstrapRelayInfo(ownerIdentityId: string): Promise<CloudBootstrapRelayInfo> {
   const relayUrl = getSavedCloudRelayUrl();
 
   if (!relayUrl) {
@@ -106,11 +109,19 @@ function resolveCloudBootstrapRelayInfo(ownerIdentityId: string): CloudBootstrap
   // Keep owner assertion strict whenever we bootstrap cloud flows from control metadata.
   assertControlOwner(ownerIdentityId);
 
-  throw new SpacesError(
-    'Relay identity is not pinned yet. Start `gssh machine serve start` against your target relay once to pin relay identity metadata before launching cloud workspaces.',
-    'USER_ERROR',
-    1
-  );
+  const relayIdentity = await fetchRelayIdentity(relayUrl);
+  bindControlRelayIdentity({
+    relayIdentityId: computeIdentityId(relayIdentity.publicKey),
+    relaySigningPublicKey: relayIdentity.publicKey,
+    relayFingerprint: relayIdentity.fingerprint,
+  });
+
+  return {
+    relayUrl,
+    relaySigningPublicKey: relayIdentity.publicKey,
+    relayFingerprint: relayIdentity.fingerprint,
+  };
+
 }
 
 async function createCloudEnrollmentInvite(
@@ -376,7 +387,7 @@ export async function cloudLaunch(
   }
 
   // 4. Resolve relay bootstrap info and generate a local workspace ID
-  const relayInfo = dependencies.relayInfo ?? resolveCloudBootstrapRelayInfo(identityId);
+  const relayInfo = dependencies.relayInfo ?? await resolveCloudBootstrapRelayInfo(identityId);
   const workspaceId = dependencies.workspaceId ?? `ws-${randomUUID().slice(0, 8)}`;
   const appId = `gssh-${identityId.slice(0, 12)}`;
   const workspaceIdentity = dependencies.workspaceIdentity ?? await ensureWorkspaceIdentity(workspaceId);
@@ -847,7 +858,7 @@ export async function cloudResume(
   const identityId = dependencies.identityId ?? await requireLocalIdentityId();
   const provider = injectedProvider ?? await makeSpritesProvider(identityId);
   const ws = requireWorkspace(workspaceId);
-  const relayInfo = dependencies.relayInfo ?? resolveCloudBootstrapRelayInfo(identityId);
+  const relayInfo = dependencies.relayInfo ?? await resolveCloudBootstrapRelayInfo(identityId);
 
   const storedIdentity = dependencies.workspaceIdentity ?? await getWorkspaceIdentity(workspaceId);
   if (!storedIdentity) {

--- a/src/commands/cloud.ts
+++ b/src/commands/cloud.ts
@@ -936,12 +936,12 @@ export async function cloudDestroy(
 
 export async function cloudConnect(
   workspaceId: string,
-  options: { relay?: string; yes?: boolean } = {},
+  options: { relay?: string; yes?: boolean; passwordStdin?: boolean } = {},
   dependencies: {
     resolveRelayUrl?: (explicitRelay?: string) => string;
     connectToRemote?: (
       target?: string,
-      options?: { relay?: string; machine?: string; relayPubkey?: string; yes?: boolean },
+      options?: { relay?: string; machine?: string; relayPubkey?: string; yes?: boolean; passwordStdin?: boolean },
     ) => Promise<void>;
   } = {},
 ): Promise<void> {
@@ -995,6 +995,7 @@ export async function cloudConnect(
   await connectToRemote(workspace.machineId, {
     relay: relayUrl,
     yes: options.yes,
+    passwordStdin: options.passwordStdin,
   });
 }
 

--- a/src/commands/cloud.ts
+++ b/src/commands/cloud.ts
@@ -67,10 +67,10 @@ function resolveCloudBootstrapRelayInfo(ownerIdentityId: string): CloudBootstrap
   const hostConfig = readHostConfig();
   const relayConfig = readRelayConfig();
 
-  // External URL for hosted mode, saved relay URL for explicit relay mode.
-  const relayUrl = hostConfig?.subdomain
-    ? `wss://${hostConfig.subdomain}.gitspace.sh/ws`
-    : relayConfig?.relayUrl;
+  // Prefer the last relay URL actually used by serve; fallback to hosted account
+  // subdomain only when no explicit relay config is available.
+  const relayUrl = relayConfig?.relayUrl
+    ?? (hostConfig?.subdomain ? `wss://${hostConfig.subdomain}.gitspace.sh/ws` : undefined);
 
   if (!relayUrl) {
     throw new SpacesError(
@@ -96,7 +96,7 @@ function resolveCloudBootstrapRelayInfo(ownerIdentityId: string): CloudBootstrap
   const relayPublicIdentity = getRelayPublicIdentity();
   if (!relayPublicIdentity) {
     throw new SpacesError(
-      'Relay identity is not initialized yet. Start `gssh machine serve start` (hosted mode) to initialize and pin relay identity first.',
+      'Relay identity is not pinned yet. Start `gssh machine serve start` against your target relay once to pin relay identity metadata before launching cloud workspaces.',
       'USER_ERROR',
       1
     );
@@ -596,6 +596,28 @@ function requireWorkspace(workspaceId: string) {
   return ws;
 }
 
+function resolveRelayUrlForCloudConnect(explicitRelay?: string): string {
+  if (explicitRelay?.trim()) {
+    return explicitRelay.trim();
+  }
+
+  const relayConfig = readRelayConfig();
+  if (relayConfig?.relayUrl) {
+    return relayConfig.relayUrl;
+  }
+
+  const hostConfig = readHostConfig();
+  if (hostConfig?.subdomain) {
+    return `wss://${hostConfig.subdomain}.gitspace.sh/ws`;
+  }
+
+  throw new SpacesError(
+    'Relay URL is required. Pass --relay <url> or start machine serve once to save relay config.',
+    'USER_ERROR',
+    1,
+  );
+}
+
 const SPRITE_BOOTSTRAP_SCRIPT_PATH = `/tmp/${CLOUD_BOOTSTRAP_BUNDLE_FILENAME}`;
 
 function buildLegacySpriteServeStartCommand(): string[] {
@@ -924,6 +946,70 @@ export async function cloudDestroy(
   logger.log('');
 }
 
+export async function cloudConnect(
+  workspaceId: string,
+  options: { relay?: string; yes?: boolean } = {},
+  dependencies: {
+    resolveRelayUrl?: (explicitRelay?: string) => string;
+    connectToRemote?: (
+      target?: string,
+      options?: { relay?: string; machine?: string; relayPubkey?: string; yes?: boolean },
+    ) => Promise<void>;
+  } = {},
+): Promise<void> {
+  const workspace = requireWorkspace(workspaceId);
+
+  if (!workspace.machineId) {
+    throw new SpacesError(
+      `Workspace '${workspaceId}' does not have an attached machine identity yet.`,
+      'USER_ERROR',
+      1,
+    );
+  }
+
+  if (workspace.status === 'hibernated') {
+    throw new SpacesError(
+      `Workspace '${workspaceId}' is hibernated. Resume it first:\n  gssh cloud resume ${workspaceId}`,
+      'USER_ERROR',
+      1,
+    );
+  }
+
+  if (workspace.status === 'destroyed') {
+    throw new SpacesError(
+      `Workspace '${workspaceId}' is destroyed and cannot be connected.`,
+      'USER_ERROR',
+      1,
+    );
+  }
+
+  if (workspace.status === 'error') {
+    throw new SpacesError(
+      `Workspace '${workspaceId}' is in error state. Inspect with:\n  gssh cloud list`,
+      'USER_ERROR',
+      1,
+    );
+  }
+
+  if (workspace.status === 'provisioning' || workspace.status === 'bootstrapping' || workspace.status === 'offline') {
+    throw new SpacesError(
+      `Workspace '${workspaceId}' is currently '${workspace.status}'. Wait until it is ready, then retry.`,
+      'USER_ERROR',
+      1,
+    );
+  }
+
+  const relayUrl = (dependencies.resolveRelayUrl ?? resolveRelayUrlForCloudConnect)(options.relay);
+  const connectToRemote = dependencies.connectToRemote
+    ?? (await import('./connect.js')).connectToRemote;
+
+  logger.info(`Connecting to cloud workspace ${workspaceId} via machine ${workspace.machineId}...`);
+  await connectToRemote(workspace.machineId, {
+    relay: relayUrl,
+    yes: options.yes,
+  });
+}
+
 export async function cloudList(): Promise<void> {
   const serveStatus = await queryServeStatus();
   if (!serveStatus) {
@@ -961,6 +1047,9 @@ export async function cloudList(): Promise<void> {
     logger.log(`  ${workspace.id}`);
     logger.log(`    Provider: ${workspace.provider}`);
     logger.log(`    Status:   ${workspace.status}`);
+    if (workspace.machineId) {
+      logger.log(`    Machine:  ${workspace.machineId}`);
+    }
     if (workspace.repo) {
       logger.log(`    Repo:     ${workspace.repo}`);
     }
@@ -970,6 +1059,9 @@ export async function cloudList(): Promise<void> {
     logger.log(`    Updated:  ${workspace.updatedAt}`);
     if (workspace.error) {
       logger.warning(`    Error:    ${workspace.error}`);
+    }
+    if (workspace.machineId && workspace.status === 'ready') {
+      logger.dim(`    Connect:  gssh cloud connect ${workspace.id}`);
     }
   }
 

--- a/src/commands/connect.ts
+++ b/src/commands/connect.ts
@@ -31,7 +31,10 @@ import {
 import {
   SpacesError,
 } from '../types/errors.js';
-import { ensureDeviceIdentityPassword } from './device-identity-password.js';
+import {
+  createDeviceIdentityPasswordContext,
+  ensureDeviceIdentityPassword,
+} from './device-identity-password.js';
 import { ensureUserRootIdentityWithRecovery } from './identity-recovery.js';
 import {
   addTrustedRelay,
@@ -197,6 +200,7 @@ export async function connectToRemote(
   target?: string,
   options: { relay?: string; machine?: string; relayPubkey?: string; yes?: boolean; passwordStdin?: boolean } = {}
 ): Promise<void> {
+  const devicePasswordContext = createDeviceIdentityPasswordContext();
   if (!target && !options.machine) {
     throw new SpacesError(
       'Connection target required.\n\nUsage:\n  gssh client connect <machine-id> --relay <url>\n  gssh client connect --machine <id> --relay <url>\n\nList available machines:\n  gssh client machines list --relay <url>',
@@ -236,13 +240,17 @@ export async function connectToRemote(
   });
 
   await ensureUserRootIdentityWithRecovery({
+    devicePasswordContext,
     yes: options.yes,
     passwordStdin: options.passwordStdin,
     context: 'remote client authorization',
   });
 
   // Step 3: Load local identity
-  const password = await ensureDeviceIdentityPassword({ yes: options.yes, passwordStdin: options.passwordStdin });
+  const password = await ensureDeviceIdentityPassword(
+    { yes: options.yes, passwordStdin: options.passwordStdin },
+    devicePasswordContext,
+  );
   if (!password) {
     logger.info('Cancelled');
     return;
@@ -379,6 +387,7 @@ export async function listRemoteMachines(options: {
   yes?: boolean;
   passwordStdin?: boolean;
 }): Promise<void> {
+  const devicePasswordContext = createDeviceIdentityPasswordContext();
   if (!options.relay) {
     throw new SpacesError('Relay URL is required. Use --relay <url>.', 'USER_ERROR', 1);
   }
@@ -390,12 +399,16 @@ export async function listRemoteMachines(options: {
   });
 
   await ensureUserRootIdentityWithRecovery({
+    devicePasswordContext,
     yes: options.yes,
     passwordStdin: options.passwordStdin,
     context: 'remote machine directory authorization',
   });
 
-  const password = await ensureDeviceIdentityPassword({ yes: options.yes, passwordStdin: options.passwordStdin });
+  const password = await ensureDeviceIdentityPassword(
+    { yes: options.yes, passwordStdin: options.passwordStdin },
+    devicePasswordContext,
+  );
   if (!password) {
     logger.info('Cancelled');
     return;

--- a/src/commands/connect.ts
+++ b/src/commands/connect.ts
@@ -208,9 +208,11 @@ async function ensureDeviceIdentityPassword(options: { yes?: boolean; passwordSt
       return null;
     }
 
-    const confirmPassword = stdinPassword ?? await promptPassword('Confirm local identity password:');
-    if (password !== confirmPassword) {
-      throw new SpacesError('Password confirmation does not match.', 'USER_ERROR', 1);
+    if (!stdinPassword) {
+      const confirmPassword = await promptPassword('Confirm local identity password:');
+      if (password !== confirmPassword) {
+        throw new SpacesError('Password confirmation does not match.', 'USER_ERROR', 1);
+      }
     }
 
     await generateAndSaveKeypair(password, os.hostname());
@@ -429,6 +431,14 @@ export async function listRemoteMachines(options: {
   }
 
   const identity = await loadKeypair(password);
+  if (!identity) {
+    throw new SpacesError(
+      'Failed to unlock identity. Check your password.',
+      'USER_ERROR',
+      1,
+    );
+  }
+
   await ensureUserRootIdentityWithRecovery({
     yes: options.yes,
     context: 'remote machine directory authorization',

--- a/src/commands/connect.ts
+++ b/src/commands/connect.ts
@@ -52,6 +52,41 @@ export interface RelayIdentityProbe {
   label?: string;
 }
 
+async function loadPasswordFromStdin(): Promise<string> {
+  const reader = process.stdin;
+  const chunks: Buffer[] = [];
+
+  const onData = (chunk: Buffer) => chunks.push(chunk);
+  reader.on('data', onData);
+
+  try {
+    await new Promise<void>((resolve, reject) => {
+      const timeoutId = setTimeout(() => reject(new Error('Timeout reading password from stdin')), 10000);
+      const onEnd = () => {
+        clearTimeout(timeoutId);
+        resolve();
+      };
+      const onError = (error: Error) => {
+        clearTimeout(timeoutId);
+        reject(error);
+      };
+
+      reader.once('end', onEnd);
+      reader.once('error', onError);
+    });
+  } finally {
+    reader.removeListener('data', onData);
+    reader.pause();
+  }
+
+  const password = Buffer.concat(chunks).toString().trim();
+  if (!password) {
+    throw new SpacesError('No password provided via stdin.', 'USER_ERROR', 1);
+  }
+
+  return password;
+}
+
 function relayHealthUrl(relayUrl: string): string {
   const parsed = new URL(relayUrl);
   const protocol = parsed.protocol === 'wss:' ? 'https:' : 'http:';
@@ -173,7 +208,9 @@ export async function verifyClientRelayTrust(
   logger.success('Relay trusted and saved.');
 }
 
-async function ensureDeviceIdentityPassword(options: { yes?: boolean } = {}): Promise<string | null> {
+async function ensureDeviceIdentityPassword(options: { yes?: boolean; passwordStdin?: boolean } = {}): Promise<string | null> {
+  const stdinPassword = options.passwordStdin ? await loadPasswordFromStdin() : null;
+
   if (!keypairExists()) {
     const shouldCreate = options.yes || await promptConfirm(
       'No local device identity found. Create one now?',
@@ -183,12 +220,12 @@ async function ensureDeviceIdentityPassword(options: { yes?: boolean } = {}): Pr
       throw new NoIdentityError();
     }
 
-    const password = await promptPassword('Create password for local device identity:');
+    const password = stdinPassword ?? await promptPassword('Create password for local device identity:');
     if (!password) {
       return null;
     }
 
-    const confirmPassword = await promptPassword('Confirm local identity password:');
+    const confirmPassword = stdinPassword ?? await promptPassword('Confirm local identity password:');
     if (password !== confirmPassword) {
       throw new SpacesError('Password confirmation does not match.', 'USER_ERROR', 1);
     }
@@ -198,7 +235,7 @@ async function ensureDeviceIdentityPassword(options: { yes?: boolean } = {}): Pr
     return password;
   }
 
-  const password = await promptPassword('Enter password to unlock identity:');
+  const password = stdinPassword ?? await promptPassword('Enter password to unlock identity:');
   return password;
 }
 
@@ -210,7 +247,7 @@ async function ensureDeviceIdentityPassword(options: { yes?: boolean } = {}): Pr
  */
 export async function connectToRemote(
   target?: string,
-  options: { relay?: string; machine?: string; relayPubkey?: string; yes?: boolean } = {}
+  options: { relay?: string; machine?: string; relayPubkey?: string; yes?: boolean; passwordStdin?: boolean } = {}
 ): Promise<void> {
   if (!target && !options.machine) {
     throw new SpacesError(
@@ -251,7 +288,7 @@ export async function connectToRemote(
   });
 
   // Step 3: Load local identity
-  const password = await ensureDeviceIdentityPassword({ yes: options.yes });
+  const password = await ensureDeviceIdentityPassword({ yes: options.yes, passwordStdin: options.passwordStdin });
   if (!password) {
     logger.info('Cancelled');
     return;
@@ -390,6 +427,7 @@ export async function listRemoteMachines(options: {
   relayPubkey?: string;
   json?: boolean;
   yes?: boolean;
+  passwordStdin?: boolean;
 }): Promise<void> {
   if (!options.relay) {
     throw new SpacesError('Relay URL is required. Use --relay <url>.', 'USER_ERROR', 1);
@@ -401,7 +439,7 @@ export async function listRemoteMachines(options: {
     yes: options.yes,
   });
 
-  const password = await ensureDeviceIdentityPassword({ yes: options.yes });
+  const password = await ensureDeviceIdentityPassword({ yes: options.yes, passwordStdin: options.passwordStdin });
   if (!password) {
     logger.info('Cancelled');
     return;

--- a/src/commands/connect.ts
+++ b/src/commands/connect.ts
@@ -272,6 +272,11 @@ export async function connectToRemote(
     yes: options.yes,
   });
 
+  await ensureUserRootIdentityWithRecovery({
+    yes: options.yes,
+    context: 'remote client authorization',
+  });
+
   // Step 3: Load local identity
   const password = await ensureDeviceIdentityPassword({ yes: options.yes, passwordStdin: options.passwordStdin });
   if (!password) {
@@ -288,10 +293,6 @@ export async function connectToRemote(
     );
   }
 
-  await ensureUserRootIdentityWithRecovery({
-    yes: options.yes,
-    context: 'remote client authorization',
-  });
   const deviceCertificate = await createLocalDeviceCertificate(identity);
 
   logger.info('Connecting to relay...');
@@ -424,6 +425,11 @@ export async function listRemoteMachines(options: {
     yes: options.yes,
   });
 
+  await ensureUserRootIdentityWithRecovery({
+    yes: options.yes,
+    context: 'remote machine directory authorization',
+  });
+
   const password = await ensureDeviceIdentityPassword({ yes: options.yes, passwordStdin: options.passwordStdin });
   if (!password) {
     logger.info('Cancelled');
@@ -439,10 +445,6 @@ export async function listRemoteMachines(options: {
     );
   }
 
-  await ensureUserRootIdentityWithRecovery({
-    yes: options.yes,
-    context: 'remote machine directory authorization',
-  });
   const deviceCertificate = await createLocalDeviceCertificate(identity);
   const signer = createNodeRelaySigner(identity);
 

--- a/src/commands/connect.ts
+++ b/src/commands/connect.ts
@@ -237,6 +237,7 @@ export async function connectToRemote(
 
   await ensureUserRootIdentityWithRecovery({
     yes: options.yes,
+    passwordStdin: options.passwordStdin,
     context: 'remote client authorization',
   });
 
@@ -390,6 +391,7 @@ export async function listRemoteMachines(options: {
 
   await ensureUserRootIdentityWithRecovery({
     yes: options.yes,
+    passwordStdin: options.passwordStdin,
     context: 'remote machine directory authorization',
   });
 

--- a/src/commands/connect.ts
+++ b/src/commands/connect.ts
@@ -8,7 +8,13 @@
 
 import { logger } from '../utils/logger.js';
 import { promptPassword, promptConfirm, promptInput, selectOne } from '../utils/prompts.js';
-import { loadKeypair, keypairExists, readRelayConfig } from '../core/identity.js';
+import os from 'os';
+import {
+  loadKeypair,
+  keypairExists,
+  readRelayConfig,
+  generateAndSaveKeypair,
+} from '../core/identity.js';
 import { createLocalDeviceCertificate } from '../core/user-identity.js';
 import WebSocket from 'ws';
 import chalk from 'chalk';
@@ -29,9 +35,172 @@ import {
   NoIdentityError,
   SpacesError,
 } from '../types/errors.js';
+import { ensureUserRootIdentityWithRecovery } from './identity-recovery.js';
+import {
+  addTrustedRelay,
+  computeRelayFingerprint,
+  getTrustedRelay,
+  isLocalhost,
+} from '../core/trusted-relays.js';
 import type {
   WorkspaceInfo,
 } from '../lib/remote-session/protocol.js';
+
+export interface RelayIdentityProbe {
+  publicKey: string;
+  fingerprint: string;
+  label?: string;
+}
+
+function relayHealthUrl(relayUrl: string): string {
+  const parsed = new URL(relayUrl);
+  const protocol = parsed.protocol === 'wss:' ? 'https:' : 'http:';
+  return `${protocol}//${parsed.host}/health`;
+}
+
+export async function fetchRelayIdentity(relayUrl: string): Promise<RelayIdentityProbe> {
+  const healthUrl = relayHealthUrl(relayUrl);
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 5000);
+
+  try {
+    const response = await fetch(healthUrl, { signal: controller.signal });
+    if (!response.ok) {
+      throw new SpacesError(
+        `Could not fetch relay identity from ${healthUrl} (${response.status} ${response.statusText}).`,
+        'USER_ERROR',
+        1,
+      );
+    }
+
+    const body = await response.json() as {
+      relayPublicKey?: string;
+      relayFingerprint?: string;
+      relayLabel?: string;
+    };
+
+    if (!body.relayPublicKey || typeof body.relayPublicKey !== 'string') {
+      throw new SpacesError(
+        `Relay at ${healthUrl} did not provide relayPublicKey.`,
+        'USER_ERROR',
+        1,
+      );
+    }
+
+    const fingerprint = body.relayFingerprint && typeof body.relayFingerprint === 'string'
+      ? body.relayFingerprint
+      : computeRelayFingerprint(body.relayPublicKey);
+
+    return {
+      publicKey: body.relayPublicKey,
+      fingerprint,
+      label: typeof body.relayLabel === 'string' ? body.relayLabel : undefined,
+    };
+  } catch (error) {
+    if (error instanceof SpacesError) {
+      throw error;
+    }
+
+    throw new SpacesError(
+      `Failed to verify relay identity (${error instanceof Error ? error.message : String(error)}).`,
+      'USER_ERROR',
+      1,
+    );
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+export async function verifyClientRelayTrust(
+  relayUrl: string,
+  relayIdentity: RelayIdentityProbe,
+  options: { relayPubkey?: string; yes?: boolean } = {},
+): Promise<void> {
+  const trustedRelay = getTrustedRelay(relayUrl);
+
+  if (trustedRelay && trustedRelay.publicKey !== relayIdentity.publicKey) {
+    logger.log('');
+    logger.error('SECURITY WARNING: Relay public key mismatch!');
+    logger.error(`Expected:  ${trustedRelay.fingerprint}`);
+    logger.error(`Received:  ${relayIdentity.fingerprint}`);
+    logger.log('');
+    throw new SpacesError(
+      'Relay identity mismatch - possible security threat. Remove the old entry from trusted relays and retry only if expected.',
+      'USER_ERROR',
+      1,
+    );
+  }
+
+  if (trustedRelay && trustedRelay.publicKey === relayIdentity.publicKey) {
+    return;
+  }
+
+  if (options.relayPubkey) {
+    if (options.relayPubkey !== relayIdentity.publicKey) {
+      throw new SpacesError(
+        `Relay public key does not match --relay-pubkey (expected ${computeRelayFingerprint(options.relayPubkey)}, got ${relayIdentity.fingerprint}).`,
+        'USER_ERROR',
+        1,
+      );
+    }
+
+    addTrustedRelay(relayUrl, relayIdentity.publicKey, relayIdentity.label);
+    logger.success('Relay trusted via explicit --relay-pubkey.');
+    return;
+  }
+
+  if (isLocalhost(relayUrl)) {
+    addTrustedRelay(relayUrl, relayIdentity.publicKey, relayIdentity.label);
+    logger.dim(`Trusted localhost relay ${relayIdentity.fingerprint}`);
+    return;
+  }
+
+  logger.log('');
+  logger.bold('Unknown Relay');
+  logger.log(`  URL:         ${relayUrl}`);
+  logger.log(`  Fingerprint: ${relayIdentity.fingerprint}`);
+  if (relayIdentity.label) {
+    logger.log(`  Label:       ${relayIdentity.label}`);
+  }
+  logger.log('');
+
+  const shouldTrust = options.yes || await promptConfirm('Trust this relay?', true);
+  if (!shouldTrust) {
+    throw new SpacesError('Relay not trusted, aborting connection.', 'USER_ERROR', 1);
+  }
+
+  addTrustedRelay(relayUrl, relayIdentity.publicKey, relayIdentity.label);
+  logger.success('Relay trusted and saved.');
+}
+
+async function ensureDeviceIdentityPassword(options: { yes?: boolean } = {}): Promise<string | null> {
+  if (!keypairExists()) {
+    const shouldCreate = options.yes || await promptConfirm(
+      'No local device identity found. Create one now?',
+      true,
+    );
+    if (!shouldCreate) {
+      throw new NoIdentityError();
+    }
+
+    const password = await promptPassword('Create password for local device identity:');
+    if (!password) {
+      return null;
+    }
+
+    const confirmPassword = await promptPassword('Confirm local identity password:');
+    if (password !== confirmPassword) {
+      throw new SpacesError('Password confirmation does not match.', 'USER_ERROR', 1);
+    }
+
+    await generateAndSaveKeypair(password, os.hostname());
+    logger.success('Created local device identity');
+    return password;
+  }
+
+  const password = await promptPassword('Enter password to unlock identity:');
+  return password;
+}
 
 /**
  * Connect to a remote machine as the owner identity.
@@ -41,7 +210,7 @@ import type {
  */
 export async function connectToRemote(
   target?: string,
-  options: { relay?: string; machine?: string } = {}
+  options: { relay?: string; machine?: string; relayPubkey?: string; yes?: boolean } = {}
 ): Promise<void> {
   if (!target && !options.machine) {
     throw new SpacesError(
@@ -69,18 +238,20 @@ export async function connectToRemote(
   logger.log(`  Relay:       ${relayUrl}`);
   logger.log('');
 
-  const confirmed = await promptConfirm('Connect to this machine?', true);
+  const confirmed = options.yes || await promptConfirm('Connect to this machine?', true);
   if (!confirmed) {
     logger.info('Cancelled');
     return;
   }
 
-  // Step 3: Load local identity
-  if (!keypairExists()) {
-    throw new NoIdentityError();
-  }
+  const relayIdentity = await fetchRelayIdentity(relayUrl);
+  await verifyClientRelayTrust(relayUrl, relayIdentity, {
+    relayPubkey: options.relayPubkey,
+    yes: options.yes,
+  });
 
-  const password = await promptPassword('Enter password to unlock identity:');
+  // Step 3: Load local identity
+  const password = await ensureDeviceIdentityPassword({ yes: options.yes });
   if (!password) {
     logger.info('Cancelled');
     return;
@@ -95,6 +266,10 @@ export async function connectToRemote(
     );
   }
 
+  await ensureUserRootIdentityWithRecovery({
+    yes: options.yes,
+    context: 'remote client authorization',
+  });
   const deviceCertificate = await createLocalDeviceCertificate(identity);
 
   logger.info('Connecting to relay...');
@@ -212,23 +387,31 @@ export async function connectToRemote(
 
 export async function listRemoteMachines(options: {
   relay?: string;
+  relayPubkey?: string;
   json?: boolean;
+  yes?: boolean;
 }): Promise<void> {
   if (!options.relay) {
     throw new SpacesError('Relay URL is required. Use --relay <url>.', 'USER_ERROR', 1);
   }
 
-  if (!keypairExists()) {
-    throw new NoIdentityError();
-  }
+  const relayIdentity = await fetchRelayIdentity(options.relay);
+  await verifyClientRelayTrust(options.relay, relayIdentity, {
+    relayPubkey: options.relayPubkey,
+    yes: options.yes,
+  });
 
-  const password = await promptPassword('Enter password to unlock identity:');
+  const password = await ensureDeviceIdentityPassword({ yes: options.yes });
   if (!password) {
     logger.info('Cancelled');
     return;
   }
 
   const identity = await loadKeypair(password);
+  await ensureUserRootIdentityWithRecovery({
+    yes: options.yes,
+    context: 'remote machine directory authorization',
+  });
   const deviceCertificate = await createLocalDeviceCertificate(identity);
   const signer = createNodeRelaySigner(identity);
 

--- a/src/commands/connect.ts
+++ b/src/commands/connect.ts
@@ -192,8 +192,6 @@ export async function verifyClientRelayTrust(
 }
 
 async function ensureDeviceIdentityPassword(options: { yes?: boolean; passwordStdin?: boolean } = {}): Promise<string | null> {
-  const stdinPassword = options.passwordStdin ? await readPasswordFromStdin() : null;
-
   if (!keypairExists()) {
     const shouldCreate = options.yes || await promptConfirm(
       'No local device identity found. Create one now?',
@@ -203,6 +201,7 @@ async function ensureDeviceIdentityPassword(options: { yes?: boolean; passwordSt
       throw new NoIdentityError();
     }
 
+    const stdinPassword = options.passwordStdin ? await readPasswordFromStdin() : null;
     const password = stdinPassword ?? await promptPassword('Create password for local device identity:');
     if (!password) {
       return null;
@@ -220,6 +219,7 @@ async function ensureDeviceIdentityPassword(options: { yes?: boolean; passwordSt
     return password;
   }
 
+  const stdinPassword = options.passwordStdin ? await readPasswordFromStdin() : null;
   const password = stdinPassword ?? await promptPassword('Enter password to unlock identity:');
   return password;
 }

--- a/src/commands/connect.ts
+++ b/src/commands/connect.ts
@@ -407,14 +407,6 @@ export async function listRemoteMachines(options: {
   }
 
   const identity = await loadKeypair(password);
-  if (!identity) {
-    throw new SpacesError(
-      'Failed to unlock identity. Check your password.',
-      'USER_ERROR',
-      1,
-    );
-  }
-
   const deviceCertificate = await createLocalDeviceCertificate(identity);
   const signer = createNodeRelaySigner(identity);
 

--- a/src/commands/connect.ts
+++ b/src/commands/connect.ts
@@ -42,6 +42,7 @@ import {
   getTrustedRelay,
   isLocalhost,
 } from '../core/trusted-relays.js';
+import { readPasswordFromStdin } from '../utils/password-stdin.js';
 import type {
   WorkspaceInfo,
 } from '../lib/remote-session/protocol.js';
@@ -50,41 +51,6 @@ export interface RelayIdentityProbe {
   publicKey: string;
   fingerprint: string;
   label?: string;
-}
-
-async function loadPasswordFromStdin(): Promise<string> {
-  const reader = process.stdin;
-  const chunks: Buffer[] = [];
-
-  const onData = (chunk: Buffer) => chunks.push(chunk);
-  reader.on('data', onData);
-
-  try {
-    await new Promise<void>((resolve, reject) => {
-      const timeoutId = setTimeout(() => reject(new Error('Timeout reading password from stdin')), 10000);
-      const onEnd = () => {
-        clearTimeout(timeoutId);
-        resolve();
-      };
-      const onError = (error: Error) => {
-        clearTimeout(timeoutId);
-        reject(error);
-      };
-
-      reader.once('end', onEnd);
-      reader.once('error', onError);
-    });
-  } finally {
-    reader.removeListener('data', onData);
-    reader.pause();
-  }
-
-  const password = Buffer.concat(chunks).toString().trim();
-  if (!password) {
-    throw new SpacesError('No password provided via stdin.', 'USER_ERROR', 1);
-  }
-
-  return password;
 }
 
 function relayHealthUrl(relayUrl: string): string {
@@ -122,9 +88,17 @@ export async function fetchRelayIdentity(relayUrl: string): Promise<RelayIdentit
       );
     }
 
-    const fingerprint = body.relayFingerprint && typeof body.relayFingerprint === 'string'
-      ? body.relayFingerprint
-      : computeRelayFingerprint(body.relayPublicKey);
+    const fingerprint = computeRelayFingerprint(body.relayPublicKey);
+    if (typeof body.relayFingerprint === 'string' && body.relayFingerprint !== fingerprint) {
+      logger.error(
+        `Relay at ${healthUrl} reported fingerprint ${body.relayFingerprint}, but computed ${fingerprint} from relayPublicKey.`,
+      );
+      throw new SpacesError(
+        `Relay at ${healthUrl} returned inconsistent identity metadata.`,
+        'USER_ERROR',
+        1,
+      );
+    }
 
     return {
       publicKey: body.relayPublicKey,
@@ -199,7 +173,16 @@ export async function verifyClientRelayTrust(
   }
   logger.log('');
 
-  const shouldTrust = options.yes || await promptConfirm('Trust this relay?', true);
+  if (options.yes) {
+    logger.error('Unknown relay requires interactive approval or --relay-pubkey.');
+    throw new SpacesError(
+      'Unknown relay requires interactive approval or --relay-pubkey.',
+      'USER_ERROR',
+      1,
+    );
+  }
+
+  const shouldTrust = await promptConfirm('Trust this relay?', true);
   if (!shouldTrust) {
     throw new SpacesError('Relay not trusted, aborting connection.', 'USER_ERROR', 1);
   }
@@ -209,7 +192,7 @@ export async function verifyClientRelayTrust(
 }
 
 async function ensureDeviceIdentityPassword(options: { yes?: boolean; passwordStdin?: boolean } = {}): Promise<string | null> {
-  const stdinPassword = options.passwordStdin ? await loadPasswordFromStdin() : null;
+  const stdinPassword = options.passwordStdin ? await readPasswordFromStdin() : null;
 
   if (!keypairExists()) {
     const shouldCreate = options.yes || await promptConfirm(

--- a/src/commands/connect.ts
+++ b/src/commands/connect.ts
@@ -35,10 +35,10 @@ import { ensureDeviceIdentityPassword } from './device-identity-password.js';
 import { ensureUserRootIdentityWithRecovery } from './identity-recovery.js';
 import {
   addTrustedRelay,
-  computeRelayFingerprint,
   getTrustedRelay,
   isLocalhost,
 } from '../core/trusted-relays.js';
+import { formatRelayFingerprint } from '../relay/identity.js';
 import type {
   WorkspaceInfo,
 } from '../lib/remote-session/protocol.js';
@@ -84,7 +84,7 @@ export async function fetchRelayIdentity(relayUrl: string): Promise<RelayIdentit
       );
     }
 
-    const fingerprint = computeRelayFingerprint(body.relayPublicKey);
+    const fingerprint = formatRelayFingerprint(body.relayPublicKey);
     if (typeof body.relayFingerprint === 'string' && body.relayFingerprint !== fingerprint) {
       logger.error(
         `Relay at ${healthUrl} reported fingerprint ${body.relayFingerprint}, but computed ${fingerprint} from relayPublicKey.`,
@@ -143,7 +143,7 @@ export async function verifyClientRelayTrust(
   if (options.relayPubkey) {
     if (options.relayPubkey !== relayIdentity.publicKey) {
       throw new SpacesError(
-        `Relay public key does not match --relay-pubkey (expected ${computeRelayFingerprint(options.relayPubkey)}, got ${relayIdentity.fingerprint}).`,
+        `Relay public key does not match --relay-pubkey (expected ${formatRelayFingerprint(options.relayPubkey)}, got ${relayIdentity.fingerprint}).`,
         'USER_ERROR',
         1,
       );

--- a/src/commands/connect.ts
+++ b/src/commands/connect.ts
@@ -200,7 +200,7 @@ export async function connectToRemote(
   target?: string,
   options: { relay?: string; machine?: string; relayPubkey?: string; yes?: boolean; passwordStdin?: boolean } = {}
 ): Promise<void> {
-  const devicePasswordContext = createDeviceIdentityPasswordContext();
+  const devicePasswordContext = createDeviceIdentityPasswordContext({ passwordStdin: options.passwordStdin });
   if (!target && !options.machine) {
     throw new SpacesError(
       'Connection target required.\n\nUsage:\n  gssh client connect <machine-id> --relay <url>\n  gssh client connect --machine <id> --relay <url>\n\nList available machines:\n  gssh client machines list --relay <url>',
@@ -242,15 +242,11 @@ export async function connectToRemote(
   await ensureUserRootIdentityWithRecovery({
     devicePasswordContext,
     yes: options.yes,
-    passwordStdin: options.passwordStdin,
     context: 'remote client authorization',
   });
 
   // Step 3: Load local identity
-  const password = await ensureDeviceIdentityPassword(
-    { yes: options.yes, passwordStdin: options.passwordStdin },
-    devicePasswordContext,
-  );
+  const password = await ensureDeviceIdentityPassword({ yes: options.yes }, devicePasswordContext);
   if (!password) {
     logger.info('Cancelled');
     return;
@@ -387,7 +383,7 @@ export async function listRemoteMachines(options: {
   yes?: boolean;
   passwordStdin?: boolean;
 }): Promise<void> {
-  const devicePasswordContext = createDeviceIdentityPasswordContext();
+  const devicePasswordContext = createDeviceIdentityPasswordContext({ passwordStdin: options.passwordStdin });
   if (!options.relay) {
     throw new SpacesError('Relay URL is required. Use --relay <url>.', 'USER_ERROR', 1);
   }
@@ -401,14 +397,10 @@ export async function listRemoteMachines(options: {
   await ensureUserRootIdentityWithRecovery({
     devicePasswordContext,
     yes: options.yes,
-    passwordStdin: options.passwordStdin,
     context: 'remote machine directory authorization',
   });
 
-  const password = await ensureDeviceIdentityPassword(
-    { yes: options.yes, passwordStdin: options.passwordStdin },
-    devicePasswordContext,
-  );
+  const password = await ensureDeviceIdentityPassword({ yes: options.yes }, devicePasswordContext);
   if (!password) {
     logger.info('Cancelled');
     return;

--- a/src/commands/connect.ts
+++ b/src/commands/connect.ts
@@ -7,13 +7,10 @@
  */
 
 import { logger } from '../utils/logger.js';
-import { promptPassword, promptConfirm, promptInput, selectOne } from '../utils/prompts.js';
-import os from 'os';
+import { promptConfirm, promptInput, selectOne } from '../utils/prompts.js';
 import {
   loadKeypair,
-  keypairExists,
   readRelayConfig,
-  generateAndSaveKeypair,
 } from '../core/identity.js';
 import { createLocalDeviceCertificate } from '../core/user-identity.js';
 import WebSocket from 'ws';
@@ -32,9 +29,9 @@ import {
   nodeRelaySocketAdapter,
 } from '../relay-client/index.js';
 import {
-  NoIdentityError,
   SpacesError,
 } from '../types/errors.js';
+import { ensureDeviceIdentityPassword } from './device-identity-password.js';
 import { ensureUserRootIdentityWithRecovery } from './identity-recovery.js';
 import {
   addTrustedRelay,
@@ -42,7 +39,6 @@ import {
   getTrustedRelay,
   isLocalhost,
 } from '../core/trusted-relays.js';
-import { readPasswordFromStdin } from '../utils/password-stdin.js';
 import type {
   WorkspaceInfo,
 } from '../lib/remote-session/protocol.js';
@@ -189,39 +185,6 @@ export async function verifyClientRelayTrust(
 
   addTrustedRelay(relayUrl, relayIdentity.publicKey, relayIdentity.label);
   logger.success('Relay trusted and saved.');
-}
-
-async function ensureDeviceIdentityPassword(options: { yes?: boolean; passwordStdin?: boolean } = {}): Promise<string | null> {
-  if (!keypairExists()) {
-    const shouldCreate = options.yes || await promptConfirm(
-      'No local device identity found. Create one now?',
-      true,
-    );
-    if (!shouldCreate) {
-      throw new NoIdentityError();
-    }
-
-    const stdinPassword = options.passwordStdin ? await readPasswordFromStdin() : null;
-    const password = stdinPassword ?? await promptPassword('Create password for local device identity:');
-    if (!password) {
-      return null;
-    }
-
-    if (!stdinPassword) {
-      const confirmPassword = await promptPassword('Confirm local identity password:');
-      if (password !== confirmPassword) {
-        throw new SpacesError('Password confirmation does not match.', 'USER_ERROR', 1);
-      }
-    }
-
-    await generateAndSaveKeypair(password, os.hostname());
-    logger.success('Created local device identity');
-    return password;
-  }
-
-  const stdinPassword = options.passwordStdin ? await readPasswordFromStdin() : null;
-  const password = stdinPassword ?? await promptPassword('Enter password to unlock identity:');
-  return password;
 }
 
 /**

--- a/src/commands/device-identity-password.ts
+++ b/src/commands/device-identity-password.ts
@@ -1,0 +1,38 @@
+import os from 'os';
+import { promptConfirm, promptPassword } from '../utils/prompts.js';
+import { generateAndSaveKeypair, keypairExists } from '../core/identity.js';
+import { NoIdentityError, SpacesError } from '../types/errors.js';
+import { logger } from '../utils/logger.js';
+import { readPasswordFromStdin } from '../utils/password-stdin.js';
+
+export async function ensureDeviceIdentityPassword(options: { yes?: boolean; passwordStdin?: boolean } = {}): Promise<string | null> {
+  if (!keypairExists()) {
+    const shouldCreate = options.yes || await promptConfirm(
+      'No local device identity found. Create one now?',
+      true,
+    );
+    if (!shouldCreate) {
+      throw new NoIdentityError();
+    }
+
+    const stdinPassword = options.passwordStdin ? await readPasswordFromStdin() : null;
+    const password = stdinPassword ?? await promptPassword('Create password for local device identity:');
+    if (!password) {
+      return null;
+    }
+
+    if (!stdinPassword) {
+      const confirmPassword = await promptPassword('Confirm local identity password:');
+      if (password !== confirmPassword) {
+        throw new SpacesError('Password confirmation does not match.', 'USER_ERROR', 1);
+      }
+    }
+
+    await generateAndSaveKeypair(password, os.hostname());
+    logger.success('Created local device identity');
+    return password;
+  }
+
+  const stdinPassword = options.passwordStdin ? await readPasswordFromStdin() : null;
+  return stdinPassword ?? await promptPassword('Enter password to unlock identity:');
+}

--- a/src/commands/device-identity-password.ts
+++ b/src/commands/device-identity-password.ts
@@ -5,7 +5,35 @@ import { NoIdentityError, SpacesError } from '../types/errors.js';
 import { logger } from '../utils/logger.js';
 import { readPasswordFromStdin } from '../utils/password-stdin.js';
 
-export async function ensureDeviceIdentityPassword(options: { yes?: boolean; passwordStdin?: boolean } = {}): Promise<string | null> {
+export interface DeviceIdentityPasswordContext {
+  resolved: boolean;
+  password: string | null;
+}
+
+export function createDeviceIdentityPasswordContext(): DeviceIdentityPasswordContext {
+  return {
+    resolved: false,
+    password: null,
+  };
+}
+
+export async function ensureDeviceIdentityPassword(
+  options: { yes?: boolean; passwordStdin?: boolean } = {},
+  context?: DeviceIdentityPasswordContext,
+): Promise<string | null> {
+  if (context?.resolved) {
+    return context.password;
+  }
+
+  const remember = (password: string | null): string | null => {
+    if (context) {
+      context.resolved = true;
+      context.password = password;
+    }
+
+    return password;
+  };
+
   if (!keypairExists()) {
     const shouldCreate = options.yes || await promptConfirm(
       'No local device identity found. Create one now?',
@@ -18,7 +46,7 @@ export async function ensureDeviceIdentityPassword(options: { yes?: boolean; pas
     const stdinPassword = options.passwordStdin ? await readPasswordFromStdin() : null;
     const password = stdinPassword ?? await promptPassword('Create password for local device identity:');
     if (!password) {
-      return null;
+      return remember(null);
     }
 
     if (!stdinPassword) {
@@ -30,9 +58,9 @@ export async function ensureDeviceIdentityPassword(options: { yes?: boolean; pas
 
     await generateAndSaveKeypair(password, os.hostname());
     logger.success('Created local device identity');
-    return password;
+    return remember(password);
   }
 
   const stdinPassword = options.passwordStdin ? await readPasswordFromStdin() : null;
-  return stdinPassword ?? await promptPassword('Enter password to unlock identity:');
+  return remember(stdinPassword ?? await promptPassword('Enter password to unlock identity:'));
 }

--- a/src/commands/device-identity-password.ts
+++ b/src/commands/device-identity-password.ts
@@ -8,12 +8,49 @@ import { readPasswordFromStdin } from '../utils/password-stdin.js';
 export interface DeviceIdentityPasswordContext {
   resolved: boolean;
   password: string | null;
+  passwordStdin: boolean;
+  stdinPasswordPromise: Promise<string> | null;
 }
 
-export function createDeviceIdentityPasswordContext(): DeviceIdentityPasswordContext {
+export function createDeviceIdentityPasswordContext(
+  options: { passwordStdin?: boolean } = {},
+): DeviceIdentityPasswordContext {
   return {
     resolved: false,
     password: null,
+    passwordStdin: Boolean(options.passwordStdin),
+    stdinPasswordPromise: null,
+  };
+}
+
+function getSharedPasswordContext(
+  context: DeviceIdentityPasswordContext | undefined,
+  options: { passwordStdin?: boolean },
+): DeviceIdentityPasswordContext | undefined {
+  if (!context && !options.passwordStdin) {
+    return undefined;
+  }
+
+  const sharedContext = context ?? createDeviceIdentityPasswordContext(options);
+  sharedContext.passwordStdin ||= Boolean(options.passwordStdin);
+  return sharedContext;
+}
+
+async function resolvePasswordInput(
+  prompt: string,
+  context: DeviceIdentityPasswordContext | undefined,
+): Promise<{ password: string | null; fromStdin: boolean }> {
+  if (context?.passwordStdin) {
+    context.stdinPasswordPromise ??= readPasswordFromStdin();
+    return {
+      password: await context.stdinPasswordPromise,
+      fromStdin: true,
+    };
+  }
+
+  return {
+    password: await promptPassword(prompt),
+    fromStdin: false,
   };
 }
 
@@ -21,14 +58,15 @@ export async function ensureDeviceIdentityPassword(
   options: { yes?: boolean; passwordStdin?: boolean } = {},
   context?: DeviceIdentityPasswordContext,
 ): Promise<string | null> {
-  if (context?.resolved) {
-    return context.password;
+  const sharedContext = getSharedPasswordContext(context, options);
+  if (sharedContext?.resolved) {
+    return sharedContext.password;
   }
 
   const remember = (password: string | null): string | null => {
-    if (context) {
-      context.resolved = true;
-      context.password = password;
+    if (sharedContext) {
+      sharedContext.resolved = true;
+      sharedContext.password = password;
     }
 
     return password;
@@ -43,13 +81,15 @@ export async function ensureDeviceIdentityPassword(
       throw new NoIdentityError();
     }
 
-    const stdinPassword = options.passwordStdin ? await readPasswordFromStdin() : null;
-    const password = stdinPassword ?? await promptPassword('Create password for local device identity:');
+    const { password, fromStdin } = await resolvePasswordInput(
+      'Create password for local device identity:',
+      sharedContext,
+    );
     if (!password) {
       return remember(null);
     }
 
-    if (!stdinPassword) {
+    if (!fromStdin) {
       const confirmPassword = await promptPassword('Confirm local identity password:');
       if (password !== confirmPassword) {
         throw new SpacesError('Password confirmation does not match.', 'USER_ERROR', 1);
@@ -61,6 +101,9 @@ export async function ensureDeviceIdentityPassword(
     return remember(password);
   }
 
-  const stdinPassword = options.passwordStdin ? await readPasswordFromStdin() : null;
-  return remember(stdinPassword ?? await promptPassword('Enter password to unlock identity:'));
+  const { password } = await resolvePasswordInput(
+    'Enter password to unlock identity:',
+    sharedContext,
+  );
+  return remember(password);
 }

--- a/src/commands/host.ts
+++ b/src/commands/host.ts
@@ -365,7 +365,16 @@ export async function syncHostConfig(interactive: boolean = false): Promise<Host
     }
   }
 
-  const selected = primary ?? activeSubdomains[0]!;
+  if (!primary) {
+    report.subdomain = configuredCheck('Active subdomains exist, but no primary subdomain is set.');
+    report.subdomain.fix = 'gssh user host set-primary <name>';
+    report.tunnelToken = missingCheck('Choose a primary subdomain before syncing host config.', 'gssh user host set-primary <name>');
+    report.serveTunnelToken = missingCheck('Choose a primary subdomain before syncing host config.', 'gssh user host set-primary <name>');
+    report.warnings.push('Host config was not updated because no primary subdomain is set.');
+    return report;
+  }
+
+  const selected = primary;
   const serveSubdomain = activeSubdomains.find((entry) => entry.subdomain === `${selected.subdomain}.serve`);
   const resolvedServeSubdomain = serveSubdomain?.subdomain ?? `${selected.subdomain}.serve`;
 
@@ -379,15 +388,7 @@ export async function syncHostConfig(interactive: boolean = false): Promise<Host
   report.primarySubdomain = selected.subdomain;
   report.serveSubdomain = resolvedServeSubdomain;
 
-  if (primary) {
-    report.subdomain = configuredCheck(`Primary subdomain ${selected.subdomain}.gitspace.sh is active.`);
-  } else {
-    report.subdomain = configuredCheck(`Using ${selected.subdomain}.gitspace.sh (no primary set).`);
-    report.subdomain.fix = 'gssh user host set-primary <name>';
-    report.warnings.push(
-      'No primary subdomain is set. Non-interactive relay startup may auto-select from available hosts.',
-    );
-  }
+  report.subdomain = configuredCheck(`Primary subdomain ${selected.subdomain}.gitspace.sh is active.`);
 
   report.tunnelToken = await ensureTokenFromApi({
     headers,

--- a/src/commands/host.ts
+++ b/src/commands/host.ts
@@ -56,8 +56,165 @@ interface SubdomainCreateResponse {
   isPrimary: boolean;
 }
 
+export type HostReadinessStatus = 'configured' | 'missing' | 'error';
+
+export interface HostReadinessCheck {
+  status: HostReadinessStatus;
+  detail: string;
+  fix?: string;
+}
+
+export interface HostSyncReport {
+  ready: boolean;
+  primarySubdomain: string | null;
+  serveSubdomain: string | null;
+  subdomain: HostReadinessCheck;
+  tunnelToken: HostReadinessCheck;
+  serveTunnelToken: HostReadinessCheck;
+  warnings: string[];
+}
+
 function normalizeSubdomain(subdomain: string): string {
   return subdomain.toLowerCase().trim();
+}
+
+function configuredCheck(detail: string): HostReadinessCheck {
+  return { status: 'configured', detail };
+}
+
+function missingCheck(detail: string, fix?: string): HostReadinessCheck {
+  return { status: 'missing', detail, fix };
+}
+
+function errorCheck(detail: string, fix?: string): HostReadinessCheck {
+  return { status: 'error', detail, fix };
+}
+
+function createInitialHostSyncReport(): HostSyncReport {
+  return {
+    ready: false,
+    primarySubdomain: null,
+    serveSubdomain: null,
+    subdomain: missingCheck('Not checked yet.'),
+    tunnelToken: missingCheck('Not checked yet.'),
+    serveTunnelToken: missingCheck('Not checked yet.'),
+    warnings: [],
+  };
+}
+
+function isConfigured(check: HostReadinessCheck): boolean {
+  return check.status === 'configured';
+}
+
+async function setPrimarySubdomainViaSync(headers: Record<string, string>, subdomain: string): Promise<boolean> {
+  try {
+    const res = await fetch(`${API_BASE}/subdomains/${normalizeSubdomain(subdomain)}/set-primary`, {
+      method: 'POST',
+      headers,
+    });
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+
+async function ensureTokenFromApi(args: {
+  headers: Record<string, string>;
+  apiSubdomain: string;
+  secretKey: string;
+  description: string;
+}): Promise<HostReadinessCheck> {
+  const existingToken = await getSecret(args.secretKey);
+  if (existingToken) {
+    return configuredCheck('Configured in keychain.');
+  }
+
+  try {
+    const tokenRes = await fetch(`${API_BASE}/subdomains/${args.apiSubdomain}/token`, {
+      headers: args.headers,
+    });
+
+    if (!tokenRes.ok) {
+      return errorCheck(
+        `Could not fetch ${args.description} (${tokenRes.status} ${tokenRes.statusText}).`,
+        'gssh user host status',
+      );
+    }
+
+    const tokenData = await tokenRes.json() as { tunnelToken?: string };
+    const token = tokenData.tunnelToken;
+    if (!token) {
+      return errorCheck(
+        `${args.description} response missing tunnelToken.`,
+        'gssh user host status',
+      );
+    }
+
+    await setSecret(args.secretKey, token);
+    return configuredCheck('Fetched from API and saved to keychain.');
+  } catch (error) {
+    return errorCheck(
+      `Could not fetch ${args.description} (${error instanceof Error ? error.message : String(error)}).`,
+      'gssh user host status',
+    );
+  }
+}
+
+function checkStatusLabel(check: HostReadinessCheck): string {
+  if (check.status === 'configured') {
+    return 'configured';
+  }
+  if (check.status === 'missing') {
+    return 'missing';
+  }
+  return 'error';
+}
+
+function collectRecommendedCommands(report: HostSyncReport): string[] {
+  const commands = [report.subdomain.fix, report.tunnelToken.fix, report.serveTunnelToken.fix]
+    .filter((value): value is string => Boolean(value));
+  return [...new Set(commands)];
+}
+
+export function printHostSyncReport(report: HostSyncReport, title: string = 'Hosted relay readiness'): void {
+  logger.bold(title);
+  logger.log('');
+
+  logger.log(`  Subdomain:         ${checkStatusLabel(report.subdomain)}`);
+  logger.dim(`    ${report.subdomain.detail}`);
+
+  logger.log(`  Tunnel token:      ${checkStatusLabel(report.tunnelToken)}`);
+  logger.dim(`    ${report.tunnelToken.detail}`);
+
+  logger.log(`  Serve token:       ${checkStatusLabel(report.serveTunnelToken)}`);
+  logger.dim(`    ${report.serveTunnelToken.detail}`);
+
+  if (report.primarySubdomain) {
+    logger.log(`  Primary host:      ${report.primarySubdomain}.gitspace.sh`);
+  }
+  if (report.serveSubdomain) {
+    logger.log(`  Serve host:        ${report.serveSubdomain}.gitspace.sh`);
+  }
+
+  for (const warning of report.warnings) {
+    logger.warning(warning);
+  }
+
+  logger.log('');
+  if (report.ready) {
+    logger.success('Hosted relay is ready.');
+  } else {
+    logger.warning('Hosted relay is not ready yet.');
+  }
+
+  const commands = collectRecommendedCommands(report);
+  if (commands.length > 0) {
+    logger.log('');
+    logger.dim('Recommended next steps:');
+    for (const cmd of commands) {
+      logger.log(`  ${logger.command(cmd)}`);
+    }
+  }
 }
 
 async function logApiFailure(context: string, response: Response): Promise<void> {
@@ -118,108 +275,139 @@ function writeHostConfig(config: HostConfig): void {
  * Called after login and subdomain changes to keep local config in sync
  * @param interactive - If true, prompt user to select primary if needed
  */
-export async function syncHostConfig(interactive: boolean = false): Promise<void> {
+export async function syncHostConfig(interactive: boolean = false): Promise<HostSyncReport> {
+  const report = createInitialHostSyncReport();
+
   const token = await getSecret('GITSPACE_TOKEN');
-  if (!token) return;
+  if (!token) {
+    report.subdomain = missingCheck('Not logged in to gitspace.sh.', 'gssh user auth login');
+    report.tunnelToken = missingCheck('Unavailable until login is complete.', 'gssh user auth login');
+    report.serveTunnelToken = missingCheck('Unavailable until login is complete.', 'gssh user auth login');
+    return report;
+  }
 
+  let headers: Record<string, string>;
   try {
-    const headers = await getAuthHeaders();
-    const res = await fetch(`${API_BASE}/subdomains`, { headers });
+    headers = await getAuthHeaders();
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    report.subdomain = errorCheck(detail, 'gssh user identity init');
+    report.tunnelToken = missingCheck('Unavailable until identity is configured.', 'gssh user identity init');
+    report.serveTunnelToken = missingCheck('Unavailable until identity is configured.', 'gssh user identity init');
+    return report;
+  }
 
-    if (!res.ok) return;
+  let activeSubdomains: SubdomainInfo[] = [];
+  try {
+    const res = await fetch(`${API_BASE}/subdomains`, { headers });
+    if (!res.ok) {
+      report.subdomain = errorCheck(
+        `Could not list subdomains (${res.status} ${res.statusText}).`,
+        'gssh user host status',
+      );
+      report.tunnelToken = missingCheck('Unavailable until subdomains are reachable.', 'gssh user host status');
+      report.serveTunnelToken = missingCheck('Unavailable until subdomains are reachable.', 'gssh user host status');
+      return report;
+    }
 
     const subdomains: SubdomainInfo[] = await res.json();
-    const activeSubdomains = subdomains.filter((s) => s.status === 'active');
-
-    // No subdomains - tell user to reserve one
-    if (activeSubdomains.length === 0) {
-      if (interactive) {
-        logger.log('');
-        logger.dim('No subdomains reserved yet.');
-        logger.dim('To enable remote access, reserve a subdomain:');
-        logger.command('  gssh user host reserve <name>');
-      }
-      return;
-    }
-
-    // Check for primary
-    let primary = activeSubdomains.find((s) => s.is_primary);
-
-    // If no primary set and interactive, ask user to pick one
-    if (!primary && interactive && activeSubdomains.length > 0) {
-      logger.log('');
-      logger.log('Your subdomains:');
-      activeSubdomains.forEach((s, i) => {
-        logger.log(`  ${i + 1}. ${s.subdomain}.gitspace.sh`);
-      });
-
-      if (activeSubdomains.length === 1) {
-        // Auto-set the only one as primary
-        primary = activeSubdomains[0];
-        logger.dim(`Setting ${primary.subdomain}.gitspace.sh as primary...`);
-        await hostSetPrimary(primary.subdomain);
-      } else {
-        logger.log('');
-        logger.dim('Select a primary subdomain for this machine:');
-        logger.command('  gssh user host set-primary <name>');
-      }
-    }
-
-    if (primary) {
-      const serveSubdomain = activeSubdomains.find(
-        (s) => s.subdomain === `${primary.subdomain}.serve`
-      );
-      const resolvedServeSubdomain = serveSubdomain?.subdomain ?? `${primary.subdomain}.serve`;
-      writeHostConfig({
-        subdomain: primary.subdomain,
-        serveSubdomain: resolvedServeSubdomain,
-        subdomains: activeSubdomains.map((s) => s.subdomain),
-        createdAt: primary.created_at,
-      });
-
-      // Sync tunnel token if not present (e.g., new machine with existing account)
-      const existingToken = await getSecret(getTunnelTokenKey(primary.subdomain));
-      if (!existingToken) {
-        if (interactive) {
-          logger.dim(`Fetching tunnel credentials for ${primary.subdomain}.gitspace.sh...`);
-        }
-        try {
-          const tokenRes = await fetch(`${API_BASE}/subdomains/${primary.subdomain}/token`, { headers });
-          if (tokenRes.ok) {
-            const { tunnelToken } = await tokenRes.json();
-            await setSecret(getTunnelTokenKey(primary.subdomain), tunnelToken);
-            if (interactive) {
-              logger.success('Tunnel credentials saved');
-            }
-          }
-        } catch {
-          // Ignore token fetch errors
-        }
-      }
-
-      const serveTokenKey = getServeTokenKey(primary.subdomain);
-      const existingServeToken = await getSecret(serveTokenKey);
-      if (!existingServeToken) {
-        if (interactive) {
-          logger.dim(`Fetching tunnel credentials for ${resolvedServeSubdomain}.gitspace.sh...`);
-        }
-        try {
-          const tokenRes = await fetch(`${API_BASE}/subdomains/${resolvedServeSubdomain}/token`, { headers });
-          if (tokenRes.ok) {
-            const { tunnelToken } = await tokenRes.json();
-            await setSecret(serveTokenKey, tunnelToken);
-            if (interactive) {
-              logger.success('Serve tunnel credentials saved');
-            }
-          }
-        } catch {
-          // Ignore token fetch errors
-        }
-      }
-    }
-  } catch {
-    // Ignore sync errors
+    activeSubdomains = subdomains.filter((entry) => entry.status === 'active');
+  } catch (error) {
+    report.subdomain = errorCheck(
+      `Could not reach gitspace.sh API (${error instanceof Error ? error.message : String(error)}).`,
+      'gssh user host status',
+    );
+    report.tunnelToken = missingCheck('Unavailable while API is unreachable.', 'gssh user host status');
+    report.serveTunnelToken = missingCheck('Unavailable while API is unreachable.', 'gssh user host status');
+    return report;
   }
+
+  if (activeSubdomains.length === 0) {
+    report.subdomain = missingCheck(
+      'No active subdomain reserved for this account.',
+      'gssh user host reserve <name>',
+    );
+    report.tunnelToken = missingCheck('No relay host selected yet.', 'gssh user host reserve <name>');
+    report.serveTunnelToken = missingCheck('No relay host selected yet.', 'gssh user host reserve <name>');
+
+    if (interactive) {
+      logger.log('');
+      logger.dim('No subdomains reserved yet.');
+      logger.dim('To enable remote access, reserve a subdomain:');
+      logger.log(`  ${logger.command('gssh user host reserve <name>')}`);
+    }
+
+    return report;
+  }
+
+  let primary = activeSubdomains.find((entry) => Boolean(entry.is_primary));
+
+  if (!primary && interactive && activeSubdomains.length > 0) {
+    logger.log('');
+    logger.log('Your subdomains:');
+    activeSubdomains.forEach((entry, index) => {
+      logger.log(`  ${index + 1}. ${entry.subdomain}.gitspace.sh`);
+    });
+
+    if (activeSubdomains.length === 1) {
+      const only = activeSubdomains[0]!;
+      logger.dim(`Setting ${only.subdomain}.gitspace.sh as primary...`);
+      const updated = await setPrimarySubdomainViaSync(headers, only.subdomain);
+      if (updated) {
+        primary = only;
+      } else {
+        report.warnings.push(`Could not auto-set ${only.subdomain}.gitspace.sh as primary.`);
+      }
+    } else {
+      logger.log('');
+      logger.dim('Select a primary subdomain for this machine:');
+      logger.log(`  ${logger.command('gssh user host set-primary <name>')}`);
+    }
+  }
+
+  const selected = primary ?? activeSubdomains[0]!;
+  const serveSubdomain = activeSubdomains.find((entry) => entry.subdomain === `${selected.subdomain}.serve`);
+  const resolvedServeSubdomain = serveSubdomain?.subdomain ?? `${selected.subdomain}.serve`;
+
+  writeHostConfig({
+    subdomain: selected.subdomain,
+    serveSubdomain: resolvedServeSubdomain,
+    subdomains: activeSubdomains.map((entry) => entry.subdomain),
+    createdAt: selected.created_at,
+  });
+
+  report.primarySubdomain = selected.subdomain;
+  report.serveSubdomain = resolvedServeSubdomain;
+
+  if (primary) {
+    report.subdomain = configuredCheck(`Primary subdomain ${selected.subdomain}.gitspace.sh is active.`);
+  } else {
+    report.subdomain = configuredCheck(`Using ${selected.subdomain}.gitspace.sh (no primary set).`);
+    report.subdomain.fix = 'gssh user host set-primary <name>';
+    report.warnings.push(
+      'No primary subdomain is set. Non-interactive relay startup may auto-select from available hosts.',
+    );
+  }
+
+  report.tunnelToken = await ensureTokenFromApi({
+    headers,
+    apiSubdomain: selected.subdomain,
+    secretKey: getTunnelTokenKey(selected.subdomain),
+    description: `tunnel credentials for ${selected.subdomain}.gitspace.sh`,
+  });
+
+  report.serveTunnelToken = await ensureTokenFromApi({
+    headers,
+    apiSubdomain: resolvedServeSubdomain,
+    secretKey: getServeTokenKey(selected.subdomain),
+    description: `serve tunnel credentials for ${resolvedServeSubdomain}.gitspace.sh`,
+  });
+
+  report.ready = isConfigured(report.subdomain)
+    && isConfigured(report.tunnelToken)
+    && isConfigured(report.serveTunnelToken);
+
+  return report;
 }
 
 // ============================================================================
@@ -602,6 +790,15 @@ export async function hostSetPrimary(subdomain: string): Promise<void> {
 // ============================================================================
 // Status
 // ============================================================================
+
+/**
+ * Check hosted relay readiness with actionable diagnostics.
+ */
+export async function hostDoctor(): Promise<void> {
+  const report = await syncHostConfig(false);
+  logger.log('');
+  printHostSyncReport(report, 'Hosted relay diagnostics');
+}
 
 /**
  * Show hosting status

--- a/src/commands/host.ts
+++ b/src/commands/host.ts
@@ -366,7 +366,7 @@ export async function syncHostConfig(interactive: boolean = false): Promise<Host
   }
 
   if (!primary) {
-    report.subdomain = configuredCheck('Active subdomains exist, but no primary subdomain is set.');
+    report.subdomain = missingCheck('Active subdomains exist, but no primary subdomain is set.', 'gssh user host set-primary <name>');
     report.subdomain.fix = 'gssh user host set-primary <name>';
     report.tunnelToken = missingCheck('Choose a primary subdomain before syncing host config.', 'gssh user host set-primary <name>');
     report.serveTunnelToken = missingCheck('Choose a primary subdomain before syncing host config.', 'gssh user host set-primary <name>');

--- a/src/commands/host.ts
+++ b/src/commands/host.ts
@@ -367,7 +367,6 @@ export async function syncHostConfig(interactive: boolean = false): Promise<Host
 
   if (!primary) {
     report.subdomain = missingCheck('Active subdomains exist, but no primary subdomain is set.', 'gssh user host set-primary <name>');
-    report.subdomain.fix = 'gssh user host set-primary <name>';
     report.tunnelToken = missingCheck('Choose a primary subdomain before syncing host config.', 'gssh user host set-primary <name>');
     report.serveTunnelToken = missingCheck('Choose a primary subdomain before syncing host config.', 'gssh user host set-primary <name>');
     report.warnings.push('Host config was not updated because no primary subdomain is set.');

--- a/src/commands/identity-recovery.ts
+++ b/src/commands/identity-recovery.ts
@@ -99,6 +99,18 @@ export async function ensureUserRootIdentityWithRecovery(
     }
   }
 
+  if (!interactive) {
+    if (options.allowSkip) {
+      return null;
+    }
+
+    throw new SpacesError(
+      `User root identity recovery for ${options.context} requires an interactive terminal. Run:\n  gssh user identity recover --cloud`,
+      'USER_ERROR',
+      1,
+    );
+  }
+
   const backupPassword = await promptPassword('Enter your identity backup password:');
   if (!backupPassword) {
     if (options.allowSkip) {

--- a/src/commands/identity-recovery.ts
+++ b/src/commands/identity-recovery.ts
@@ -9,6 +9,7 @@ import { authLogin } from './auth.js';
 
 export interface EnsureUserRootIdentityWithRecoveryOptions {
   yes?: boolean;
+  passwordStdin?: boolean;
   context: string;
   allowSkip?: boolean;
   force?: boolean;
@@ -74,6 +75,7 @@ export async function ensureUserRootIdentityWithRecovery(
     try {
       await authLogin({
         yes: options.yes,
+        passwordStdin: options.passwordStdin,
         interactiveHostSync: false,
         showHostSyncSummary: false,
       });

--- a/src/commands/identity-recovery.ts
+++ b/src/commands/identity-recovery.ts
@@ -6,7 +6,10 @@ import { recoverUserRootFromCloudBackup } from '../core/identity-backup.js';
 import type { UserRootIdentity } from '../types/identity.js';
 import { SpacesError } from '../types/errors.js';
 import { authLogin } from './auth.js';
-import type { DeviceIdentityPasswordContext } from './device-identity-password.js';
+import {
+  createDeviceIdentityPasswordContext,
+  type DeviceIdentityPasswordContext,
+} from './device-identity-password.js';
 
 export interface EnsureUserRootIdentityWithRecoveryOptions {
   devicePasswordContext?: DeviceIdentityPasswordContext;
@@ -36,6 +39,9 @@ function missingIdentityError(context: string): SpacesError {
 export async function ensureUserRootIdentityWithRecovery(
   options: EnsureUserRootIdentityWithRecoveryOptions,
 ): Promise<UserRootIdentity | null> {
+  const devicePasswordContext = options.devicePasswordContext
+    ?? createDeviceIdentityPasswordContext({ passwordStdin: options.passwordStdin });
+
   let userRoot = await loadUserRootIdentity();
   if (userRoot) {
     return userRoot;
@@ -76,9 +82,8 @@ export async function ensureUserRootIdentityWithRecovery(
 
     try {
       await authLogin({
-        devicePasswordContext: options.devicePasswordContext,
+        devicePasswordContext,
         yes: options.yes,
-        passwordStdin: options.passwordStdin,
         interactiveHostSync: false,
         showHostSyncSummary: false,
       });

--- a/src/commands/identity-recovery.ts
+++ b/src/commands/identity-recovery.ts
@@ -1,0 +1,125 @@
+import { logger } from '../utils/logger.js';
+import { promptConfirm, promptPassword } from '../utils/prompts.js';
+import { getSecret } from '../utils/secrets.js';
+import { loadUserRootIdentity } from '../core/user-identity.js';
+import { recoverUserRootFromCloudBackup } from '../core/identity-backup.js';
+import type { UserRootIdentity } from '../types/identity.js';
+import { SpacesError } from '../types/errors.js';
+import { authLogin } from './auth.js';
+
+export interface EnsureUserRootIdentityWithRecoveryOptions {
+  yes?: boolean;
+  context: string;
+  allowSkip?: boolean;
+  force?: boolean;
+}
+
+function canPromptInteractively(): boolean {
+  return Boolean(process.stdin.isTTY && process.stdout.isTTY);
+}
+
+function missingIdentityError(context: string): SpacesError {
+  return new SpacesError(
+    `User root identity is required for ${context}.\n\nRun:\n  gssh user identity recover --cloud`,
+    'USER_ERROR',
+    1,
+  );
+}
+
+/**
+ * Ensure a local user root identity exists, optionally guiding recovery from
+ * cloud backup when missing.
+ */
+export async function ensureUserRootIdentityWithRecovery(
+  options: EnsureUserRootIdentityWithRecoveryOptions,
+): Promise<UserRootIdentity | null> {
+  let userRoot = await loadUserRootIdentity();
+  if (userRoot) {
+    return userRoot;
+  }
+
+  const interactive = canPromptInteractively();
+  if (!interactive && !options.yes) {
+    if (options.allowSkip) {
+      return null;
+    }
+    throw missingIdentityError(options.context);
+  }
+
+  const shouldRecover = options.yes || await promptConfirm(
+    `No user root identity found for ${options.context}. Recover from GitSpace cloud backup now?`,
+    true,
+  );
+  if (!shouldRecover) {
+    if (options.allowSkip) {
+      return null;
+    }
+    throw missingIdentityError(options.context);
+  }
+
+  let token = await getSecret('GITSPACE_TOKEN');
+  if (!token) {
+    const shouldLogin = options.yes || await promptConfirm(
+      'You are not logged in to gitspace.sh. Run login now?',
+      true,
+    );
+
+    if (!shouldLogin) {
+      if (options.allowSkip) {
+        return null;
+      }
+      throw missingIdentityError(options.context);
+    }
+
+    try {
+      await authLogin({
+        yes: options.yes,
+        interactiveHostSync: false,
+        showHostSyncSummary: false,
+      });
+    } catch (error) {
+      if (options.allowSkip) {
+        logger.warning(
+          `Login failed while attempting cloud recovery (${error instanceof Error ? error.message : String(error)}). Continuing without recovery.`,
+        );
+        return null;
+      }
+      throw error;
+    }
+    token = await getSecret('GITSPACE_TOKEN');
+    if (!token) {
+      if (options.allowSkip) {
+        return null;
+      }
+      throw new SpacesError(
+        'Login did not produce an auth token. Cannot recover identity from cloud backup.',
+        'USER_ERROR',
+        1,
+      );
+    }
+  }
+
+  const backupPassword = await promptPassword('Enter your identity backup password:');
+  if (!backupPassword) {
+    if (options.allowSkip) {
+      return null;
+    }
+    throw new SpacesError('Identity recovery cancelled.', 'USER_ERROR', 1);
+  }
+
+  try {
+    userRoot = await recoverUserRootFromCloudBackup(backupPassword, {
+      force: options.force,
+    });
+    logger.success('Recovered user root identity from cloud backup');
+    return userRoot;
+  } catch (error) {
+    if (options.allowSkip) {
+      logger.warning(
+        `Cloud identity recovery failed (${error instanceof Error ? error.message : String(error)}). Continuing without recovery.`,
+      );
+      return null;
+    }
+    throw error;
+  }
+}

--- a/src/commands/identity-recovery.ts
+++ b/src/commands/identity-recovery.ts
@@ -6,8 +6,10 @@ import { recoverUserRootFromCloudBackup } from '../core/identity-backup.js';
 import type { UserRootIdentity } from '../types/identity.js';
 import { SpacesError } from '../types/errors.js';
 import { authLogin } from './auth.js';
+import type { DeviceIdentityPasswordContext } from './device-identity-password.js';
 
 export interface EnsureUserRootIdentityWithRecoveryOptions {
+  devicePasswordContext?: DeviceIdentityPasswordContext;
   yes?: boolean;
   passwordStdin?: boolean;
   context: string;
@@ -74,6 +76,7 @@ export async function ensureUserRootIdentityWithRecovery(
 
     try {
       await authLogin({
+        devicePasswordContext: options.devicePasswordContext,
         yes: options.yes,
         passwordStdin: options.passwordStdin,
         interactiveHostSync: false,

--- a/src/commands/identity-recovery.ts
+++ b/src/commands/identity-recovery.ts
@@ -17,6 +17,7 @@ export interface EnsureUserRootIdentityWithRecoveryOptions {
   passwordStdin?: boolean;
   context: string;
   allowSkip?: boolean;
+  allowAuthLogin?: boolean;
   force?: boolean;
 }
 
@@ -41,6 +42,7 @@ export async function ensureUserRootIdentityWithRecovery(
 ): Promise<UserRootIdentity | null> {
   const devicePasswordContext = options.devicePasswordContext
     ?? createDeviceIdentityPasswordContext({ passwordStdin: options.passwordStdin });
+  const allowAuthLogin = options.allowAuthLogin !== false;
 
   let userRoot = await loadUserRootIdentity();
   if (userRoot) {
@@ -68,6 +70,13 @@ export async function ensureUserRootIdentityWithRecovery(
 
   let token = await getSecret('GITSPACE_TOKEN');
   if (!token) {
+    if (!allowAuthLogin) {
+      if (options.allowSkip) {
+        return null;
+      }
+      throw missingIdentityError(options.context);
+    }
+
     const shouldLogin = options.yes || await promptConfirm(
       'You are not logged in to gitspace.sh. Run login now?',
       true,

--- a/src/commands/identity.ts
+++ b/src/commands/identity.ts
@@ -12,7 +12,7 @@
  */
 
 import { logger } from '../utils/logger.js';
-import { promptConfirm, promptInput } from '../utils/prompts.js';
+import { promptConfirm, promptInput, promptPassword } from '../utils/prompts.js';
 import {
   generateNewMnemonic,
   initFromMnemonic,
@@ -20,9 +20,15 @@ import {
   getUserRootPublicInfo,
   userRootIdentityExists,
   removeUserRootIdentity,
-  verifyMnemonicMatchesStored,
   formatFingerprint,
 } from '../core/user-identity.js';
+import {
+  backupCurrentUserRootToCloud,
+  deleteCloudIdentityBackup,
+  getCloudIdentityBackup,
+  getCloudIdentityBackupStatus,
+  recoverUserRootFromCloudBackup,
+} from '../core/identity-backup.js';
 import { formatUserRootPublicKey } from '../lib/tmux-lite/crypto/user-identity.js';
 import { SpacesError } from '../types/errors.js';
 
@@ -160,7 +166,14 @@ export async function showIdentity(
  * Recover identity from a 24-word mnemonic.
  * Prompts the user to enter their mnemonic, derives keys, stores in keychain.
  */
-export async function recoverIdentity(options: { force?: boolean } = {}): Promise<void> {
+export async function recoverIdentity(
+  options: { force?: boolean; cloud?: boolean; yes?: boolean } = {},
+): Promise<void> {
+  if (options.cloud) {
+    await recoverIdentityFromCloud(options);
+    return;
+  }
+
   const exists = await userRootIdentityExists();
 
   if (exists && !options.force) {
@@ -171,7 +184,7 @@ export async function recoverIdentity(options: { force?: boolean } = {}): Promis
     );
   }
 
-  if (exists && options.force) {
+  if (exists && options.force && !options.yes) {
     const confirmed = await promptConfirm(
       'This will replace your current identity. Continue?',
       false,
@@ -199,11 +212,50 @@ export async function recoverIdentity(options: { force?: boolean } = {}): Promis
   // Derive and store
   logger.info('Deriving identity from mnemonic...');
   const identity = await initFromMnemonic(normalized, options.force ?? exists ?? false);
+  logIdentityRecovered(identity, 'Identity recovered and stored in keychain');
+}
 
+export async function recoverIdentityFromCloud(options: { force?: boolean; yes?: boolean } = {}): Promise<void> {
+  const exists = await userRootIdentityExists();
+
+  if (exists && !options.force) {
+    throw new SpacesError(
+      'Identity already exists. Use --force to overwrite.',
+      'USER_ERROR',
+      1,
+    );
+  }
+
+  if (exists && options.force && !options.yes) {
+    const confirmed = await promptConfirm(
+      'This will replace your current identity using cloud backup. Continue?',
+      false,
+    );
+    if (!confirmed) {
+      logger.info('Cancelled');
+      return;
+    }
+  }
+
+  const backupPassword = await promptPassword('Enter your identity backup password:');
+  if (!backupPassword) {
+    logger.info('Cancelled');
+    return;
+  }
+
+  logger.info('Recovering identity from cloud backup...');
+  const identity = await recoverUserRootFromCloudBackup(backupPassword, {
+    force: options.force ?? exists ?? false,
+  });
+
+  logIdentityRecovered(identity, 'Identity recovered from cloud backup and stored in keychain');
+}
+
+function logIdentityRecovered(identity: Awaited<ReturnType<typeof initFromMnemonic>>, successMessage: string): void {
   const publicKeyString = formatUserRootPublicKey(identity);
   const fingerprint = formatFingerprint(identity.signing.publicKey);
 
-  logger.success('Identity recovered and stored in keychain');
+  logger.success(successMessage);
   logger.log('');
   logger.bold('Identity Information:');
   logger.log(`  ID:          ${identity.id}`);
@@ -302,4 +354,122 @@ export async function removeIdentity(options: { force?: boolean } = {}): Promise
   } else {
     logger.info('No identity found in keychain.');
   }
+}
+
+export async function enableIdentityBackup(options: { yes?: boolean } = {}): Promise<void> {
+  const identity = await loadUserRootIdentity();
+  if (!identity) {
+    throw new SpacesError(
+      'No identity found. Run `gssh user identity init` or `gssh user identity recover` first.',
+      'USER_ERROR',
+      1,
+    );
+  }
+
+  const existing = await getCloudIdentityBackup();
+  if (existing && !options.yes) {
+    const confirmed = await promptConfirm(
+      'An identity backup already exists in the cloud. Overwrite it?',
+      false,
+    );
+    if (!confirmed) {
+      logger.info('Cancelled');
+      return;
+    }
+  }
+
+  const backupPassword = await promptPassword('Create identity backup password:');
+  if (!backupPassword) {
+    logger.info('Cancelled');
+    return;
+  }
+
+  const confirmPassword = await promptPassword('Confirm identity backup password:');
+  if (backupPassword !== confirmPassword) {
+    throw new SpacesError('Password confirmation does not match.', 'USER_ERROR', 1);
+  }
+
+  const record = await backupCurrentUserRootToCloud(backupPassword);
+  logger.success('Encrypted identity backup saved to GitSpace cloud');
+  logger.log(`  Owner ID: ${record.ownerUserRootId}`);
+  logger.log(`  Updated:  ${new Date(record.updatedAt).toISOString()}`);
+}
+
+export async function showIdentityBackupStatus(): Promise<void> {
+  const status = await getCloudIdentityBackupStatus();
+  if (!status.enabled) {
+    logger.info('Cloud identity backup is not enabled for this account.');
+    logger.dim('Run `gssh user identity backup enable` to create one.');
+    return;
+  }
+
+  logger.bold('Cloud Identity Backup');
+  logger.log(`  Enabled:  yes`);
+  if (status.ownerUserRootId) {
+    logger.log(`  Owner ID: ${status.ownerUserRootId}`);
+  }
+  if (status.createdAt) {
+    logger.log(`  Created:  ${new Date(status.createdAt).toISOString()}`);
+  }
+  if (status.updatedAt) {
+    logger.log(`  Updated:  ${new Date(status.updatedAt).toISOString()}`);
+  }
+}
+
+export async function disableIdentityBackup(options: { yes?: boolean } = {}): Promise<void> {
+  if (!options.yes) {
+    const confirmed = await promptConfirm(
+      'Delete your cloud identity backup? You will need your mnemonic to recover if no backup exists.',
+      false,
+    );
+    if (!confirmed) {
+      logger.info('Cancelled');
+      return;
+    }
+  }
+
+  const removed = await deleteCloudIdentityBackup();
+  if (!removed) {
+    logger.info('No cloud identity backup found.');
+    return;
+  }
+
+  logger.success('Cloud identity backup deleted');
+}
+
+export async function rotateIdentityBackupPassword(options: { yes?: boolean } = {}): Promise<void> {
+  const existing = await getCloudIdentityBackup();
+  if (!existing) {
+    throw new SpacesError(
+      'No cloud identity backup found. Run `gssh user identity backup enable` first.',
+      'USER_ERROR',
+      1,
+    );
+  }
+
+  if (!options.yes) {
+    const confirmed = await promptConfirm(
+      'Rotate cloud backup password now?',
+      true,
+    );
+    if (!confirmed) {
+      logger.info('Cancelled');
+      return;
+    }
+  }
+
+  const backupPassword = await promptPassword('Enter new identity backup password:');
+  if (!backupPassword) {
+    logger.info('Cancelled');
+    return;
+  }
+
+  const confirmPassword = await promptPassword('Confirm new identity backup password:');
+  if (backupPassword !== confirmPassword) {
+    throw new SpacesError('Password confirmation does not match.', 'USER_ERROR', 1);
+  }
+
+  const record = await backupCurrentUserRootToCloud(backupPassword);
+  logger.success('Cloud identity backup password rotated');
+  logger.log(`  Updated: ${new Date(record.updatedAt).toISOString()}`);
 }

--- a/src/commands/machine-enroll.ts
+++ b/src/commands/machine-enroll.ts
@@ -13,6 +13,7 @@ import {
   addTrustedRelay,
   getTrustedRelay,
   getTrustedRelays,
+  isCloudReachableRelayUrl,
   isLocalhost,
   isRelayTrusted,
 } from '../core/trusted-relays.js';
@@ -346,6 +347,7 @@ export async function enrollMachine(options: {
 
   writeRelayConfig({
     relayUrl: result.relayUrl,
+    cloudRelayUrl: isCloudReachableRelayUrl(result.relayUrl) ? result.relayUrl : undefined,
     machineId: result.machineId,
     savedAt: Date.now(),
   });

--- a/src/commands/relay.ts
+++ b/src/commands/relay.ts
@@ -445,11 +445,8 @@ export async function startRelay(options: {
           1,
         );
       }
-      if (!existingOwner) {
-        if (isVaultInitialized()) {
-          logger.info('Relay vault is initialized but owner metadata is missing; repairing owner binding from the current user root identity.');
-        }
-
+      if (!existingOwner && isVaultInitialized()) {
+        logger.info('Relay vault is initialized but owner metadata is missing; repairing owner binding from the current user root identity.');
       }
 
       bindControlOwner(ownerUserRootId);

--- a/src/commands/relay.ts
+++ b/src/commands/relay.ts
@@ -24,6 +24,7 @@ import {
   setVaultMeta,
   getVaultMeta,
   isVaultInitialized,
+  listVaultMachines,
   listVaultMachinesForOwner,
   removeVaultMachineForOwner,
 } from "../relay/control/store.js";
@@ -42,6 +43,21 @@ const RELAY_RUNTIME_DIR = ".relay/runtime";
 const RELAY_STATE_FILE = "relay-state.json";
 const CLOUDFLARED_STARTUP_DELAY_MS = 1200;
 const CLOUDFLARED_EARLY_EXIT_RACE_MS = 100;
+
+export function assertRelayOwnerRepairIsSafe(ownerUserRootId: string): void {
+  const machineOwners = new Set(listVaultMachines().map((machine) => machine.ownerUserRootId));
+  if (machineOwners.size === 0) {
+    return;
+  }
+
+  if (machineOwners.size !== 1 || !machineOwners.has(ownerUserRootId)) {
+    throw new SpacesError(
+      'Relay vault owner metadata is missing, but persisted machine registrations belong to a different owner. Recover with the original owner identity or clear relay state before rebinding.',
+      'USER_ERROR',
+      1,
+    );
+  }
+}
 
 interface RelayRuntimeState {
   pid: number;
@@ -446,6 +462,7 @@ export async function startRelay(options: {
         );
       }
       if (!existingOwner && isVaultInitialized()) {
+        assertRelayOwnerRepairIsSafe(ownerUserRootId);
         logger.info('Relay vault is initialized but owner metadata is missing; repairing owner binding from the current user root identity.');
       }
 

--- a/src/commands/relay.ts
+++ b/src/commands/relay.ts
@@ -443,7 +443,6 @@ export async function startRelay(options: {
           1,
         );
       }
-      setVaultMeta("vault_initialized", "1");
       setVaultMeta("owner_user_root_id", ownerUserRootId);
       logger.dim(`  Owner identity: ${ownerUserRootId.slice(0, 8)}...`);
     } else {

--- a/src/commands/relay.ts
+++ b/src/commands/relay.ts
@@ -59,6 +59,40 @@ export function assertRelayOwnerRepairIsSafe(ownerUserRootId: string): void {
   }
 }
 
+export function bindRelayOwnerForStartup(ownerUserRootId: string): {
+  repairedOwnerBinding: boolean;
+  missingVaultInitialization: boolean;
+} {
+  ensureControlStore();
+
+  const existingOwner = getVaultMeta("owner_user_root_id");
+  if (existingOwner && existingOwner !== ownerUserRootId) {
+    throw new SpacesError(
+      `Relay is already owned by a different user root identity.\n`
+      + `  Existing owner: ${existingOwner.slice(0, 8)}...\n`
+      + `  Current user:   ${ownerUserRootId.slice(0, 8)}...`,
+      "USER_ERROR",
+      1,
+    );
+  }
+
+  const vaultInitialized = isVaultInitialized();
+  if (!existingOwner) {
+    assertRelayOwnerRepairIsSafe(ownerUserRootId);
+  }
+
+  bindControlOwner(ownerUserRootId);
+
+  if (!existingOwner) {
+    setVaultMeta("owner_user_root_id", ownerUserRootId);
+  }
+
+  return {
+    repairedOwnerBinding: !existingOwner,
+    missingVaultInitialization: !vaultInitialized,
+  };
+}
+
 interface RelayRuntimeState {
   pid: number;
   startedAt: number;
@@ -446,7 +480,6 @@ export async function startRelay(options: {
   // knows who its owner is. This enables owner-based authorization for
   // machines and clients without requiring enrollment tokens.
   let ownerUserRootId: string | null = null;
-  let shouldMarkVaultInitialized = false;
   try {
     const userRoot = await loadUserRootIdentity()
       ?? await ensureUserRootIdentityWithRecovery({
@@ -456,35 +489,13 @@ export async function startRelay(options: {
       });
     if (userRoot) {
       ownerUserRootId = userRoot.id;
-      ensureControlStore();
-      const existingOwner = getVaultMeta("owner_user_root_id");
-      if (existingOwner && existingOwner !== ownerUserRootId) {
-        throw new SpacesError(
-          `Relay is already owned by a different user root identity.\n` +
-          `  Existing owner: ${existingOwner.slice(0, 8)}...\n` +
-          `  Current user:   ${ownerUserRootId.slice(0, 8)}...`,
-          "USER_ERROR",
-          1,
-        );
-      }
-      const vaultInitialized = isVaultInitialized();
-      if (!existingOwner) {
-        assertRelayOwnerRepairIsSafe(ownerUserRootId);
-        if (vaultInitialized) {
-          logger.info('Relay vault is initialized but owner metadata is missing; repairing owner binding from the current user root identity.');
-        }
-      } else if (!vaultInitialized) {
-        logger.info('Relay vault initialization metadata is incomplete; repairing it after startup succeeds.');
+      const ownerBinding = bindRelayOwnerForStartup(ownerUserRootId);
+      if (ownerBinding.repairedOwnerBinding && !ownerBinding.missingVaultInitialization) {
+        logger.info('Relay vault is initialized but owner metadata is missing; repairing owner binding from the current user root identity.');
+      } else if (ownerBinding.missingVaultInitialization) {
+        logger.info('Relay vault is not initialized yet; owner binding will be completed when the owner first unlocks the relay.');
       }
 
-      bindControlOwner(ownerUserRootId);
-
-      if (!existingOwner) {
-        // bindControlOwner persists the control-store owner binding; the vault keeps
-        // its own owner metadata and must be repaired separately for later startups.
-        setVaultMeta("owner_user_root_id", ownerUserRootId);
-      }
-      shouldMarkVaultInitialized = !vaultInitialized;
       logger.dim(`  Owner identity: ${ownerUserRootId.slice(0, 8)}...`);
     } else {
       // User root identity not initialized - relay starts without an owner.
@@ -557,10 +568,6 @@ export async function startRelay(options: {
       tunnelPid: tunnelProcess?.pid,
       tunnelSubdomain,
     });
-
-    if (shouldMarkVaultInitialized) {
-      setVaultMeta("vault_initialized", "1");
-    }
 
     logger.success(`Relay listening on ws://${hostname || bind}:${port}`);
     if (tunnelSubdomain) {

--- a/src/commands/relay.ts
+++ b/src/commands/relay.ts
@@ -447,11 +447,7 @@ export async function startRelay(options: {
       }
       if (!existingOwner) {
         if (isVaultInitialized()) {
-          throw new SpacesError(
-            'Relay vault is initialized but owner metadata is missing. Repair the control store before starting the relay.',
-            'SYSTEM_ERROR',
-            2,
-          );
+          logger.info('Relay vault is initialized but owner metadata is missing; repairing owner binding from the current user root identity.');
         }
 
       }

--- a/src/commands/relay.ts
+++ b/src/commands/relay.ts
@@ -486,6 +486,7 @@ export async function startRelay(options: {
         yes: options.yes,
         context: 'relay startup owner binding',
         allowSkip: true,
+        allowAuthLogin: false,
       });
     if (userRoot) {
       ownerUserRootId = userRoot.id;

--- a/src/commands/relay.ts
+++ b/src/commands/relay.ts
@@ -469,6 +469,8 @@ export async function startRelay(options: {
       bindControlOwner(ownerUserRootId);
 
       if (!existingOwner) {
+        // bindControlOwner persists the control-store owner binding; the vault keeps
+        // its own owner metadata and must be repaired separately for later startups.
         setVaultMeta("owner_user_root_id", ownerUserRootId);
       }
       logger.dim(`  Owner identity: ${ownerUserRootId.slice(0, 8)}...`);

--- a/src/commands/relay.ts
+++ b/src/commands/relay.ts
@@ -19,6 +19,9 @@ import {
 import { loadUserRootIdentity } from "../core/user-identity.js";
 import { getSpacesDir } from "../core/config.js";
 import {
+  ensureControlStore,
+  setVaultMeta,
+  getVaultMeta,
   listVaultMachinesForOwner,
   removeVaultMachineForOwner,
 } from "../relay/control/store.js";
@@ -29,6 +32,7 @@ import {
 } from "./host.js";
 import { selectOne } from "../utils/prompts.js";
 import { isCloudflaredInstalled, trackCloudflaredOutput } from "../utils/cloudflared.js";
+import { ensureUserRootIdentityWithRecovery } from "./identity-recovery.js";
 
 /** Default port for relay server (4480 = "GIT0" on phone keypad) */
 const DEFAULT_PORT = 4480;
@@ -61,6 +65,8 @@ interface RelayStatusSnapshot {
   publicRelayUrl: string | null;
   startedAt: number | null;
 }
+
+type RelayStartMode = "auto" | "hosted" | "local";
 
 function getRelayRuntimeDir(): string {
   return join(getSpacesDir(), RELAY_RUNTIME_DIR);
@@ -305,7 +311,9 @@ export async function startRelay(options: {
   port?: number;
   hostname?: string;
   bind?: string;
+  mode?: RelayStartMode;
   label?: string;
+  yes?: boolean;
 }): Promise<void> {
   const existingState = readRelayState();
   if (existingState?.pid && isProcessRunning(existingState.pid)) {
@@ -348,33 +356,107 @@ export async function startRelay(options: {
     }
   }
 
+  const mode: RelayStartMode = options.mode ?? "auto";
   const port = options.port ?? parseInt(process.env.PORT ?? String(DEFAULT_PORT), 10);
   const bind = options.bind ?? process.env.RELAY_BIND ?? "0.0.0.0";
   let hostname = options.hostname ?? process.env.RELAY_HOST;
   let tunnelSubdomain: string | undefined;
   let tunnelToken: string | undefined;
 
-  if (!hostname) {
+  if (mode === "hosted" && hostname) {
+    throw new SpacesError(
+      "Hosted mode does not support explicit --hostname. Remove --hostname and use your account host.",
+      "USER_ERROR",
+      1,
+    );
+  }
+
+  if (mode !== "local") {
     const accountTarget = await resolveAccountRelayTarget();
-    if (accountTarget) {
+    if (!accountTarget) {
+      if (mode === "hosted") {
+        throw new SpacesError(
+          "Hosted relay startup requires an active gitspace.sh host.\n\nRun:\n  gssh user host reserve <name>\n  gssh user host status",
+          "USER_ERROR",
+          1,
+        );
+      }
+    } else {
       try {
         tunnelToken = await ensureSubdomainTunnelToken(accountTarget.subdomain);
         hostname = accountTarget.hostname;
         tunnelSubdomain = accountTarget.subdomain;
         logger.info(`Using account host ${hostname} for relay tunnel`);
       } catch (error) {
+        const detail = error instanceof Error ? error.message : String(error);
+        if (mode === "hosted") {
+          throw new SpacesError(
+            `Hosted relay startup failed while loading tunnel credentials for ${accountTarget.subdomain}.gitspace.sh.\n\n${detail}\n\nRun:\n  gssh user host status`,
+            "USER_ERROR",
+            1,
+          );
+        }
+
         logger.warning(
           `Could not load tunnel token for ${accountTarget.subdomain}.gitspace.sh. `
           + "Falling back to local relay start without tunnel.",
         );
-        logger.dim(error instanceof Error ? error.message : String(error));
+        logger.dim(detail);
       }
     }
+  }
+
+  if (mode === "hosted" && !tunnelToken) {
+    throw new SpacesError(
+      "Hosted relay mode requires an active tunnel but none was configured.\n\nRun:\n  gssh user host status",
+      "USER_ERROR",
+      1,
+    );
   }
 
   // Load or create relay identity
   const identity = await loadOrCreateRelayIdentity(options.label);
   const fingerprint = formatRelayFingerprint(identity.signingPublicKey);
+
+  // ── Bind owner identity to relay ──────────────────────────────────────
+  // Read the user root identity (from mnemonic in keychain) so the relay
+  // knows who its owner is. This enables owner-based authorization for
+  // machines and clients without requiring enrollment tokens.
+  let ownerUserRootId: string | null = null;
+  try {
+    const userRoot = await loadUserRootIdentity()
+      ?? await ensureUserRootIdentityWithRecovery({
+        yes: options.yes,
+        context: 'relay startup owner binding',
+        allowSkip: true,
+      });
+    if (userRoot) {
+      ownerUserRootId = userRoot.id;
+      ensureControlStore();
+      const existingOwner = getVaultMeta("owner_user_root_id");
+      if (existingOwner && existingOwner !== ownerUserRootId) {
+        throw new SpacesError(
+          `Relay is already owned by a different user root identity.\n` +
+          `  Existing owner: ${existingOwner.slice(0, 8)}...\n` +
+          `  Current user:   ${ownerUserRootId.slice(0, 8)}...`,
+          "USER_ERROR",
+          1,
+        );
+      }
+      setVaultMeta("vault_initialized", "1");
+      setVaultMeta("owner_user_root_id", ownerUserRootId);
+      logger.dim(`  Owner identity: ${ownerUserRootId.slice(0, 8)}...`);
+    } else {
+      // User root identity not initialized - relay starts without an owner.
+      // Machines will need enrollment tokens to register.
+      logger.dim("  No user root identity found - machines will need enrollment tokens");
+    }
+  } catch (error) {
+    if (error instanceof SpacesError) throw error;
+    // User root identity not initialized - relay starts without an owner.
+    // Machines will need enrollment tokens to register.
+    logger.dim("  No user root identity found - machines will need enrollment tokens");
+  }
 
   // Display relay identity prominently
   logger.log("");
@@ -392,11 +474,15 @@ export async function startRelay(options: {
 
   logger.log(`  Port:     ${port}`);
   logger.log(`  Bind:     ${bind}`);
+  logger.log(`  Mode:     ${mode}`);
   if (hostname) {
     logger.log(`  Hostname: ${hostname} (only serving this domain)`);
   }
   if (tunnelSubdomain) {
     logger.log(`  Tunnel:   ${tunnelSubdomain}.gitspace.sh`);
+  }
+  if (ownerUserRootId) {
+    logger.log(`  Owner:    ${ownerUserRootId.slice(0, 16)}...`);
   }
   logger.log("");
 
@@ -425,7 +511,7 @@ export async function startRelay(options: {
       tunnelSubdomain,
     });
 
-    logger.success(`Relay listening on ws://${hostname || bind}:${port}`);
+    logger.success(`Relay listening on ws://${hostname || bind}:${port}/ws`);
     if (tunnelSubdomain) {
       logger.success(`Public relay URL: wss://${tunnelSubdomain}.gitspace.sh/ws`);
     }
@@ -524,7 +610,7 @@ function getRelayStatusSnapshot(): RelayStatusSnapshot {
   const running = isProcessRunning(state.pid);
   const tunnelRunning = typeof state.tunnelPid === "number" && isProcessRunning(state.tunnelPid);
 
-  const relayUrl = `ws://${state.hostname || state.bind}:${state.port}`;
+  const relayUrl = `ws://${state.hostname || state.bind}:${state.port}/ws`;
   const publicRelayUrl = state.tunnelSubdomain
     ? `wss://${state.tunnelSubdomain}.gitspace.sh/ws`
     : null;

--- a/src/commands/relay.ts
+++ b/src/commands/relay.ts
@@ -68,7 +68,7 @@ interface RelayStatusSnapshot {
   startedAt: number | null;
 }
 
-type RelayStartMode = "auto" | "hosted" | "local";
+export type RelayStartMode = "auto" | "hosted" | "local";
 
 function getRelayRuntimeDir(): string {
   return join(getSpacesDir(), RELAY_RUNTIME_DIR);

--- a/src/commands/relay.ts
+++ b/src/commands/relay.ts
@@ -441,6 +441,7 @@ export async function startRelay(options: {
   // knows who its owner is. This enables owner-based authorization for
   // machines and clients without requiring enrollment tokens.
   let ownerUserRootId: string | null = null;
+  let shouldMarkVaultInitialized = false;
   try {
     const userRoot = await loadUserRootIdentity()
       ?? await ensureUserRootIdentityWithRecovery({
@@ -474,7 +475,7 @@ export async function startRelay(options: {
         // bindControlOwner persists the control-store owner binding; the vault keeps
         // its own owner metadata and must be repaired separately for later startups.
         setVaultMeta("owner_user_root_id", ownerUserRootId);
-        setVaultMeta("vault_initialized", "1");
+        shouldMarkVaultInitialized = true;
       }
       logger.dim(`  Owner identity: ${ownerUserRootId.slice(0, 8)}...`);
     } else {
@@ -548,6 +549,10 @@ export async function startRelay(options: {
       tunnelPid: tunnelProcess?.pid,
       tunnelSubdomain,
     });
+
+    if (shouldMarkVaultInitialized) {
+      setVaultMeta("vault_initialized", "1");
+    }
 
     logger.success(`Relay listening on ws://${hostname || bind}:${port}`);
     if (tunnelSubdomain) {

--- a/src/commands/relay.ts
+++ b/src/commands/relay.ts
@@ -371,7 +371,7 @@ export async function startRelay(options: {
     );
   }
 
-  if (mode !== "local") {
+  if (mode !== "local" && !hostname) {
     const accountTarget = await resolveAccountRelayTarget();
     if (!accountTarget) {
       if (mode === "hosted") {
@@ -386,7 +386,7 @@ export async function startRelay(options: {
         tunnelToken = await ensureSubdomainTunnelToken(accountTarget.subdomain);
         hostname = accountTarget.hostname;
         tunnelSubdomain = accountTarget.subdomain;
-        logger.info(`Using account host ${hostname} for relay tunnel`);
+        logger.info(`Using account host ${accountTarget.hostname} for relay tunnel`);
       } catch (error) {
         const detail = error instanceof Error ? error.message : String(error);
         if (mode === "hosted") {

--- a/src/commands/relay.ts
+++ b/src/commands/relay.ts
@@ -474,6 +474,7 @@ export async function startRelay(options: {
         // bindControlOwner persists the control-store owner binding; the vault keeps
         // its own owner metadata and must be repaired separately for later startups.
         setVaultMeta("owner_user_root_id", ownerUserRootId);
+        setVaultMeta("vault_initialized", "1");
       }
       logger.dim(`  Owner identity: ${ownerUserRootId.slice(0, 8)}...`);
     } else {

--- a/src/commands/relay.ts
+++ b/src/commands/relay.ts
@@ -377,16 +377,21 @@ export async function startRelay(options: {
   const mode: RelayStartMode = options.mode ?? "auto";
   const port = options.port ?? parseInt(process.env.PORT ?? String(DEFAULT_PORT), 10);
   const bind = options.bind ?? process.env.RELAY_BIND ?? "0.0.0.0";
-  let hostname = options.hostname ?? process.env.RELAY_HOST;
+  const explicitHostname = options.hostname;
+  let hostname = explicitHostname ?? process.env.RELAY_HOST;
   let tunnelSubdomain: string | undefined;
   let tunnelToken: string | undefined;
 
-  if (mode === "hosted" && hostname) {
+  if (mode === "hosted" && explicitHostname) {
     throw new SpacesError(
       "Hosted mode does not support explicit --hostname. Remove --hostname and use your account host.",
       "USER_ERROR",
       1,
     );
+  }
+
+  if (mode === "hosted") {
+    hostname = undefined;
   }
 
   if (mode !== "local" && !hostname) {
@@ -462,11 +467,14 @@ export async function startRelay(options: {
           1,
         );
       }
+      const vaultInitialized = isVaultInitialized();
       if (!existingOwner) {
         assertRelayOwnerRepairIsSafe(ownerUserRootId);
-        if (isVaultInitialized()) {
+        if (vaultInitialized) {
           logger.info('Relay vault is initialized but owner metadata is missing; repairing owner binding from the current user root identity.');
         }
+      } else if (!vaultInitialized) {
+        logger.info('Relay vault initialization metadata is incomplete; repairing it after startup succeeds.');
       }
 
       bindControlOwner(ownerUserRootId);
@@ -475,8 +483,8 @@ export async function startRelay(options: {
         // bindControlOwner persists the control-store owner binding; the vault keeps
         // its own owner metadata and must be repaired separately for later startups.
         setVaultMeta("owner_user_root_id", ownerUserRootId);
-        shouldMarkVaultInitialized = true;
       }
+      shouldMarkVaultInitialized = !vaultInitialized;
       logger.dim(`  Owner identity: ${ownerUserRootId.slice(0, 8)}...`);
     } else {
       // User root identity not initialized - relay starts without an owner.

--- a/src/commands/relay.ts
+++ b/src/commands/relay.ts
@@ -19,9 +19,11 @@ import {
 import { loadUserRootIdentity } from "../core/user-identity.js";
 import { getSpacesDir } from "../core/config.js";
 import {
+  bindControlOwner,
   ensureControlStore,
   setVaultMeta,
   getVaultMeta,
+  isVaultInitialized,
   listVaultMachinesForOwner,
   removeVaultMachineForOwner,
 } from "../relay/control/store.js";
@@ -433,6 +435,7 @@ export async function startRelay(options: {
     if (userRoot) {
       ownerUserRootId = userRoot.id;
       ensureControlStore();
+      bindControlOwner(ownerUserRootId);
       const existingOwner = getVaultMeta("owner_user_root_id");
       if (existingOwner && existingOwner !== ownerUserRootId) {
         throw new SpacesError(
@@ -443,7 +446,17 @@ export async function startRelay(options: {
           1,
         );
       }
-      setVaultMeta("owner_user_root_id", ownerUserRootId);
+      if (!existingOwner) {
+        if (isVaultInitialized()) {
+          throw new SpacesError(
+            'Relay vault is initialized but owner metadata is missing. Repair the control store before starting the relay.',
+            'SYSTEM_ERROR',
+            2,
+          );
+        }
+
+        setVaultMeta("owner_user_root_id", ownerUserRootId);
+      }
       logger.dim(`  Owner identity: ${ownerUserRootId.slice(0, 8)}...`);
     } else {
       // User root identity not initialized - relay starts without an owner.

--- a/src/commands/relay.ts
+++ b/src/commands/relay.ts
@@ -451,10 +451,17 @@ export async function startRelay(options: {
       logger.dim("  No user root identity found - machines will need enrollment tokens");
     }
   } catch (error) {
-    if (error instanceof SpacesError) throw error;
-    // User root identity not initialized - relay starts without an owner.
-    // Machines will need enrollment tokens to register.
-    logger.dim("  No user root identity found - machines will need enrollment tokens");
+    if (error instanceof SpacesError) {
+      throw error;
+    }
+
+    const detail = error instanceof Error ? error.message : String(error);
+    logger.error(`Failed to load relay owner identity: ${detail}`);
+    throw new SpacesError(
+      'Failed to determine relay owner identity during startup.',
+      'SYSTEM_ERROR',
+      2,
+    );
   }
 
   // Display relay identity prominently

--- a/src/commands/relay.ts
+++ b/src/commands/relay.ts
@@ -435,7 +435,6 @@ export async function startRelay(options: {
     if (userRoot) {
       ownerUserRootId = userRoot.id;
       ensureControlStore();
-      bindControlOwner(ownerUserRootId);
       const existingOwner = getVaultMeta("owner_user_root_id");
       if (existingOwner && existingOwner !== ownerUserRootId) {
         throw new SpacesError(
@@ -455,6 +454,11 @@ export async function startRelay(options: {
           );
         }
 
+      }
+
+      bindControlOwner(ownerUserRootId);
+
+      if (!existingOwner) {
         setVaultMeta("owner_user_root_id", ownerUserRootId);
       }
       logger.dim(`  Owner identity: ${ownerUserRootId.slice(0, 8)}...`);

--- a/src/commands/relay.ts
+++ b/src/commands/relay.ts
@@ -461,9 +461,11 @@ export async function startRelay(options: {
           1,
         );
       }
-      if (!existingOwner && isVaultInitialized()) {
+      if (!existingOwner) {
         assertRelayOwnerRepairIsSafe(ownerUserRootId);
-        logger.info('Relay vault is initialized but owner metadata is missing; repairing owner binding from the current user root identity.');
+        if (isVaultInitialized()) {
+          logger.info('Relay vault is initialized but owner metadata is missing; repairing owner binding from the current user root identity.');
+        }
       }
 
       bindControlOwner(ownerUserRootId);
@@ -546,7 +548,7 @@ export async function startRelay(options: {
       tunnelSubdomain,
     });
 
-    logger.success(`Relay listening on ws://${hostname || bind}:${port}/ws`);
+    logger.success(`Relay listening on ws://${hostname || bind}:${port}`);
     if (tunnelSubdomain) {
       logger.success(`Public relay URL: wss://${tunnelSubdomain}.gitspace.sh/ws`);
     }
@@ -645,7 +647,7 @@ function getRelayStatusSnapshot(): RelayStatusSnapshot {
   const running = isProcessRunning(state.pid);
   const tunnelRunning = typeof state.tunnelPid === "number" && isProcessRunning(state.tunnelPid);
 
-  const relayUrl = `ws://${state.hostname || state.bind}:${state.port}/ws`;
+  const relayUrl = `ws://${state.hostname || state.bind}:${state.port}`;
   const publicRelayUrl = state.tunnelSubdomain
     ? `wss://${state.tunnelSubdomain}.gitspace.sh/ws`
     : null;

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -172,6 +172,43 @@ async function resolveUserRootAuthorizationConfig(options: { yes?: boolean } = {
   };
 }
 
+async function ensureServeDeviceIdentityPassword(options: { yes?: boolean; passwordStdin?: boolean } = {}): Promise<string | null> {
+  let password: string | null = null;
+
+  if (!keypairExists()) {
+    const shouldCreate = options.yes || await promptConfirm(
+      'No local device identity found. Create one now?',
+      true,
+    );
+    if (!shouldCreate) {
+      throw new NoIdentityError();
+    }
+
+    const stdinPassword = options.passwordStdin ? await readPasswordFromStdin() : null;
+    password = stdinPassword ?? await promptPassword('Create password for local device identity:');
+    if (!password) {
+      return null;
+    }
+
+    if (!stdinPassword) {
+      const confirmPassword = await promptPassword('Confirm local identity password:');
+      if (password !== confirmPassword) {
+        throw new SpacesError('Password confirmation does not match.', 'USER_ERROR', 1);
+      }
+    }
+
+    await generateAndSaveKeypair(password, os.hostname());
+    logger.success('Created local device identity');
+  }
+
+  if (!password) {
+    const stdinPassword = options.passwordStdin ? await readPasswordFromStdin() : null;
+    password = stdinPassword ?? await promptPassword('Enter password to unlock identity:');
+  }
+
+  return password;
+}
+
 async function isRelayHealthy(relayUrl: string): Promise<boolean> {
   try {
     const relay = new URL(relayUrl);
@@ -960,43 +997,10 @@ export async function serveStart(options: {
         throw new SpacesError('Unlock mode requires --enrollment-token', 'USER_ERROR', 1);
       }
     } else {
-      if (!keypairExists()) {
-        const shouldCreate = options.yes || await promptConfirm(
-          'No local device identity found. Create one now?',
-          true,
-        );
-        if (!shouldCreate) {
-          throw new NoIdentityError();
-        }
-
-        if (options.passwordStdin) {
-          password = await readPasswordFromStdin();
-        } else {
-          password = await promptPassword('Create password for local device identity:');
-          if (!password) {
-            logger.info('Cancelled');
-            return;
-          }
-          const confirmPassword = await promptPassword('Confirm local identity password:');
-          if (password !== confirmPassword) {
-            throw new SpacesError('Password confirmation does not match.', 'USER_ERROR', 1);
-          }
-        }
-
-        await generateAndSaveKeypair(password, os.hostname());
-        logger.success('Created local device identity');
-      }
-
-      if (options.passwordStdin) {
-        if (!password) {
-          password = await readPasswordFromStdin();
-        }
-      } else if (!password) {
-        password = await promptPassword('Enter password to unlock identity:');
-        if (!password) {
-          logger.info('Cancelled');
-          return;
-        }
+      password = await ensureServeDeviceIdentityPassword({ yes: options.yes, passwordStdin: options.passwordStdin });
+      if (!password) {
+        logger.info('Cancelled');
+        return;
       }
 
       // Validate password before daemonizing
@@ -1134,47 +1138,11 @@ export async function serveStart(options: {
     identity = unlocked.identity;
     registerPermit = unlocked.registerPermit;
   } else {
-    if (!keypairExists()) {
-      const shouldCreate = options.yes || await promptConfirm(
-        'No local device identity found. Create one now?',
-        true,
-      );
-      if (!shouldCreate) {
-        cleanupServeFiles();
-        throw new NoIdentityError();
-      }
-
-      if (options.passwordStdin) {
-        password = await readPasswordFromStdin();
-      } else {
-        password = await promptPassword('Create password for local device identity:');
-        if (!password) {
-          logger.info('Cancelled');
-          cleanupServeFiles();
-          return;
-        }
-        const confirmPassword = await promptPassword('Confirm local identity password:');
-        if (password !== confirmPassword) {
-          cleanupServeFiles();
-          throw new SpacesError('Password confirmation does not match.', 'USER_ERROR', 1);
-        }
-      }
-
-      await generateAndSaveKeypair(password, os.hostname());
-      logger.success('Created local device identity');
-    }
-
-    if (options.passwordStdin) {
-      if (!password) {
-        password = await readPasswordFromStdin();
-      }
-    } else if (!password) {
-      password = await promptPassword('Enter password to unlock identity:');
-      if (!password) {
-        logger.info('Cancelled');
-        cleanupServeFiles();
-        return;
-      }
+    password = await ensureServeDeviceIdentityPassword({ yes: options.yes, passwordStdin: options.passwordStdin });
+    if (!password) {
+      logger.info('Cancelled');
+      cleanupServeFiles();
+      return;
     }
 
     identity = await loadKeypair(password);

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -271,11 +271,25 @@ async function resolveRelayUrlForServe(
 }
 
 function resolveCloudRelayUrlForConfig(relayUrl: string, hostConfig: HostConfig | null): string | undefined {
-  if (hostConfig?.subdomain) {
-    return `wss://${hostConfig.subdomain}.gitspace.sh/ws`;
+  if (isCloudReachableRelayUrl(relayUrl)) {
+    return relayUrl;
   }
 
-  return isCloudReachableRelayUrl(relayUrl) ? relayUrl : undefined;
+  if (!hostConfig?.subdomain) {
+    return undefined;
+  }
+
+  try {
+    const parsed = new URL(relayUrl);
+    const port = parsed.port || (parsed.protocol === 'wss:' ? '443' : parsed.protocol === 'ws:' ? '80' : '');
+    if (port === String(LOCAL_RELAY_PORT) && isLocalhost(parsed.hostname)) {
+      return `wss://${hostConfig.subdomain}.gitspace.sh/ws`;
+    }
+  } catch {
+    return undefined;
+  }
+
+  return undefined;
 }
 
 /**

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -924,6 +924,7 @@ function formatUptime(seconds: number): string {
 export async function serveStart(options: {
   relay?: string;
   relayPubkey?: string;
+  skipRelayTrustVerification?: boolean;
   bootstrapToken?: string;
   enrollmentToken?: string;
   unlockToken?: string;
@@ -1004,6 +1005,7 @@ export async function serveStart(options: {
       }
 
       options.relayPubkey ??= relayIdentity.publicKey;
+      options.skipRelayTrustVerification = true;
     }
 
     logger.log('Starting serve daemon...');
@@ -1015,6 +1017,7 @@ export async function serveStart(options: {
     const serveArgs = ['machine', 'serve', 'start', '--foreground'];
     if (options.relay) serveArgs.push('--relay', options.relay);
     if (options.relayPubkey) serveArgs.push('--relay-pubkey', options.relayPubkey);
+    if (options.skipRelayTrustVerification) serveArgs.push('--skip-relay-trust-verification');
     if (options.bootstrapToken) serveArgs.push('--bootstrap-token', options.bootstrapToken);
     if (options.enrollmentToken) serveArgs.push('--enrollment-token', options.enrollmentToken);
     if (options.unlockToken) serveArgs.push('--unlock-token', options.unlockToken);
@@ -1310,6 +1313,7 @@ export async function serveStart(options: {
       enrollmentToken,
       deviceCertificate,
       options.yes,
+      options.skipRelayTrustVerification,
     );
 
     if (trustedRelayIdentity) {

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -1050,7 +1050,11 @@ export async function serveStart(options: {
 
     // Send password via stdin (non-unlock mode)
     if (!usingUnlockMode) {
-      child.stdin.write(password ?? '');
+      if (!password) {
+        throw new SpacesError('Failed to pass identity password to serve daemon startup.', 'SYSTEM_ERROR', 2);
+      }
+
+      child.stdin.write(password);
       child.stdin.end();
     } else {
       child.stdin.end();

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -282,7 +282,7 @@ function resolveCloudRelayUrlForConfig(relayUrl: string, hostConfig: HostConfig 
   try {
     const parsed = new URL(relayUrl);
     const port = parsed.port || (parsed.protocol === 'wss:' ? '443' : parsed.protocol === 'ws:' ? '80' : '');
-    if (port === String(LOCAL_RELAY_PORT) && isLocalhost(parsed.hostname)) {
+    if (port === String(LOCAL_RELAY_PORT) && isLocalhost(relayUrl)) {
       return `wss://${hostConfig.subdomain}.gitspace.sh/ws`;
     }
   } catch {

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -12,6 +12,7 @@
 import { appendFileSync, existsSync, writeFileSync, readdirSync } from 'fs';
 import { join } from 'path';
 import { createHash } from 'crypto';
+import os from 'os';
 import { spawn, type Subprocess } from 'bun';
 import { logger } from '../utils/logger.js';
 import { promptPassword, promptConfirm, selectOne } from '../utils/prompts.js';
@@ -27,12 +28,13 @@ import {
 import {
   loadKeypair,
   keypairExists,
+  generateAndSaveKeypair,
   readMachineIdentity,
   getPublicKeyWithoutPassword,
   writeRelayConfig,
   clearRelayConfig,
 } from '../core/identity.js';
-import { loadUserRootIdentity } from '../core/user-identity.js';
+import { loadUserRootIdentity, createLocalDeviceCertificate } from '../core/user-identity.js';
 import { ClientSessionManager } from '../serve/client-session-manager.js';
 import type { ServeEventHandler } from '../serve/types.js';
 import type { Identity, StoredIdentity } from '../types/identity.js';
@@ -46,7 +48,11 @@ import {
   resolveRelaySubdomains,
   type HostConfig,
 } from './host.js';
-import { deserializeIdentity, getPublicIdentity as getPublicIdentityFromPrivate } from '../lib/tmux-lite/crypto/identity.js';
+import {
+  deriveIdentityId,
+  deserializeIdentity,
+  getPublicIdentity as getPublicIdentityFromPrivate,
+} from '../lib/tmux-lite/crypto/identity.js';
 import { generateEphemeralKeypair, validateX25519PublicKey, x25519SharedSecret } from '../lib/tmux-lite/crypto/keyexchange.js';
 import { open } from '../lib/tmux-lite/crypto/secretbox.js';
 import {
@@ -74,6 +80,7 @@ import { getGitspaceDir } from '../core/config.js';
 import { buildProcessHostname, normalizeHostLabel } from '../utils/hostnames.js';
 import type { ProcessPortConfig } from '../types/processes.js';
 import {
+  bindControlRelayIdentity,
   bindControlOwner,
   ensureControlStore,
   getVaultMeta,
@@ -87,6 +94,7 @@ import {
 import { deriveUnlockKey } from '../relay/unlock-kdf.js';
 import { parseRootInviteToken } from '../lib/tmux-lite/crypto/root-invites.js';
 import { isCloudflaredInstalled, trackCloudflaredOutput } from '../utils/cloudflared.js';
+import { ensureUserRootIdentityWithRecovery } from './identity-recovery.js';
 
 /** Package version for daemon status */
 const PACKAGE_VERSION = '1.0.0';
@@ -127,8 +135,12 @@ function resolveOwnerUserRootIdFromEnrollmentToken(enrollmentToken: string | und
   return parsed.ownerUserRootId;
 }
 
-async function resolveUserRootAuthorizationConfig(): Promise<UserRootAuthorizationConfig> {
-  const userRoot = await loadUserRootIdentity();
+async function resolveUserRootAuthorizationConfig(options: { yes?: boolean } = {}): Promise<UserRootAuthorizationConfig> {
+  const userRoot = await loadUserRootIdentity()
+    ?? await ensureUserRootIdentityWithRecovery({
+      yes: options.yes,
+      context: 'machine serve authorization',
+    });
   if (!userRoot) {
     throw new SpacesError(
       'User root identity is required for serve authorization. Run `gssh user identity init` or `gssh user identity recover` first.',
@@ -280,7 +292,8 @@ async function verifyRelayTrust(
   relayPublicKey: string,
   relayFingerprint: string,
   relayLabel: string | undefined,
-  explicitPubkey?: string
+  explicitPubkey?: string,
+  autoYes: boolean = false,
 ): Promise<RelayTrustResult> {
   const trustStatus = isRelayTrusted(relayUrl, relayPublicKey);
 
@@ -325,7 +338,7 @@ async function verifyRelayTrust(
       logger.log('');
 
       // Ask for confirmation
-      const shouldTrust = await promptConfirm('Trust this relay?');
+      const shouldTrust = autoYes || await promptConfirm('Trust this relay?');
 
       if (!shouldTrust) {
         logger.info('Relay not trusted, aborting connection');
@@ -784,20 +797,46 @@ async function connectToRelay(
   bootstrapToken?: string,
   registerPermit?: string,
   enrollmentToken?: string,
-): Promise<void> {
+  deviceCertificate?: string,
+  autoYes?: boolean,
+): Promise<{ relayPublicKey: string; relayFingerprint: string; relayLabel?: string } | null> {
+  let trustedRelayIdentity: { relayPublicKey: string; relayFingerprint: string; relayLabel?: string } | null = null;
+
   await connectMachineRelay(
     relayUrl,
     machineId,
     publicIdentity,
     sessionManager,
     eventHandler,
-    verifyRelayTrust,
+    async (url, relayPublicKey, relayFingerprint, relayLabel, explicitPubkey) => {
+      const trustResult = await verifyRelayTrust(
+        url,
+        relayPublicKey,
+        relayFingerprint,
+        relayLabel,
+        explicitPubkey,
+        Boolean(autoYes),
+      );
+
+      if (trustResult.trusted) {
+        trustedRelayIdentity = {
+          relayPublicKey,
+          relayFingerprint,
+          relayLabel,
+        };
+      }
+
+      return trustResult;
+    },
     signingPrivateKey,
     relayPubkey,
     bootstrapToken,
     registerPermit,
     enrollmentToken,
+    deviceCertificate,
   );
+
+  return trustedRelayIdentity;
 }
 
 /**
@@ -858,6 +897,7 @@ export async function serveStart(options: {
   passwordStdin?: boolean;
   foreground?: boolean;
   ignoreKeychainAndSkipSecrets?: boolean;
+  yes?: boolean;
 } = {}): Promise<void> {
   // Check if already running
   if (isServeRunning()) {
@@ -920,12 +960,37 @@ export async function serveStart(options: {
       }
     } else {
       if (!keypairExists()) {
-        throw new NoIdentityError();
+        const shouldCreate = options.yes || await promptConfirm(
+          'No local device identity found. Create one now?',
+          true,
+        );
+        if (!shouldCreate) {
+          throw new NoIdentityError();
+        }
+
+        if (options.passwordStdin) {
+          password = await loadPasswordFromStdin();
+        } else {
+          password = await promptPassword('Create password for local device identity:');
+          if (!password) {
+            logger.info('Cancelled');
+            return;
+          }
+          const confirmPassword = await promptPassword('Confirm local identity password:');
+          if (password !== confirmPassword) {
+            throw new SpacesError('Password confirmation does not match.', 'USER_ERROR', 1);
+          }
+        }
+
+        await generateAndSaveKeypair(password, os.hostname());
+        logger.success('Created local device identity');
       }
 
       if (options.passwordStdin) {
-        password = await loadPasswordFromStdin();
-      } else {
+        if (!password) {
+          password = await loadPasswordFromStdin();
+        }
+      } else if (!password) {
         password = await promptPassword('Enter password to unlock identity:');
         if (!password) {
           logger.info('Cancelled');
@@ -964,6 +1029,9 @@ export async function serveStart(options: {
     if (options.workspaceId) serveArgs.push('--workspace-id', options.workspaceId);
     if (options.ignoreKeychainAndSkipSecrets) {
       serveArgs.push('--ignore-keychain-and-skip-secrets');
+    }
+    if (options.yes) {
+      serveArgs.push('--yes');
     }
     if (!usingUnlockMode) {
       serveArgs.push('--password-stdin');
@@ -1040,13 +1108,40 @@ export async function serveStart(options: {
     registerPermit = unlocked.registerPermit;
   } else {
     if (!keypairExists()) {
-      cleanupServeFiles();
-      throw new NoIdentityError();
+      const shouldCreate = options.yes || await promptConfirm(
+        'No local device identity found. Create one now?',
+        true,
+      );
+      if (!shouldCreate) {
+        cleanupServeFiles();
+        throw new NoIdentityError();
+      }
+
+      if (options.passwordStdin) {
+        password = await loadPasswordFromStdin();
+      } else {
+        password = await promptPassword('Create password for local device identity:');
+        if (!password) {
+          logger.info('Cancelled');
+          cleanupServeFiles();
+          return;
+        }
+        const confirmPassword = await promptPassword('Confirm local identity password:');
+        if (password !== confirmPassword) {
+          cleanupServeFiles();
+          throw new SpacesError('Password confirmation does not match.', 'USER_ERROR', 1);
+        }
+      }
+
+      await generateAndSaveKeypair(password, os.hostname());
+      logger.success('Created local device identity');
     }
 
     if (options.passwordStdin) {
-      password = await loadPasswordFromStdin();
-    } else {
+      if (!password) {
+        password = await loadPasswordFromStdin();
+      }
+    } else if (!password) {
       password = await promptPassword('Enter password to unlock identity:');
       if (!password) {
         logger.info('Cancelled');
@@ -1102,6 +1197,7 @@ export async function serveStart(options: {
   }
 
   let ownerUserRootId: string;
+  let deviceCertificate: string | undefined;
   if (usingUnlockMode) {
     try {
       ownerUserRootId = resolveOwnerUserRootIdFromEnrollmentToken(enrollmentToken);
@@ -1112,7 +1208,7 @@ export async function serveStart(options: {
     }
   } else {
     try {
-      const userRootAuth = await resolveUserRootAuthorizationConfig();
+      const userRootAuth = await resolveUserRootAuthorizationConfig({ yes: options.yes });
       ownerUserRootId = userRootAuth.ownerUserRootId;
       ensureControlStore();
       bindControlOwner(ownerUserRootId);
@@ -1120,6 +1216,21 @@ export async function serveStart(options: {
       stopStatusServer();
       cleanupServeFiles();
       throw error;
+    }
+
+    // Create a device certificate: proves this machine belongs to the user root.
+    // The relay can verify this cert to auto-authorize the machine without
+    // needing enrollment tokens or preAuthorizedMachines.
+    try {
+      deviceCertificate = await createLocalDeviceCertificate(identity!);
+      logger.info(`[serve] Device certificate created for owner ${ownerUserRootId}`);
+    } catch (error) {
+      // Device cert is not strictly required — the machine may still be
+      // authorized via vault_machines, enrollmentToken, or preAuthorizedMachines.
+      // Log a warning but don't fail startup.
+      logger.warning(
+        `[serve] Could not create device certificate: ${error instanceof Error ? error.message : String(error)}`
+      );
     }
   }
 
@@ -1226,7 +1337,7 @@ export async function serveStart(options: {
 
   // Connect to relay
   try {
-    await connectToRelay(
+    const trustedRelayIdentity = await connectToRelay(
       effectiveRelayUrl,
       machineId,
       publicIdentity,
@@ -1237,10 +1348,25 @@ export async function serveStart(options: {
       options.bootstrapToken,
       registerPermit,
       enrollmentToken,
+      deviceCertificate,
+      options.yes,
     );
+
+    if (trustedRelayIdentity) {
+      const relayIdentityId = deriveIdentityId(new Uint8Array(Buffer.from(trustedRelayIdentity.relayPublicKey, 'base64')));
+      bindControlRelayIdentity({
+        relayIdentityId,
+        relaySigningPublicKey: trustedRelayIdentity.relayPublicKey,
+        relayFingerprint: trustedRelayIdentity.relayFingerprint,
+      });
+    }
+
     updateDaemonState({ relay: { url: effectiveRelayUrl, status: 'connected' } });
   } catch (error) {
     await cleanupServeStartupFailure(sessionManager, processHostManager, processHostRefreshTimer);
+    if (error instanceof SpacesError) {
+      throw error;
+    }
     throw new SpacesError(
       `Failed to connect to relay: ${error instanceof Error ? error.message : String(error)}`,
       'SYSTEM_ERROR',

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -73,6 +73,7 @@ import {
   type StatusResponse,
 } from '../serve/daemon.js';
 import { initializeSecretRuntime } from '../core/secret-runtime.js';
+import { readPasswordFromStdin } from '../utils/password-stdin.js';
 import { listSessions } from '../lib/tmux-lite/cli.js';
 import { loadProcessesConfig } from '../lib/processes/config.js';
 import { parseProcessSessionName } from '../lib/processes/names.js';
@@ -300,6 +301,14 @@ async function verifyRelayTrust(
   explicitPubkey?: string,
   autoYes: boolean = false,
 ): Promise<RelayTrustResult> {
+  const computedFingerprint = computeRelayFingerprint(relayPublicKey);
+  if (relayFingerprint !== computedFingerprint) {
+    logger.error(
+      `Relay at ${relayUrl} reported fingerprint ${relayFingerprint}, but computed ${computedFingerprint} from relayPublicKey.`,
+    );
+    return { trusted: false, reason: 'Relay identity response is inconsistent' };
+  }
+
   const trustStatus = isRelayTrusted(relayUrl, relayPublicKey);
 
   if (trustStatus === 'mismatch') {
@@ -307,7 +316,7 @@ async function verifyRelayTrust(
     logger.log('');
     logger.error('SECURITY WARNING: Relay public key mismatch!');
     logger.error(`Expected:  ${getTrustedRelay(relayUrl)?.fingerprint}`);
-    logger.error(`Received:  ${relayFingerprint}`);
+    logger.error(`Received:  ${computedFingerprint}`);
     logger.log('');
     logger.error('The relay identity has changed. This could indicate a man-in-the-middle attack.');
     logger.error('If this is expected, remove the old relay entry from ~/.gitspace/.identity/trusted-relays.json and retry.');
@@ -328,7 +337,7 @@ async function verifyRelayTrust(
       } else {
         logger.error('Relay public key does not match --relay-pubkey');
         logger.error(`Expected:  ${computeRelayFingerprint(explicitPubkey)}`);
-        logger.error(`Received:  ${relayFingerprint}`);
+        logger.error(`Received:  ${computedFingerprint}`);
         return { trusted: false, reason: 'Relay public key does not match --relay-pubkey' };
       }
     } else {
@@ -336,14 +345,19 @@ async function verifyRelayTrust(
       logger.log('');
       logger.bold('Unknown Relay');
       logger.log(`  URL:         ${relayUrl}`);
-      logger.log(`  Fingerprint: ${relayFingerprint}`);
+      logger.log(`  Fingerprint: ${computedFingerprint}`);
       if (relayLabel) {
         logger.log(`  Label:       ${relayLabel}`);
       }
       logger.log('');
 
       // Ask for confirmation
-      const shouldTrust = autoYes || await promptConfirm('Trust this relay?');
+      if (autoYes) {
+        logger.error('Unknown relay requires interactive approval or --relay-pubkey.');
+        return { trusted: false, reason: 'Unknown relay requires interactive approval or --relay-pubkey' };
+      }
+
+      const shouldTrust = await promptConfirm('Trust this relay?');
 
       if (!shouldTrust) {
         logger.info('Relay not trusted, aborting connection');
@@ -814,10 +828,11 @@ async function connectToRelay(
     sessionManager,
     eventHandler,
     async (url, relayPublicKey, relayFingerprint, relayLabel, explicitPubkey) => {
+      const computedFingerprint = computeRelayFingerprint(relayPublicKey);
       const trustResult = await verifyRelayTrust(
         url,
         relayPublicKey,
-        relayFingerprint,
+        computedFingerprint,
         relayLabel,
         explicitPubkey,
         Boolean(autoYes),
@@ -826,7 +841,7 @@ async function connectToRelay(
       if (trustResult.trusted) {
         trustedRelayIdentity = {
           relayPublicKey,
-          relayFingerprint,
+          relayFingerprint: computedFingerprint,
           relayLabel,
         };
       }
@@ -920,37 +935,6 @@ export async function serveStart(options: {
   let registerPermit: string | undefined;
   let enrollmentToken = options.enrollmentToken;
 
-  const loadPasswordFromStdin = async (): Promise<string> => {
-    const reader = process.stdin;
-    const chunks: Buffer[] = [];
-
-    const onData = (chunk: Buffer) => chunks.push(chunk);
-    reader.on('data', onData);
-
-    await new Promise<void>((resolve, reject) => {
-      const timeoutId = setTimeout(() => reject(new Error('Timeout reading password from stdin')), 10000);
-      const onEnd = () => {
-        clearTimeout(timeoutId);
-        resolve();
-      };
-      const onError = (err: Error) => {
-        clearTimeout(timeoutId);
-        reject(err);
-      };
-      reader.once('end', onEnd);
-      reader.once('error', onError);
-    });
-
-    reader.removeListener('data', onData);
-    reader.pause();
-
-    const result = Buffer.concat(chunks).toString().trim();
-    if (!result) {
-      throw new SpacesError('No password provided via stdin', 'USER_ERROR', 1);
-    }
-    return result;
-  };
-
   // If not foreground mode, fork to background
   if (!options.foreground) {
     if (usingUnlockMode) {
@@ -974,7 +958,7 @@ export async function serveStart(options: {
         }
 
         if (options.passwordStdin) {
-          password = await loadPasswordFromStdin();
+          password = await readPasswordFromStdin();
         } else {
           password = await promptPassword('Create password for local device identity:');
           if (!password) {
@@ -993,7 +977,7 @@ export async function serveStart(options: {
 
       if (options.passwordStdin) {
         if (!password) {
-          password = await loadPasswordFromStdin();
+          password = await readPasswordFromStdin();
         }
       } else if (!password) {
         password = await promptPassword('Enter password to unlock identity:');
@@ -1123,7 +1107,7 @@ export async function serveStart(options: {
       }
 
       if (options.passwordStdin) {
-        password = await loadPasswordFromStdin();
+        password = await readPasswordFromStdin();
       } else {
         password = await promptPassword('Create password for local device identity:');
         if (!password) {
@@ -1144,7 +1128,7 @@ export async function serveStart(options: {
 
     if (options.passwordStdin) {
       if (!password) {
-        password = await loadPasswordFromStdin();
+        password = await readPasswordFromStdin();
       }
     } else if (!password) {
       password = await promptPassword('Enter password to unlock identity:');

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -93,7 +93,11 @@ import { deriveUnlockKey } from '../relay/unlock-kdf.js';
 import { parseRootInviteToken } from '../lib/tmux-lite/crypto/root-invites.js';
 import { computeIdentityId, formatRelayFingerprint } from '../relay/identity.js';
 import { isCloudflaredInstalled, trackCloudflaredOutput } from '../utils/cloudflared.js';
-import { ensureDeviceIdentityPassword } from './device-identity-password.js';
+import {
+  createDeviceIdentityPasswordContext,
+  ensureDeviceIdentityPassword,
+  type DeviceIdentityPasswordContext,
+} from './device-identity-password.js';
 import { ensureUserRootIdentityWithRecovery } from './identity-recovery.js';
 
 /** Package version for daemon status */
@@ -135,10 +139,16 @@ function resolveOwnerUserRootIdFromEnrollmentToken(enrollmentToken: string | und
   return parsed.ownerUserRootId;
 }
 
-async function resolveUserRootAuthorizationConfig(options: { yes?: boolean } = {}): Promise<UserRootAuthorizationConfig> {
+async function resolveUserRootAuthorizationConfig(options: {
+  yes?: boolean;
+  passwordStdin?: boolean;
+  devicePasswordContext?: DeviceIdentityPasswordContext;
+} = {}): Promise<UserRootAuthorizationConfig> {
   const userRoot = await loadUserRootIdentity()
     ?? await ensureUserRootIdentityWithRecovery({
+      devicePasswordContext: options.devicePasswordContext,
       yes: options.yes,
+      passwordStdin: options.passwordStdin,
       context: 'machine serve authorization',
     });
   if (!userRoot) {
@@ -934,6 +944,8 @@ export async function serveStart(options: {
   ignoreKeychainAndSkipSecrets?: boolean;
   yes?: boolean;
 } = {}): Promise<void> {
+  const devicePasswordContext = createDeviceIdentityPasswordContext();
+
   // Check if already running
   if (isServeRunning()) {
     const pid = getServePid();
@@ -963,7 +975,10 @@ export async function serveStart(options: {
         throw new SpacesError('Unlock mode requires --enrollment-token', 'USER_ERROR', 1);
       }
     } else {
-      password = await ensureDeviceIdentityPassword({ yes: options.yes, passwordStdin: options.passwordStdin });
+      password = await ensureDeviceIdentityPassword(
+        { yes: options.yes, passwordStdin: options.passwordStdin },
+        devicePasswordContext,
+      );
       if (!password) {
         logger.info('Cancelled');
         return;
@@ -1100,7 +1115,10 @@ export async function serveStart(options: {
     identity = unlocked.identity;
     registerPermit = unlocked.registerPermit;
   } else {
-    password = await ensureDeviceIdentityPassword({ yes: options.yes, passwordStdin: options.passwordStdin });
+    password = await ensureDeviceIdentityPassword(
+      { yes: options.yes, passwordStdin: options.passwordStdin },
+      devicePasswordContext,
+    );
     if (!password) {
       logger.info('Cancelled');
       cleanupServeFiles();
@@ -1165,7 +1183,11 @@ export async function serveStart(options: {
     }
   } else {
     try {
-      const userRootAuth = await resolveUserRootAuthorizationConfig({ yes: options.yes });
+      const userRootAuth = await resolveUserRootAuthorizationConfig({
+        yes: options.yes,
+        passwordStdin: options.passwordStdin,
+        devicePasswordContext,
+      });
       ownerUserRootId = userRootAuth.ownerUserRootId;
       ensureControlStore();
       bindControlOwner(ownerUserRootId);

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -832,7 +832,7 @@ async function connectToRelay(
       const trustResult = await verifyRelayTrust(
         url,
         relayPublicKey,
-        computedFingerprint,
+        relayFingerprint,
         relayLabel,
         explicitPubkey,
         Boolean(autoYes),

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -1377,12 +1377,20 @@ export async function serveStart(options: {
 
     updateDaemonState({ relay: { url: effectiveRelayUrl, status: 'connected' } });
   } catch (error) {
-    await cleanupServeStartupFailure(sessionManager, processHostManager, processHostRefreshTimer);
-    if (error instanceof SpacesError) {
-      throw error;
+    const originalError = error;
+    try {
+      await cleanupServeStartupFailure(sessionManager, processHostManager, processHostRefreshTimer);
+    } catch (cleanupError) {
+      logger.error(
+        `[serve] Cleanup after relay connection failure also failed: ${cleanupError instanceof Error ? cleanupError.message : String(cleanupError)}`,
+      );
+    }
+
+    if (originalError instanceof SpacesError) {
+      throw originalError;
     }
     throw new SpacesError(
-      `Failed to connect to relay: ${error instanceof Error ? error.message : String(error)}`,
+      `Failed to connect to relay: ${originalError instanceof Error ? originalError.message : String(originalError)}`,
       'SYSTEM_ERROR',
       2
     );

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -1033,6 +1033,8 @@ export async function serveStart(options: {
       if (!trustResult.trusted) {
         throw new SpacesError(trustResult.reason, 'USER_ERROR', 1);
       }
+
+      options.relayPubkey ??= relayIdentity.publicKey;
     }
 
     logger.log('Starting serve daemon...');

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -271,7 +271,11 @@ async function resolveRelayUrlForServe(
   return selectedRelay;
 }
 
-function resolveCloudRelayUrlForConfig(relayUrl: string): string | undefined {
+function resolveCloudRelayUrlForConfig(relayUrl: string, hostConfig: HostConfig | null): string | undefined {
+  if (hostConfig?.subdomain) {
+    return `wss://${hostConfig.subdomain}.gitspace.sh/ws`;
+  }
+
   return isCloudReachableRelayUrl(relayUrl) ? relayUrl : undefined;
 }
 
@@ -1342,7 +1346,7 @@ export async function serveStart(options: {
   try {
     writeRelayConfig({
       relayUrl: effectiveRelayUrl,
-      cloudRelayUrl: resolveCloudRelayUrlForConfig(effectiveRelayUrl),
+      cloudRelayUrl: resolveCloudRelayUrlForConfig(effectiveRelayUrl, hostConfig),
       machineId,
       savedAt: Date.now(),
     });

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -47,7 +47,6 @@ import {
   type HostConfig,
 } from './host.js';
 import {
-  deriveIdentityId,
   deserializeIdentity,
   getPublicIdentity as getPublicIdentityFromPrivate,
 } from '../lib/tmux-lite/crypto/identity.js';
@@ -92,7 +91,7 @@ import {
 } from '../relay-client/machine-relay-client.js';
 import { deriveUnlockKey } from '../relay/unlock-kdf.js';
 import { parseRootInviteToken } from '../lib/tmux-lite/crypto/root-invites.js';
-import { formatRelayFingerprint } from '../relay/identity.js';
+import { computeIdentityId, formatRelayFingerprint } from '../relay/identity.js';
 import { isCloudflaredInstalled, trackCloudflaredOutput } from '../utils/cloudflared.js';
 import { ensureDeviceIdentityPassword } from './device-identity-password.js';
 import { ensureUserRootIdentityWithRecovery } from './identity-recovery.js';
@@ -1302,7 +1301,7 @@ export async function serveStart(options: {
     );
 
     if (trustedRelayIdentity) {
-      const relayIdentityId = deriveIdentityId(new Uint8Array(Buffer.from(trustedRelayIdentity.relayPublicKey, 'base64')));
+      const relayIdentityId = computeIdentityId(trustedRelayIdentity.relayPublicKey);
       bindControlRelayIdentity({
         relayIdentityId,
         relaySigningPublicKey: trustedRelayIdentity.relayPublicKey,

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -931,7 +931,6 @@ export async function serveStart(options: {
   ignoreKeychainAndSkipSecrets?: boolean;
   yes?: boolean;
 } = {}): Promise<void> {
-  const skipRelayTrustVerification = process.env.GITSPACE_SKIP_RELAY_TRUST_VERIFICATION === '1';
   // Check if already running
   if (isServeRunning()) {
     const pid = getServePid();

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -78,6 +78,7 @@ import { listSessions } from '../lib/tmux-lite/cli.js';
 import { loadProcessesConfig } from '../lib/processes/config.js';
 import { parseProcessSessionName } from '../lib/processes/names.js';
 import { resolveWorkspaceRef } from '../lib/events/paths.js';
+import { fetchRelayIdentity } from './connect.js';
 import { getGitspaceDir } from '../core/config.js';
 import { buildProcessHostname, normalizeHostLabel } from '../utils/hostnames.js';
 import type { ProcessPortConfig } from '../types/processes.js';
@@ -997,12 +998,30 @@ export async function serveStart(options: {
         );
       }
 
-      await resolveUserRootAuthorizationConfig({ yes: options.yes });
     }
 
     if (!options.relay) {
       const daemonHostConfig = readHostConfig();
       options.relay = await resolveRelayUrlForServe(undefined, daemonHostConfig);
+    }
+
+    if (!usingUnlockMode) {
+      const userRootAuth = await resolveUserRootAuthorizationConfig({ yes: options.yes });
+      ensureControlStore();
+      bindControlOwner(userRootAuth.ownerUserRootId);
+
+      const relayIdentity = await fetchRelayIdentity(options.relay);
+      const trustResult = await verifyRelayTrust(
+        options.relay,
+        relayIdentity.publicKey,
+        relayIdentity.fingerprint,
+        relayIdentity.label,
+        options.relayPubkey,
+        Boolean(options.yes),
+      );
+      if (!trustResult.trusted) {
+        throw new SpacesError(trustResult.reason, 'USER_ERROR', 1);
+      }
     }
 
     logger.log('Starting serve daemon...');

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -296,7 +296,7 @@ function resolveCloudRelayUrlForConfig(relayUrl: string, hostConfig: HostConfig 
  * Result of relay trust verification
  */
 type RelayTrustResult =
-  | { trusted: true }
+  | { trusted: true; fingerprint: string }
   | { trusted: false; reason: string };
 
 /**
@@ -386,7 +386,7 @@ async function verifyRelayTrust(
     }
   }
 
-  return { trusted: true };
+  return { trusted: true, fingerprint: computedFingerprint };
 }
 
 function decryptUnlockGrant(
@@ -844,7 +844,6 @@ async function connectToRelay(
     sessionManager,
     eventHandler,
     async (url, relayPublicKey, relayFingerprint, relayLabel, explicitPubkey) => {
-      const computedFingerprint = formatRelayFingerprint(relayPublicKey);
       const trustResult = await verifyRelayTrust(
         url,
         relayPublicKey,
@@ -857,7 +856,7 @@ async function connectToRelay(
       if (trustResult.trusted) {
         trustedRelayIdentity = {
           relayPublicKey,
-          relayFingerprint: computedFingerprint,
+          relayFingerprint: trustResult.fingerprint,
           relayLabel,
         };
       }
@@ -988,10 +987,6 @@ export async function serveStart(options: {
     }
 
     if (!usingUnlockMode) {
-      const userRootAuth = await resolveUserRootAuthorizationConfig({ yes: options.yes });
-      ensureControlStore();
-      bindControlOwner(userRootAuth.ownerUserRootId);
-
       const relayIdentity = await fetchRelayIdentity(options.relay);
       const trustResult = await verifyRelayTrust(
         options.relay,

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -278,7 +278,16 @@ async function resolveRelayUrlForServe(
   return selectedRelay;
 }
 
-function resolveCloudRelayUrlForConfig(relayUrl: string, hostConfig: HostConfig | null): string | undefined {
+function isLocalRelayBindUrl(relayUrl: string): boolean {
+  try {
+    const parsed = new URL(relayUrl);
+    return isLocalhost(relayUrl) || parsed.hostname === '0.0.0.0' || parsed.hostname === '::';
+  } catch {
+    return false;
+  }
+}
+
+export function resolveCloudRelayUrlForConfig(relayUrl: string, hostConfig: HostConfig | null): string | undefined {
   if (isCloudReachableRelayUrl(relayUrl)) {
     return relayUrl;
   }
@@ -290,7 +299,7 @@ function resolveCloudRelayUrlForConfig(relayUrl: string, hostConfig: HostConfig 
   try {
     const parsed = new URL(relayUrl);
     const port = parsed.port || (parsed.protocol === 'wss:' ? '443' : parsed.protocol === 'ws:' ? '80' : '');
-    if (port === String(LOCAL_RELAY_PORT) && isLocalhost(relayUrl)) {
+    if (port === String(LOCAL_RELAY_PORT) && isLocalRelayBindUrl(relayUrl)) {
       return `wss://${hostConfig.subdomain}.gitspace.sh/ws`;
     }
   } catch {

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -996,6 +996,8 @@ export async function serveStart(options: {
           1
         );
       }
+
+      await resolveUserRootAuthorizationConfig({ yes: options.yes });
     }
 
     if (!options.relay) {

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -821,7 +821,6 @@ async function connectToRelay(
   enrollmentToken?: string,
   deviceCertificate?: string,
   autoYes?: boolean,
-  skipRelayTrustVerification?: boolean,
 ): Promise<{ relayPublicKey: string; relayFingerprint: string; relayLabel?: string } | null> {
   let trustedRelayIdentity: { relayPublicKey: string; relayFingerprint: string; relayLabel?: string } | null = null;
 
@@ -833,16 +832,6 @@ async function connectToRelay(
     eventHandler,
     async (url, relayPublicKey, relayFingerprint, relayLabel, explicitPubkey) => {
       const computedFingerprint = formatRelayFingerprint(relayPublicKey);
-      if (skipRelayTrustVerification) {
-        trustedRelayIdentity = {
-          relayPublicKey,
-          relayFingerprint: computedFingerprint,
-          relayLabel,
-        };
-
-        return { trusted: true };
-      }
-
       const trustResult = await verifyRelayTrust(
         url,
         relayPublicKey,
@@ -924,7 +913,6 @@ function formatUptime(seconds: number): string {
 export async function serveStart(options: {
   relay?: string;
   relayPubkey?: string;
-  skipRelayTrustVerification?: boolean;
   bootstrapToken?: string;
   enrollmentToken?: string;
   unlockToken?: string;
@@ -1005,7 +993,6 @@ export async function serveStart(options: {
       }
 
       options.relayPubkey ??= relayIdentity.publicKey;
-      options.skipRelayTrustVerification = true;
     }
 
     logger.log('Starting serve daemon...');
@@ -1017,7 +1004,6 @@ export async function serveStart(options: {
     const serveArgs = ['machine', 'serve', 'start', '--foreground'];
     if (options.relay) serveArgs.push('--relay', options.relay);
     if (options.relayPubkey) serveArgs.push('--relay-pubkey', options.relayPubkey);
-    if (options.skipRelayTrustVerification) serveArgs.push('--skip-relay-trust-verification');
     if (options.bootstrapToken) serveArgs.push('--bootstrap-token', options.bootstrapToken);
     if (options.enrollmentToken) serveArgs.push('--enrollment-token', options.enrollmentToken);
     if (options.unlockToken) serveArgs.push('--unlock-token', options.unlockToken);
@@ -1313,7 +1299,6 @@ export async function serveStart(options: {
       enrollmentToken,
       deviceCertificate,
       options.yes,
-      options.skipRelayTrustVerification,
     );
 
     if (trustedRelayIdentity) {

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -15,7 +15,7 @@ import { createHash } from 'crypto';
 import os from 'os';
 import { spawn, type Subprocess } from 'bun';
 import { logger } from '../utils/logger.js';
-import { promptPassword, promptConfirm, selectOne } from '../utils/prompts.js';
+import { promptConfirm, selectOne } from '../utils/prompts.js';
 import { getSecret } from '../utils/secrets.js';
 import {
   isRelayTrusted,
@@ -28,8 +28,6 @@ import {
 } from '../core/trusted-relays.js';
 import {
   loadKeypair,
-  keypairExists,
-  generateAndSaveKeypair,
   readMachineIdentity,
   getPublicKeyWithoutPassword,
   writeRelayConfig,
@@ -73,7 +71,6 @@ import {
   type StatusResponse,
 } from '../serve/daemon.js';
 import { initializeSecretRuntime } from '../core/secret-runtime.js';
-import { readPasswordFromStdin } from '../utils/password-stdin.js';
 import { listSessions } from '../lib/tmux-lite/cli.js';
 import { loadProcessesConfig } from '../lib/processes/config.js';
 import { parseProcessSessionName } from '../lib/processes/names.js';
@@ -97,6 +94,7 @@ import {
 import { deriveUnlockKey } from '../relay/unlock-kdf.js';
 import { parseRootInviteToken } from '../lib/tmux-lite/crypto/root-invites.js';
 import { isCloudflaredInstalled, trackCloudflaredOutput } from '../utils/cloudflared.js';
+import { ensureDeviceIdentityPassword } from './device-identity-password.js';
 import { ensureUserRootIdentityWithRecovery } from './identity-recovery.js';
 
 /** Package version for daemon status */
@@ -170,43 +168,6 @@ async function resolveUserRootAuthorizationConfig(options: { yes?: boolean } = {
   return {
     ownerUserRootId: userRoot.id,
   };
-}
-
-async function ensureServeDeviceIdentityPassword(options: { yes?: boolean; passwordStdin?: boolean } = {}): Promise<string | null> {
-  let password: string | null = null;
-
-  if (!keypairExists()) {
-    const shouldCreate = options.yes || await promptConfirm(
-      'No local device identity found. Create one now?',
-      true,
-    );
-    if (!shouldCreate) {
-      throw new NoIdentityError();
-    }
-
-    const stdinPassword = options.passwordStdin ? await readPasswordFromStdin() : null;
-    password = stdinPassword ?? await promptPassword('Create password for local device identity:');
-    if (!password) {
-      return null;
-    }
-
-    if (!stdinPassword) {
-      const confirmPassword = await promptPassword('Confirm local identity password:');
-      if (password !== confirmPassword) {
-        throw new SpacesError('Password confirmation does not match.', 'USER_ERROR', 1);
-      }
-    }
-
-    await generateAndSaveKeypair(password, os.hostname());
-    logger.success('Created local device identity');
-  }
-
-  if (!password) {
-    const stdinPassword = options.passwordStdin ? await readPasswordFromStdin() : null;
-    password = stdinPassword ?? await promptPassword('Enter password to unlock identity:');
-  }
-
-  return password;
 }
 
 async function isRelayHealthy(relayUrl: string): Promise<boolean> {
@@ -997,7 +958,7 @@ export async function serveStart(options: {
         throw new SpacesError('Unlock mode requires --enrollment-token', 'USER_ERROR', 1);
       }
     } else {
-      password = await ensureServeDeviceIdentityPassword({ yes: options.yes, passwordStdin: options.passwordStdin });
+      password = await ensureDeviceIdentityPassword({ yes: options.yes, passwordStdin: options.passwordStdin });
       if (!password) {
         logger.info('Cancelled');
         return;
@@ -1138,7 +1099,7 @@ export async function serveStart(options: {
     identity = unlocked.identity;
     registerPermit = unlocked.registerPermit;
   } else {
-    password = await ensureServeDeviceIdentityPassword({ yes: options.yes, passwordStdin: options.passwordStdin });
+    password = await ensureDeviceIdentityPassword({ yes: options.yes, passwordStdin: options.passwordStdin });
     if (!password) {
       logger.info('Cancelled');
       cleanupServeFiles();

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -819,6 +819,7 @@ async function connectToRelay(
   enrollmentToken?: string,
   deviceCertificate?: string,
   autoYes?: boolean,
+  skipRelayTrustVerification?: boolean,
 ): Promise<{ relayPublicKey: string; relayFingerprint: string; relayLabel?: string } | null> {
   let trustedRelayIdentity: { relayPublicKey: string; relayFingerprint: string; relayLabel?: string } | null = null;
 
@@ -830,6 +831,16 @@ async function connectToRelay(
     eventHandler,
     async (url, relayPublicKey, relayFingerprint, relayLabel, explicitPubkey) => {
       const computedFingerprint = computeRelayFingerprint(relayPublicKey);
+      if (skipRelayTrustVerification) {
+        trustedRelayIdentity = {
+          relayPublicKey,
+          relayFingerprint: computedFingerprint,
+          relayLabel,
+        };
+
+        return { trusted: true };
+      }
+
       const trustResult = await verifyRelayTrust(
         url,
         relayPublicKey,
@@ -920,6 +931,7 @@ export async function serveStart(options: {
   ignoreKeychainAndSkipSecrets?: boolean;
   yes?: boolean;
 } = {}): Promise<void> {
+  const skipRelayTrustVerification = process.env.GITSPACE_SKIP_RELAY_TRUST_VERIFICATION === '1';
   // Check if already running
   if (isServeRunning()) {
     const pid = getServePid();
@@ -1064,7 +1076,10 @@ export async function serveStart(options: {
       stdin: 'pipe',
       stdout: Bun.file(logFile),
       stderr: Bun.file(logFile),
-      env: process.env,
+      env: {
+        ...process.env,
+        ...(usingUnlockMode ? {} : { GITSPACE_SKIP_RELAY_TRUST_VERIFICATION: '1' }),
+      },
     });
 
     // Send password via stdin (non-unlock mode)
@@ -1364,6 +1379,7 @@ export async function serveStart(options: {
       enrollmentToken,
       deviceCertificate,
       options.yes,
+      skipRelayTrustVerification,
     );
 
     if (trustedRelayIdentity) {

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -21,6 +21,7 @@ import {
   isRelayTrusted,
   addTrustedRelay,
   getTrustedRelay,
+  isCloudReachableRelayUrl,
   isLocalhost,
   computeRelayFingerprint,
   type RelayTrustStatus,
@@ -268,6 +269,10 @@ async function resolveRelayUrlForServe(
   }
 
   return selectedRelay;
+}
+
+function resolveCloudRelayUrlForConfig(relayUrl: string): string | undefined {
+  return isCloudReachableRelayUrl(relayUrl) ? relayUrl : undefined;
 }
 
 /**
@@ -1378,6 +1383,7 @@ export async function serveStart(options: {
   try {
     writeRelayConfig({
       relayUrl: effectiveRelayUrl,
+      cloudRelayUrl: resolveCloudRelayUrlForConfig(effectiveRelayUrl),
       machineId,
       savedAt: Date.now(),
     });

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -141,14 +141,12 @@ function resolveOwnerUserRootIdFromEnrollmentToken(enrollmentToken: string | und
 
 async function resolveUserRootAuthorizationConfig(options: {
   yes?: boolean;
-  passwordStdin?: boolean;
   devicePasswordContext?: DeviceIdentityPasswordContext;
 } = {}): Promise<UserRootAuthorizationConfig> {
   const userRoot = await loadUserRootIdentity()
     ?? await ensureUserRootIdentityWithRecovery({
       devicePasswordContext: options.devicePasswordContext,
       yes: options.yes,
-      passwordStdin: options.passwordStdin,
       context: 'machine serve authorization',
     });
   if (!userRoot) {
@@ -944,7 +942,7 @@ export async function serveStart(options: {
   ignoreKeychainAndSkipSecrets?: boolean;
   yes?: boolean;
 } = {}): Promise<void> {
-  const devicePasswordContext = createDeviceIdentityPasswordContext();
+  const devicePasswordContext = createDeviceIdentityPasswordContext({ passwordStdin: options.passwordStdin });
 
   // Check if already running
   if (isServeRunning()) {
@@ -975,10 +973,7 @@ export async function serveStart(options: {
         throw new SpacesError('Unlock mode requires --enrollment-token', 'USER_ERROR', 1);
       }
     } else {
-      password = await ensureDeviceIdentityPassword(
-        { yes: options.yes, passwordStdin: options.passwordStdin },
-        devicePasswordContext,
-      );
+      password = await ensureDeviceIdentityPassword({ yes: options.yes }, devicePasswordContext);
       if (!password) {
         logger.info('Cancelled');
         return;
@@ -1115,10 +1110,7 @@ export async function serveStart(options: {
     identity = unlocked.identity;
     registerPermit = unlocked.registerPermit;
   } else {
-    password = await ensureDeviceIdentityPassword(
-      { yes: options.yes, passwordStdin: options.passwordStdin },
-      devicePasswordContext,
-    );
+    password = await ensureDeviceIdentityPassword({ yes: options.yes }, devicePasswordContext);
     if (!password) {
       logger.info('Cancelled');
       cleanupServeFiles();
@@ -1185,7 +1177,6 @@ export async function serveStart(options: {
     try {
       const userRootAuth = await resolveUserRootAuthorizationConfig({
         yes: options.yes,
-        passwordStdin: options.passwordStdin,
         devicePasswordContext,
       });
       ownerUserRootId = userRootAuth.ownerUserRootId;

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -1076,10 +1076,7 @@ export async function serveStart(options: {
       stdin: 'pipe',
       stdout: Bun.file(logFile),
       stderr: Bun.file(logFile),
-      env: {
-        ...process.env,
-        ...(usingUnlockMode ? {} : { GITSPACE_SKIP_RELAY_TRUST_VERIFICATION: '1' }),
-      },
+      env: process.env,
     });
 
     // Send password via stdin (non-unlock mode)
@@ -1379,7 +1376,6 @@ export async function serveStart(options: {
       enrollmentToken,
       deviceCertificate,
       options.yes,
-      skipRelayTrustVerification,
     );
 
     if (trustedRelayIdentity) {

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -23,7 +23,6 @@ import {
   getTrustedRelay,
   isCloudReachableRelayUrl,
   isLocalhost,
-  computeRelayFingerprint,
   type RelayTrustStatus,
 } from '../core/trusted-relays.js';
 import {
@@ -93,6 +92,7 @@ import {
 } from '../relay-client/machine-relay-client.js';
 import { deriveUnlockKey } from '../relay/unlock-kdf.js';
 import { parseRootInviteToken } from '../lib/tmux-lite/crypto/root-invites.js';
+import { formatRelayFingerprint } from '../relay/identity.js';
 import { isCloudflaredInstalled, trackCloudflaredOutput } from '../utils/cloudflared.js';
 import { ensureDeviceIdentityPassword } from './device-identity-password.js';
 import { ensureUserRootIdentityWithRecovery } from './identity-recovery.js';
@@ -300,7 +300,7 @@ async function verifyRelayTrust(
   explicitPubkey?: string,
   autoYes: boolean = false,
 ): Promise<RelayTrustResult> {
-  const computedFingerprint = computeRelayFingerprint(relayPublicKey);
+  const computedFingerprint = formatRelayFingerprint(relayPublicKey);
   if (relayFingerprint !== computedFingerprint) {
     logger.error(
       `Relay at ${relayUrl} reported fingerprint ${relayFingerprint}, but computed ${computedFingerprint} from relayPublicKey.`,
@@ -335,7 +335,7 @@ async function verifyRelayTrust(
         addTrustedRelay(relayUrl, relayPublicKey, relayLabel);
       } else {
         logger.error('Relay public key does not match --relay-pubkey');
-        logger.error(`Expected:  ${computeRelayFingerprint(explicitPubkey)}`);
+        logger.error(`Expected:  ${formatRelayFingerprint(explicitPubkey)}`);
         logger.error(`Received:  ${computedFingerprint}`);
         return { trusted: false, reason: 'Relay public key does not match --relay-pubkey' };
       }
@@ -828,7 +828,7 @@ async function connectToRelay(
     sessionManager,
     eventHandler,
     async (url, relayPublicKey, relayFingerprint, relayLabel, explicitPubkey) => {
-      const computedFingerprint = computeRelayFingerprint(relayPublicKey);
+      const computedFingerprint = formatRelayFingerprint(relayPublicKey);
       if (skipRelayTrustVerification) {
         trustedRelayIdentity = {
           relayPublicKey,

--- a/src/core/__tests__/identity-backup.test.ts
+++ b/src/core/__tests__/identity-backup.test.ts
@@ -28,4 +28,15 @@ describe('identity-backup crypto', () => {
     };
     await expect(decryptMnemonicEnvelope(tampered, 'backup-pass-1')).rejects.toThrow();
   });
+
+  test('decrypt rejects weakened PBKDF2 iteration counts', async () => {
+    const mnemonic = generateMnemonic();
+    const envelope = await encryptMnemonicEnvelope(mnemonic, 'backup-pass-1');
+    const weakened = {
+      ...envelope,
+      iterations: 1,
+    };
+
+    await expect(decryptMnemonicEnvelope(weakened, 'backup-pass-1')).rejects.toThrow(/unsupported key derivation parameters/i);
+  });
 });

--- a/src/core/__tests__/identity-backup.test.ts
+++ b/src/core/__tests__/identity-backup.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from 'bun:test';
+import { generateMnemonic } from '../../lib/tmux-lite/crypto/user-identity.js';
+import {
+  decryptMnemonicEnvelope,
+  encryptMnemonicEnvelope,
+} from '../identity-backup.js';
+
+describe('identity-backup crypto', () => {
+  test('encrypt/decrypt roundtrip works', async () => {
+    const mnemonic = generateMnemonic();
+    const envelope = await encryptMnemonicEnvelope(mnemonic, 'backup-pass-1');
+    const decrypted = await decryptMnemonicEnvelope(envelope, 'backup-pass-1');
+    expect(decrypted).toBe(mnemonic);
+  });
+
+  test('decrypt fails with wrong password', async () => {
+    const mnemonic = generateMnemonic();
+    const envelope = await encryptMnemonicEnvelope(mnemonic, 'backup-pass-1');
+    await expect(decryptMnemonicEnvelope(envelope, 'wrong-pass')).rejects.toThrow('Invalid backup password');
+  });
+
+  test('decrypt fails when ciphertext is corrupted', async () => {
+    const mnemonic = generateMnemonic();
+    const envelope = await encryptMnemonicEnvelope(mnemonic, 'backup-pass-1');
+    const tampered = {
+      ...envelope,
+      ciphertext: envelope.ciphertext.slice(0, -4) + 'AAAA',
+    };
+    await expect(decryptMnemonicEnvelope(tampered, 'backup-pass-1')).rejects.toThrow();
+  });
+});

--- a/src/core/__tests__/identity-backup.test.ts
+++ b/src/core/__tests__/identity-backup.test.ts
@@ -1,9 +1,36 @@
+import { createCipheriv, pbkdf2Sync, randomBytes } from 'node:crypto';
 import { describe, expect, test } from 'bun:test';
 import { generateMnemonic } from '../../lib/tmux-lite/crypto/user-identity.js';
 import {
   decryptMnemonicEnvelope,
   encryptMnemonicEnvelope,
 } from '../identity-backup.js';
+
+const LEGACY_PBKDF2_ITERATIONS = 100_000;
+
+function encodeBase64(input: Uint8Array): string {
+  return Buffer.from(input).toString('base64');
+}
+
+async function encryptLegacyEnvelope(mnemonic: string, passphrase: string) {
+  const salt = randomBytes(16);
+  const iv = randomBytes(12);
+  const key = pbkdf2Sync(passphrase, salt, LEGACY_PBKDF2_ITERATIONS, 32, 'sha256');
+  const cipher = createCipheriv('aes-256-gcm', key, iv);
+  const ciphertext = Buffer.concat([cipher.update(Buffer.from(mnemonic, 'utf-8')), cipher.final()]);
+  const authTag = cipher.getAuthTag();
+
+  return {
+    version: 1 as const,
+    algorithm: 'PBKDF2-AES-GCM' as const,
+    iterations: LEGACY_PBKDF2_ITERATIONS,
+    salt: encodeBase64(salt),
+    iv: encodeBase64(iv),
+    ciphertext: encodeBase64(Buffer.concat([ciphertext, authTag])),
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+  };
+}
 
 describe('identity-backup crypto', () => {
   test('encrypt/decrypt roundtrip works', async () => {
@@ -17,6 +44,13 @@ describe('identity-backup crypto', () => {
     const mnemonic = generateMnemonic();
     const envelope = await encryptMnemonicEnvelope(mnemonic, 'backup-pass-1');
     await expect(decryptMnemonicEnvelope(envelope, 'wrong-pass')).rejects.toThrow('Invalid backup password');
+  });
+
+  test('decrypt accepts legacy PBKDF2 iteration counts above the floor', async () => {
+    const mnemonic = generateMnemonic();
+    const envelope = await encryptLegacyEnvelope(mnemonic, 'backup-pass-1');
+
+    await expect(decryptMnemonicEnvelope(envelope, 'backup-pass-1')).resolves.toBe(mnemonic);
   });
 
   test('decrypt fails when ciphertext is corrupted', async () => {

--- a/src/core/__tests__/identity-backup.test.ts
+++ b/src/core/__tests__/identity-backup.test.ts
@@ -39,4 +39,15 @@ describe('identity-backup crypto', () => {
 
     await expect(decryptMnemonicEnvelope(weakened, 'backup-pass-1')).rejects.toThrow(/unsupported key derivation parameters/i);
   });
+
+  test('decrypt rejects excessive PBKDF2 iteration counts', async () => {
+    const mnemonic = generateMnemonic();
+    const envelope = await encryptMnemonicEnvelope(mnemonic, 'backup-pass-1');
+    const excessive = {
+      ...envelope,
+      iterations: 5_000_000,
+    };
+
+    await expect(decryptMnemonicEnvelope(excessive, 'backup-pass-1')).rejects.toThrow(/unsupported key derivation parameters/i);
+  });
 });

--- a/src/core/__tests__/trusted-relays.test.ts
+++ b/src/core/__tests__/trusted-relays.test.ts
@@ -30,6 +30,7 @@ describe('isCloudReachableRelayUrl', () => {
   test('rejects IPv4 special-use ranges', () => {
     expect(isCloudReachableRelayUrl('ws://0.0.0.0:4480/ws')).toBe(false);
     expect(isCloudReachableRelayUrl('ws://100.64.0.1:4480/ws')).toBe(false);
+    expect(isCloudReachableRelayUrl('ws://198.51.100.1:4480/ws')).toBe(false);
     expect(isCloudReachableRelayUrl('ws://224.0.0.1:4480/ws')).toBe(false);
     expect(isCloudReachableRelayUrl('ws://255.255.255.255:4480/ws')).toBe(false);
     expect(isCloudReachableRelayUrl('wss://93.184.216.34/ws')).toBe(true);

--- a/src/core/__tests__/trusted-relays.test.ts
+++ b/src/core/__tests__/trusted-relays.test.ts
@@ -38,9 +38,13 @@ describe('isCloudReachableRelayUrl', () => {
 
   test('rejects IPv6 special-use ranges and mapped loopback', () => {
     expect(isCloudReachableRelayUrl('ws://[::]:4480/ws')).toBe(false);
+    expect(isCloudReachableRelayUrl('ws://[fc00::1]:4480/ws')).toBe(false);
+    expect(isCloudReachableRelayUrl('ws://[fd12::1]:4480/ws')).toBe(false);
+    expect(isCloudReachableRelayUrl('ws://[fe80::1]:4480/ws')).toBe(false);
     expect(isCloudReachableRelayUrl('ws://[ff02::1]:4480/ws')).toBe(false);
     expect(isCloudReachableRelayUrl('ws://[::ffff:127.0.0.1]:4480/ws')).toBe(false);
     expect(isCloudReachableRelayUrl('wss://[::ffff:93.184.216.34]/ws')).toBe(true);
+    expect(isCloudReachableRelayUrl('wss://[2606:4700:4700::1111]/ws')).toBe(true);
   });
 
   test('normalizes relay URLs with and without /ws consistently', () => {

--- a/src/core/__tests__/trusted-relays.test.ts
+++ b/src/core/__tests__/trusted-relays.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, test } from 'bun:test';
+import { isCloudReachableRelayUrl } from '../trusted-relays.js';
+
+describe('isCloudReachableRelayUrl', () => {
+  test('rejects IPv4 special-use ranges', () => {
+    expect(isCloudReachableRelayUrl('ws://0.0.0.0:4480/ws')).toBe(false);
+    expect(isCloudReachableRelayUrl('ws://100.64.0.1:4480/ws')).toBe(false);
+    expect(isCloudReachableRelayUrl('ws://224.0.0.1:4480/ws')).toBe(false);
+    expect(isCloudReachableRelayUrl('ws://255.255.255.255:4480/ws')).toBe(false);
+    expect(isCloudReachableRelayUrl('wss://93.184.216.34/ws')).toBe(true);
+  });
+
+  test('rejects IPv6 special-use ranges and mapped loopback', () => {
+    expect(isCloudReachableRelayUrl('ws://[::]:4480/ws')).toBe(false);
+    expect(isCloudReachableRelayUrl('ws://[ff02::1]:4480/ws')).toBe(false);
+    expect(isCloudReachableRelayUrl('ws://[::ffff:127.0.0.1]:4480/ws')).toBe(false);
+    expect(isCloudReachableRelayUrl('wss://[::ffff:93.184.216.34]/ws')).toBe(true);
+  });
+});

--- a/src/core/__tests__/trusted-relays.test.ts
+++ b/src/core/__tests__/trusted-relays.test.ts
@@ -54,10 +54,23 @@ describe('isCloudReachableRelayUrl', () => {
     expect(getTrustedRelay('wss://relay.example.test/ws/')).not.toBeNull();
   });
 
+  test('matches legacy bare trusted relay entries against /ws lookups', () => {
+    addTrustedRelay('wss://relay.example.test', 'pubkey-bare', 'relay');
+
+    expect(getTrustedRelay('wss://relay.example.test/ws')?.publicKey).toBe('pubkey-bare');
+  });
+
   test('preserves path case while normalizing host and protocol', () => {
     addTrustedRelay('ws://Relay.EXAMPLE.test/RelayA', 'pubkey-case', 'relay');
 
     expect(getTrustedRelay('wss://relay.example.test/RelayA')).not.toBeNull();
     expect(getTrustedRelay('wss://relay.example.test/relaya')).toBeNull();
+  });
+
+  test('preserves non-root trailing slash semantics', () => {
+    addTrustedRelay('wss://relay.example.test/relay/', 'pubkey-slash', 'relay');
+
+    expect(getTrustedRelay('wss://relay.example.test/relay/')?.publicKey).toBe('pubkey-slash');
+    expect(getTrustedRelay('wss://relay.example.test/relay')).toBeNull();
   });
 });

--- a/src/core/__tests__/trusted-relays.test.ts
+++ b/src/core/__tests__/trusted-relays.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import { addTrustedRelay, getTrustedRelay, isCloudReachableRelayUrl } from '../trusted-relays.js';
+import { addTrustedRelay, getTrustedRelay, isCloudReachableRelayUrl, isRelayTrusted, removeTrustedRelay } from '../trusted-relays.js';
 import { afterEach, beforeEach } from 'bun:test';
 import { existsSync, mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
@@ -73,5 +73,19 @@ describe('isCloudReachableRelayUrl', () => {
 
     expect(getTrustedRelay('wss://relay.example.test/relay/')?.publicKey).toBe('pubkey-slash');
     expect(getTrustedRelay('wss://relay.example.test/relay')).toBeNull();
+  });
+
+  test('removeTrustedRelay matches legacy bare and /ws variants consistently', () => {
+    addTrustedRelay('wss://relay.example.test', 'pubkey-remove', 'relay');
+
+    expect(removeTrustedRelay('wss://relay.example.test/ws')?.publicKey).toBe('pubkey-remove');
+    expect(getTrustedRelay('wss://relay.example.test')).toBeNull();
+  });
+
+  test('localhost relay entries still detect key mismatches', () => {
+    addTrustedRelay('ws://127.0.0.1:4480/ws', 'pubkey-localhost-a', 'relay');
+
+    expect(isRelayTrusted('ws://127.0.0.1:4480/ws', 'pubkey-localhost-a')).toBe('trusted');
+    expect(isRelayTrusted('ws://127.0.0.1:4480/ws', 'pubkey-localhost-b')).toBe('mismatch');
   });
 });

--- a/src/core/__tests__/trusted-relays.test.ts
+++ b/src/core/__tests__/trusted-relays.test.ts
@@ -49,4 +49,11 @@ describe('isCloudReachableRelayUrl', () => {
     expect(getTrustedRelay('ws://relay.example.test')).not.toBeNull();
     expect(getTrustedRelay('wss://relay.example.test/ws/')).not.toBeNull();
   });
+
+  test('preserves path case while normalizing host and protocol', () => {
+    addTrustedRelay('ws://Relay.EXAMPLE.test/RelayA', 'pubkey-case', 'relay');
+
+    expect(getTrustedRelay('wss://relay.example.test/RelayA')).not.toBeNull();
+    expect(getTrustedRelay('wss://relay.example.test/relaya')).toBeNull();
+  });
 });

--- a/src/core/__tests__/trusted-relays.test.ts
+++ b/src/core/__tests__/trusted-relays.test.ts
@@ -1,5 +1,30 @@
 import { describe, expect, test } from 'bun:test';
-import { isCloudReachableRelayUrl } from '../trusted-relays.js';
+import { addTrustedRelay, getTrustedRelay, isCloudReachableRelayUrl } from '../trusted-relays.js';
+import { afterEach, beforeEach } from 'bun:test';
+import { existsSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+let originalHome: string | undefined;
+let testDir: string;
+
+beforeEach(() => {
+  originalHome = process.env.HOME;
+  testDir = mkdtempSync(join(tmpdir(), 'gssh-trusted-relays-'));
+  process.env.HOME = testDir;
+});
+
+afterEach(() => {
+  if (originalHome === undefined) {
+    delete process.env.HOME;
+  } else {
+    process.env.HOME = originalHome;
+  }
+
+  if (testDir && existsSync(testDir)) {
+    rmSync(testDir, { recursive: true, force: true });
+  }
+});
 
 describe('isCloudReachableRelayUrl', () => {
   test('rejects IPv4 special-use ranges', () => {
@@ -8,6 +33,7 @@ describe('isCloudReachableRelayUrl', () => {
     expect(isCloudReachableRelayUrl('ws://224.0.0.1:4480/ws')).toBe(false);
     expect(isCloudReachableRelayUrl('ws://255.255.255.255:4480/ws')).toBe(false);
     expect(isCloudReachableRelayUrl('wss://93.184.216.34/ws')).toBe(true);
+    expect(isCloudReachableRelayUrl('wss://192.0.3.1/ws')).toBe(true);
   });
 
   test('rejects IPv6 special-use ranges and mapped loopback', () => {
@@ -15,5 +41,12 @@ describe('isCloudReachableRelayUrl', () => {
     expect(isCloudReachableRelayUrl('ws://[ff02::1]:4480/ws')).toBe(false);
     expect(isCloudReachableRelayUrl('ws://[::ffff:127.0.0.1]:4480/ws')).toBe(false);
     expect(isCloudReachableRelayUrl('wss://[::ffff:93.184.216.34]/ws')).toBe(true);
+  });
+
+  test('normalizes relay URLs with and without /ws consistently', () => {
+    addTrustedRelay('ws://relay.example.test/ws', 'pubkey-1', 'relay');
+
+    expect(getTrustedRelay('ws://relay.example.test')).not.toBeNull();
+    expect(getTrustedRelay('wss://relay.example.test/ws/')).not.toBeNull();
   });
 });

--- a/src/core/__tests__/trusted-relays.test.ts
+++ b/src/core/__tests__/trusted-relays.test.ts
@@ -82,6 +82,13 @@ describe('isCloudReachableRelayUrl', () => {
     expect(getTrustedRelay('wss://relay.example.test')).toBeNull();
   });
 
+  test('removeTrustedRelay matches relay URL variants regardless of host case', () => {
+    addTrustedRelay('wss://Relay.Example.test', 'pubkey-remove-case', 'relay');
+
+    expect(removeTrustedRelay('WSS://relay.example.test/ws')?.publicKey).toBe('pubkey-remove-case');
+    expect(getTrustedRelay('wss://relay.example.test')).toBeNull();
+  });
+
   test('localhost relay entries still detect key mismatches', () => {
     addTrustedRelay('ws://127.0.0.1:4480/ws', 'pubkey-localhost-a', 'relay');
 

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -27,7 +27,8 @@ import { notifyOwnerSyncCategoryDirty } from './owner-sync-events.js'
  * Get the global gitspace directory path
  */
 export function getGitspaceDir(): string {
-	return join(homedir(), 'gitspace')
+	const home = process.env.HOME?.trim() || homedir()
+	return join(home, 'gitspace')
 }
 
 /**

--- a/src/core/identity-backup.ts
+++ b/src/core/identity-backup.ts
@@ -24,6 +24,7 @@ const BACKUP_ENDPOINT = `${API_BASE}/identity/backup`;
 const BACKUP_STATUS_ENDPOINT = `${API_BASE}/identity/backup/status`;
 
 const PBKDF2_ITERATIONS = 210_000;
+const PBKDF2_MIN_ACCEPTED_ITERATIONS = 100_000;
 const PBKDF2_MAX_ITERATIONS = 1_000_000;
 const PBKDF2_KEY_LENGTH = 32;
 const PBKDF2_DIGEST = 'sha256';
@@ -232,7 +233,7 @@ export async function decryptMnemonicEnvelope(
 
   if (
     !Number.isSafeInteger(envelope.iterations)
-    || envelope.iterations < PBKDF2_ITERATIONS
+    || envelope.iterations < PBKDF2_MIN_ACCEPTED_ITERATIONS
     || envelope.iterations > PBKDF2_MAX_ITERATIONS
   ) {
     throw new SpacesError('Cloud backup payload uses unsupported key derivation parameters.', 'USER_ERROR', 1);

--- a/src/core/identity-backup.ts
+++ b/src/core/identity-backup.ts
@@ -399,6 +399,8 @@ export async function recoverUserRootFromCloudBackup(
   }
 
   const exists = await userRootIdentityExists();
+  // Default recovery behavior overwrites an existing local identity unless the
+  // caller explicitly passes force: false.
   const force = options.force ?? exists;
   return initFromMnemonic(mnemonic, force);
 }

--- a/src/core/identity-backup.ts
+++ b/src/core/identity-backup.ts
@@ -1,0 +1,404 @@
+/**
+ * Optional, account-backed encrypted user-root identity backup.
+ *
+ * The API stores only ciphertext. Encryption/decryption happens locally.
+ */
+
+import { createCipheriv, createDecipheriv, pbkdf2 as pbkdf2Callback, randomBytes } from 'node:crypto';
+import { promisify } from 'node:util';
+import { getSecret } from '../utils/secrets.js';
+import { getPublicKeyWithoutPassword } from './identity.js';
+import {
+  initFromMnemonic,
+  loadUserRootIdentity,
+  loadUserRootMnemonic,
+  userRootIdentityExists,
+} from './user-identity.js';
+import { mnemonicToUserIdentity, validateMnemonic } from '../lib/tmux-lite/crypto/user-identity.js';
+import type { UserRootIdentity } from '../types/identity.js';
+import { SpacesError } from '../types/errors.js';
+
+const API_BASE = process.env.GITSPACE_API_URL || 'https://api.gitspace.sh';
+const BACKUP_ENDPOINT = `${API_BASE}/identity/backup`;
+const BACKUP_STATUS_ENDPOINT = `${API_BASE}/identity/backup/status`;
+
+const PBKDF2_ITERATIONS = 210_000;
+const PBKDF2_KEY_LENGTH = 32;
+const PBKDF2_DIGEST = 'sha256';
+const AES_ALGORITHM = 'aes-256-gcm';
+const AES_IV_BYTES = 12;
+const AES_AUTH_TAG_BYTES = 16;
+
+const pbkdf2 = promisify(pbkdf2Callback);
+
+export interface EncryptedMnemonicEnvelope {
+  version: 1;
+  algorithm: 'PBKDF2-AES-GCM';
+  iterations: number;
+  salt: string;
+  iv: string;
+  ciphertext: string;
+  createdAt: number;
+  updatedAt: number;
+}
+
+export interface CloudIdentityBackupRecord {
+  version: 1;
+  kind: 'user-root-mnemonic';
+  ownerUserRootId: string;
+  envelope: EncryptedMnemonicEnvelope;
+  createdAt: number;
+  updatedAt: number;
+}
+
+export interface CloudIdentityBackupStatus {
+  enabled: boolean;
+  ownerUserRootId?: string;
+  createdAt?: number;
+  updatedAt?: number;
+}
+
+function normalizeMnemonicInput(mnemonic: string): string {
+  return mnemonic
+    .normalize('NFKD')
+    .trim()
+    .toLowerCase()
+    .replace(/\s+/g, ' ');
+}
+
+function encodeBase64(input: Uint8Array): string {
+  return Buffer.from(input).toString('base64');
+}
+
+function decodeBase64(input: string): Buffer {
+  return Buffer.from(input, 'base64');
+}
+
+async function deriveKey(passphrase: string, salt: Uint8Array, iterations: number): Promise<Buffer> {
+  return pbkdf2(passphrase, salt, iterations, PBKDF2_KEY_LENGTH, PBKDF2_DIGEST);
+}
+
+function normalizeRecord(value: unknown): CloudIdentityBackupRecord | null {
+  if (!value || typeof value !== 'object') {
+    return null;
+  }
+
+  const raw = value as Partial<CloudIdentityBackupRecord>;
+  const envelope = raw.envelope as Partial<EncryptedMnemonicEnvelope> | undefined;
+  if (
+    raw.version !== 1 ||
+    raw.kind !== 'user-root-mnemonic' ||
+    typeof raw.ownerUserRootId !== 'string' ||
+    !envelope ||
+    envelope.version !== 1 ||
+    envelope.algorithm !== 'PBKDF2-AES-GCM' ||
+    typeof envelope.iterations !== 'number' ||
+    typeof envelope.salt !== 'string' ||
+    typeof envelope.iv !== 'string' ||
+    typeof envelope.ciphertext !== 'string' ||
+    typeof envelope.createdAt !== 'number' ||
+    typeof envelope.updatedAt !== 'number' ||
+    typeof raw.createdAt !== 'number' ||
+    typeof raw.updatedAt !== 'number'
+  ) {
+    return null;
+  }
+
+  return {
+    version: 1,
+    kind: 'user-root-mnemonic',
+    ownerUserRootId: raw.ownerUserRootId,
+    envelope: {
+      version: 1,
+      algorithm: 'PBKDF2-AES-GCM',
+      iterations: envelope.iterations,
+      salt: envelope.salt,
+      iv: envelope.iv,
+      ciphertext: envelope.ciphertext,
+      createdAt: envelope.createdAt,
+      updatedAt: envelope.updatedAt,
+    },
+    createdAt: raw.createdAt,
+    updatedAt: raw.updatedAt,
+  };
+}
+
+function normalizeStatus(value: unknown): CloudIdentityBackupStatus | null {
+  if (!value || typeof value !== 'object') {
+    return null;
+  }
+
+  const raw = value as Partial<CloudIdentityBackupStatus>;
+  if (typeof raw.enabled !== 'boolean') {
+    return null;
+  }
+
+  return {
+    enabled: raw.enabled,
+    ownerUserRootId: typeof raw.ownerUserRootId === 'string' ? raw.ownerUserRootId : undefined,
+    createdAt: typeof raw.createdAt === 'number' ? raw.createdAt : undefined,
+    updatedAt: typeof raw.updatedAt === 'number' ? raw.updatedAt : undefined,
+  };
+}
+
+async function getAuthHeaders(extra: Record<string, string> = {}): Promise<Record<string, string>> {
+  const token = await getSecret('GITSPACE_TOKEN');
+  if (!token) {
+    throw new SpacesError('Not logged in. Run `gssh user auth login` first.', 'USER_ERROR', 1);
+  }
+
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${token}`,
+    'Content-Type': 'application/json',
+    ...extra,
+  };
+
+  const identity = getPublicKeyWithoutPassword();
+  if (identity?.signingPublicKey) {
+    headers['X-Device-Fingerprint'] = identity.signingPublicKey;
+  }
+
+  return headers;
+}
+
+function parseApiError(status: number, statusText: string, body: string): string {
+  if (!body) {
+    return `${status} ${statusText}`;
+  }
+
+  try {
+    const parsed = JSON.parse(body) as { error?: string; message?: string };
+    return parsed.error || parsed.message || `${status} ${statusText}`;
+  } catch {
+    return body;
+  }
+}
+
+export async function encryptMnemonicEnvelope(
+  mnemonic: string,
+  passphrase: string,
+  now: number = Date.now(),
+): Promise<EncryptedMnemonicEnvelope> {
+  const normalizedMnemonic = normalizeMnemonicInput(mnemonic);
+  if (!validateMnemonic(normalizedMnemonic)) {
+    throw new SpacesError('Invalid 24-word recovery phrase.', 'USER_ERROR', 1);
+  }
+  if (!passphrase.trim()) {
+    throw new SpacesError('Backup password is required.', 'USER_ERROR', 1);
+  }
+
+  const salt = randomBytes(16);
+  const iv = randomBytes(AES_IV_BYTES);
+  const key = await deriveKey(passphrase, salt, PBKDF2_ITERATIONS);
+
+  const cipher = createCipheriv(AES_ALGORITHM, key, iv);
+  const ciphertext = Buffer.concat([
+    cipher.update(Buffer.from(normalizedMnemonic, 'utf-8')),
+    cipher.final(),
+  ]);
+  const authTag = cipher.getAuthTag();
+
+  return {
+    version: 1,
+    algorithm: 'PBKDF2-AES-GCM',
+    iterations: PBKDF2_ITERATIONS,
+    salt: encodeBase64(salt),
+    iv: encodeBase64(iv),
+    ciphertext: encodeBase64(Buffer.concat([ciphertext, authTag])),
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+export async function decryptMnemonicEnvelope(
+  envelope: EncryptedMnemonicEnvelope,
+  passphrase: string,
+): Promise<string> {
+  if (!passphrase.trim()) {
+    throw new SpacesError('Backup password is required.', 'USER_ERROR', 1);
+  }
+
+  const salt = decodeBase64(envelope.salt);
+  const iv = decodeBase64(envelope.iv);
+  const packedCiphertext = decodeBase64(envelope.ciphertext);
+  if (packedCiphertext.byteLength <= AES_AUTH_TAG_BYTES) {
+    throw new SpacesError('Cloud backup payload is corrupted.', 'USER_ERROR', 1);
+  }
+
+  const ciphertext = packedCiphertext.subarray(0, packedCiphertext.byteLength - AES_AUTH_TAG_BYTES);
+  const authTag = packedCiphertext.subarray(packedCiphertext.byteLength - AES_AUTH_TAG_BYTES);
+  const key = await deriveKey(passphrase, salt, envelope.iterations);
+
+  let plaintext: Buffer;
+  try {
+    const decipher = createDecipheriv(AES_ALGORITHM, key, iv);
+    decipher.setAuthTag(authTag);
+    plaintext = Buffer.concat([decipher.update(ciphertext), decipher.final()]);
+  } catch {
+    throw new SpacesError('Invalid backup password.', 'USER_ERROR', 1);
+  }
+
+  const mnemonic = normalizeMnemonicInput(plaintext.toString('utf-8'));
+  if (!validateMnemonic(mnemonic)) {
+    throw new SpacesError('Decrypted backup mnemonic is invalid.', 'USER_ERROR', 1);
+  }
+
+  return mnemonic;
+}
+
+export async function getCloudIdentityBackup(): Promise<CloudIdentityBackupRecord | null> {
+  const headers = await getAuthHeaders();
+  const response = await fetch(BACKUP_ENDPOINT, { method: 'GET', headers });
+
+  if (response.status === 404) {
+    return null;
+  }
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new SpacesError(
+      `Failed to fetch identity backup: ${parseApiError(response.status, response.statusText, body)}`,
+      'SYSTEM_ERROR',
+      2,
+    );
+  }
+
+  const payload = await response.json().catch(() => null);
+  const record = normalizeRecord(payload)
+    ?? normalizeRecord((payload as { backup?: unknown } | null)?.backup ?? null)
+    ?? normalizeRecord((payload as { data?: unknown } | null)?.data ?? null);
+
+  if (!record) {
+    throw new SpacesError('Identity backup response is malformed.', 'SYSTEM_ERROR', 2);
+  }
+
+  return record;
+}
+
+export async function putCloudIdentityBackup(record: CloudIdentityBackupRecord): Promise<void> {
+  const headers = await getAuthHeaders();
+  const response = await fetch(BACKUP_ENDPOINT, {
+    method: 'PUT',
+    headers,
+    body: JSON.stringify(record),
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new SpacesError(
+      `Failed to save identity backup: ${parseApiError(response.status, response.statusText, body)}`,
+      'SYSTEM_ERROR',
+      2,
+    );
+  }
+}
+
+export async function deleteCloudIdentityBackup(): Promise<boolean> {
+  const headers = await getAuthHeaders();
+  const response = await fetch(BACKUP_ENDPOINT, { method: 'DELETE', headers });
+
+  if (response.status === 404) {
+    return false;
+  }
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new SpacesError(
+      `Failed to delete identity backup: ${parseApiError(response.status, response.statusText, body)}`,
+      'SYSTEM_ERROR',
+      2,
+    );
+  }
+
+  return true;
+}
+
+export async function getCloudIdentityBackupStatus(): Promise<CloudIdentityBackupStatus> {
+  const headers = await getAuthHeaders();
+  const response = await fetch(BACKUP_STATUS_ENDPOINT, { method: 'GET', headers });
+
+  if (response.status === 404) {
+    const backup = await getCloudIdentityBackup();
+    if (!backup) {
+      return { enabled: false };
+    }
+    return {
+      enabled: true,
+      ownerUserRootId: backup.ownerUserRootId,
+      createdAt: backup.createdAt,
+      updatedAt: backup.updatedAt,
+    };
+  }
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new SpacesError(
+      `Failed to fetch backup status: ${parseApiError(response.status, response.statusText, body)}`,
+      'SYSTEM_ERROR',
+      2,
+    );
+  }
+
+  const payload = await response.json().catch(() => null);
+  const status = normalizeStatus(payload)
+    ?? normalizeStatus((payload as { status?: unknown } | null)?.status ?? null)
+    ?? normalizeStatus((payload as { data?: unknown } | null)?.data ?? null);
+  if (!status) {
+    throw new SpacesError('Identity backup status response is malformed.', 'SYSTEM_ERROR', 2);
+  }
+  return status;
+}
+
+export async function backupCurrentUserRootToCloud(passphrase: string): Promise<CloudIdentityBackupRecord> {
+  const userRoot = await loadUserRootIdentity();
+  if (!userRoot) {
+    throw new SpacesError(
+      'No user root identity found. Run `gssh user identity init` first.',
+      'USER_ERROR',
+      1,
+    );
+  }
+
+  const mnemonic = await loadUserRootMnemonic();
+  if (!mnemonic) {
+    throw new SpacesError('Stored user root mnemonic could not be loaded.', 'SYSTEM_ERROR', 2);
+  }
+
+  const now = Date.now();
+  const envelope = await encryptMnemonicEnvelope(mnemonic, passphrase, now);
+  const record: CloudIdentityBackupRecord = {
+    version: 1,
+    kind: 'user-root-mnemonic',
+    ownerUserRootId: userRoot.id,
+    envelope,
+    createdAt: now,
+    updatedAt: now,
+  };
+
+  await putCloudIdentityBackup(record);
+  return record;
+}
+
+export async function recoverUserRootFromCloudBackup(
+  passphrase: string,
+  options: { force?: boolean } = {},
+): Promise<UserRootIdentity> {
+  const backup = await getCloudIdentityBackup();
+  if (!backup) {
+    throw new SpacesError('No cloud identity backup found for this account.', 'USER_ERROR', 1);
+  }
+
+  const mnemonic = await decryptMnemonicEnvelope(backup.envelope, passphrase);
+  const derived = mnemonicToUserIdentity(mnemonic);
+  if (backup.ownerUserRootId && backup.ownerUserRootId !== derived.id) {
+    throw new SpacesError(
+      'Cloud backup ownership mismatch. The decrypted mnemonic does not match backup metadata.',
+      'SYSTEM_ERROR',
+      2,
+    );
+  }
+
+  const exists = await userRootIdentityExists();
+  const force = options.force ?? exists;
+  return initFromMnemonic(mnemonic, force);
+}

--- a/src/core/identity-backup.ts
+++ b/src/core/identity-backup.ts
@@ -17,12 +17,14 @@ import {
 import { mnemonicToUserIdentity, validateMnemonic } from '../lib/tmux-lite/crypto/user-identity.js';
 import type { UserRootIdentity } from '../types/identity.js';
 import { SpacesError } from '../types/errors.js';
+import { logger } from '../utils/logger.js';
 
 const API_BASE = process.env.GITSPACE_API_URL || 'https://api.gitspace.sh';
 const BACKUP_ENDPOINT = `${API_BASE}/identity/backup`;
 const BACKUP_STATUS_ENDPOINT = `${API_BASE}/identity/backup/status`;
 
 const PBKDF2_ITERATIONS = 210_000;
+const PBKDF2_MAX_ITERATIONS = 1_000_000;
 const PBKDF2_KEY_LENGTH = 32;
 const PBKDF2_DIGEST = 'sha256';
 const AES_ALGORITHM = 'aes-256-gcm';
@@ -174,6 +176,16 @@ function parseApiError(status: number, statusText: string, body: string): string
   }
 }
 
+async function fetchBackupApi(url: string, init: RequestInit, context: string): Promise<Response> {
+  try {
+    return await fetch(url, init);
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    logger.error(`${context}: ${detail}`);
+    throw new SpacesError(`${context}: ${detail}`, 'SERVICE_ERROR', 3);
+  }
+}
+
 export async function encryptMnemonicEnvelope(
   mnemonic: string,
   passphrase: string,
@@ -218,7 +230,11 @@ export async function decryptMnemonicEnvelope(
     throw new SpacesError('Backup password is required.', 'USER_ERROR', 1);
   }
 
-  if (!Number.isSafeInteger(envelope.iterations) || envelope.iterations < PBKDF2_ITERATIONS) {
+  if (
+    !Number.isSafeInteger(envelope.iterations)
+    || envelope.iterations < PBKDF2_ITERATIONS
+    || envelope.iterations > PBKDF2_MAX_ITERATIONS
+  ) {
     throw new SpacesError('Cloud backup payload uses unsupported key derivation parameters.', 'USER_ERROR', 1);
   }
 
@@ -252,7 +268,7 @@ export async function decryptMnemonicEnvelope(
 
 export async function getCloudIdentityBackup(): Promise<CloudIdentityBackupRecord | null> {
   const headers = await getAuthHeaders();
-  const response = await fetch(BACKUP_ENDPOINT, { method: 'GET', headers });
+  const response = await fetchBackupApi(BACKUP_ENDPOINT, { method: 'GET', headers }, 'Failed to fetch identity backup');
 
   if (response.status === 404) {
     return null;
@@ -281,11 +297,11 @@ export async function getCloudIdentityBackup(): Promise<CloudIdentityBackupRecor
 
 export async function putCloudIdentityBackup(record: CloudIdentityBackupRecord): Promise<void> {
   const headers = await getAuthHeaders();
-  const response = await fetch(BACKUP_ENDPOINT, {
+  const response = await fetchBackupApi(BACKUP_ENDPOINT, {
     method: 'PUT',
     headers,
     body: JSON.stringify(record),
-  });
+  }, 'Failed to save identity backup');
 
   if (!response.ok) {
     const body = await response.text();
@@ -299,7 +315,7 @@ export async function putCloudIdentityBackup(record: CloudIdentityBackupRecord):
 
 export async function deleteCloudIdentityBackup(): Promise<boolean> {
   const headers = await getAuthHeaders();
-  const response = await fetch(BACKUP_ENDPOINT, { method: 'DELETE', headers });
+  const response = await fetchBackupApi(BACKUP_ENDPOINT, { method: 'DELETE', headers }, 'Failed to delete identity backup');
 
   if (response.status === 404) {
     return false;
@@ -319,7 +335,7 @@ export async function deleteCloudIdentityBackup(): Promise<boolean> {
 
 export async function getCloudIdentityBackupStatus(): Promise<CloudIdentityBackupStatus> {
   const headers = await getAuthHeaders();
-  const response = await fetch(BACKUP_STATUS_ENDPOINT, { method: 'GET', headers });
+  const response = await fetchBackupApi(BACKUP_STATUS_ENDPOINT, { method: 'GET', headers }, 'Failed to fetch backup status');
 
   if (response.status === 404) {
     const backup = await getCloudIdentityBackup();

--- a/src/core/identity-backup.ts
+++ b/src/core/identity-backup.ts
@@ -218,6 +218,10 @@ export async function decryptMnemonicEnvelope(
     throw new SpacesError('Backup password is required.', 'USER_ERROR', 1);
   }
 
+  if (!Number.isSafeInteger(envelope.iterations) || envelope.iterations < PBKDF2_ITERATIONS) {
+    throw new SpacesError('Cloud backup payload uses unsupported key derivation parameters.', 'USER_ERROR', 1);
+  }
+
   const salt = decodeBase64(envelope.salt);
   const iv = decodeBase64(envelope.iv);
   const packedCiphertext = decodeBase64(envelope.ciphertext);

--- a/src/core/identity.ts
+++ b/src/core/identity.ts
@@ -374,6 +374,8 @@ export function writeMachineIdentity(identity: MachineIdentity): void {
 export interface RelayConfig {
 	/** Relay WebSocket URL */
 	relayUrl: string;
+	/** Cloud-reachable/public relay URL for bootstrap/connect flows */
+	cloudRelayUrl?: string;
 	/** Machine ID registered with relay */
 	machineId: string;
 	/** When this config was saved */

--- a/src/core/trusted-relays.ts
+++ b/src/core/trusted-relays.ts
@@ -133,7 +133,8 @@ function isPrivateIpv6Host(host: string): boolean {
   }
 
   if (host.startsWith("::ffff:")) {
-    return true;
+    const mappedIpv4 = host.slice("::ffff:".length);
+    return isPrivateIpv4Host(mappedIpv4);
   }
 
   return host.startsWith("fc") || host.startsWith("fd") || host.startsWith("fe80:");

--- a/src/core/trusted-relays.ts
+++ b/src/core/trusted-relays.ts
@@ -81,10 +81,12 @@ export function computeRelayFingerprint(publicKey: string): string {
  * Removes trailing slashes and normalizes protocol
  */
 function normalizeUrl(url: string): string {
-  const normalized = url.toLowerCase().trim();
+  const normalized = url.trim();
 
   try {
     const parsed = new URL(normalized);
+    parsed.protocol = parsed.protocol.toLowerCase();
+    parsed.hostname = parsed.hostname.toLowerCase();
     const local = isLocalhostUrl(parsed.toString());
     if (parsed.protocol === 'ws:' && !local) {
       parsed.protocol = 'wss:';
@@ -179,11 +181,17 @@ function isPrivateIpv6Host(host: string): boolean {
     return isPrivateIpv4Host(mappedIpv4);
   }
 
-  return host.startsWith("fc")
-    || host.startsWith("fd")
-    || host.startsWith("fe80:")
-    || host.startsWith("ff")
-    || host.startsWith("2001:db8:");
+  const hextets = host.split(':');
+  const firstHextet = Number.parseInt(hextets[0] || '0', 16);
+  const secondHextet = Number.parseInt(hextets[1] || '0', 16);
+  if (Number.isNaN(firstHextet) || Number.isNaN(secondHextet)) {
+    return false;
+  }
+
+  return (firstHextet & 0xfe00) === 0xfc00
+    || (firstHextet & 0xffc0) === 0xfe80
+    || (firstHextet & 0xff00) === 0xff00
+    || (firstHextet === 0x2001 && secondHextet === 0x0db8);
 }
 
 export function isCloudReachableRelayUrl(url: string): boolean {

--- a/src/core/trusted-relays.ts
+++ b/src/core/trusted-relays.ts
@@ -94,7 +94,7 @@ function normalizeUrl(url: string): string {
 
     if (parsed.pathname === '/' || parsed.pathname === '') {
       parsed.pathname = '';
-    } else if (/^\/ws\/+$/i.test(parsed.pathname)) {
+    } else if (/^\/ws\/?$/i.test(parsed.pathname)) {
       parsed.pathname = '/ws';
     }
     parsed.search = '';
@@ -388,15 +388,15 @@ export function removeTrustedRelay(
 ): TrustedRelay | null {
   const relays = getTrustedRelays();
   const searchLower = urlOrFingerprint.toLowerCase();
+  const candidateUrls = new Set(getNormalizedUrlVariants(urlOrFingerprint));
 
   const index = relays.findIndex((r) => {
-    const urlLower = normalizeUrl(r.url);
+    const relayUrlVariants = getNormalizedUrlVariants(r.url).map((candidate) => candidate.toLowerCase());
     const fingerprintLower = r.fingerprint.toLowerCase();
     const labelLower = r.label?.toLowerCase();
 
     return (
-      urlLower === searchLower ||
-      urlLower.includes(searchLower) ||
+      relayUrlVariants.some((candidate) => candidate === searchLower || candidate.includes(searchLower) || candidateUrls.has(candidate)) ||
       fingerprintLower === searchLower ||
       fingerprintLower.startsWith(searchLower) ||
       labelLower === searchLower
@@ -463,12 +463,11 @@ export function isRelayTrusted(
   url: string,
   publicKey: string
 ): RelayTrustStatus {
-  // Localhost is always auto-trusted
-  if (isLocalhostUrl(url)) {
-    return "trusted";
-  }
-
   const trustedRelay = getTrustedRelay(url);
+
+  if (!trustedRelay && isLocalhostUrl(url)) {
+    return "unknown";
+  }
 
   if (!trustedRelay) {
     return "unknown";

--- a/src/core/trusted-relays.ts
+++ b/src/core/trusted-relays.ts
@@ -103,8 +103,12 @@ function normalizeUrl(url: string): string {
 function isLocalhostUrl(url: string): boolean {
   try {
     const parsed = new URL(url);
-    const host = parsed.hostname.toLowerCase();
-    return host === "localhost" || host === "127.0.0.1" || host === "::1";
+    const host = normalizeHost(parsed.hostname);
+    const mappedIpv4 = extractMappedIpv4Host(host);
+    return host === "localhost"
+      || host === "127.0.0.1"
+      || host === "::1"
+      || mappedIpv4 === '127.0.0.1';
   } catch {
     return false;
   }
@@ -114,30 +118,64 @@ function normalizeHost(host: string): string {
   return host.toLowerCase().replace(/^\[/, "").replace(/\]$/, "").split("%", 1)[0] ?? host.toLowerCase();
 }
 
+function extractMappedIpv4Host(host: string): string | null {
+  if (!host.startsWith('::ffff:')) {
+    return null;
+  }
+
+  const mapped = host.slice('::ffff:'.length);
+  if (mapped.includes('.')) {
+    return mapped;
+  }
+
+  const parts = mapped.split(':');
+  if (parts.length !== 2) {
+    return null;
+  }
+
+  const upper = Number.parseInt(parts[0], 16);
+  const lower = Number.parseInt(parts[1], 16);
+  if (Number.isNaN(upper) || Number.isNaN(lower) || upper < 0 || lower < 0 || upper > 0xffff || lower > 0xffff) {
+    return null;
+  }
+
+  return `${upper >> 8}.${upper & 0xff}.${lower >> 8}.${lower & 0xff}`;
+}
+
 function isPrivateIpv4Host(host: string): boolean {
   const parts = host.split(".").map((part) => Number.parseInt(part, 10));
   if (parts.length !== 4 || parts.some((part) => Number.isNaN(part) || part < 0 || part > 255)) {
     return false;
   }
 
-  return parts[0] === 10
+  return parts[0] === 0
+    || parts[0] === 10
     || parts[0] === 127
+    || (parts[0] === 100 && parts[1] >= 64 && parts[1] <= 127)
     || (parts[0] === 169 && parts[1] === 254)
     || (parts[0] === 172 && parts[1] >= 16 && parts[1] <= 31)
-    || (parts[0] === 192 && parts[1] === 168);
+    || (parts[0] === 192 && parts[1] === 0)
+    || (parts[0] === 192 && parts[1] === 168)
+    || (parts[0] === 198 && (parts[1] === 18 || parts[1] === 19))
+    || (parts[0] === 203 && parts[1] === 0 && parts[2] === 113)
+    || parts[0] >= 224;
 }
 
 function isPrivateIpv6Host(host: string): boolean {
-  if (host === "::1") {
+  if (host === "::" || host === "::1") {
     return true;
   }
 
-  if (host.startsWith("::ffff:")) {
-    const mappedIpv4 = host.slice("::ffff:".length);
+  const mappedIpv4 = extractMappedIpv4Host(host);
+  if (mappedIpv4) {
     return isPrivateIpv4Host(mappedIpv4);
   }
 
-  return host.startsWith("fc") || host.startsWith("fd") || host.startsWith("fe80:");
+  return host.startsWith("fc")
+    || host.startsWith("fd")
+    || host.startsWith("fe80:")
+    || host.startsWith("ff")
+    || host.startsWith("2001:db8:");
 }
 
 export function isCloudReachableRelayUrl(url: string): boolean {
@@ -154,7 +192,7 @@ export function isCloudReachableRelayUrl(url: string): boolean {
       return !isPrivateIpv4Host(host);
     }
 
-    if (ipVersion === 6) {
+    if (ipVersion === 6 || host.includes(':')) {
       return !isPrivateIpv6Host(host);
     }
 

--- a/src/core/trusted-relays.ts
+++ b/src/core/trusted-relays.ts
@@ -8,6 +8,7 @@
  */
 
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { isIP } from "node:net";
 import { join } from "node:path";
 import { sha256 } from "@noble/hashes/sha2.js";
 import { getIdentityDir } from "./identity.js";
@@ -104,6 +105,59 @@ function isLocalhostUrl(url: string): boolean {
     const parsed = new URL(url);
     const host = parsed.hostname.toLowerCase();
     return host === "localhost" || host === "127.0.0.1" || host === "::1";
+  } catch {
+    return false;
+  }
+}
+
+function normalizeHost(host: string): string {
+  return host.toLowerCase().replace(/^\[/, "").replace(/\]$/, "").split("%", 1)[0] ?? host.toLowerCase();
+}
+
+function isPrivateIpv4Host(host: string): boolean {
+  const parts = host.split(".").map((part) => Number.parseInt(part, 10));
+  if (parts.length !== 4 || parts.some((part) => Number.isNaN(part) || part < 0 || part > 255)) {
+    return false;
+  }
+
+  return parts[0] === 10
+    || parts[0] === 127
+    || (parts[0] === 169 && parts[1] === 254)
+    || (parts[0] === 172 && parts[1] >= 16 && parts[1] <= 31)
+    || (parts[0] === 192 && parts[1] === 168);
+}
+
+function isPrivateIpv6Host(host: string): boolean {
+  if (host === "::1") {
+    return true;
+  }
+
+  if (host.startsWith("::ffff:")) {
+    return true;
+  }
+
+  return host.startsWith("fc") || host.startsWith("fd") || host.startsWith("fe80:");
+}
+
+export function isCloudReachableRelayUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    const host = normalizeHost(parsed.hostname);
+
+    if (host === "localhost" || host.endsWith(".local")) {
+      return false;
+    }
+
+    const ipVersion = isIP(host);
+    if (ipVersion === 4) {
+      return !isPrivateIpv4Host(host);
+    }
+
+    if (ipVersion === 6) {
+      return !isPrivateIpv6Host(host);
+    }
+
+    return true;
   } catch {
     return false;
   }

--- a/src/core/trusted-relays.ts
+++ b/src/core/trusted-relays.ts
@@ -92,8 +92,11 @@ function normalizeUrl(url: string): string {
       parsed.protocol = 'wss:';
     }
 
-    const path = parsed.pathname.replace(/\/+$/, '');
-    parsed.pathname = !path || path === '/' ? '/ws' : path;
+    if (parsed.pathname === '/' || parsed.pathname === '') {
+      parsed.pathname = '';
+    } else if (/^\/ws\/+$/i.test(parsed.pathname)) {
+      parsed.pathname = '/ws';
+    }
     parsed.search = '';
     parsed.hash = '';
 
@@ -105,6 +108,26 @@ function normalizeUrl(url: string): string {
     }
     return fallback;
   }
+}
+
+function getNormalizedUrlVariants(url: string): string[] {
+  const normalized = normalizeUrl(url);
+  const variants = new Set([normalized]);
+
+  try {
+    const parsed = new URL(normalized);
+    const base = `${parsed.protocol}//${parsed.host}`;
+
+    if (parsed.pathname === '' || parsed.pathname === '/') {
+      variants.add(`${base}/ws`);
+    } else if (parsed.pathname === '/ws') {
+      variants.add(base);
+    }
+  } catch {
+    // Keep only the fallback normalized form.
+  }
+
+  return [...variants];
 }
 
 /**
@@ -323,9 +346,10 @@ export function addTrustedRelay(
 ): TrustedRelay {
   const relays = getTrustedRelays();
   const normalizedUrl = normalizeUrl(url);
+  const candidateUrls = new Set(getNormalizedUrlVariants(url));
 
   // Check if already exists by URL
-  const existing = relays.find((r) => normalizeUrl(r.url) === normalizedUrl);
+  const existing = relays.find((r) => getNormalizedUrlVariants(r.url).some((candidate) => candidateUrls.has(candidate)));
 
   if (existing) {
     // Update existing entry
@@ -396,9 +420,9 @@ export function removeTrustedRelay(
  */
 export function getTrustedRelay(url: string): TrustedRelay | null {
   const relays = getTrustedRelays();
-  const normalizedUrl = normalizeUrl(url);
+  const candidateUrls = new Set(getNormalizedUrlVariants(url));
 
-  return relays.find((r) => normalizeUrl(r.url) === normalizedUrl) ?? null;
+  return relays.find((r) => getNormalizedUrlVariants(r.url).some((candidate) => candidateUrls.has(candidate))) ?? null;
 }
 
 /**

--- a/src/core/trusted-relays.ts
+++ b/src/core/trusted-relays.ts
@@ -10,8 +10,8 @@
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { isIP } from "node:net";
 import { join } from "node:path";
-import { sha256 } from "@noble/hashes/sha2.js";
 import { getIdentityDir } from "./identity.js";
+import { formatRelayFingerprint } from "../relay/identity.js";
 
 // ============================================================================
 // Types
@@ -64,12 +64,7 @@ function getTrustedRelaysPath(): string {
  *
  * Format: "Kx4f:2nB9:mP3q:vR8s" (16 chars with colons)
  */
-export function computeRelayFingerprint(publicKey: string): string {
-  const keyBytes = Buffer.from(publicKey, "base64");
-  const hash = sha256(keyBytes);
-  const b64url = Buffer.from(hash).toString("base64url").substring(0, 16);
-  return b64url.match(/.{1,4}/g)?.join(":") || b64url;
-}
+export const computeRelayFingerprint = formatRelayFingerprint;
 
 // ============================================================================
 // URL Normalization

--- a/src/core/trusted-relays.ts
+++ b/src/core/trusted-relays.ts
@@ -231,6 +231,7 @@ function isPrivateIpv4Host(host: string): boolean {
     || (parts[0] === 192 && parts[1] === 0 && (parts[2] === 0 || parts[2] === 2))
     || (parts[0] === 192 && parts[1] === 168)
     || (parts[0] === 198 && (parts[1] === 18 || parts[1] === 19))
+    || (parts[0] === 198 && parts[1] === 51 && parts[2] === 100)
     || (parts[0] === 203 && parts[1] === 0 && parts[2] === 113)
     || parts[0] >= 224;
 }

--- a/src/core/trusted-relays.ts
+++ b/src/core/trusted-relays.ts
@@ -388,7 +388,7 @@ export function removeTrustedRelay(
 ): TrustedRelay | null {
   const relays = getTrustedRelays();
   const searchLower = urlOrFingerprint.toLowerCase();
-  const candidateUrls = new Set(getNormalizedUrlVariants(urlOrFingerprint));
+  const candidateUrls = new Set(getNormalizedUrlVariants(urlOrFingerprint).map((candidate) => candidate.toLowerCase()));
 
   const index = relays.findIndex((r) => {
     const relayUrlVariants = getNormalizedUrlVariants(r.url).map((candidate) => candidate.toLowerCase());

--- a/src/core/trusted-relays.ts
+++ b/src/core/trusted-relays.ts
@@ -152,6 +152,47 @@ function extractMappedIpv4Host(host: string): string | null {
   return `${upper >> 8}.${upper & 0xff}.${lower >> 8}.${lower & 0xff}`;
 }
 
+function expandIpv6Hextets(host: string): number[] | null {
+  if (host.includes('.')) {
+    return null;
+  }
+
+  const parts = host.split('::');
+  if (parts.length > 2) {
+    return null;
+  }
+
+  const parseSegment = (segment: string): number[] | null => {
+    if (!segment) {
+      return [];
+    }
+
+    const values = segment.split(':').map((part) => Number.parseInt(part, 16));
+    if (values.some((value) => Number.isNaN(value) || value < 0 || value > 0xffff)) {
+      return null;
+    }
+
+    return values;
+  };
+
+  const left = parseSegment(parts[0] ?? '');
+  const right = parseSegment(parts[1] ?? '');
+  if (!left || !right) {
+    return null;
+  }
+
+  if (parts.length === 1) {
+    return left.length === 8 ? left : null;
+  }
+
+  const missing = 8 - (left.length + right.length);
+  if (missing < 1) {
+    return null;
+  }
+
+  return [...left, ...Array(missing).fill(0), ...right];
+}
+
 function isPrivateIpv4Host(host: string): boolean {
   const parts = host.split(".").map((part) => Number.parseInt(part, 10));
   if (parts.length !== 4 || parts.some((part) => Number.isNaN(part) || part < 0 || part > 255)) {
@@ -181,12 +222,13 @@ function isPrivateIpv6Host(host: string): boolean {
     return isPrivateIpv4Host(mappedIpv4);
   }
 
-  const hextets = host.split(':');
-  const firstHextet = Number.parseInt(hextets[0] || '0', 16);
-  const secondHextet = Number.parseInt(hextets[1] || '0', 16);
-  if (Number.isNaN(firstHextet) || Number.isNaN(secondHextet)) {
+  const hextets = expandIpv6Hextets(host);
+  if (!hextets) {
     return false;
   }
+
+  const firstHextet = hextets[0] ?? 0;
+  const secondHextet = hextets[1] ?? 0;
 
   return (firstHextet & 0xfe00) === 0xfc00
     || (firstHextet & 0xffc0) === 0xfe80

--- a/src/core/trusted-relays.ts
+++ b/src/core/trusted-relays.ts
@@ -81,20 +81,28 @@ export function computeRelayFingerprint(publicKey: string): string {
  * Removes trailing slashes and normalizes protocol
  */
 function normalizeUrl(url: string): string {
-  // Normalize the URL
-  let normalized = url.toLowerCase().trim();
+  const normalized = url.toLowerCase().trim();
 
-  // Remove trailing slashes
-  while (normalized.endsWith("/")) {
-    normalized = normalized.slice(0, -1);
+  try {
+    const parsed = new URL(normalized);
+    const local = isLocalhostUrl(parsed.toString());
+    if (parsed.protocol === 'ws:' && !local) {
+      parsed.protocol = 'wss:';
+    }
+
+    const path = parsed.pathname.replace(/\/+$/, '');
+    parsed.pathname = !path || path === '/' ? '/ws' : path;
+    parsed.search = '';
+    parsed.hash = '';
+
+    return `${parsed.protocol}//${parsed.host}${parsed.pathname}`;
+  } catch {
+    let fallback = normalized;
+    while (fallback.endsWith('/')) {
+      fallback = fallback.slice(0, -1);
+    }
+    return fallback;
   }
-
-  // Normalize ws:// to wss:// for non-localhost
-  if (normalized.startsWith("ws://") && !isLocalhostUrl(normalized)) {
-    normalized = "wss://" + normalized.slice(5);
-  }
-
-  return normalized;
 }
 
 /**
@@ -154,7 +162,7 @@ function isPrivateIpv4Host(host: string): boolean {
     || (parts[0] === 100 && parts[1] >= 64 && parts[1] <= 127)
     || (parts[0] === 169 && parts[1] === 254)
     || (parts[0] === 172 && parts[1] >= 16 && parts[1] <= 31)
-    || (parts[0] === 192 && parts[1] === 0)
+    || (parts[0] === 192 && parts[1] === 0 && (parts[2] === 0 || parts[2] === 2))
     || (parts[0] === 192 && parts[1] === 168)
     || (parts[0] === 198 && (parts[1] === 18 || parts[1] === 19))
     || (parts[0] === 203 && parts[1] === 0 && parts[2] === 113)

--- a/src/core/user-identity.ts
+++ b/src/core/user-identity.ts
@@ -192,6 +192,53 @@ export async function loadUserRootIdentity(): Promise<UserRootIdentity | null> {
 }
 
 /**
+ * Load only the stored mnemonic from keychain.
+ *
+ * Use this sparingly and only for local cryptographic operations
+ * (for example, creating an encrypted cloud backup).
+ */
+export async function loadUserRootMnemonic(): Promise<string | null> {
+  const raw = await getSecret(KEYCHAIN_KEY);
+  if (!raw) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(raw) as { version?: unknown };
+
+    if (parsed.version === 1) {
+      throw new SpacesError(
+        'Legacy identity format detected. Recover your identity with `gssh user identity recover` using your 24-word mnemonic.',
+        'USER_ERROR',
+        1,
+      );
+    }
+
+    if (parsed.version !== 2) {
+      throw new SpacesError(
+        `Unsupported user root identity version: ${String(parsed.version)}`,
+        'SYSTEM_ERROR',
+        2,
+      );
+    }
+
+    const stored = parsed as StoredUserRootIdentity;
+    if (typeof stored.mnemonic !== 'string') {
+      throw new SpacesError('Invalid user root identity payload in keychain', 'SYSTEM_ERROR', 2);
+    }
+
+    return stored.mnemonic;
+  } catch (error) {
+    if (error instanceof SpacesError) throw error;
+    throw new SpacesError(
+      `Failed to parse user root identity from keychain: ${error instanceof Error ? error.message : 'Unknown error'}`,
+      'SYSTEM_ERROR',
+      2,
+    );
+  }
+}
+
+/**
  * Check if a user root identity exists in keychain.
  *
  * @returns true if identity is stored

--- a/src/relay-client/machine-relay-client.ts
+++ b/src/relay-client/machine-relay-client.ts
@@ -158,6 +158,7 @@ function signChallengeAndCreateRegistration(
   bootstrapToken?: string,
   registerPermit?: string,
   enrollmentToken?: string,
+  deviceCertificate?: string,
 ): { challengeResponse: string; message: object } | null {
   try {
     const nonceBytes = new Uint8Array(Buffer.from(challenge, 'base64'));
@@ -177,6 +178,7 @@ function signChallengeAndCreateRegistration(
         bootstrapToken,
         registerPermit,
         enrollmentToken,
+        deviceCertificate,
       },
     };
   } catch (err) {
@@ -220,6 +222,7 @@ export async function connectMachineRelay(
   bootstrapToken?: string,
   registerPermit?: string,
   enrollmentToken?: string,
+  deviceCertificate?: string,
 ): Promise<void> {
   const url = new URL(relayUrl);
   url.searchParams.set('role', 'machine');
@@ -338,6 +341,7 @@ export async function connectMachineRelay(
                 bootstrapToken,
                 registerPermit,
                 enrollmentToken,
+                deviceCertificate,
               );
 
               if (!registration) {

--- a/src/relay/__tests__/e2e-flow.test.ts
+++ b/src/relay/__tests__/e2e-flow.test.ts
@@ -533,8 +533,77 @@ describe("E2E: Encrypted Data Exchange", () => {
 });
 
 describe("E2E: Error Scenarios", () => {
-  test.skip("unauthorized client is rejected", async () => {
-    // Replaced by ACL-gated authorization coverage in relay/server.test.ts.
+  test("unauthorized client is rejected when connecting to machine", async () => {
+    // Register the machine so it's online
+    const accessList = new AccessControlList();
+    const { ws: machineWs } = await createMachineConnection(
+      testFixtures.machine,
+      accessList,
+    );
+
+    // Grant relay+machine access for the OWNER (testUserRoot) so the machine
+    // is fully set up, but do NOT grant access for the outsider.
+    grantRelayAccess({
+      ownerUserRootId: testOwnerUserRootId,
+      clientUserRootId: testUserRoot.id,
+      label: "e2e-unauth-owner",
+    });
+    grantMachineAccess({
+      machineId: testFixtures.machine.id,
+      ownerUserRootId: testOwnerUserRootId,
+      clientUserRootId: testUserRoot.id,
+      label: "e2e-unauth-owner",
+    });
+
+    // Create an outsider user root (different from relay owner)
+    const outsiderUserRoot = mnemonicToUserIdentity(generateMnemonic());
+    const outsiderClient = createTestIdentity("Outsider Client");
+    const outsiderCert = JSON.stringify(createDeviceCertificate(
+      outsiderUserRoot,
+      outsiderClient.signing.publicKey,
+      outsiderClient.keyExchange.publicKey,
+    ));
+
+    // Connect outsider — should be rejected at the relay level
+    let errorReceived: Error | null = null;
+    let disconnected = false;
+
+    const client = new RelayClient(
+      {
+        relayUrl,
+        machineId: testFixtures.machine.id,
+        identity: outsiderClient,
+        deviceCertificate: outsiderCert,
+      },
+      {
+        onError: (error) => {
+          errorReceived = error;
+        },
+        onDisconnect: () => {
+          disconnected = true;
+        },
+      },
+    );
+
+    await client.connect();
+
+    // Wait for the error/disconnect to arrive
+    await new Promise<void>((resolve) => {
+      const check = setInterval(() => {
+        if (errorReceived || disconnected) {
+          clearInterval(check);
+          resolve();
+        }
+      }, 50);
+      setTimeout(() => { clearInterval(check); resolve(); }, 5000);
+    });
+
+    // The relay should have rejected the outsider
+    expect(errorReceived).not.toBeNull();
+    expect(errorReceived!.message).toMatch(/not authorized|FORBIDDEN/i);
+
+    client.disconnect();
+    machineWs.close();
   });
 
   test("client handles machine disconnect gracefully", async () => {
@@ -867,7 +936,7 @@ describe("E2E: PTY Session Flow", () => {
     machineWs.close();
   });
 
-  test.skip("ClientSessionManager handles multiple concurrent clients", async () => {
+  test("ClientSessionManager handles multiple concurrent clients", async () => {
     // Create a second client identity
     const bob = createTestIdentity("Bob");
 
@@ -946,7 +1015,20 @@ describe("E2E: PTY Session Flow", () => {
       };
     });
 
-    // Relay-side ACL auth uses user-root access checks only.
+    // Grant relay + machine access for the owner user root.
+    // Both alice and bob present device certs signed by testUserRoot,
+    // so a single grant covers both clients.
+    grantRelayAccess({
+      ownerUserRootId: testOwnerUserRootId,
+      clientUserRootId: testUserRoot.id,
+      label: 'e2e-concurrent',
+    });
+    grantMachineAccess({
+      machineId: testFixtures.machine.id,
+      ownerUserRootId: testOwnerUserRootId,
+      clientUserRootId: testUserRoot.id,
+      label: 'e2e-concurrent',
+    });
 
     // Machine message handler
     machineWs.onmessage = async (event) => {
@@ -975,7 +1057,7 @@ describe("E2E: PTY Session Flow", () => {
       }
     };
 
-    // Connect both clients concurrently (no tokens needed)
+    // Connect both clients concurrently
     let aliceHandshakeComplete = false;
     let bobHandshakeComplete = false;
 
@@ -985,7 +1067,6 @@ describe("E2E: PTY Session Flow", () => {
         machineId: testFixtures.machine.id,
         identity: testFixtures.alice,
         deviceCertificate: createTestDeviceCertificate(testFixtures.alice),
-        // No token needed
       },
       {
         onHandshakeComplete: () => {
@@ -1003,7 +1084,6 @@ describe("E2E: PTY Session Flow", () => {
         machineId: testFixtures.machine.id,
         identity: bob,
         deviceCertificate: createTestDeviceCertificate(bob),
-        // No token needed
       },
       {
         onHandshakeComplete: () => {

--- a/src/relay/__tests__/e2e-flow.test.ts
+++ b/src/relay/__tests__/e2e-flow.test.ts
@@ -588,14 +588,23 @@ describe("E2E: Error Scenarios", () => {
     await client.connect();
 
     // Wait for the error/disconnect to arrive
-    await new Promise<void>((resolve) => {
+    await new Promise<void>((resolve, reject) => {
       const check = setInterval(() => {
-        if (errorReceived || disconnected) {
+        if (errorReceived) {
           clearInterval(check);
           resolve();
+          return;
+        }
+
+        if (disconnected) {
+          clearInterval(check);
+          reject(new Error('Client disconnected before surfacing the authorization error'));
         }
       }, 50);
-      setTimeout(() => { clearInterval(check); resolve(); }, 5000);
+      setTimeout(() => {
+        clearInterval(check);
+        reject(new Error('Timed out waiting for authorization error'));
+      }, 5000);
     });
 
     // The relay should have rejected the outsider

--- a/src/relay/__tests__/identity-chain.e2e.test.ts
+++ b/src/relay/__tests__/identity-chain.e2e.test.ts
@@ -1,0 +1,814 @@
+/**
+ * Identity Chain E2E Test (North Star)
+ *
+ * Proves the complete identity chain works end-to-end with 3 isolated containers:
+ *
+ * 1. RELAY CONTAINER  - Starts a relay that knows its owner (user root identity)
+ * 2. MACHINE CONTAINER - Registers with the relay using a device certificate
+ * 3. CLIENT CONTAINER  - Connects through the relay to the machine via X3DH
+ *
+ * The ONLY shared secret across all 3 containers is a single BIP39 mnemonic.
+ * Each container independently derives the user root identity from that mnemonic.
+ * This proves the cryptographic chain: mnemonic -> user root -> device certs -> relay auth -> E2E session.
+ *
+ * Key difference from e2e-flow.test.ts:
+ * - No explicit grantRelayAccess() / grantMachineAccess() calls
+ * - Authorization is purely owner-identity-based (same user root across all containers)
+ * - Each container has its own isolated temp dir and state
+ */
+
+import { describe, expect, test, beforeAll, afterAll } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { Server } from "bun";
+
+// Relay
+import { createRelayServer } from "../server.js";
+import { generateRelayIdentity } from "../identity.js";
+import { ensureControlStore, setVaultMeta } from "../control/store.js";
+
+// Crypto & Identity
+import { generateMnemonic, mnemonicToUserIdentity } from "../../lib/tmux-lite/crypto/user-identity.js";
+import { generateIdentity } from "../../lib/tmux-lite/crypto/identity.js";
+import { createDeviceCertificate } from "../../lib/tmux-lite/crypto/device-cert.js";
+import { HandshakeHandler } from "../../lib/tmux-lite/handshake-handler.js";
+import { RelayClient } from "../../lib/tmux-lite/relay-client.js";
+import { createFrame, openFrame } from "../../lib/tmux-lite/crypto/frames.js";
+import type { Identity, UserRootIdentity } from "../../types/identity.js";
+
+// Test helpers
+import { signChallenge, signClientMessage } from "./helpers/auth.js";
+import { startRelayServer } from "./helpers/ports.js";
+import { toPublicIdentity } from "../../lib/tmux-lite/crypto/__tests__/helpers/test-identities.js";
+import { getRelayClientTestAccess } from "../../__tests__/test-utils.js";
+
+// ============================================================================
+// 3 Isolated Test Containers
+// ============================================================================
+
+/** State for each isolated container */
+interface RelayContainer {
+  tempDir: string;
+  relayIdentity: ReturnType<typeof generateRelayIdentity>;
+  ownerUserRootId: string;
+  server: Server<any>;
+  port: number;
+  url: string;
+  httpBase: string;
+}
+
+interface MachineContainer {
+  tempDir: string;
+  deviceIdentity: Identity;
+  userRoot: UserRootIdentity;
+  deviceCertificate: string;
+  ws: WebSocket | null;
+  handshakeHandler: HandshakeHandler | null;
+}
+
+interface ClientContainer {
+  tempDir: string;
+  deviceIdentity: Identity;
+  userRoot: UserRootIdentity;
+  deviceCertificate: string;
+}
+
+// ============================================================================
+// Shared secret: ONE mnemonic, derived independently in each container
+// ============================================================================
+
+const sharedMnemonic = generateMnemonic();
+
+// Each container derives the user root independently (proving deterministic derivation)
+const relayUserRoot = mnemonicToUserIdentity(sharedMnemonic);
+const machineUserRoot = mnemonicToUserIdentity(sharedMnemonic);
+const clientUserRoot = mnemonicToUserIdentity(sharedMnemonic);
+
+// Sanity: all three derive the same identity
+if (relayUserRoot.id !== machineUserRoot.id || machineUserRoot.id !== clientUserRoot.id) {
+  throw new Error("BUG: same mnemonic produced different user root IDs");
+}
+
+// ============================================================================
+// Container setup
+// ============================================================================
+
+let relay: RelayContainer;
+let machine: MachineContainer;
+let client: ClientContainer;
+let previousControlDir: string | undefined;
+
+beforeAll(async () => {
+  // Save original env
+  previousControlDir = process.env.GITSPACE_CONTROL_DIR;
+
+  // ── RELAY CONTAINER ────────────────────────────────────────────────────
+  const relayTempDir = mkdtempSync(join(tmpdir(), "gssh-identity-chain-relay-"));
+  process.env.GITSPACE_CONTROL_DIR = relayTempDir;
+  ensureControlStore();
+  setVaultMeta("vault_initialized", "1");
+  setVaultMeta("owner_user_root_id", relayUserRoot.id);
+
+  // ── MACHINE CONTAINER ──────────────────────────────────────────────────
+  const machineTempDir = mkdtempSync(join(tmpdir(), "gssh-identity-chain-machine-"));
+  const machineDevice = generateIdentity("Test Machine");
+  const machineCert = JSON.stringify(createDeviceCertificate(
+    machineUserRoot,
+    machineDevice.signing.publicKey,
+    machineDevice.keyExchange.publicKey,
+  ));
+
+  // ── CLIENT CONTAINER ───────────────────────────────────────────────────
+  const clientTempDir = mkdtempSync(join(tmpdir(), "gssh-identity-chain-client-"));
+  const clientDevice = generateIdentity("Test Client");
+  const clientCert = JSON.stringify(createDeviceCertificate(
+    clientUserRoot,
+    clientDevice.signing.publicKey,
+    clientDevice.keyExchange.publicKey,
+  ));
+
+  // ── START RELAY ────────────────────────────────────────────────────────
+  // The relay knows its owner via owner_user_root_id in the vault (set above).
+  // NO preAuthorizedMachines — the machine will authenticate purely via
+  // its device certificate (signed by the user root identity).
+  const relayIdentity = generateRelayIdentity("identity-chain-test-relay");
+  const server = startRelayServer({
+    bind: "127.0.0.1",
+    hostname: "127.0.0.1",
+    disableRateLimit: true,
+    identity: relayIdentity,
+  });
+
+  const port = server.port!;
+  const url = `ws://127.0.0.1:${port}/ws`;
+  const httpBase = `http://127.0.0.1:${port}`;
+
+  // Wait for relay to become healthy
+  const deadline = Date.now() + 3000;
+  while (true) {
+    try {
+      const res = await fetch(`${httpBase}/health`);
+      if (res.ok) break;
+    } catch {
+      // retry
+    }
+    if (Date.now() > deadline) {
+      throw new Error("Relay server did not become healthy in time");
+    }
+    await new Promise((r) => setTimeout(r, 50));
+  }
+
+  // ── ASSIGN CONTAINERS ─────────────────────────────────────────────────
+  relay = {
+    tempDir: relayTempDir,
+    relayIdentity,
+    ownerUserRootId: relayUserRoot.id,
+    server,
+    port,
+    url,
+    httpBase,
+  };
+
+  machine = {
+    tempDir: machineTempDir,
+    deviceIdentity: machineDevice,
+    userRoot: machineUserRoot,
+    deviceCertificate: machineCert,
+    ws: null,
+    handshakeHandler: null,
+  };
+
+  client = {
+    tempDir: clientTempDir,
+    deviceIdentity: clientDevice,
+    userRoot: clientUserRoot,
+    deviceCertificate: clientCert,
+  };
+});
+
+afterAll(() => {
+  // Stop relay
+  if (relay?.server) {
+    relay.server.stop(true);
+  }
+
+  // Close WebSocket connections
+  if (machine?.ws && machine.ws.readyState === WebSocket.OPEN) {
+    machine.ws.close();
+  }
+
+  // Restore env
+  if (previousControlDir === undefined) {
+    delete process.env.GITSPACE_CONTROL_DIR;
+  } else {
+    process.env.GITSPACE_CONTROL_DIR = previousControlDir;
+  }
+
+  // Clean up temp dirs
+  for (const dir of [relay?.tempDir, machine?.tempDir, client?.tempDir]) {
+    if (dir) {
+      try {
+        rmSync(dir, { recursive: true, force: true });
+      } catch {
+        // best-effort cleanup
+      }
+    }
+  }
+});
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/** Connect a machine WebSocket and complete challenge-response registration */
+async function registerMachine(
+  relayUrl: string,
+  identity: Identity,
+  deviceCertificate?: string,
+): Promise<WebSocket> {
+  const url = new URL(relayUrl);
+  url.searchParams.set("role", "machine");
+
+  const ws = new WebSocket(url.toString());
+  ws.binaryType = "arraybuffer";
+
+  // Wait for open
+  await new Promise<void>((resolve, reject) => {
+    ws.onopen = () => resolve();
+    ws.onerror = () => reject(new Error("Machine WebSocket connection failed"));
+    setTimeout(() => reject(new Error("Connection timeout")), 5000);
+  });
+
+  // Wait for relay_identity with challenge nonce
+  const challenge = await new Promise<Uint8Array>((resolve, reject) => {
+    const timeout = setTimeout(() => reject(new Error("Challenge timeout")), 5000);
+    ws.onmessage = (event) => {
+      try {
+        const data = typeof event.data === "string"
+          ? event.data
+          : new TextDecoder().decode(event.data);
+        const msg = JSON.parse(data);
+        if (msg.type === "relay_identity" && msg.challenge) {
+          clearTimeout(timeout);
+          resolve(Buffer.from(msg.challenge, "base64"));
+        }
+      } catch {
+        // ignore
+      }
+    };
+  });
+
+  // Sign challenge, send register_machine with device certificate
+  const signature = signChallenge(challenge, identity.signing.secretKey);
+  const pub = toPublicIdentity(identity);
+
+  const regMsg: Record<string, unknown> = {
+    type: "register_machine",
+    machineId: identity.id,
+    signingKey: pub.signingPublicKey,
+    keyExchangeKey: pub.keyExchangePublicKey,
+    challengeResponse: signature,
+    label: identity.label ?? "test-machine",
+  };
+  if (deviceCertificate) {
+    regMsg.deviceCertificate = deviceCertificate;
+  }
+
+  ws.send(JSON.stringify(regMsg));
+
+  // Wait for registered or error
+  await new Promise<void>((resolve, reject) => {
+    const timeout = setTimeout(() => reject(new Error("Registration timeout")), 5000);
+    ws.onmessage = (event) => {
+      try {
+        const data = typeof event.data === "string"
+          ? event.data
+          : new TextDecoder().decode(event.data);
+        const msg = JSON.parse(data);
+        if (msg.type === "registered") {
+          clearTimeout(timeout);
+          resolve();
+        } else if (msg.type === "error") {
+          clearTimeout(timeout);
+          reject(new Error(`Registration rejected: ${msg.message || msg.code}`));
+        }
+      } catch {
+        // ignore
+      }
+    };
+  });
+
+  return ws;
+}
+
+/** Parse a relay WebSocket message */
+function parseWsMessage(event: MessageEvent): any {
+  const data = typeof event.data === "string"
+    ? event.data
+    : new TextDecoder().decode(event.data);
+  return JSON.parse(data);
+}
+
+// ============================================================================
+// Tests - run sequentially (each builds on the previous)
+// ============================================================================
+
+describe("Identity Chain E2E: Relay -> Machine -> Client", () => {
+
+  // ──────────────────────────────────────────────────────────────────────
+  // Test 1: Verify the 3 containers are properly isolated
+  // ──────────────────────────────────────────────────────────────────────
+
+  test("all three containers derive the same user root from the shared mnemonic", () => {
+    // Same user root ID
+    expect(relayUserRoot.id).toBe(machineUserRoot.id);
+    expect(machineUserRoot.id).toBe(clientUserRoot.id);
+
+    // Same signing public key
+    expect(Buffer.from(relayUserRoot.signing.publicKey).toString("base64"))
+      .toBe(Buffer.from(machineUserRoot.signing.publicKey).toString("base64"));
+    expect(Buffer.from(machineUserRoot.signing.publicKey).toString("base64"))
+      .toBe(Buffer.from(clientUserRoot.signing.publicKey).toString("base64"));
+
+    // But the device identities are all different (random keypairs)
+    expect(machine.deviceIdentity.id).not.toBe(client.deviceIdentity.id);
+
+    // And temp dirs are all different
+    expect(relay.tempDir).not.toBe(machine.tempDir);
+    expect(machine.tempDir).not.toBe(client.tempDir);
+  });
+
+  // ──────────────────────────────────────────────────────────────────────
+  // Test 2: Relay is healthy and knows its owner
+  // ──────────────────────────────────────────────────────────────────────
+
+  test("relay is healthy and reports its owner", async () => {
+    const res = await fetch(`${relay.httpBase}/health`);
+    expect(res.ok).toBe(true);
+
+    const body = await res.json();
+    expect(body.status).toBe("ok");
+  });
+
+  // ──────────────────────────────────────────────────────────────────────
+  // Test 3: Machine connects and registers (owner pre-authorization)
+  // ──────────────────────────────────────────────────────────────────────
+
+  test("machine registers with relay via device certificate (no enrollment token)", async () => {
+    // This is the critical test. The machine connects with NO enrollment token,
+    // NO bootstrap token, NO preAuthorizedMachines, and NO prior registration.
+    // It succeeds because:
+    //   - The machine sends a device certificate signed by the user root identity
+    //   - The relay verifies the certificate and checks the signer matches owner_user_root_id
+    const ws = await registerMachine(relay.url, machine.deviceIdentity, machine.deviceCertificate);
+    expect(ws.readyState).toBe(WebSocket.OPEN);
+
+    // Store for subsequent tests
+    machine.ws = ws;
+
+    // Create handshake handler for machine side
+    machine.handshakeHandler = new HandshakeHandler({
+      identity: machine.deviceIdentity,
+      handshakeTimeoutMs: 30000,
+      ownerUserRootId: machineUserRoot.id,
+    });
+  });
+
+  // ──────────────────────────────────────────────────────────────────────
+  // Test 4: Client lists machines via signed request
+  // ──────────────────────────────────────────────────────────────────────
+
+  test("owner client can list machines through relay", async () => {
+    const clientWs = new WebSocket(`${relay.url}?role=client`);
+    clientWs.binaryType = "arraybuffer";
+
+    await new Promise<void>((resolve, reject) => {
+      clientWs.onopen = () => resolve();
+      clientWs.onerror = () => reject(new Error("Client connection failed"));
+      setTimeout(() => reject(new Error("Timeout")), 5000);
+    });
+
+    // Send signed list_machines with device certificate
+    const listMsg = signClientMessage({
+      type: "list_machines",
+      clientIdentityId: client.deviceIdentity.id,
+      deviceCertificate: client.deviceCertificate,
+    }, client.deviceIdentity);
+
+    const machineListPromise = new Promise<any>((resolve, reject) => {
+      const timeout = setTimeout(() => reject(new Error("list_machines timeout")), 5000);
+      clientWs.onmessage = (event) => {
+        try {
+          const msg = parseWsMessage(event);
+          if (msg.type === "machine_list") {
+            clearTimeout(timeout);
+            resolve(msg);
+          } else if (msg.type === "error") {
+            clearTimeout(timeout);
+            reject(new Error(`list_machines rejected: ${msg.message || msg.code}`));
+          }
+        } catch { /* ignore */ }
+      };
+    });
+
+    clientWs.send(JSON.stringify(listMsg));
+    const response = await machineListPromise;
+
+    // Owner should see the registered machine
+    expect(response.machines).toBeDefined();
+    expect(response.machines.length).toBeGreaterThanOrEqual(1);
+
+    const found = response.machines.find((m: any) => m.machineId === machine.deviceIdentity.id);
+    expect(found).toBeDefined();
+
+    clientWs.close();
+  });
+
+  // ──────────────────────────────────────────────────────────────────────
+  // Test 5: Client connects to machine through relay + X3DH handshake
+  // ──────────────────────────────────────────────────────────────────────
+
+  test("client connects to machine through relay and completes X3DH handshake", async () => {
+    let machineHandshakeComplete = false;
+    let machineSessionKeys: { sendKey: Uint8Array; receiveKey: Uint8Array } | null = null;
+    let machinePeerIdentityId: string | null = null;
+
+    // Set up machine-side message handler for handshake
+    machine.ws!.onmessage = async (event) => {
+      const msg = parseWsMessage(event);
+
+      if (msg.type === "client_connected") {
+        // New client arriving
+      } else if (msg.type === "data" && msg.connectionId) {
+        // Handshake data from client via relay
+        const msgData = Buffer.from(msg.data, "base64");
+        try {
+          const jsonStr = new TextDecoder().decode(msgData);
+          const envelope = JSON.parse(jsonStr);
+
+          if (envelope.type === "handshake") {
+            const result = await machine.handshakeHandler!.processMessage(
+              msg.connectionId,
+              envelope,
+            );
+
+            if (result.type === "reply" || result.type === "established") {
+              // Send handshake response back through relay
+              const response = JSON.stringify(result.message);
+              machine.ws!.send(JSON.stringify({
+                type: "data",
+                connectionId: msg.connectionId,
+                data: Buffer.from(response).toString("base64"),
+              }));
+
+              if (result.type === "established") {
+                machineHandshakeComplete = true;
+                machineSessionKeys = {
+                  sendKey: result.session.sessionKeys.sendKey,
+                  receiveKey: result.session.sessionKeys.receiveKey,
+                };
+                machinePeerIdentityId = result.session.peerIdentityId;
+              }
+            }
+          }
+        } catch {
+          // Not handshake JSON - ignore
+        }
+      }
+    };
+
+    // Create client using RelayClient (uses signed connect_to_machine internally)
+    let clientHandshakeComplete = false;
+    let clientPeerIdentityId: string | null = null;
+
+    const relayClient = new RelayClient(
+      {
+        relayUrl: relay.url,
+        machineId: machine.deviceIdentity.id,
+        identity: client.deviceIdentity,
+        deviceCertificate: client.deviceCertificate,
+      },
+      {
+        onHandshakeComplete: (peerIdentityId) => {
+          clientHandshakeComplete = true;
+          clientPeerIdentityId = peerIdentityId;
+        },
+        onError: (error) => {
+          console.error("[identity-chain] Client error:", error);
+        },
+      },
+    );
+
+    await relayClient.connect();
+
+    // Wait for both sides to complete handshake
+    await new Promise<void>((resolve, reject) => {
+      const check = setInterval(() => {
+        if (clientHandshakeComplete && machineHandshakeComplete) {
+          clearInterval(check);
+          resolve();
+        }
+      }, 100);
+      setTimeout(() => {
+        clearInterval(check);
+        reject(new Error(
+          `X3DH handshake timeout (client: ${clientHandshakeComplete}, machine: ${machineHandshakeComplete})`,
+        ));
+      }, 10000);
+    });
+
+    // Verify handshake completed on both sides
+    expect(clientHandshakeComplete).toBe(true);
+    expect(machineHandshakeComplete).toBe(true);
+
+    // Verify peer identity IDs match (client sees machine, machine sees client)
+    expect(clientPeerIdentityId!).toBe(machine.deviceIdentity.id);
+    expect(machinePeerIdentityId!).toBe(client.deviceIdentity.id);
+
+    // Verify key symmetry: client's send key === machine's receive key
+    const clientAccess = getRelayClientTestAccess(relayClient);
+    expect(clientAccess.writeKey).not.toBeNull();
+    expect(clientAccess.readKey).not.toBeNull();
+    expect(machineSessionKeys).not.toBeNull();
+
+    const clientWriteHex = Buffer.from(clientAccess.writeKey!).toString("hex");
+    const clientReadHex = Buffer.from(clientAccess.readKey!).toString("hex");
+    const machineReceiveHex = Buffer.from(machineSessionKeys!.receiveKey).toString("hex");
+    const machineSendHex = Buffer.from(machineSessionKeys!.sendKey).toString("hex");
+
+    expect(clientWriteHex).toBe(machineReceiveHex);
+    expect(clientReadHex).toBe(machineSendHex);
+
+    // Clean up client (machine stays for next test)
+    relayClient.disconnect();
+  });
+
+  // ──────────────────────────────────────────────────────────────────────
+  // Test 6: Encrypted data round-trips through relay
+  // ──────────────────────────────────────────────────────────────────────
+
+  test("encrypted data flows bidirectionally through relay", async () => {
+    let machineSessionKeys: { sendKey: Uint8Array; receiveKey: Uint8Array } | null = null;
+    let machineConnectionId: string | null = null;
+    const machineDecryptedMessages: string[] = [];
+
+    // Fresh handshake handler for this test
+    const handshakeHandler = new HandshakeHandler({
+      identity: machine.deviceIdentity,
+      handshakeTimeoutMs: 30000,
+      ownerUserRootId: machineUserRoot.id,
+    });
+
+    // Machine message handler: handshake then encrypted data
+    machine.ws!.onmessage = async (event) => {
+      const msg = parseWsMessage(event);
+
+      if (msg.type === "client_connected") {
+        machineConnectionId = msg.connectionId;
+      } else if (msg.type === "data" && msg.connectionId) {
+        const msgData = Buffer.from(msg.data, "base64");
+
+        // Try handshake first
+        try {
+          const jsonStr = new TextDecoder().decode(msgData);
+          const envelope = JSON.parse(jsonStr);
+
+          if (envelope.type === "handshake") {
+            const result = await handshakeHandler.processMessage(msg.connectionId, envelope);
+            if (result.type === "reply" || result.type === "established") {
+              machine.ws!.send(JSON.stringify({
+                type: "data",
+                connectionId: msg.connectionId,
+                data: Buffer.from(JSON.stringify(result.message)).toString("base64"),
+              }));
+              if (result.type === "established") {
+                machineSessionKeys = {
+                  sendKey: result.session.sessionKeys.sendKey,
+                  receiveKey: result.session.sessionKeys.receiveKey,
+                };
+              }
+            }
+            return;
+          }
+        } catch {
+          // Not JSON - treat as encrypted frame
+        }
+
+        // Decrypt incoming frame
+        if (machineSessionKeys) {
+          try {
+            const opened = openFrame(msgData, machineSessionKeys.receiveKey);
+            if (!opened) return;
+            machineDecryptedMessages.push(new TextDecoder().decode(opened.data));
+
+            // Send a response back
+            const responseFrame = createFrame(
+              0,
+              Buffer.from("hello from machine"),
+              machineSessionKeys.sendKey,
+            );
+            machine.ws!.send(JSON.stringify({
+              type: "data",
+              connectionId: msg.connectionId,
+              data: Buffer.from(responseFrame).toString("base64"),
+            }));
+          } catch (e) {
+            console.error("[identity-chain] Machine decrypt error:", e);
+          }
+        }
+      }
+    };
+
+    // Connect client
+    const clientDecryptedMessages: string[] = [];
+    let clientReady = false;
+
+    const relayClient = new RelayClient(
+      {
+        relayUrl: relay.url,
+        machineId: machine.deviceIdentity.id,
+        identity: client.deviceIdentity,
+        deviceCertificate: client.deviceCertificate,
+      },
+      {
+        onHandshakeComplete: () => {
+          clientReady = true;
+        },
+        onMessage: (_streamId, data) => {
+          clientDecryptedMessages.push(data.toString("utf-8"));
+        },
+        onError: (error) => {
+          console.error("[identity-chain] Client error:", error);
+        },
+      },
+    );
+
+    await relayClient.connect();
+
+    // Wait for handshake
+    await new Promise<void>((resolve, reject) => {
+      const check = setInterval(() => {
+        if (clientReady && machineSessionKeys) {
+          clearInterval(check);
+          resolve();
+        }
+      }, 100);
+      setTimeout(() => {
+        clearInterval(check);
+        reject(new Error("Handshake timeout for data exchange test"));
+      }, 10000);
+    });
+
+    // Client sends encrypted data
+    const sent = relayClient.send(Buffer.from("hello from client"));
+    expect(sent).toBe(true);
+
+    // Wait for round-trip
+    await new Promise<void>((resolve, reject) => {
+      const check = setInterval(() => {
+        if (machineDecryptedMessages.length > 0 && clientDecryptedMessages.length > 0) {
+          clearInterval(check);
+          resolve();
+        }
+      }, 50);
+      setTimeout(() => {
+        clearInterval(check);
+        reject(new Error(
+          `Data exchange timeout (machine received: ${machineDecryptedMessages.length}, client received: ${clientDecryptedMessages.length})`,
+        ));
+      }, 5000);
+    });
+
+    // Verify bidirectional encrypted data
+    expect(machineDecryptedMessages).toContain("hello from client");
+    expect(clientDecryptedMessages).toContain("hello from machine");
+
+    relayClient.disconnect();
+  });
+
+  // ──────────────────────────────────────────────────────────────────────
+  // Test 7: Non-owner is rejected
+  // ──────────────────────────────────────────────────────────────────────
+
+  test("client with different user root identity is rejected", async () => {
+    // Generate a completely different mnemonic -> different user root
+    const imposterMnemonic = generateMnemonic();
+    const imposterUserRoot = mnemonicToUserIdentity(imposterMnemonic);
+    const imposterDevice = generateIdentity("Imposter Client");
+    const imposterCert = JSON.stringify(createDeviceCertificate(
+      imposterUserRoot,
+      imposterDevice.signing.publicKey,
+      imposterDevice.keyExchange.publicKey,
+    ));
+
+    // Imposter should NOT have the same user root as the owner
+    expect(imposterUserRoot.id).not.toBe(relayUserRoot.id);
+
+    // Try to list machines as the imposter
+    const imposterWs = new WebSocket(`${relay.url}?role=client`);
+    imposterWs.binaryType = "arraybuffer";
+
+    await new Promise<void>((resolve, reject) => {
+      imposterWs.onopen = () => resolve();
+      imposterWs.onerror = () => reject(new Error("Connection failed"));
+      setTimeout(() => reject(new Error("Timeout")), 5000);
+    });
+
+    const listMsg = signClientMessage({
+      type: "list_machines",
+      clientIdentityId: imposterDevice.id,
+      deviceCertificate: imposterCert,
+    }, imposterDevice);
+
+    const listPromise = new Promise<any>((resolve, reject) => {
+      const timeout = setTimeout(() => reject(new Error("Timeout")), 5000);
+      imposterWs.onmessage = (event) => {
+        try {
+          const msg = parseWsMessage(event);
+          if (msg.type === "machine_list" || msg.type === "error") {
+            clearTimeout(timeout);
+            resolve(msg);
+          }
+        } catch { /* ignore */ }
+      };
+    });
+
+    imposterWs.send(JSON.stringify(listMsg));
+    const listResult = await listPromise;
+
+    // Imposter should see no machines (they're not the owner)
+    if (listResult.type === "machine_list") {
+      expect(listResult.machines.length).toBe(0);
+    }
+    // OR it may be rejected with an error - either is acceptable
+
+    // Try to connect to the machine as the imposter
+    const connectMsg = signClientMessage({
+      type: "connect_to_machine",
+      machineId: machine.deviceIdentity.id,
+      clientIdentityId: imposterDevice.id,
+      deviceCertificate: imposterCert,
+    }, imposterDevice);
+
+    const connectPromise = new Promise<any>((resolve, reject) => {
+      const timeout = setTimeout(() => reject(new Error("Timeout")), 5000);
+      imposterWs.onmessage = (event) => {
+        try {
+          const msg = parseWsMessage(event);
+          clearTimeout(timeout);
+          resolve(msg);
+        } catch { /* ignore */ }
+      };
+    });
+
+    imposterWs.send(JSON.stringify(connectMsg));
+    const connectResult = await connectPromise;
+
+    // Connection must be rejected - imposter is not the owner
+    expect(connectResult.type).toBe("error");
+
+    imposterWs.close();
+  });
+
+  // ──────────────────────────────────────────────────────────────────────
+  // Test 8: Health check works with hostname filter
+  // ──────────────────────────────────────────────────────────────────────
+
+  test("health check works from localhost even when hostname filter is set", async () => {
+    // Start a second relay WITH a non-localhost hostname
+    // (simulates a relay configured for cloudflared tunnel)
+    const tempDir = mkdtempSync(join(tmpdir(), "gssh-identity-chain-health-"));
+    const prevDir = process.env.GITSPACE_CONTROL_DIR;
+    process.env.GITSPACE_CONTROL_DIR = tempDir;
+    ensureControlStore();
+
+    const server2 = startRelayServer({
+      bind: "127.0.0.1",
+      hostname: "myrelay.gitspace.sh", // Non-localhost hostname
+      disableRateLimit: true,
+      identity: generateRelayIdentity("health-test-relay"),
+    });
+
+    try {
+      // This request comes from localhost with Host: 127.0.0.1:{port}
+      // If the hostname filter blocks /health, this will fail (the bug)
+      const res = await fetch(`http://127.0.0.1:${server2.port}/health`);
+      expect(res.ok).toBe(true);
+
+      const body = await res.json();
+      expect(body.status).toBe("ok");
+    } finally {
+      server2.stop(true);
+      if (prevDir === undefined) {
+        delete process.env.GITSPACE_CONTROL_DIR;
+      } else {
+        process.env.GITSPACE_CONTROL_DIR = prevDir;
+      }
+      // Restore the relay container's control dir for any remaining tests
+      process.env.GITSPACE_CONTROL_DIR = relay.tempDir;
+      ensureControlStore();
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/relay/__tests__/pairing-scenarios.e2e.test.ts
+++ b/src/relay/__tests__/pairing-scenarios.e2e.test.ts
@@ -1,0 +1,787 @@
+/**
+ * Pairing Scenarios E2E Test
+ *
+ * Covers every machine authorization path through the relay with isolated
+ * "test containers" (separate identities, separate temp dirs, one relay):
+ *
+ * ACCEPT scenarios:
+ *   1. Owner device cert    - Machine presents cert signed by relay owner -> auto-authorized
+ *   2. Enrollment token     - Machine enrolled via root-signed relay-machine invite -> authorized
+ *
+ * REJECT scenarios:
+ *   3. Non-owner device cert - Cert signed by different user -> rejected
+ *   4. Expired device cert   - Owner cert with past expiry -> rejected
+ *   5. Key-mismatch cert     - Cert keys don't match register_machine keys -> rejected
+ *   6. No credentials        - No cert, no token, no pre-auth -> rejected
+ *   7. Wrong-owner invite    - Enrollment token signed by non-owner -> rejected
+ *
+ * CLIENT scenarios:
+ *   8. Owner client lists authorized machines
+ *   9. Owner client X3DH to device-cert machine -> encrypted data exchange
+ *  10. Owner client X3DH to enrolled machine -> encrypted data exchange
+ *  11. Non-owner client sees no machines
+ *  12. Non-owner client cannot connect to authorized machine
+ *
+ * Every "container" has its own random device keypair.  The ONLY shared secret
+ * across containers is a BIP39 mnemonic (owner) or nothing (outsider).
+ */
+
+import { describe, expect, test, beforeAll, afterAll } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { Server } from "bun";
+
+// Relay
+import { createRelayServer } from "../server.js";
+import { generateRelayIdentity } from "../identity.js";
+import { ensureControlStore, setVaultMeta } from "../control/store.js";
+
+// Crypto & Identity
+import {
+  generateMnemonic,
+  mnemonicToUserIdentity,
+} from "../../lib/tmux-lite/crypto/user-identity.js";
+import { generateIdentity } from "../../lib/tmux-lite/crypto/identity.js";
+import {
+  createDeviceCertificate,
+} from "../../lib/tmux-lite/crypto/device-cert.js";
+import { ed25519 } from "@noble/curves/ed25519.js";
+import { createRootInviteToken } from "../../lib/tmux-lite/crypto/root-invites.js";
+import { HandshakeHandler } from "../../lib/tmux-lite/handshake-handler.js";
+import { RelayClient } from "../../lib/tmux-lite/relay-client.js";
+import { createFrame, openFrame } from "../../lib/tmux-lite/crypto/frames.js";
+import type { Identity, UserRootIdentity } from "../../types/identity.js";
+
+// Test helpers
+import {
+  signChallenge,
+  signClientMessage,
+  connectClient,
+  sendAndWait,
+} from "./helpers/auth.js";
+import { startRelayServer } from "./helpers/ports.js";
+import { toPublicIdentity } from "../../lib/tmux-lite/crypto/__tests__/helpers/test-identities.js";
+import { getRelayClientTestAccess } from "../../__tests__/test-utils.js";
+
+// ============================================================================
+// Identities — each is an isolated "test container"
+// ============================================================================
+
+// Owner mnemonic (shared by relay + owner machines + owner client)
+const ownerMnemonic = generateMnemonic();
+const ownerUserRoot = mnemonicToUserIdentity(ownerMnemonic);
+
+// Outsider mnemonic (different user entirely)
+const outsiderMnemonic = generateMnemonic();
+const outsiderUserRoot = mnemonicToUserIdentity(outsiderMnemonic);
+
+// Sanity: owner and outsider are different users
+if (ownerUserRoot.id === outsiderUserRoot.id) {
+  throw new Error("BUG: two different mnemonics produced the same user root ID");
+}
+
+// Device identities (random keypairs — one per "container")
+const ownerMachineDevice = generateIdentity("Owner Machine");
+const enrolledMachineDevice = generateIdentity("Enrolled Machine");
+const outsiderMachineDevice = generateIdentity("Outsider Machine");
+const expiredCertMachineDevice = generateIdentity("Expired Cert Machine");
+const keyMismatchMachineDevice = generateIdentity("Key Mismatch Machine");
+const noCredsMachineDevice = generateIdentity("No Credentials Machine");
+const wrongOwnerInviteMachineDevice = generateIdentity("Wrong Owner Invite Machine");
+const ownerClientDevice = generateIdentity("Owner Client");
+const outsiderClientDevice = generateIdentity("Outsider Client");
+
+// ============================================================================
+// Device certificates
+// ============================================================================
+
+function buildCert(device: Identity, userRoot: UserRootIdentity): string {
+  return JSON.stringify(
+    createDeviceCertificate(
+      userRoot,
+      device.signing.publicKey,
+      device.keyExchange.publicKey,
+    ),
+  );
+}
+
+/**
+ * Build a properly-signed cert whose expiresAt is already in the past.
+ * We can't use createDeviceCertificate because it validates expiresAt > issuedAt.
+ * So we replicate the signing logic with backdated timestamps.
+ */
+function buildExpiredCert(device: Identity, userRoot: UserRootIdentity): string {
+  const issuedAt = Date.now() - 200_000; // issued 200s ago
+  const expiresAt = Date.now() - 100_000; // expired 100s ago
+
+  // Build the payload: domain || sigPub || kexPub || issuedAt(8B) || expiresAt(8B)
+  const domain = new TextEncoder().encode("gitspace-device-cert-v1");
+  const timestamps = new Uint8Array(16);
+  const view = new DataView(timestamps.buffer);
+  view.setBigUint64(0, BigInt(issuedAt), false);
+  view.setBigUint64(8, BigInt(expiresAt), false);
+
+  const payload = new Uint8Array(domain.length + 32 + 32 + 16);
+  let offset = 0;
+  payload.set(domain, offset); offset += domain.length;
+  payload.set(device.signing.publicKey, offset); offset += 32;
+  payload.set(device.keyExchange.publicKey, offset); offset += 32;
+  payload.set(timestamps, offset);
+
+  const privateKey = userRoot.signing.secretKey.slice(0, 32);
+  const signature = ed25519.sign(payload, privateKey);
+
+  return JSON.stringify({
+    deviceSigningPublicKey: Buffer.from(device.signing.publicKey).toString("base64"),
+    deviceKeyExchangePublicKey: Buffer.from(device.keyExchange.publicKey).toString("base64"),
+    userRootSigningPublicKey: Buffer.from(userRoot.signing.publicKey).toString("base64"),
+    signature: Buffer.from(signature).toString("base64"),
+    issuedAt,
+    expiresAt,
+  });
+}
+
+/** Build a cert for a *different* device's keys, creating a key mismatch */
+function buildMismatchedKeysCert(
+  deviceThatRegisters: Identity,
+  userRoot: UserRootIdentity,
+): string {
+  // Cert is signed for a random throwaway device — keys won't match register_machine
+  const throwaway = generateIdentity("Throwaway");
+  return JSON.stringify(
+    createDeviceCertificate(
+      userRoot,
+      throwaway.signing.publicKey,
+      throwaway.keyExchange.publicKey,
+    ),
+  );
+}
+
+const ownerMachineCert = buildCert(ownerMachineDevice, ownerUserRoot);
+const outsiderMachineCert = buildCert(outsiderMachineDevice, outsiderUserRoot);
+const expiredMachineCert = buildExpiredCert(expiredCertMachineDevice, ownerUserRoot);
+const mismatchKeysCert = buildMismatchedKeysCert(keyMismatchMachineDevice, ownerUserRoot);
+const ownerClientCert = buildCert(ownerClientDevice, ownerUserRoot);
+const outsiderClientCert = buildCert(outsiderClientDevice, outsiderUserRoot);
+
+// ============================================================================
+// Relay setup
+// ============================================================================
+
+let relayUrl: string;
+let relayHttpBase: string;
+let server: Server<any>;
+let tempDir: string;
+let previousControlDir: string | undefined;
+
+beforeAll(async () => {
+  previousControlDir = process.env.GITSPACE_CONTROL_DIR;
+
+  // Isolated relay temp dir
+  tempDir = mkdtempSync(join(tmpdir(), "gssh-pairing-scenarios-"));
+  process.env.GITSPACE_CONTROL_DIR = tempDir;
+  ensureControlStore();
+  setVaultMeta("vault_initialized", "1");
+  setVaultMeta("owner_user_root_id", ownerUserRoot.id);
+
+  // Start relay — NO preAuthorizedMachines.  All auth must come from
+  // device certificates or enrollment tokens.
+  const relayIdentity = generateRelayIdentity("pairing-scenarios-relay");
+  server = startRelayServer({
+    bind: "127.0.0.1",
+    hostname: "127.0.0.1",
+    disableRateLimit: true,
+    identity: relayIdentity,
+  });
+
+  const port = server.port!;
+  relayUrl = `ws://127.0.0.1:${port}/ws`;
+  relayHttpBase = `http://127.0.0.1:${port}`;
+
+  // Wait for relay to become healthy
+  const deadline = Date.now() + 3000;
+  while (true) {
+    try {
+      const res = await fetch(`${relayHttpBase}/health`);
+      if (res.ok) break;
+    } catch {
+      // retry
+    }
+    if (Date.now() > deadline) throw new Error("Relay did not start");
+    await new Promise((r) => setTimeout(r, 50));
+  }
+});
+
+afterAll(() => {
+  server?.stop(true);
+
+  if (previousControlDir === undefined) {
+    delete process.env.GITSPACE_CONTROL_DIR;
+  } else {
+    process.env.GITSPACE_CONTROL_DIR = previousControlDir;
+  }
+
+  if (tempDir) {
+    try { rmSync(tempDir, { recursive: true, force: true }); } catch { /* */ }
+  }
+});
+
+// ============================================================================
+// Machine registration helper
+// ============================================================================
+
+/** Result of a machine registration attempt */
+interface RegistrationResult {
+  ws: WebSocket;
+  success: boolean;
+}
+
+/**
+ * Attempt to register a machine with the relay.
+ * Returns the WebSocket and whether registration succeeded.
+ * Does NOT throw on rejection — returns { success: false } instead.
+ */
+async function attemptRegisterMachine(
+  identity: Identity,
+  options: {
+    deviceCertificate?: string;
+    enrollmentToken?: string;
+  } = {},
+): Promise<RegistrationResult> {
+  const url = new URL(relayUrl);
+  url.searchParams.set("role", "machine");
+
+  const ws = new WebSocket(url.toString());
+  ws.binaryType = "arraybuffer";
+
+  await new Promise<void>((resolve, reject) => {
+    ws.onopen = () => resolve();
+    ws.onerror = () => reject(new Error("WebSocket failed"));
+    setTimeout(() => reject(new Error("Connection timeout")), 5000);
+  });
+
+  // Wait for relay_identity challenge
+  const challenge = await new Promise<Uint8Array>((resolve, reject) => {
+    const timeout = setTimeout(() => reject(new Error("Challenge timeout")), 5000);
+    ws.onmessage = (event) => {
+      try {
+        const data = typeof event.data === "string"
+          ? event.data
+          : new TextDecoder().decode(event.data);
+        const msg = JSON.parse(data);
+        if (msg.type === "relay_identity" && msg.challenge) {
+          clearTimeout(timeout);
+          resolve(Buffer.from(msg.challenge, "base64"));
+        }
+      } catch { /* ignore */ }
+    };
+  });
+
+  // Build register_machine message
+  const signature = signChallenge(challenge, identity.signing.secretKey);
+  const pub = toPublicIdentity(identity);
+  const regMsg: Record<string, unknown> = {
+    type: "register_machine",
+    machineId: identity.id,
+    signingKey: pub.signingPublicKey,
+    keyExchangeKey: pub.keyExchangePublicKey,
+    challengeResponse: signature,
+    label: identity.label ?? "test-machine",
+  };
+  if (options.deviceCertificate) regMsg.deviceCertificate = options.deviceCertificate;
+  if (options.enrollmentToken) regMsg.enrollmentToken = options.enrollmentToken;
+
+  ws.send(JSON.stringify(regMsg));
+
+  // Wait for registered or error
+  const result = await new Promise<{ type: string; message?: string }>((resolve, reject) => {
+    const timeout = setTimeout(() => reject(new Error("Registration timeout")), 5000);
+    ws.onmessage = (event) => {
+      try {
+        const data = typeof event.data === "string"
+          ? event.data
+          : new TextDecoder().decode(event.data);
+        const msg = JSON.parse(data);
+        if (msg.type === "registered" || msg.type === "error") {
+          clearTimeout(timeout);
+          resolve(msg);
+        }
+      } catch { /* ignore */ }
+    };
+  });
+
+  if (result.type === "error") {
+    ws.close();
+  }
+
+  return { ws, success: result.type === "registered" };
+}
+
+/** Register machine, expecting success.  Returns the open WebSocket. */
+async function registerMachine(
+  identity: Identity,
+  options: { deviceCertificate?: string; enrollmentToken?: string } = {},
+): Promise<WebSocket> {
+  const result = await attemptRegisterMachine(identity, options);
+  if (!result.success) {
+    throw new Error("Expected machine registration to succeed, but it was rejected");
+  }
+  return result.ws;
+}
+
+/** Attempt registration and expect rejection. */
+async function expectRegistrationRejected(
+  identity: Identity,
+  options: { deviceCertificate?: string; enrollmentToken?: string } = {},
+): Promise<void> {
+  const result = await attemptRegisterMachine(identity, options);
+  if (result.success) {
+    result.ws.close();
+    throw new Error("Expected machine registration to be rejected, but it succeeded");
+  }
+}
+
+/** Parse a relay WS message */
+function parseWsMessage(event: MessageEvent): any {
+  const data = typeof event.data === "string"
+    ? event.data
+    : new TextDecoder().decode(event.data);
+  return JSON.parse(data);
+}
+
+// ============================================================================
+// Tests — sequential within each describe, describes are independent
+// ============================================================================
+
+describe("Pairing Scenarios E2E", () => {
+  // Track open WebSockets for cleanup
+  const openSockets: WebSocket[] = [];
+  afterAll(() => {
+    for (const ws of openSockets) {
+      if (ws.readyState === WebSocket.OPEN) ws.close();
+    }
+  });
+
+  // ════════════════════════════════════════════════════════════════════════
+  // ACCEPT: Owner device certificate (same-machine / remote-same-owner)
+  // ════════════════════════════════════════════════════════════════════════
+
+  describe("Scenario 1: Owner device certificate", () => {
+    let machineWs: WebSocket;
+
+    test("machine registers via device cert signed by relay owner", async () => {
+      machineWs = await registerMachine(ownerMachineDevice, {
+        deviceCertificate: ownerMachineCert,
+      });
+      openSockets.push(machineWs);
+      expect(machineWs.readyState).toBe(WebSocket.OPEN);
+    });
+
+    test("owner client lists the device-cert machine", async () => {
+      const clientWs = await connectClient(relayUrl);
+
+      const listMsg = signClientMessage({
+        type: "list_machines",
+        clientIdentityId: ownerClientDevice.id,
+        deviceCertificate: ownerClientCert,
+      }, ownerClientDevice);
+
+      const response = await sendAndWait<any>(clientWs, listMsg, "machine_list");
+      const found = response.machines.find(
+        (m: any) => m.machineId === ownerMachineDevice.id,
+      );
+      expect(found).toBeDefined();
+      expect(found.label).toBe("Owner Machine");
+
+      clientWs.close();
+    });
+
+    test("owner client X3DH handshake + encrypted data exchange", async () => {
+      let machineSessionKeys: { sendKey: Uint8Array; receiveKey: Uint8Array } | null = null;
+      const machineDecrypted: string[] = [];
+
+      const handshakeHandler = new HandshakeHandler({
+        identity: ownerMachineDevice,
+        handshakeTimeoutMs: 30000,
+        ownerUserRootId: ownerUserRoot.id,
+      });
+
+      // Machine-side handler
+      machineWs.onmessage = async (event) => {
+        const msg = parseWsMessage(event);
+        if (msg.type !== "data" || !msg.connectionId) return;
+        const msgData = Buffer.from(msg.data, "base64");
+
+        // Try handshake
+        try {
+          const envelope = JSON.parse(new TextDecoder().decode(msgData));
+          if (envelope.type === "handshake") {
+            const result = await handshakeHandler.processMessage(msg.connectionId, envelope);
+            if (result.type === "reply" || result.type === "established") {
+              machineWs.send(JSON.stringify({
+                type: "data",
+                connectionId: msg.connectionId,
+                data: Buffer.from(JSON.stringify(result.message)).toString("base64"),
+              }));
+              if (result.type === "established") {
+                machineSessionKeys = {
+                  sendKey: result.session.sessionKeys.sendKey,
+                  receiveKey: result.session.sessionKeys.receiveKey,
+                };
+              }
+            }
+            return;
+          }
+        } catch { /* not handshake JSON */ }
+
+        // Decrypt + echo back
+        if (machineSessionKeys) {
+          try {
+            const opened = openFrame(msgData, machineSessionKeys.receiveKey);
+            if (!opened) return;
+            machineDecrypted.push(new TextDecoder().decode(opened.data));
+            const reply = createFrame(0, Buffer.from("pong:device-cert-machine"), machineSessionKeys.sendKey);
+            machineWs.send(JSON.stringify({
+              type: "data",
+              connectionId: msg.connectionId,
+              data: Buffer.from(reply).toString("base64"),
+            }));
+          } catch { /* decrypt error */ }
+        }
+      };
+
+      const clientDecrypted: string[] = [];
+      let clientReady = false;
+
+      const relayClient = new RelayClient(
+        {
+          relayUrl,
+          machineId: ownerMachineDevice.id,
+          identity: ownerClientDevice,
+          deviceCertificate: ownerClientCert,
+        },
+        {
+          onHandshakeComplete: () => { clientReady = true; },
+          onMessage: (_sid, data) => { clientDecrypted.push(data.toString("utf-8")); },
+          onError: (err) => { console.error("[pairing] Client error:", err); },
+        },
+      );
+
+      await relayClient.connect();
+
+      // Wait for handshake
+      await waitUntil(() => clientReady && machineSessionKeys !== null, 10000);
+
+      // Send encrypted payload
+      expect(relayClient.send(Buffer.from("ping:device-cert-client"))).toBe(true);
+
+      // Wait for round-trip
+      await waitUntil(() => machineDecrypted.length > 0 && clientDecrypted.length > 0, 5000);
+
+      expect(machineDecrypted).toContain("ping:device-cert-client");
+      expect(clientDecrypted).toContain("pong:device-cert-machine");
+
+      // Verify key symmetry
+      const ca = getRelayClientTestAccess(relayClient);
+      expect(Buffer.from(ca.writeKey!).toString("hex")).toBe(
+        Buffer.from(machineSessionKeys!.receiveKey).toString("hex"),
+      );
+      expect(Buffer.from(ca.readKey!).toString("hex")).toBe(
+        Buffer.from(machineSessionKeys!.sendKey).toString("hex"),
+      );
+
+      relayClient.disconnect();
+    });
+  });
+
+  // ════════════════════════════════════════════════════════════════════════
+  // ACCEPT: Enrollment token (remote collaborator machine)
+  // ════════════════════════════════════════════════════════════════════════
+
+  describe("Scenario 2: Enrollment token", () => {
+    let enrolledMachineWs: WebSocket;
+
+    test("owner creates relay-machine invite and machine enrolls", async () => {
+      // Step 1: Owner creates the enrollment token
+      const enrollmentToken = createRootInviteToken({
+        type: "relay-machine",
+        owner: ownerUserRoot,
+        relayUrl,
+        targetMachineSigningKey: Buffer.from(enrolledMachineDevice.signing.publicKey).toString("base64"),
+        targetMachineKeyExchangeKey: Buffer.from(enrolledMachineDevice.keyExchange.publicKey).toString("base64"),
+        expiresAt: Date.now() + 60_000,
+        maxUses: 1,
+        label: "enrolled-test-machine",
+      });
+
+      // Step 2: Owner registers the invite with the relay
+      const ownerWs = await connectClient(relayUrl);
+      const created = await sendAndWait<any>(
+        ownerWs,
+        signClientMessage({
+          type: "create_root_invite",
+          clientIdentityId: ownerClientDevice.id,
+          inviteToken: enrollmentToken,
+          deviceCertificate: ownerClientCert,
+        }, ownerClientDevice),
+        "root_invite_created",
+      );
+      expect(created.type).toBe("root_invite_created");
+      ownerWs.close();
+
+      // Step 3: Machine enrolls using the token (NO device cert needed)
+      enrolledMachineWs = await registerMachine(enrolledMachineDevice, {
+        enrollmentToken,
+      });
+      openSockets.push(enrolledMachineWs);
+      expect(enrolledMachineWs.readyState).toBe(WebSocket.OPEN);
+    });
+
+    test("owner client lists the enrolled machine alongside device-cert machine", async () => {
+      const clientWs = await connectClient(relayUrl);
+      const listMsg = signClientMessage({
+        type: "list_machines",
+        clientIdentityId: ownerClientDevice.id,
+        deviceCertificate: ownerClientCert,
+      }, ownerClientDevice);
+
+      const response = await sendAndWait<any>(clientWs, listMsg, "machine_list");
+
+      // Both machines should be visible
+      const deviceCertMachine = response.machines.find(
+        (m: any) => m.machineId === ownerMachineDevice.id,
+      );
+      const enrolledMachine = response.machines.find(
+        (m: any) => m.machineId === enrolledMachineDevice.id,
+      );
+      expect(deviceCertMachine).toBeDefined();
+      expect(enrolledMachine).toBeDefined();
+
+      clientWs.close();
+    });
+
+    test("owner client X3DH + data exchange with enrolled machine", async () => {
+      let machineKeys: { sendKey: Uint8Array; receiveKey: Uint8Array } | null = null;
+      const machineDecrypted: string[] = [];
+
+      const handler = new HandshakeHandler({
+        identity: enrolledMachineDevice,
+        handshakeTimeoutMs: 30000,
+        ownerUserRootId: ownerUserRoot.id,
+      });
+
+      enrolledMachineWs.onmessage = async (event) => {
+        const msg = parseWsMessage(event);
+        if (msg.type !== "data" || !msg.connectionId) return;
+        const msgData = Buffer.from(msg.data, "base64");
+
+        try {
+          const envelope = JSON.parse(new TextDecoder().decode(msgData));
+          if (envelope.type === "handshake") {
+            const result = await handler.processMessage(msg.connectionId, envelope);
+            if (result.type === "reply" || result.type === "established") {
+              enrolledMachineWs.send(JSON.stringify({
+                type: "data",
+                connectionId: msg.connectionId,
+                data: Buffer.from(JSON.stringify(result.message)).toString("base64"),
+              }));
+              if (result.type === "established") {
+                machineKeys = {
+                  sendKey: result.session.sessionKeys.sendKey,
+                  receiveKey: result.session.sessionKeys.receiveKey,
+                };
+              }
+            }
+            return;
+          }
+        } catch { /* */ }
+
+        if (machineKeys) {
+          try {
+            const opened = openFrame(msgData, machineKeys.receiveKey);
+            if (!opened) return;
+            machineDecrypted.push(new TextDecoder().decode(opened.data));
+            const reply = createFrame(0, Buffer.from("pong:enrolled-machine"), machineKeys.sendKey);
+            enrolledMachineWs.send(JSON.stringify({
+              type: "data",
+              connectionId: msg.connectionId,
+              data: Buffer.from(reply).toString("base64"),
+            }));
+          } catch { /* */ }
+        }
+      };
+
+      const clientDecrypted: string[] = [];
+      let ready = false;
+
+      const client = new RelayClient(
+        {
+          relayUrl,
+          machineId: enrolledMachineDevice.id,
+          identity: ownerClientDevice,
+          deviceCertificate: ownerClientCert,
+        },
+        {
+          onHandshakeComplete: () => { ready = true; },
+          onMessage: (_sid, data) => { clientDecrypted.push(data.toString("utf-8")); },
+          onError: (err) => { console.error("[pairing] Enrolled machine client error:", err); },
+        },
+      );
+
+      await client.connect();
+      await waitUntil(() => ready && machineKeys !== null, 10000);
+
+      expect(client.send(Buffer.from("ping:enrolled-client"))).toBe(true);
+      await waitUntil(() => machineDecrypted.length > 0 && clientDecrypted.length > 0, 5000);
+
+      expect(machineDecrypted).toContain("ping:enrolled-client");
+      expect(clientDecrypted).toContain("pong:enrolled-machine");
+
+      client.disconnect();
+    });
+  });
+
+  // ════════════════════════════════════════════════════════════════════════
+  // REJECT: Various failure scenarios
+  // ════════════════════════════════════════════════════════════════════════
+
+  describe("Scenario 3: Rejection cases", () => {
+    test("non-owner device cert is rejected", async () => {
+      // Machine presents a valid cert, but signed by outsider (not relay owner)
+      await expectRegistrationRejected(outsiderMachineDevice, {
+        deviceCertificate: outsiderMachineCert,
+      });
+    });
+
+    test("expired device cert is rejected", async () => {
+      await expectRegistrationRejected(expiredCertMachineDevice, {
+        deviceCertificate: expiredMachineCert,
+      });
+    });
+
+    test("device cert with mismatched keys is rejected", async () => {
+      // Cert is signed by owner but for different device keys than those
+      // presented in the register_machine message
+      await expectRegistrationRejected(keyMismatchMachineDevice, {
+        deviceCertificate: mismatchKeysCert,
+      });
+    });
+
+    test("machine with no credentials is rejected", async () => {
+      await expectRegistrationRejected(noCredsMachineDevice);
+    });
+
+    test("enrollment token signed by non-owner is rejected", async () => {
+      // Outsider creates an enrollment token for a machine, but the relay
+      // only accepts tokens signed by the relay owner
+      const outsiderToken = createRootInviteToken({
+        type: "relay-machine",
+        owner: outsiderUserRoot,
+        relayUrl,
+        targetMachineSigningKey: Buffer.from(wrongOwnerInviteMachineDevice.signing.publicKey).toString("base64"),
+        targetMachineKeyExchangeKey: Buffer.from(wrongOwnerInviteMachineDevice.keyExchange.publicKey).toString("base64"),
+        expiresAt: Date.now() + 60_000,
+        maxUses: 1,
+        label: "outsider-invite",
+      });
+
+      // Outsider tries to register the invite — should be rejected since they're
+      // not the relay owner.  We attempt via WS first.
+      const outsiderWs = await connectClient(relayUrl);
+      const createInviteMsg = signClientMessage({
+        type: "create_root_invite",
+        clientIdentityId: outsiderClientDevice.id,
+        inviteToken: outsiderToken,
+        deviceCertificate: outsiderClientCert,
+      }, outsiderClientDevice);
+
+      // The relay should reject the invite creation since outsider is not the owner.
+      // But even if it somehow gets registered, the machine enrollment should fail.
+      let inviteRegistered = false;
+      try {
+        const result = await sendAndWait<any>(outsiderWs, createInviteMsg, "root_invite_created", 3000);
+        inviteRegistered = result.type === "root_invite_created";
+      } catch {
+        // Expected: rejected
+      }
+      outsiderWs.close();
+
+      // If the invite was not registered, the machine can't enroll at all.
+      // If it somehow was, the enrollment should still be rejected (owner mismatch).
+      await expectRegistrationRejected(wrongOwnerInviteMachineDevice, {
+        enrollmentToken: outsiderToken,
+      });
+    });
+  });
+
+  // ════════════════════════════════════════════════════════════════════════
+  // Non-owner client access
+  // ════════════════════════════════════════════════════════════════════════
+
+  describe("Scenario 4: Non-owner client access control", () => {
+    test("non-owner client sees no machines in list", async () => {
+      const clientWs = await connectClient(relayUrl);
+
+      const listMsg = signClientMessage({
+        type: "list_machines",
+        clientIdentityId: outsiderClientDevice.id,
+        deviceCertificate: outsiderClientCert,
+      }, outsiderClientDevice);
+
+      const response = await sendAndWait<any>(clientWs, listMsg, "machine_list");
+
+      // Outsider should see zero machines
+      expect(response.machines).toBeDefined();
+      expect(response.machines.length).toBe(0);
+
+      clientWs.close();
+    });
+
+    test("non-owner client cannot connect to authorized machine", async () => {
+      const clientWs = await connectClient(relayUrl);
+
+      const connectMsg = signClientMessage({
+        type: "connect_to_machine",
+        machineId: ownerMachineDevice.id,
+        clientIdentityId: outsiderClientDevice.id,
+        deviceCertificate: outsiderClientCert,
+      }, outsiderClientDevice);
+
+      // Should receive an error
+      const result = await sendAndWait<any>(clientWs, connectMsg, "error", 5000)
+        .catch((err) => {
+          // sendAndWait rejects on error messages, which is what we expect
+          return { type: "error", message: err.message };
+        });
+
+      expect(result.type).toBe("error");
+
+      clientWs.close();
+    });
+  });
+});
+
+// ============================================================================
+// Utility
+// ============================================================================
+
+/** Poll until predicate is true or timeout */
+function waitUntil(
+  predicate: () => boolean,
+  timeoutMs: number,
+  pollMs = 50,
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const check = setInterval(() => {
+      if (predicate()) {
+        clearInterval(check);
+        resolve();
+      }
+    }, pollMs);
+    setTimeout(() => {
+      clearInterval(check);
+      reject(new Error(`waitUntil timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
+  });
+}

--- a/src/relay/control/bootstrap-store.test.ts
+++ b/src/relay/control/bootstrap-store.test.ts
@@ -13,6 +13,7 @@ import {
   getCloudWorkspace,
   getLatestCloudBootstrapToken,
   listCloudEvents,
+  markCloudBootstrapVmCreated,
   markCloudBootstrapReady,
   upsertCloudWorkspace,
   validateCloudBootstrapToken,
@@ -107,6 +108,7 @@ describe('cloud bootstrap tokens', () => {
       id: 'ws-bootstrap-1',
       provider: 'sprites',
       providerWorkspaceId: 'sprite-1',
+      machinePublicKey: 'machine-signing-pub',
       status: 'bootstrapping',
       repo: 'owner/repo',
       branch: 'main',
@@ -204,6 +206,16 @@ describe('cloud bootstrap tokens', () => {
   });
 
   test('can look up workspace by machine public key', () => {
+    upsertCloudWorkspace({
+      id: 'ws-bootstrap-1',
+      provider: 'sprites',
+      providerWorkspaceId: 'sprite-1',
+      machinePublicKey: 'machine-pub-by-key',
+      status: 'bootstrapping',
+      repo: 'owner/repo',
+      branch: 'main',
+    });
+
     const issued = createCloudBootstrapToken({
       workspaceId: 'ws-bootstrap-1',
       ownerIdentityId: 'owner-abc',
@@ -259,7 +271,115 @@ describe('cloud bootstrap tokens', () => {
     expect(consumed).toBeNull();
   });
 
+  test('consumes bootstrap token in vm_created state', () => {
+    const issued = createCloudBootstrapToken({
+      workspaceId: 'ws-bootstrap-1',
+      ownerIdentityId: 'owner-abc',
+      ttlMs: 5 * 60 * 1000,
+    });
+
+    markCloudBootstrapVmCreated('ws-bootstrap-1');
+
+    const unlock = consumeCloudBootstrapTokenForUnlock({
+      token: issued.token,
+      workspaceId: 'ws-bootstrap-1',
+      machineSigningPublicKey: 'machine-signing-pub',
+    });
+    expect(unlock).toBeDefined();
+  });
+
+  test('unlock grant fails when workspace is not bootstrapping', () => {
+    upsertCloudWorkspace({
+      id: 'ws-ready',
+      provider: 'sprites',
+      providerWorkspaceId: 'sprite-ready',
+      machinePublicKey: 'machine-ready-key',
+      status: 'ready',
+      repo: 'owner/repo',
+      branch: 'main',
+    });
+
+    const issued = createCloudBootstrapToken({
+      workspaceId: 'ws-ready',
+      ownerIdentityId: 'owner-abc',
+      ttlMs: 5 * 60 * 1000,
+    });
+
+    const consumed = consumeCloudBootstrapTokenForUnlock({
+      token: issued.token,
+      workspaceId: 'ws-ready',
+      machineSigningPublicKey: 'machine-ready-key',
+    });
+    expect(consumed).toBeNull();
+
+    const latest = getLatestCloudBootstrapToken('ws-ready');
+    expect(latest?.state).toBe('pending');
+  });
+
+  test('unlock grant fails when workspace already has machine id', () => {
+    upsertCloudWorkspace({
+      id: 'ws-has-machine',
+      provider: 'sprites',
+      providerWorkspaceId: 'sprite-has-machine',
+      machineId: 'machine-existing',
+      machinePublicKey: 'machine-existing-key',
+      status: 'bootstrapping',
+      repo: 'owner/repo',
+      branch: 'main',
+    });
+
+    const issued = createCloudBootstrapToken({
+      workspaceId: 'ws-has-machine',
+      ownerIdentityId: 'owner-abc',
+      ttlMs: 5 * 60 * 1000,
+    });
+
+    const consumed = consumeCloudBootstrapTokenForUnlock({
+      token: issued.token,
+      workspaceId: 'ws-has-machine',
+      machineSigningPublicKey: 'machine-existing-key',
+    });
+    expect(consumed).toBeNull();
+  });
+
+  test('unlock grant fails when workspace machine key is missing', () => {
+    upsertCloudWorkspace({
+      id: 'ws-no-key',
+      provider: 'sprites',
+      providerWorkspaceId: 'sprite-no-key',
+      status: 'bootstrapping',
+      repo: 'owner/repo',
+      branch: 'main',
+    });
+
+    const issued = createCloudBootstrapToken({
+      workspaceId: 'ws-no-key',
+      ownerIdentityId: 'owner-abc',
+      ttlMs: 5 * 60 * 1000,
+    });
+
+    const consumed = consumeCloudBootstrapTokenForUnlock({
+      token: issued.token,
+      workspaceId: 'ws-no-key',
+      machineSigningPublicKey: 'machine-signing-no-key',
+    });
+    expect(consumed).toBeNull();
+
+    const latest = getLatestCloudBootstrapToken('ws-no-key');
+    expect(latest?.state).toBe('failed');
+  });
+
   test('token cannot be consumed by a different machine key once workspace key is established', () => {
+    upsertCloudWorkspace({
+      id: 'ws-bootstrap-1',
+      provider: 'sprites',
+      providerWorkspaceId: 'sprite-1',
+      machinePublicKey: 'machine-pub-1',
+      status: 'bootstrapping',
+      repo: 'owner/repo',
+      branch: 'main',
+    });
+
     const first = createCloudBootstrapToken({
       workspaceId: 'ws-bootstrap-1',
       ownerIdentityId: 'owner-abc',
@@ -324,5 +444,72 @@ describe('cloud bootstrap tokens', () => {
       machineSigningPublicKey: 'machine-signing-other',
     });
     expect(wrongKey).toBeNull();
+  });
+
+  test('register permit fails when workspace is no longer bootstrapping', () => {
+    const issued = createCloudBootstrapToken({
+      workspaceId: 'ws-bootstrap-1',
+      ownerIdentityId: 'owner-abc',
+      ttlMs: 5 * 60 * 1000,
+    });
+
+    const unlock = consumeCloudBootstrapTokenForUnlock({
+      token: issued.token,
+      workspaceId: 'ws-bootstrap-1',
+      machineSigningPublicKey: 'machine-signing-pub',
+    });
+    expect(unlock).toBeDefined();
+
+    upsertCloudWorkspace({
+      id: 'ws-bootstrap-1',
+      provider: 'sprites',
+      providerWorkspaceId: 'sprite-1',
+      machinePublicKey: 'machine-signing-pub',
+      status: 'ready',
+      repo: 'owner/repo',
+      branch: 'main',
+    });
+
+    const register = consumeCloudRegisterPermit({
+      registerPermit: unlock!.registerPermit,
+      workspaceId: 'ws-bootstrap-1',
+      machineId: 'machine-xyz',
+      machineSigningPublicKey: 'machine-signing-pub',
+    });
+    expect(register).toBeNull();
+  });
+
+  test('register permit fails when workspace machine id conflicts', () => {
+    const issued = createCloudBootstrapToken({
+      workspaceId: 'ws-bootstrap-1',
+      ownerIdentityId: 'owner-abc',
+      ttlMs: 5 * 60 * 1000,
+    });
+
+    const unlock = consumeCloudBootstrapTokenForUnlock({
+      token: issued.token,
+      workspaceId: 'ws-bootstrap-1',
+      machineSigningPublicKey: 'machine-signing-pub',
+    });
+    expect(unlock).toBeDefined();
+
+    upsertCloudWorkspace({
+      id: 'ws-bootstrap-1',
+      provider: 'sprites',
+      providerWorkspaceId: 'sprite-1',
+      machineId: 'machine-existing',
+      machinePublicKey: 'machine-signing-pub',
+      status: 'bootstrapping',
+      repo: 'owner/repo',
+      branch: 'main',
+    });
+
+    const register = consumeCloudRegisterPermit({
+      registerPermit: unlock!.registerPermit,
+      workspaceId: 'ws-bootstrap-1',
+      machineId: 'machine-new',
+      machineSigningPublicKey: 'machine-signing-pub',
+    });
+    expect(register).toBeNull();
   });
 });

--- a/src/relay/control/sprites-provider.ts
+++ b/src/relay/control/sprites-provider.ts
@@ -23,8 +23,8 @@ export interface SpritesProviderOptions {
 
 export interface CreateWorkspaceOptions {
   name: string;
-  repo: string;
-  branch: string;
+  repo?: string;
+  branch?: string;
   image?: string;
   env?: Record<string, string>;
 }

--- a/src/relay/control/store.ts
+++ b/src/relay/control/store.ts
@@ -856,7 +856,10 @@ export function consumeCloudBootstrapTokenForUnlock(
           workspace_id,
           owner_identity_id,
           expires_at,
-          consumed_at
+          consumed_at,
+          state,
+          machine_public_key,
+          machine_id
         FROM cloud_bootstrap_tokens
         WHERE token_hash = ?
         LIMIT 1
@@ -867,6 +870,9 @@ export function consumeCloudBootstrapTokenForUnlock(
         owner_identity_id: string;
         expires_at: string;
         consumed_at: string | null;
+        state: string;
+        machine_public_key: string | null;
+        machine_id: string | null;
       } | null;
 
       if (!row) {
@@ -880,6 +886,11 @@ export function consumeCloudBootstrapTokenForUnlock(
       }
 
       if (row.consumed_at) {
+        db.exec('ROLLBACK');
+        return null;
+      }
+
+      if (row.state !== 'pending' && row.state !== 'vm_created') {
         db.exec('ROLLBACK');
         return null;
       }
@@ -898,21 +909,59 @@ export function consumeCloudBootstrapTokenForUnlock(
 
       const workspaceRow = db.query(
         `
-        SELECT machine_public_key
+        SELECT machine_public_key, machine_id, status
         FROM cloud_workspaces
         WHERE id = ?
         `
-      ).get(row.workspace_id) as { machine_public_key: string | null } | null;
+      ).get(row.workspace_id) as {
+        machine_public_key: string | null;
+        machine_id: string | null;
+        status: string;
+      } | null;
 
       if (!workspaceRow) {
         db.exec('ROLLBACK');
         return null;
       }
 
+      if (workspaceRow.status !== 'bootstrapping') {
+        db.exec('ROLLBACK');
+        return null;
+      }
+
+      if (workspaceRow.machine_id) {
+        db.exec('ROLLBACK');
+        return null;
+      }
+
+      if (!workspaceRow.machine_public_key) {
+        db.query(
+          `
+          UPDATE cloud_bootstrap_tokens
+          SET state = 'failed', last_error = ?, updated_at = ?
+          WHERE token_id = ?
+          `
+        ).run('Workspace machine key is missing for unlock grant', now, row.token_id);
+        db.exec('COMMIT');
+        return null;
+      }
+
       if (
-        workspaceRow.machine_public_key &&
         workspaceRow.machine_public_key !== input.machineSigningPublicKey
       ) {
+        db.exec('ROLLBACK');
+        return null;
+      }
+
+      if (
+        row.machine_public_key &&
+        row.machine_public_key !== input.machineSigningPublicKey
+      ) {
+        db.exec('ROLLBACK');
+        return null;
+      }
+
+      if (row.machine_id) {
         db.exec('ROLLBACK');
         return null;
       }
@@ -1017,7 +1066,8 @@ export function consumeCloudRegisterPermit(
           p.machine_public_key,
           p.expires_at,
           p.consumed_at,
-          b.owner_identity_id
+          b.owner_identity_id,
+          b.state AS bootstrap_state
         FROM cloud_register_permits p
         INNER JOIN cloud_bootstrap_tokens b ON b.token_id = p.token_id
         WHERE p.permit_hash = ?
@@ -1031,6 +1081,7 @@ export function consumeCloudRegisterPermit(
         expires_at: string;
         consumed_at: string | null;
         owner_identity_id: string;
+        bootstrap_state: string;
       } | null;
 
       if (!row) {
@@ -1053,6 +1104,11 @@ export function consumeCloudRegisterPermit(
         return null;
       }
 
+      if (row.bootstrap_state !== 'unlock_granted') {
+        db.exec('ROLLBACK');
+        return null;
+      }
+
       if (row.machine_public_key !== input.machineSigningPublicKey) {
         db.exec('ROLLBACK');
         return null;
@@ -1060,13 +1116,22 @@ export function consumeCloudRegisterPermit(
 
       const workspaceRow = db.query(
         `
-        SELECT machine_public_key
+        SELECT machine_public_key, machine_id, status
         FROM cloud_workspaces
         WHERE id = ?
         `
-      ).get(row.workspace_id) as { machine_public_key: string | null } | null;
+      ).get(row.workspace_id) as {
+        machine_public_key: string | null;
+        machine_id: string | null;
+        status: string;
+      } | null;
 
       if (!workspaceRow) {
+        db.exec('ROLLBACK');
+        return null;
+      }
+
+      if (workspaceRow.status !== 'bootstrapping') {
         db.exec('ROLLBACK');
         return null;
       }
@@ -1075,6 +1140,11 @@ export function consumeCloudRegisterPermit(
         workspaceRow.machine_public_key &&
         workspaceRow.machine_public_key !== input.machineSigningPublicKey
       ) {
+        db.exec('ROLLBACK');
+        return null;
+      }
+
+      if (workspaceRow.machine_id && workspaceRow.machine_id !== input.machineId) {
         db.exec('ROLLBACK');
         return null;
       }

--- a/src/relay/identity.ts
+++ b/src/relay/identity.ts
@@ -120,7 +120,7 @@ export function formatRelayFingerprint(publicKey: string): string {
  * @param publicKey - Base64 encoded Ed25519 public key
  * @returns Identity ID string
  */
-function computeIdentityId(publicKey: string): string {
+export function computeIdentityId(publicKey: string): string {
   const pubKeyBytes = Buffer.from(publicKey, "base64");
   const hash = sha256(pubKeyBytes);
   return Buffer.from(hash).toString("base64url").substring(0, 22);

--- a/src/relay/protocol.ts
+++ b/src/relay/protocol.ts
@@ -629,7 +629,10 @@ function validateMessageFields(msg: Record<string, unknown>): ProtocolMessage | 
       if (msg.bootstrapToken !== undefined && !isValidIdentifier(msg.bootstrapToken)) return null;
       if (msg.registerPermit !== undefined && !isValidIdentifier(msg.registerPermit)) return null;
       if (msg.enrollmentToken !== undefined && !isValidKeyString(msg.enrollmentToken)) return null;
-      if (msg.deviceCertificate !== undefined && typeof msg.deviceCertificate !== 'string') return null;
+      if (
+        msg.deviceCertificate !== undefined
+        && (typeof msg.deviceCertificate !== 'string' || msg.deviceCertificate.length === 0)
+      ) return null;
       return {
         type: "register_machine",
         machineId: msg.machineId,

--- a/src/relay/protocol.ts
+++ b/src/relay/protocol.ts
@@ -44,6 +44,10 @@ export interface RegisterMachineMessage {
   registerPermit?: string;
   /** One-time relay-machine invite token for machine enrollment */
   enrollmentToken?: string;
+  /** JSON-serialized device certificate signed by owner's user root identity.
+   *  If present and valid, the relay can auto-authorize the machine when the
+   *  certificate's userRootId matches the relay's owner. */
+  deviceCertificate?: string;
   /** Ed25519 signature of message */
   signature?: SignatureBlock;
 }
@@ -625,6 +629,7 @@ function validateMessageFields(msg: Record<string, unknown>): ProtocolMessage | 
       if (msg.bootstrapToken !== undefined && !isValidIdentifier(msg.bootstrapToken)) return null;
       if (msg.registerPermit !== undefined && !isValidIdentifier(msg.registerPermit)) return null;
       if (msg.enrollmentToken !== undefined && !isValidKeyString(msg.enrollmentToken)) return null;
+      if (msg.deviceCertificate !== undefined && typeof msg.deviceCertificate !== 'string') return null;
       return {
         type: "register_machine",
         machineId: msg.machineId,
@@ -636,6 +641,7 @@ function validateMessageFields(msg: Record<string, unknown>): ProtocolMessage | 
         bootstrapToken: msg.bootstrapToken,
         registerPermit: msg.registerPermit,
         enrollmentToken: msg.enrollmentToken,
+        deviceCertificate: msg.deviceCertificate,
       };
     }
 

--- a/src/relay/server-unlock.test.ts
+++ b/src/relay/server-unlock.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import type { Server } from 'bun';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { clearAllRegistries } from './registries';
+import { generateRelayIdentity } from './identity';
+import { startRelayServer } from './__tests__/helpers/ports';
+import { connectClient, sendAndWait } from './__tests__/helpers/auth';
+import { signMessage } from './signing';
+import { ensureControlStore, getVaultMeta, setVaultMeta } from './control/store.js';
+import { generateMnemonic, mnemonicToUserIdentity } from '../lib/tmux-lite/crypto/user-identity';
+import { _resetVaultState } from './vault.js';
+
+const TEST_HOST = '127.0.0.1';
+
+let previousControlDir: string | undefined;
+let tempControlDir: string | undefined;
+let server: Server<any> | undefined;
+
+function signUnlockMessage(ownerUserRoot: ReturnType<typeof mnemonicToUserIdentity>, proof: Uint8Array) {
+  return signMessage(
+    {
+      type: 'unlock_relay',
+      userRootPublicKey: Buffer.from(ownerUserRoot.signing.publicKey).toString('base64'),
+      proof: Buffer.from(proof).toString('base64'),
+    },
+    ownerUserRoot.signing.secretKey.slice(0, 32),
+    ownerUserRoot.signing.publicKey,
+  );
+}
+
+afterEach(() => {
+  server?.stop(true);
+  server = undefined;
+  clearAllRegistries();
+  _resetVaultState();
+
+  if (previousControlDir === undefined) {
+    delete process.env.GITSPACE_CONTROL_DIR;
+  } else {
+    process.env.GITSPACE_CONTROL_DIR = previousControlDir;
+  }
+
+  if (tempControlDir) {
+    rmSync(tempControlDir, { recursive: true, force: true });
+    tempControlDir = undefined;
+  }
+});
+
+describe('relay unlock repair', () => {
+  test('repairs incomplete legacy vault metadata during first unlock', async () => {
+    previousControlDir = process.env.GITSPACE_CONTROL_DIR;
+    tempControlDir = mkdtempSync(join(tmpdir(), 'gssh-relay-unlock-test-'));
+    process.env.GITSPACE_CONTROL_DIR = tempControlDir;
+
+    const ownerUserRoot = mnemonicToUserIdentity(generateMnemonic());
+    ensureControlStore();
+    setVaultMeta('owner_user_root_id', ownerUserRoot.id);
+    setVaultMeta('vault_initialized', '1');
+
+    server = startRelayServer({
+      bind: TEST_HOST,
+      hostname: TEST_HOST,
+      disableRateLimit: true,
+      identity: generateRelayIdentity('unlock-repair-test-relay'),
+    });
+
+    const relayUrl = `ws://${TEST_HOST}:${server.port}/ws`;
+    const clientWs = await connectClient(relayUrl);
+
+    const unlockResult = await sendAndWait<any>(
+      clientWs,
+      signUnlockMessage(ownerUserRoot, ownerUserRoot.signing.secretKey.slice(0, 32)),
+      'unlock_relay_result',
+    );
+
+    expect(unlockResult.success).toBe(true);
+    expect(getVaultMeta('vault_salt')).toBeTruthy();
+    expect(getVaultMeta('vault_key_check')).toBeTruthy();
+
+    clientWs.close();
+  });
+});

--- a/src/relay/server.ts
+++ b/src/relay/server.ts
@@ -591,26 +591,28 @@ export function createRelayServer(config: RelayConfig): Server<WebSocketData> {
     async fetch(req, server) {
       const url = new URL(req.url);
 
-      // Check Host header if hostname is specified
-      if (hostname) {
-        const hostHeader = req.headers.get("host");
-        const host = hostHeader?.split(":")[0]; // Remove port
-        console.log(`[relay] Request: ${url.pathname} Host: ${hostHeader} -> ${host} (expected: ${hostname})`);
-        if (host !== hostname) {
-          console.log(`[relay] Rejecting request - hostname mismatch`);
-          return new Response("Not found", { status: 404 });
-        }
-      }
-
-      // Health check
+      // Health check - always allowed regardless of hostname filter
+      // (must be reachable from localhost for local relay discovery)
       if (url.pathname === "/health") {
         const stats = getRegistryStats();
         const clientCount = clientConnections.size;
         return Response.json({
           status: "ok",
+          relayPublicKey: relayIdentity.signingPublicKey,
+          relayFingerprint: formatRelayFingerprint(relayIdentity.signingPublicKey),
+          relayLabel: relayIdentity.label ?? null,
           ...stats,
           connectedClients: clientCount,
         });
+      }
+
+      // Check Host header if hostname is specified (after health check which is always allowed)
+      if (hostname) {
+        const hostHeader = req.headers.get("host");
+        const host = hostHeader?.split(":")[0]; // Remove port
+        if (host !== hostname) {
+          return new Response("Not found", { status: 404 });
+        }
       }
 
       // WebSocket upgrade
@@ -909,11 +911,12 @@ async function handleProtocolMessage(
       state.pendingChallenges.delete(connectionId);
 
       // Check if machine is authorized to connect to this relay.
-      // Sources of authorization:
+      // Sources of authorization (checked in order):
       // 1) pre-authorized key set (ephemeral local relay startup)
       // 2) persisted machine registration (vault_machines)
-      // 3) valid one-time register permit (legacy cloud unlock flow)
-      // 4) valid root-signed relay-machine invite token
+      // 3) device certificate signed by relay owner's user root identity
+      // 4) valid one-time register permit (cloud unlock flow)
+      // 5) valid root-signed relay-machine invite token
       const persistedMachine = getVaultMachine(regMsg.machineId);
       if (persistedMachine && persistedMachine.signingKey !== regMsg.signingKey) {
         ws.send(serializeMessage(createErrorMessage(
@@ -947,6 +950,66 @@ async function handleProtocolMessage(
         : isPersistedMachine
           ? 'persisted-machine'
           : null;
+
+      // ── Auth path 3: Device certificate signed by relay owner ─────────
+      // If the machine presents a valid device certificate signed by the
+      // relay's owner, auto-authorize it. This enables same-machine and
+      // remote-same-owner pairing without enrollment tokens.
+      if (!isAuthorizedMachine && regMsg.deviceCertificate) {
+        try {
+          const cert: DeviceCertificate = JSON.parse(regMsg.deviceCertificate);
+
+          // Verify cert signature is cryptographically valid
+          if (!verifyDeviceCertificate(cert)) {
+            console.warn(`[relay] Device certificate signature verification failed for ${regMsg.machineId}`);
+            ws.send(serializeMessage(createErrorMessage("INVALID_SIGNATURE", "Device certificate signature invalid")));
+            ws.close();
+            return;
+          }
+
+          // Verify cert is not expired
+          if (isDeviceCertExpired(cert)) {
+            console.warn(`[relay] Device certificate expired for ${regMsg.machineId}`);
+            ws.send(serializeMessage(createErrorMessage("EXPIRED", "Device certificate has expired")));
+            ws.close();
+            return;
+          }
+
+          // Verify the cert's device keys match the registration message keys
+          if (cert.deviceSigningPublicKey !== regMsg.signingKey) {
+            console.warn(`[relay] Device cert signing key mismatch for ${regMsg.machineId}`);
+            ws.send(serializeMessage(createErrorMessage("FORBIDDEN", "Device certificate signing key does not match registration")));
+            ws.close();
+            return;
+          }
+          if (cert.deviceKeyExchangePublicKey !== regMsg.keyExchangeKey) {
+            console.warn(`[relay] Device cert key exchange key mismatch for ${regMsg.machineId}`);
+            ws.send(serializeMessage(createErrorMessage("FORBIDDEN", "Device certificate key exchange key does not match registration")));
+            ws.close();
+            return;
+          }
+
+          // Extract user root ID from the certificate and check against relay owner
+          const certUserRootId = getUserRootIdFromCert(cert);
+          const relayOwnerUserRootId = state.ownerUserRootId ?? getVaultMeta('owner_user_root_id') ?? null;
+
+          if (relayOwnerUserRootId && certUserRootId === relayOwnerUserRootId) {
+            // Certificate is signed by the relay's owner — auto-authorize
+            isAuthorizedMachine = true;
+            enrollmentOwnerUserRootId = certUserRootId;
+            authorizationSource = 'owner-device-cert';
+            console.log(`[relay] Machine ${regMsg.machineId.slice(0, 8)}... authorized via owner device certificate`);
+          } else if (!relayOwnerUserRootId) {
+            console.warn(`[relay] Device cert presented but relay has no owner set — cannot verify ownership`);
+          } else {
+            console.warn(`[relay] Device cert user root ${certUserRootId.slice(0, 8)}... does not match relay owner ${relayOwnerUserRootId.slice(0, 8)}...`);
+          }
+        } catch (err) {
+          console.warn(`[relay] Failed to parse device certificate: ${err instanceof Error ? err.message : String(err)}`);
+          // Don't reject — fall through to other auth paths
+        }
+      }
+
       const cloudWorkspaceForKey = getCloudWorkspaceByMachinePublicKey(regMsg.signingKey);
 
       // Owner-gated wake flow for cloud workspaces:

--- a/src/relay/server.ts
+++ b/src/relay/server.ts
@@ -990,6 +990,14 @@ async function handleProtocolMessage(
             return;
           }
 
+          const certMachineId = getMachineIdFromCert(cert);
+          if (certMachineId !== regMsg.machineId) {
+            console.warn(`[relay] Device cert machine ID mismatch for ${regMsg.machineId}`);
+            ws.send(serializeMessage(createErrorMessage("FORBIDDEN", "Device certificate machine ID does not match registration")));
+            ws.close();
+            return;
+          }
+
           // Extract user root ID from the certificate and check against relay owner
           const certUserRootId = getUserRootIdFromCert(cert);
           const relayOwnerUserRootId = state.ownerUserRootId ?? getVaultMeta('owner_user_root_id') ?? null;
@@ -1597,6 +1605,16 @@ async function handleProtocolMessage(
         return;
       }
 
+      const storedOwner = getVaultMeta('owner_user_root_id');
+      if (storedOwner && storedOwner !== userRootId) {
+        ws.send(serializeMessage({
+          type: "unlock_relay_result",
+          success: false,
+          error: "Not the vault owner",
+        }));
+        return;
+      }
+
       const needsVaultRepair = isVaultInitialized() && !isVaultMetadataComplete();
 
       // If vault is not initialized, initialize it with the proof as seed material.
@@ -1643,16 +1661,6 @@ async function handleProtocolMessage(
       }
 
       // Vault exists — verify owner and unlock
-      const storedOwner = getVaultMeta('owner_user_root_id');
-      if (storedOwner && storedOwner !== userRootId) {
-        ws.send(serializeMessage({
-          type: "unlock_relay_result",
-          success: false,
-          error: "Not the vault owner",
-        }));
-        return;
-      }
-
       if (isVaultUnlocked()) {
         // Already unlocked
         const unlockKeys = openAllMachineUnlockKeys();

--- a/src/relay/server.ts
+++ b/src/relay/server.ts
@@ -171,6 +171,7 @@ import {
 } from "./sync/runtime.js";
 import {
   isVaultUnlocked,
+  isVaultMetadataComplete,
   unlockVault,
   initializeVault,
   openAllMachineUnlockKeys,
@@ -570,8 +571,8 @@ export function createRelayServer(config: RelayConfig): Server<WebSocketData> {
   // Determine owner from vault metadata when available
   const ownerUserRootId = getVaultMeta('owner_user_root_id') ?? null;
   if (ownerUserRootId) {
-    console.log(`[relay] Vault initialized, owner: ${ownerUserRootId.slice(0, 8)}...`);
-    console.log(`[relay] Vault state: ${getVaultLockState()}`);
+    console.log(`[relay] Vault owner: ${ownerUserRootId.slice(0, 8)}...`);
+    console.log(`[relay] Vault state: ${isVaultInitialized() ? getVaultLockState() : 'uninitialized'}`);
   }
 
   const state: RelayServerState = {
@@ -1596,19 +1597,36 @@ async function handleProtocolMessage(
         return;
       }
 
-      // If vault is not initialized, initialize it with the proof as seed material
-      // The proof field carries the HKDF-derived material the vault needs
-      if (!isVaultInitialized()) {
+      const needsVaultRepair = isVaultInitialized() && !isVaultMetadataComplete();
+
+      // If vault is not initialized, initialize it with the proof as seed material.
+      // The proof field carries the HKDF-derived material the vault needs.
+      // Legacy relays may also have an incomplete init flag without salt/key-check;
+      // allow a repair only for that broken state.
+      if (!isVaultInitialized() || needsVaultRepair) {
         // First-time vault init: derive vault key from the proof
         // The proof is HMAC(challenge, userRootPrivateKey) — we use it as the key material
         const proofBytes = new Uint8Array(Buffer.from(unlockMsg.proof, "base64"));
-        const success = initializeVault(proofBytes);
+        let success = false;
+        try {
+          success = initializeVault(proofBytes, { allowRepair: needsVaultRepair });
+        } catch (error) {
+          ws.send(serializeMessage({
+            type: "unlock_relay_result",
+            success: false,
+            error: error instanceof Error ? error.message : "Vault initialization failed",
+          }));
+          return;
+        }
+
         if (success) {
           // Store owner identity
           const { setVaultMeta: setMeta } = await import("./control/store.js");
           setMeta('owner_user_root_id', userRootId);
           state.ownerUserRootId = userRootId;
-          console.log(`[relay] Vault initialized by owner ${userRootId.slice(0, 8)}...`);
+          console.log(
+            `[relay] Vault ${needsVaultRepair ? 'repaired' : 'initialized'} by owner ${userRootId.slice(0, 8)}...`
+          );
           ws.send(serializeMessage({
             type: "unlock_relay_result",
             success: true,
@@ -1618,7 +1636,7 @@ async function handleProtocolMessage(
           ws.send(serializeMessage({
             type: "unlock_relay_result",
             success: false,
-            error: "Vault already initialized",
+            error: needsVaultRepair ? "Vault repair failed" : "Vault already initialized",
           }));
         }
         return;

--- a/src/relay/server.ts
+++ b/src/relay/server.ts
@@ -1605,7 +1605,7 @@ async function handleProtocolMessage(
         return;
       }
 
-      const storedOwner = getVaultMeta('owner_user_root_id');
+      const storedOwner = state.ownerUserRootId ?? getVaultMeta('owner_user_root_id');
       if (storedOwner && storedOwner !== userRootId) {
         ws.send(serializeMessage({
           type: "unlock_relay_result",

--- a/src/relay/vault.test.ts
+++ b/src/relay/vault.test.ts
@@ -12,7 +12,9 @@ import { join } from 'node:path';
 import { randomBytes } from 'node:crypto';
 import {
   ensureControlStore,
+  getVaultMeta,
   isVaultInitialized,
+  setVaultMeta,
   upsertVaultCategory,
   upsertVaultMachine,
 } from './control/store.js';
@@ -106,6 +108,18 @@ describe('relay vault', () => {
 
       const result = initializeVault(key);
       expect(result).toBe(false);
+    });
+
+    test('initializeVault can repair incomplete legacy metadata when allowed', () => {
+      const key = fakePrivateKey();
+      setVaultMeta('vault_initialized', '1');
+
+      const result = initializeVault(key, { allowRepair: true });
+
+      expect(result).toBe(true);
+      expect(getVaultMeta('vault_salt')).toBeTruthy();
+      expect(getVaultMeta('vault_key_check')).toBeTruthy();
+      expect(isVaultUnlocked()).toBe(true);
     });
 
     test('initializeVault with different keys creates different vaults', () => {

--- a/src/relay/vault.ts
+++ b/src/relay/vault.ts
@@ -28,6 +28,8 @@ import { createHash, randomBytes } from 'node:crypto';
 import { hkdf } from '@noble/hashes/hkdf.js';
 import { sha256 } from '@noble/hashes/sha2.js';
 import { seal, open } from '../lib/tmux-lite/crypto/secretbox.js';
+import { logger } from '../utils/logger.js';
+import { SpacesError } from '../types/errors.js';
 import {
   getVaultCategory,
   getVaultMeta,
@@ -144,13 +146,28 @@ export function initializeVault(
   userRootPrivateKey: Uint8Array,
   options: { allowRepair?: boolean } = {},
 ): boolean {
+  const encryptedStateExists = hasVaultEncryptedState();
+  if (!isVaultInitialized() && encryptedStateExists) {
+    logger.error('Vault has encrypted state but is missing initialization metadata. Refusing to reinitialize.');
+    throw new SpacesError(
+      'Vault has encrypted state but is missing initialization metadata.',
+      'SYSTEM_ERROR',
+      2,
+    );
+  }
+
   if (isVaultInitialized()) {
     if (!options.allowRepair || isVaultMetadataComplete()) {
       return false;
     }
 
-    if (hasVaultEncryptedState()) {
-      throw new Error('Vault metadata is incomplete but encrypted data already exists');
+    if (encryptedStateExists) {
+      logger.error('Vault metadata is incomplete but encrypted data already exists. Refusing repair.');
+      throw new SpacesError(
+        'Vault metadata is incomplete but encrypted data already exists.',
+        'SYSTEM_ERROR',
+        2,
+      );
     }
   }
 

--- a/src/relay/vault.ts
+++ b/src/relay/vault.ts
@@ -76,6 +76,14 @@ export function getVaultLockState(): VaultLockState {
   return vaultKey !== null ? 'unlocked' : 'locked';
 }
 
+export function isVaultMetadataComplete(): boolean {
+  return Boolean(getVaultMeta('vault_salt') && getVaultMeta('vault_key_check'));
+}
+
+function hasVaultEncryptedState(): boolean {
+  return listVaultCategories().length > 0 || listVaultMachineUnlockKeys().length > 0;
+}
+
 /**
  * Check if vault is currently unlocked (key held in memory).
  */
@@ -132,9 +140,18 @@ function checksumPayload(payload: Uint8Array): string {
  * @returns true if initialized, false if already initialized
  * @throws {Error} If initialization fails
  */
-export function initializeVault(userRootPrivateKey: Uint8Array): boolean {
+export function initializeVault(
+  userRootPrivateKey: Uint8Array,
+  options: { allowRepair?: boolean } = {},
+): boolean {
   if (isVaultInitialized()) {
-    return false;
+    if (!options.allowRepair || isVaultMetadataComplete()) {
+      return false;
+    }
+
+    if (hasVaultEncryptedState()) {
+      throw new Error('Vault metadata is incomplete but encrypted data already exists');
+    }
   }
 
   // Generate random salt

--- a/src/utils/password-stdin.ts
+++ b/src/utils/password-stdin.ts
@@ -4,34 +4,65 @@ export async function readPasswordFromStdin(): Promise<string> {
   const reader = process.stdin;
   const chunks: Buffer[] = [];
 
-  const onData = (chunk: Buffer) => chunks.push(chunk);
-  reader.on('data', onData);
+  const readAvailableChunks = () => {
+    let chunk = reader.read();
+    while (chunk !== null) {
+      chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+      chunk = reader.read();
+    }
+  };
+
+  readAvailableChunks();
 
   try {
-    await new Promise<void>((resolve, reject) => {
-      const timeoutId = setTimeout(() => {
-        reject(new SpacesError('Timeout reading password from stdin.', 'USER_ERROR', 1));
-      }, 10000);
+    if (!reader.readableEnded) {
+      await new Promise<void>((resolve, reject) => {
+        const cleanup = () => {
+          clearTimeout(timeoutId);
+          reader.removeListener('readable', onReadable);
+          reader.removeListener('end', onEnd);
+          reader.removeListener('error', onError);
+        };
 
-      const onEnd = () => {
-        clearTimeout(timeoutId);
-        resolve();
-      };
+        const timeoutId = setTimeout(() => {
+          cleanup();
+          reject(new SpacesError('Timeout reading password from stdin.', 'USER_ERROR', 1));
+        }, 10000);
 
-      const onError = (error: Error) => {
-        clearTimeout(timeoutId);
-        reject(new SpacesError(
-          `Failed to read password from stdin: ${error.message}`,
-          'USER_ERROR',
-          1,
-        ));
-      };
+        const onReadable = () => {
+          readAvailableChunks();
+          if (reader.readableEnded) {
+            cleanup();
+            resolve();
+          }
+        };
 
-      reader.once('end', onEnd);
-      reader.once('error', onError);
-    });
+        const onEnd = () => {
+          readAvailableChunks();
+          cleanup();
+          resolve();
+        };
+
+        const onError = (error: Error) => {
+          cleanup();
+          reject(new SpacesError(
+            `Failed to read password from stdin: ${error.message}`,
+            'USER_ERROR',
+            1,
+          ));
+        };
+
+        reader.on('readable', onReadable);
+        reader.once('end', onEnd);
+        reader.once('error', onError);
+        readAvailableChunks();
+        if (reader.readableEnded) {
+          cleanup();
+          resolve();
+        }
+      });
+    }
   } finally {
-    reader.removeListener('data', onData);
     reader.pause();
   }
 

--- a/src/utils/password-stdin.ts
+++ b/src/utils/password-stdin.ts
@@ -1,0 +1,44 @@
+import { SpacesError } from '../types/errors.js';
+
+export async function readPasswordFromStdin(): Promise<string> {
+  const reader = process.stdin;
+  const chunks: Buffer[] = [];
+
+  const onData = (chunk: Buffer) => chunks.push(chunk);
+  reader.on('data', onData);
+
+  try {
+    await new Promise<void>((resolve, reject) => {
+      const timeoutId = setTimeout(() => {
+        reject(new SpacesError('Timeout reading password from stdin.', 'USER_ERROR', 1));
+      }, 10000);
+
+      const onEnd = () => {
+        clearTimeout(timeoutId);
+        resolve();
+      };
+
+      const onError = (error: Error) => {
+        clearTimeout(timeoutId);
+        reject(new SpacesError(
+          `Failed to read password from stdin: ${error.message}`,
+          'USER_ERROR',
+          1,
+        ));
+      };
+
+      reader.once('end', onEnd);
+      reader.once('error', onError);
+    });
+  } finally {
+    reader.removeListener('data', onData);
+    reader.pause();
+  }
+
+  const password = Buffer.concat(chunks).toString('utf-8').replace(/\r?\n$/, '');
+  if (!password) {
+    throw new SpacesError('No password provided via stdin.', 'USER_ERROR', 1);
+  }
+
+  return password;
+}

--- a/worker/bun.lock
+++ b/worker/bun.lock
@@ -10,6 +10,7 @@
       },
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20241127.0",
+        "miniflare": "^3.20250718.3",
         "typescript": "^5.7.2",
         "wrangler": "^3.95.0",
       },

--- a/worker/package.json
+++ b/worker/package.json
@@ -6,6 +6,8 @@
   "scripts": {
     "dev": "wrangler dev",
     "deploy": "wrangler deploy",
+    "test": "bun test",
+    "test:watch": "bun test --watch",
     "typecheck": "tsc --noEmit",
     "db:init": "wrangler d1 execute gitspace --local --file=schema.sql",
     "db:migrate": "wrangler d1 execute gitspace --file=schema.sql"
@@ -15,6 +17,7 @@
     "@noble/curves": "^1.7.0"
   },
   "devDependencies": {
+    "miniflare": "^3.20250718.3",
     "wrangler": "^3.95.0",
     "@cloudflare/workers-types": "^4.20241127.0",
     "typescript": "^5.7.2"

--- a/worker/schema.sql
+++ b/worker/schema.sql
@@ -44,6 +44,17 @@ CREATE TABLE IF NOT EXISTS sessions (
 CREATE INDEX IF NOT EXISTS idx_sessions_user ON sessions(user_id);
 CREATE INDEX IF NOT EXISTS idx_sessions_expires ON sessions(expires_at);
 
+-- Encrypted user-root identity backups (ciphertext only)
+CREATE TABLE IF NOT EXISTS identity_backups (
+  user_id TEXT PRIMARY KEY REFERENCES users(id) ON DELETE CASCADE,
+  version INTEGER NOT NULL,
+  kind TEXT NOT NULL,
+  owner_user_root_id TEXT NOT NULL,
+  envelope_json TEXT NOT NULL,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL
+);
+
 -- Subdomains (users can have MULTIPLE subdomains)
 -- Free tier: 3 subdomains max
 -- Paid tier: 10 subdomains max

--- a/worker/src/handlers/auth.ts
+++ b/worker/src/handlers/auth.ts
@@ -12,6 +12,21 @@ import { hashToken } from '../middleware/auth';
 const app = new Hono<{ Bindings: Env }>();
 const OAUTH_STATE_COOKIE = 'gitspace_oauth_state';
 
+function getCookieValue(cookieHeader: string | undefined, name: string): string | null {
+  if (!cookieHeader) {
+    return null;
+  }
+
+  for (const part of cookieHeader.split(';')) {
+    const [rawName, ...rawValue] = part.trim().split('=');
+    if (rawName === name) {
+      return rawValue.join('=') || null;
+    }
+  }
+
+  return null;
+}
+
 function getGitHubOauthBase(env: Env): string {
   return env.GITHUB_OAUTH_BASE ?? 'https://github.com';
 }
@@ -54,7 +69,8 @@ app.get('/github', (c) => {
 app.get('/github/callback', async (c) => {
   const code = c.req.query('code');
   const state = c.req.query('state');
-  const stateCookie = c.req.header('Cookie')?.match(new RegExp(`${OAUTH_STATE_COOKIE}=([^;]+)`))?.[1];
+  const redirectUri = new URL('/auth/github/callback', c.req.url).toString();
+  const stateCookie = getCookieValue(c.req.header('Cookie') ?? undefined, OAUTH_STATE_COOKIE);
 
   if (!code) {
     return c.redirect(`${c.env.PORTAL_URL}?error=missing_code`);
@@ -76,6 +92,7 @@ app.get('/github/callback', async (c) => {
         client_id: c.env.GITHUB_CLIENT_ID,
         client_secret: c.env.GITHUB_CLIENT_SECRET,
         code,
+        redirect_uri: redirectUri,
       }),
     });
 

--- a/worker/src/handlers/auth.ts
+++ b/worker/src/handlers/auth.ts
@@ -10,6 +10,7 @@ import type { Env, User, GitHubUser } from '../types';
 import { hashToken } from '../middleware/auth';
 
 const app = new Hono<{ Bindings: Env }>();
+const OAUTH_STATE_COOKIE = 'gitspace_oauth_state';
 
 function getGitHubOauthBase(env: Env): string {
   return env.GITHUB_OAUTH_BASE ?? 'https://github.com';
@@ -28,14 +29,22 @@ function getGitHubApiBase(env: Env): string {
  * GET /auth/github
  */
 app.get('/github', (c) => {
+  const redirectUri = new URL('/auth/github/callback', c.req.url).toString();
+  const state = crypto.randomUUID();
   const params = new URLSearchParams({
     client_id: c.env.GITHUB_CLIENT_ID,
-    redirect_uri: `https://api.gitspace.sh/auth/github/callback`,
+    redirect_uri: redirectUri,
     scope: 'read:user user:email',
-    state: crypto.randomUUID(),
+    state,
   });
 
-  return c.redirect(`${getGitHubOauthBase(c.env)}/login/oauth/authorize?${params}`);
+  return new Response(null, {
+    status: 302,
+    headers: {
+      Location: `${getGitHubOauthBase(c.env)}/login/oauth/authorize?${params}`,
+      'Set-Cookie': `${OAUTH_STATE_COOKIE}=${state}; Path=/auth/github; HttpOnly; Secure; SameSite=Lax; Max-Age=600`,
+    },
+  });
 });
 
 /**
@@ -44,9 +53,15 @@ app.get('/github', (c) => {
  */
 app.get('/github/callback', async (c) => {
   const code = c.req.query('code');
+  const state = c.req.query('state');
+  const stateCookie = c.req.header('Cookie')?.match(new RegExp(`${OAUTH_STATE_COOKIE}=([^;]+)`))?.[1];
 
   if (!code) {
     return c.redirect(`${c.env.PORTAL_URL}?error=missing_code`);
+  }
+
+  if (!state || !stateCookie || state !== stateCookie) {
+    return c.redirect(`${c.env.PORTAL_URL}?error=invalid_state`);
   }
 
   try {

--- a/worker/src/handlers/auth.ts
+++ b/worker/src/handlers/auth.ts
@@ -11,6 +11,14 @@ import { hashToken } from '../middleware/auth';
 
 const app = new Hono<{ Bindings: Env }>();
 
+function getGitHubOauthBase(env: Env): string {
+  return env.GITHUB_OAUTH_BASE ?? 'https://github.com';
+}
+
+function getGitHubApiBase(env: Env): string {
+  return env.GITHUB_API_BASE ?? 'https://api.github.com';
+}
+
 // ============================================================================
 // GitHub OAuth (Portal - redirect-based)
 // ============================================================================
@@ -27,7 +35,7 @@ app.get('/github', (c) => {
     state: crypto.randomUUID(),
   });
 
-  return c.redirect(`https://github.com/login/oauth/authorize?${params}`);
+  return c.redirect(`${getGitHubOauthBase(c.env)}/login/oauth/authorize?${params}`);
 });
 
 /**
@@ -43,7 +51,7 @@ app.get('/github/callback', async (c) => {
 
   try {
     // Exchange code for access token
-    const tokenRes = await fetch('https://github.com/login/oauth/access_token', {
+      const tokenRes = await fetch(`${getGitHubOauthBase(c.env)}/login/oauth/access_token`, {
       method: 'POST',
       headers: {
         Accept: 'application/json',
@@ -66,7 +74,7 @@ app.get('/github/callback', async (c) => {
     }
 
     // Fetch GitHub user
-    const githubUser = await fetchGitHubUser(tokenData.access_token);
+      const githubUser = await fetchGitHubUser(c.env, tokenData.access_token);
 
     // Find or create user (with account limit check)
     const maxAccounts = parseInt(c.env.MAX_ACCOUNTS, 10) || undefined;
@@ -212,7 +220,7 @@ app.post('/github/device', async (c) => {
 
   let githubUser: GitHubUser;
   try {
-    githubUser = await fetchGitHubUser(github_token);
+    githubUser = await fetchGitHubUser(c.env, github_token);
   } catch (error) {
     return c.json({ error: 'Invalid GitHub token' }, 401);
   }
@@ -311,8 +319,8 @@ app.post('/logout', async (c) => {
 /**
  * Fetch GitHub user info from API
  */
-async function fetchGitHubUser(accessToken: string): Promise<GitHubUser> {
-  const userRes = await fetch('https://api.github.com/user', {
+async function fetchGitHubUser(env: Env, accessToken: string): Promise<GitHubUser> {
+  const userRes = await fetch(`${getGitHubApiBase(env)}/user`, {
     headers: {
       Authorization: `Bearer ${accessToken}`,
       'User-Agent': 'gitspace.sh',
@@ -328,7 +336,7 @@ async function fetchGitHubUser(accessToken: string): Promise<GitHubUser> {
 
   // If email not in profile, try to get it from emails endpoint
   if (!user.email) {
-    const emailsRes = await fetch('https://api.github.com/user/emails', {
+    const emailsRes = await fetch(`${getGitHubApiBase(env)}/user/emails`, {
       headers: {
         Authorization: `Bearer ${accessToken}`,
         'User-Agent': 'gitspace.sh',

--- a/worker/src/handlers/identity.ts
+++ b/worker/src/handlers/identity.ts
@@ -106,7 +106,6 @@ app.put('/backup', async (c) => {
       kind = excluded.kind,
       owner_user_root_id = excluded.owner_user_root_id,
       envelope_json = excluded.envelope_json,
-      created_at = excluded.created_at,
       updated_at = excluded.updated_at
   `,
   )
@@ -116,12 +115,13 @@ app.put('/backup', async (c) => {
       payload.kind,
       payload.ownerUserRootId,
       JSON.stringify(payload.envelope),
-      payload.createdAt ?? now,
-      payload.updatedAt ?? now,
+      now,
+      now,
     )
     .run();
 
-  return c.json({ success: true, backup: payload });
+  const backup = await getBackupRow(c.env.DB, user.id);
+  return c.json({ success: true, backup: backup ? serializeBackup(backup) : payload });
 });
 
 app.delete('/backup', async (c) => {

--- a/worker/src/handlers/identity.ts
+++ b/worker/src/handlers/identity.ts
@@ -1,0 +1,155 @@
+import { Hono } from 'hono';
+import type { Env, IdentityBackupRecord } from '../types';
+import type { AuthContext } from '../middleware/auth';
+
+interface IdentityBackupEnvelope {
+  version: number;
+  algorithm: string;
+  iterations: number;
+  salt: string;
+  iv: string;
+  ciphertext: string;
+  createdAt: number;
+  updatedAt: number;
+}
+
+interface IdentityBackupPayload {
+  version: number;
+  kind: string;
+  ownerUserRootId: string;
+  envelope: IdentityBackupEnvelope;
+  createdAt: number;
+  updatedAt: number;
+}
+
+const app = new Hono<{ Bindings: Env; Variables: AuthContext }>();
+
+function isValidEnvelope(value: unknown): value is IdentityBackupEnvelope {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+
+  const envelope = value as Partial<IdentityBackupEnvelope>;
+  return envelope.version === 1
+    && typeof envelope.algorithm === 'string'
+    && typeof envelope.iterations === 'number'
+    && typeof envelope.salt === 'string'
+    && typeof envelope.iv === 'string'
+    && typeof envelope.ciphertext === 'string'
+    && typeof envelope.createdAt === 'number'
+    && typeof envelope.updatedAt === 'number';
+}
+
+function isValidBackupPayload(value: unknown): value is IdentityBackupPayload {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+
+  const payload = value as Partial<IdentityBackupPayload>;
+  return payload.version === 1
+    && payload.kind === 'user-root-mnemonic'
+    && typeof payload.ownerUserRootId === 'string'
+    && typeof payload.createdAt === 'number'
+    && typeof payload.updatedAt === 'number'
+    && isValidEnvelope(payload.envelope);
+}
+
+function serializeBackup(record: IdentityBackupRecord): IdentityBackupPayload {
+  return {
+    version: record.version,
+    kind: record.kind,
+    ownerUserRootId: record.owner_user_root_id,
+    envelope: JSON.parse(record.envelope_json) as IdentityBackupEnvelope,
+    createdAt: record.created_at,
+    updatedAt: record.updated_at,
+  };
+}
+
+async function getBackupRow(db: D1Database, userId: string): Promise<IdentityBackupRecord | null> {
+  return db
+    .prepare(
+      `
+      SELECT user_id, version, kind, owner_user_root_id, envelope_json, created_at, updated_at
+      FROM identity_backups
+      WHERE user_id = ?
+    `,
+    )
+    .bind(userId)
+    .first<IdentityBackupRecord>();
+}
+
+app.get('/backup', async (c) => {
+  const user = c.get('user');
+  const record = await getBackupRow(c.env.DB, user.id);
+  if (!record) {
+    return c.json({ error: 'Identity backup not found' }, 404);
+  }
+
+  return c.json(serializeBackup(record));
+});
+
+app.put('/backup', async (c) => {
+  const user = c.get('user');
+  const payload = await c.req.json().catch(() => null);
+  if (!isValidBackupPayload(payload)) {
+    return c.json({ error: 'Invalid identity backup payload' }, 400);
+  }
+
+  const now = Date.now();
+  await c.env.DB.prepare(
+    `
+    INSERT INTO identity_backups (
+      user_id, version, kind, owner_user_root_id, envelope_json, created_at, updated_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?)
+    ON CONFLICT(user_id) DO UPDATE SET
+      version = excluded.version,
+      kind = excluded.kind,
+      owner_user_root_id = excluded.owner_user_root_id,
+      envelope_json = excluded.envelope_json,
+      created_at = excluded.created_at,
+      updated_at = excluded.updated_at
+  `,
+  )
+    .bind(
+      user.id,
+      payload.version,
+      payload.kind,
+      payload.ownerUserRootId,
+      JSON.stringify(payload.envelope),
+      payload.createdAt ?? now,
+      payload.updatedAt ?? now,
+    )
+    .run();
+
+  return c.json({ success: true, backup: payload });
+});
+
+app.delete('/backup', async (c) => {
+  const user = c.get('user');
+  const result = await c.env.DB.prepare('DELETE FROM identity_backups WHERE user_id = ?')
+    .bind(user.id)
+    .run();
+
+  if ((result.meta.changes ?? 0) === 0) {
+    return c.json({ error: 'Identity backup not found' }, 404);
+  }
+
+  return c.json({ success: true });
+});
+
+app.get('/backup/status', async (c) => {
+  const user = c.get('user');
+  const record = await getBackupRow(c.env.DB, user.id);
+  if (!record) {
+    return c.json({ enabled: false });
+  }
+
+  return c.json({
+    enabled: true,
+    ownerUserRootId: record.owner_user_root_id,
+    createdAt: record.created_at,
+    updatedAt: record.updated_at,
+  });
+});
+
+export default app;

--- a/worker/src/handlers/identity.ts
+++ b/worker/src/handlers/identity.ts
@@ -23,6 +23,9 @@ interface IdentityBackupPayload {
 }
 
 const app = new Hono<{ Bindings: Env; Variables: AuthContext }>();
+const BACKUP_ENVELOPE_ALGORITHM = 'PBKDF2-AES-GCM';
+const BACKUP_MIN_ITERATIONS = 210_000;
+const BACKUP_MAX_ITERATIONS = 1_000_000;
 
 function isValidEnvelope(value: unknown): value is IdentityBackupEnvelope {
   if (!value || typeof value !== 'object') {
@@ -30,9 +33,13 @@ function isValidEnvelope(value: unknown): value is IdentityBackupEnvelope {
   }
 
   const envelope = value as Partial<IdentityBackupEnvelope>;
+  const iterations = envelope.iterations;
   return envelope.version === 1
-    && typeof envelope.algorithm === 'string'
-    && typeof envelope.iterations === 'number'
+    && envelope.algorithm === BACKUP_ENVELOPE_ALGORITHM
+    && typeof iterations === 'number'
+    && Number.isSafeInteger(iterations)
+    && iterations >= BACKUP_MIN_ITERATIONS
+    && iterations <= BACKUP_MAX_ITERATIONS
     && typeof envelope.salt === 'string'
     && typeof envelope.iv === 'string'
     && typeof envelope.ciphertext === 'string'

--- a/worker/src/handlers/subdomains.ts
+++ b/worker/src/handlers/subdomains.ts
@@ -46,6 +46,12 @@ interface StoredSubdomainRecord {
 interface ExistingSubdomainRecord extends StoredSubdomainRecord {
   user_id: string;
   status: string;
+  tunnel_token_encrypted: string;
+  is_primary: number;
+}
+
+async function getStoredTunnelToken(env: Env, record: Pick<ExistingSubdomainRecord, 'tunnel_token_encrypted'>): Promise<string> {
+  return decryptToken(env, record.tunnel_token_encrypted);
 }
 
 async function cleanupStoredSubdomain(env: Env, record: StoredSubdomainRecord): Promise<void> {
@@ -253,7 +259,11 @@ app.post('/', async (c) => {
 
   // Check if subdomain exists
   const existing = await c.env.DB.prepare(
-    "SELECT id, user_id, status, tunnel_id, dns_record_ids, custom_hostname_id FROM subdomains WHERE subdomain = ?"
+    `
+    SELECT id, user_id, status, tunnel_id, dns_record_ids, custom_hostname_id, tunnel_token_encrypted, is_primary
+    FROM subdomains
+    WHERE subdomain = ?
+  `
   )
     .bind(subdomain)
     .first<ExistingSubdomainRecord>();
@@ -263,19 +273,20 @@ app.post('/', async (c) => {
     if (existing.user_id !== user.id && existing.status !== 'deleted') {
       return c.json({ error: 'This subdomain is already taken' }, 400);
     }
-
-    // If it's the same user or was deleted, we'll reconfigure it
-    // Delete the old record first (we'll create a fresh one)
-    if (existing.user_id === user.id || existing.status === 'deleted') {
+    if (existing.status === 'deleted') {
       await hardDeleteStoredSubdomain(c.env, existing);
     }
   }
 
   // Check user's subdomain limit
   const countResult = await c.env.DB.prepare(
-    "SELECT COUNT(*) as count FROM subdomains WHERE user_id = ? AND status = 'active' AND subdomain NOT LIKE '%.serve'"
+    `
+    SELECT COUNT(*) as count
+    FROM subdomains
+    WHERE user_id = ? AND status = 'active' AND subdomain NOT LIKE '%.serve' AND subdomain != ?
+  `
   )
-    .bind(user.id)
+    .bind(user.id, subdomain)
     .first<{ count: number }>();
 
   const count = countResult?.count ?? 0;
@@ -287,20 +298,17 @@ app.post('/', async (c) => {
   }
 
   // Check if this is user's first subdomain (set as primary)
-  const isPrimary = count === 0 || body.isPrimary;
-
-  // If setting as primary, unset other primaries
-  if (isPrimary) {
-    await c.env.DB.prepare(
-      "UPDATE subdomains SET is_primary = 0 WHERE user_id = ? AND status = 'active' AND subdomain NOT LIKE '%.serve'"
-    )
-      .bind(user.id)
-      .run();
-  }
+  const isPrimary = existing?.user_id === user.id && existing.status === 'active' && existing.is_primary === 1
+    ? true
+    : count === 0 || Boolean(body.isPrimary);
 
   const serveSubdomain = getServeSubdomain(subdomain);
   const existingServe = await c.env.DB.prepare(
-    "SELECT id, user_id, status, tunnel_id, dns_record_ids, custom_hostname_id FROM subdomains WHERE subdomain = ?"
+    `
+    SELECT id, user_id, status, tunnel_id, dns_record_ids, custom_hostname_id, tunnel_token_encrypted, is_primary
+    FROM subdomains
+    WHERE subdomain = ?
+  `
   )
     .bind(serveSubdomain)
     .first<ExistingSubdomainRecord>();
@@ -309,17 +317,47 @@ app.post('/', async (c) => {
     if (existingServe.user_id !== user.id && existingServe.status !== 'deleted') {
       return c.json({ error: 'Serve subdomain is already taken' }, 400);
     }
-
-    if (existingServe.user_id === user.id || existingServe.status === 'deleted') {
+    if (existingServe.status === 'deleted') {
       await hardDeleteStoredSubdomain(c.env, existingServe);
     }
   }
 
   let createdPrimary: { id: string; tunnelToken: string } | null = null;
+  let createdServe: { id: string; tunnelToken: string } | null = null;
+  let createdPrimaryNew = false;
+  let createdServeNew = false;
 
   try {
-    createdPrimary = await createManagedSubdomain(c.env, user.id, subdomain, Boolean(isPrimary));
-    const createdServe = await createManagedSubdomain(c.env, user.id, serveSubdomain, false);
+    if (existing && existing.user_id === user.id && existing.status === 'active') {
+      createdPrimary = {
+        id: existing.id,
+        tunnelToken: await getStoredTunnelToken(c.env, existing),
+      };
+    } else {
+      createdPrimary = await createManagedSubdomain(c.env, user.id, subdomain, false);
+      createdPrimaryNew = true;
+    }
+
+    if (existingServe && existingServe.user_id === user.id && existingServe.status === 'active') {
+      createdServe = {
+        id: existingServe.id,
+        tunnelToken: await getStoredTunnelToken(c.env, existingServe),
+      };
+    } else {
+      createdServe = await createManagedSubdomain(c.env, user.id, serveSubdomain, false);
+      createdServeNew = true;
+    }
+
+    if (isPrimary) {
+      await c.env.DB.batch([
+        c.env.DB.prepare(
+          "UPDATE subdomains SET is_primary = 0 WHERE user_id = ? AND status = 'active' AND subdomain NOT LIKE '%.serve'"
+        ).bind(user.id),
+        c.env.DB.prepare(
+          "UPDATE subdomains SET is_primary = 1, updated_at = ? WHERE id = ?"
+        ).bind(Date.now(), createdPrimary.id),
+      ]);
+    }
 
     return c.json({
       id: createdPrimary.id,
@@ -331,7 +369,26 @@ app.post('/', async (c) => {
       isPrimary,
     });
   } catch (error) {
-    if (createdPrimary) {
+    if (createdServeNew && createdServe) {
+      const serveRecord = await c.env.DB.prepare(
+        `
+        SELECT id, tunnel_id, dns_record_ids, custom_hostname_id
+        FROM subdomains
+        WHERE id = ?
+      `,
+      )
+        .bind(createdServe.id)
+        .first<StoredSubdomainRecord>();
+
+      if (serveRecord) {
+        await cleanupStoredSubdomain(c.env, serveRecord);
+        await c.env.DB.prepare("UPDATE subdomains SET status = 'deleted', updated_at = ? WHERE id = ?")
+          .bind(Date.now(), serveRecord.id)
+          .run();
+      }
+    }
+
+    if (createdPrimaryNew && createdPrimary) {
       const primaryRecord = await c.env.DB.prepare(
         `
         SELECT id, tunnel_id, dns_record_ids, custom_hostname_id

--- a/worker/src/handlers/subdomains.ts
+++ b/worker/src/handlers/subdomains.ts
@@ -43,6 +43,11 @@ interface StoredSubdomainRecord {
   custom_hostname_id: string | null;
 }
 
+interface ExistingSubdomainRecord extends StoredSubdomainRecord {
+  user_id: string;
+  status: string;
+}
+
 async function cleanupStoredSubdomain(env: Env, record: StoredSubdomainRecord): Promise<void> {
   try {
     await deleteTunnel(env, record.tunnel_id);
@@ -64,6 +69,11 @@ async function cleanupStoredSubdomain(env: Env, record: StoredSubdomainRecord): 
       console.error('Custom hostname deletion failed:', error);
     }
   }
+}
+
+async function hardDeleteStoredSubdomain(env: Env, record: StoredSubdomainRecord): Promise<void> {
+  await cleanupStoredSubdomain(env, record);
+  await env.DB.prepare('DELETE FROM subdomains WHERE id = ?').bind(record.id).run();
 }
 
 async function createManagedSubdomain(
@@ -106,32 +116,42 @@ async function createManagedSubdomain(
     console.error('Custom hostname creation failed (non-fatal):', error);
   }
 
-  const encryptedToken = await encryptToken(env, tunnel.token);
   const now = Date.now();
   const subdomainId = crypto.randomUUID();
 
-  await env.DB.prepare(
-    `
-    INSERT INTO subdomains (
-      id, subdomain, user_id, tunnel_id, dns_record_ids, custom_hostname_id,
-      tunnel_token_encrypted, status, is_primary, created_at, updated_at
-    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-  `,
-  )
-    .bind(
-      subdomainId,
-      subdomain,
-      userId,
-      tunnel.id,
-      JSON.stringify(dnsRecordIds),
-      customHostnameId,
-      encryptedToken,
-      'active',
-      isPrimary ? 1 : 0,
-      now,
-      now,
+  try {
+    const encryptedToken = await encryptToken(env, tunnel.token);
+
+    await env.DB.prepare(
+      `
+      INSERT INTO subdomains (
+        id, subdomain, user_id, tunnel_id, dns_record_ids, custom_hostname_id,
+        tunnel_token_encrypted, status, is_primary, created_at, updated_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `,
     )
-    .run();
+      .bind(
+        subdomainId,
+        subdomain,
+        userId,
+        tunnel.id,
+        JSON.stringify(dnsRecordIds),
+        customHostnameId,
+        encryptedToken,
+        'active',
+        isPrimary ? 1 : 0,
+        now,
+        now,
+      )
+      .run();
+  } catch (error) {
+    await Promise.allSettled([
+      deleteTunnel(env, tunnel.id),
+      deleteDNSRecords(env, dnsRecordIds),
+      customHostnameId ? deleteCustomHostname(env, customHostnameId) : Promise.resolve(),
+    ]);
+    throw error;
+  }
 
   return { id: subdomainId, tunnelToken: tunnel.token };
 }
@@ -233,10 +253,10 @@ app.post('/', async (c) => {
 
   // Check if subdomain exists
   const existing = await c.env.DB.prepare(
-    "SELECT id, user_id, status FROM subdomains WHERE subdomain = ?"
+    "SELECT id, user_id, status, tunnel_id, dns_record_ids, custom_hostname_id FROM subdomains WHERE subdomain = ?"
   )
     .bind(subdomain)
-    .first<{ id: string; user_id: string; status: string }>();
+    .first<ExistingSubdomainRecord>();
 
   if (existing) {
     // If it belongs to another user and is active, reject
@@ -247,9 +267,7 @@ app.post('/', async (c) => {
     // If it's the same user or was deleted, we'll reconfigure it
     // Delete the old record first (we'll create a fresh one)
     if (existing.user_id === user.id || existing.status === 'deleted') {
-      await c.env.DB.prepare('DELETE FROM subdomains WHERE id = ?')
-        .bind(existing.id)
-        .run();
+      await hardDeleteStoredSubdomain(c.env, existing);
     }
   }
 
@@ -282,10 +300,10 @@ app.post('/', async (c) => {
 
   const serveSubdomain = getServeSubdomain(subdomain);
   const existingServe = await c.env.DB.prepare(
-    "SELECT id, user_id, status FROM subdomains WHERE subdomain = ?"
+    "SELECT id, user_id, status, tunnel_id, dns_record_ids, custom_hostname_id FROM subdomains WHERE subdomain = ?"
   )
     .bind(serveSubdomain)
-    .first<{ id: string; user_id: string; status: string }>();
+    .first<ExistingSubdomainRecord>();
 
   if (existingServe) {
     if (existingServe.user_id !== user.id && existingServe.status !== 'deleted') {
@@ -293,9 +311,7 @@ app.post('/', async (c) => {
     }
 
     if (existingServe.user_id === user.id || existingServe.status === 'deleted') {
-      await c.env.DB.prepare('DELETE FROM subdomains WHERE id = ?')
-        .bind(existingServe.id)
-        .run();
+      await hardDeleteStoredSubdomain(c.env, existingServe);
     }
   }
 
@@ -412,6 +428,10 @@ app.post('/:subdomain/set-primary', async (c) => {
 app.delete('/:subdomain', async (c) => {
   const user = c.get('user');
   const subdomain = c.req.param('subdomain');
+
+  if (isServeSubdomain(subdomain)) {
+    return c.json({ error: 'Serve subdomains cannot be deleted directly' }, 400);
+  }
 
   const record = await c.env.DB.prepare(
     `

--- a/worker/src/handlers/subdomains.ts
+++ b/worker/src/handlers/subdomains.ts
@@ -28,6 +28,114 @@ const PAID_SUBDOMAIN_LIMIT = 10;
 // Subdomain format validation
 const SUBDOMAIN_REGEX = /^[a-z0-9][a-z0-9-]{1,18}[a-z0-9]$/;
 
+function isServeSubdomain(subdomain: string): boolean {
+  return subdomain.endsWith('.serve');
+}
+
+function getServeSubdomain(subdomain: string): string {
+  return `${subdomain}.serve`;
+}
+
+interface StoredSubdomainRecord {
+  id: string;
+  tunnel_id: string;
+  dns_record_ids: string;
+  custom_hostname_id: string | null;
+}
+
+async function cleanupStoredSubdomain(env: Env, record: StoredSubdomainRecord): Promise<void> {
+  try {
+    await deleteTunnel(env, record.tunnel_id);
+  } catch (error) {
+    console.error('Tunnel deletion failed:', error);
+  }
+
+  try {
+    const dnsRecordIds = JSON.parse(record.dns_record_ids) as string[];
+    await deleteDNSRecords(env, dnsRecordIds);
+  } catch (error) {
+    console.error('DNS deletion failed:', error);
+  }
+
+  if (record.custom_hostname_id) {
+    try {
+      await deleteCustomHostname(env, record.custom_hostname_id);
+    } catch (error) {
+      console.error('Custom hostname deletion failed:', error);
+    }
+  }
+}
+
+async function createManagedSubdomain(
+  env: Env,
+  userId: string,
+  subdomain: string,
+  isPrimary: boolean,
+): Promise<{ id: string; tunnelToken: string }> {
+  let tunnel;
+  try {
+    tunnel = await createTunnel(env, subdomain);
+  } catch (error) {
+    console.error('Tunnel creation failed:', error);
+    throw new Error('Failed to create tunnel');
+  }
+
+  try {
+    await configureTunnelIngress(env, tunnel.id, subdomain);
+  } catch (error) {
+    await deleteTunnel(env, tunnel.id).catch(() => {});
+    console.error('Tunnel ingress configuration failed:', error);
+    throw new Error('Failed to configure tunnel');
+  }
+
+  let dnsRecordIds: string[];
+  try {
+    dnsRecordIds = await createDNSRecords(env, subdomain, tunnel.id);
+  } catch (error) {
+    await deleteTunnel(env, tunnel.id).catch(() => {});
+    console.error('DNS creation failed:', error);
+    throw new Error('Failed to create DNS records');
+  }
+
+  let customHostnameId: string | null = null;
+  try {
+    const customHostname = await createCustomHostname(env, subdomain);
+    customHostnameId = customHostname.id;
+    console.log(`Custom hostname created: ${customHostname.hostname} (${customHostname.status})`);
+  } catch (error) {
+    console.error('Custom hostname creation failed (non-fatal):', error);
+  }
+
+  const encryptedToken = await encryptToken(env, tunnel.token);
+  const now = Date.now();
+  const subdomainId = crypto.randomUUID();
+
+  await env.DB.prepare(
+    `
+    INSERT INTO subdomains (
+      id, subdomain, user_id, tunnel_id, dns_record_ids, custom_hostname_id,
+      tunnel_token_encrypted, status, is_primary, created_at, updated_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `,
+  )
+    .bind(
+      subdomainId,
+      subdomain,
+      userId,
+      tunnel.id,
+      JSON.stringify(dnsRecordIds),
+      customHostnameId,
+      encryptedToken,
+      'active',
+      isPrimary ? 1 : 0,
+      now,
+      now,
+    )
+    .run();
+
+  return { id: subdomainId, tunnelToken: tunnel.token };
+}
+
 /**
  * List user's subdomains
  * GET /subdomains
@@ -39,7 +147,7 @@ app.get('/', async (c) => {
     `
     SELECT id, subdomain, status, is_primary, created_at, updated_at
     FROM subdomains
-    WHERE user_id = ? AND status != 'deleted'
+    WHERE user_id = ? AND status != 'deleted' AND subdomain NOT LIKE '%.serve'
     ORDER BY is_primary DESC, created_at DESC
   `
   )
@@ -147,7 +255,7 @@ app.post('/', async (c) => {
 
   // Check user's subdomain limit
   const countResult = await c.env.DB.prepare(
-    "SELECT COUNT(*) as count FROM subdomains WHERE user_id = ? AND status = 'active'"
+    "SELECT COUNT(*) as count FROM subdomains WHERE user_id = ? AND status = 'active' AND subdomain NOT LIKE '%.serve'"
   )
     .bind(user.id)
     .first<{ count: number }>();
@@ -160,95 +268,74 @@ app.post('/', async (c) => {
     );
   }
 
-  // Create tunnel via Cloudflare API
-  let tunnel;
-  try {
-    tunnel = await createTunnel(c.env, subdomain);
-  } catch (error) {
-    console.error('Tunnel creation failed:', error);
-    return c.json({ error: 'Failed to create tunnel' }, 500);
-  }
-
-  // Configure tunnel ingress (routes traffic to local relay on port 4480)
-  try {
-    await configureTunnelIngress(c.env, tunnel.id, subdomain);
-  } catch (error) {
-    // Cleanup: delete the tunnel we just created
-    await deleteTunnel(c.env, tunnel.id).catch(() => {});
-    console.error('Tunnel ingress configuration failed:', error);
-    return c.json({ error: 'Failed to configure tunnel' }, 500);
-  }
-
-  // Create DNS records
-  let dnsRecordIds: string[];
-  try {
-    dnsRecordIds = await createDNSRecords(c.env, subdomain, tunnel.id);
-  } catch (error) {
-    // Cleanup: delete the tunnel we just created
-    await deleteTunnel(c.env, tunnel.id).catch(() => {});
-    console.error('DNS creation failed:', error);
-    return c.json({ error: 'Failed to create DNS records' }, 500);
-  }
-
-  // Create custom hostname for wildcard SSL (Cloudflare for SaaS)
-  let customHostnameId: string | null = null;
-  try {
-    const customHostname = await createCustomHostname(c.env, subdomain);
-    customHostnameId = customHostname.id;
-    console.log(`Custom hostname created: ${customHostname.hostname} (${customHostname.status})`);
-  } catch (error) {
-    // Non-fatal: wildcard SSL won't work but base subdomain will
-    console.error('Custom hostname creation failed (non-fatal):', error);
-  }
-
-  // Encrypt tunnel token for storage
-  const encryptedToken = await encryptToken(c.env, tunnel.token);
-
   // Check if this is user's first subdomain (set as primary)
   const isPrimary = count === 0 || body.isPrimary;
 
   // If setting as primary, unset other primaries
   if (isPrimary) {
     await c.env.DB.prepare(
-      "UPDATE subdomains SET is_primary = 0 WHERE user_id = ? AND status = 'active'"
+      "UPDATE subdomains SET is_primary = 0 WHERE user_id = ? AND status = 'active' AND subdomain NOT LIKE '%.serve'"
     )
       .bind(user.id)
       .run();
   }
 
-  // Store in database
-  const now = Date.now();
-  const subdomainId = crypto.randomUUID();
-
-  await c.env.DB.prepare(
-    `
-    INSERT INTO subdomains (
-      id, subdomain, user_id, tunnel_id, dns_record_ids, custom_hostname_id,
-      tunnel_token_encrypted, status, is_primary, created_at, updated_at
-    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-  `
+  const serveSubdomain = getServeSubdomain(subdomain);
+  const existingServe = await c.env.DB.prepare(
+    "SELECT id, user_id, status FROM subdomains WHERE subdomain = ?"
   )
-    .bind(
-      subdomainId,
-      subdomain,
-      user.id,
-      tunnel.id,
-      JSON.stringify(dnsRecordIds),
-      customHostnameId,
-      encryptedToken,
-      'active',
-      isPrimary ? 1 : 0,
-      now,
-      now
-    )
-    .run();
+    .bind(serveSubdomain)
+    .first<{ id: string; user_id: string; status: string }>();
 
-  return c.json({
-    id: subdomainId,
-    subdomain,
-    hosts: [`${subdomain}.gitspace.sh`, `*.${subdomain}.gitspace.sh`],
-    isPrimary,
-  });
+  if (existingServe) {
+    if (existingServe.user_id !== user.id && existingServe.status !== 'deleted') {
+      return c.json({ error: 'Serve subdomain is already taken' }, 400);
+    }
+
+    if (existingServe.user_id === user.id || existingServe.status === 'deleted') {
+      await c.env.DB.prepare('DELETE FROM subdomains WHERE id = ?')
+        .bind(existingServe.id)
+        .run();
+    }
+  }
+
+  let createdPrimary: { id: string; tunnelToken: string } | null = null;
+
+  try {
+    createdPrimary = await createManagedSubdomain(c.env, user.id, subdomain, Boolean(isPrimary));
+    const createdServe = await createManagedSubdomain(c.env, user.id, serveSubdomain, false);
+
+    return c.json({
+      id: createdPrimary.id,
+      subdomain,
+      tunnelToken: createdPrimary.tunnelToken,
+      serveSubdomain,
+      serveTunnelToken: createdServe.tunnelToken,
+      hosts: [`${subdomain}.gitspace.sh`, `*.${subdomain}.gitspace.sh`],
+      isPrimary,
+    });
+  } catch (error) {
+    if (createdPrimary) {
+      const primaryRecord = await c.env.DB.prepare(
+        `
+        SELECT id, tunnel_id, dns_record_ids, custom_hostname_id
+        FROM subdomains
+        WHERE id = ?
+      `,
+      )
+        .bind(createdPrimary.id)
+        .first<StoredSubdomainRecord>();
+
+      if (primaryRecord) {
+        await cleanupStoredSubdomain(c.env, primaryRecord);
+        await c.env.DB.prepare("UPDATE subdomains SET status = 'deleted', updated_at = ? WHERE id = ?")
+          .bind(Date.now(), primaryRecord.id)
+          .run();
+      }
+    }
+
+    return c.json({ error: error instanceof Error ? error.message : 'Failed to reserve subdomain' }, 500);
+  }
 });
 
 /**
@@ -286,9 +373,13 @@ app.post('/:subdomain/set-primary', async (c) => {
   const user = c.get('user');
   const subdomain = c.req.param('subdomain');
 
+  if (isServeSubdomain(subdomain)) {
+    return c.json({ error: 'Serve subdomains cannot be primary' }, 400);
+  }
+
   // Verify ownership
   const record = await c.env.DB.prepare(
-    "SELECT id FROM subdomains WHERE subdomain = ? AND user_id = ? AND status = 'active'"
+    "SELECT id FROM subdomains WHERE subdomain = ? AND user_id = ? AND status = 'active' AND subdomain NOT LIKE '%.serve'"
   )
     .bind(subdomain, user.id)
     .first();
@@ -299,7 +390,7 @@ app.post('/:subdomain/set-primary', async (c) => {
 
   // Unset all primaries
   await c.env.DB.prepare(
-    "UPDATE subdomains SET is_primary = 0 WHERE user_id = ? AND status = 'active'"
+    "UPDATE subdomains SET is_primary = 0 WHERE user_id = ? AND status = 'active' AND subdomain NOT LIKE '%.serve'"
   )
     .bind(user.id)
     .run();
@@ -336,39 +427,30 @@ app.delete('/:subdomain', async (c) => {
     return c.json({ error: 'Subdomain not found' }, 404);
   }
 
-  // Delete tunnel (this immediately blocks new connections)
-  try {
-    await deleteTunnel(c.env, record.tunnel_id);
-  } catch (error) {
-    console.error('Tunnel deletion failed:', error);
-    // Continue anyway to clean up database
-  }
+  const recordsToDelete: Array<StoredSubdomainRecord> = [record];
+  if (!isServeSubdomain(subdomain)) {
+    const serveRecord = await c.env.DB.prepare(
+      `
+      SELECT id, tunnel_id, dns_record_ids, custom_hostname_id
+      FROM subdomains
+      WHERE subdomain = ? AND user_id = ? AND status = 'active'
+    `,
+    )
+      .bind(getServeSubdomain(subdomain), user.id)
+      .first<StoredSubdomainRecord>();
 
-  // Delete DNS records
-  try {
-    const dnsRecordIds = JSON.parse(record.dns_record_ids) as string[];
-    await deleteDNSRecords(c.env, dnsRecordIds);
-  } catch (error) {
-    console.error('DNS deletion failed:', error);
-    // Continue anyway
-  }
-
-  // Delete custom hostname (Cloudflare for SaaS)
-  if (record.custom_hostname_id) {
-    try {
-      await deleteCustomHostname(c.env, record.custom_hostname_id);
-    } catch (error) {
-      console.error('Custom hostname deletion failed:', error);
-      // Continue anyway
+    if (serveRecord) {
+      recordsToDelete.push(serveRecord);
     }
   }
 
-  // Mark as deleted in database
-  await c.env.DB.prepare(
-    "UPDATE subdomains SET status = 'deleted', updated_at = ? WHERE id = ?"
-  )
-    .bind(Date.now(), record.id)
-    .run();
+  const deletedAt = Date.now();
+  for (const target of recordsToDelete) {
+    await cleanupStoredSubdomain(c.env, target);
+    await c.env.DB.prepare("UPDATE subdomains SET status = 'deleted', updated_at = ? WHERE id = ?")
+      .bind(deletedAt, target.id)
+      .run();
+  }
 
   return c.json({ success: true });
 });

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -12,6 +12,7 @@ import { cors } from 'hono/cors';
 import type { Env, User } from './types';
 import { authMiddleware, type AuthContext } from './middleware/auth';
 import authHandlers from './handlers/auth';
+import identityHandlers from './handlers/identity';
 import userHandlers from './handlers/user';
 import subdomainHandlers from './handlers/subdomains';
 
@@ -46,10 +47,15 @@ app.get('/config', (c) => {
 app.route('/auth', authHandlers);
 
 // Protected routes (require valid token)
+app.use('/me', authMiddleware);
 app.use('/me/*', authMiddleware);
+app.use('/subdomains', authMiddleware);
 app.use('/subdomains/*', authMiddleware);
+app.use('/identity', authMiddleware);
+app.use('/identity/*', authMiddleware);
 app.route('/me', userHandlers);
 app.route('/subdomains', subdomainHandlers);
+app.route('/identity', identityHandlers);
 
 // Root redirect to portal
 app.get('/', (c) => {

--- a/worker/src/services/cloudflare.ts
+++ b/worker/src/services/cloudflare.ts
@@ -6,8 +6,31 @@
 
 import type { Env } from '../types';
 
+type CryptoKeyUsageValue = 'encrypt' | 'decrypt' | 'sign' | 'verify' | 'deriveKey' | 'deriveBits' | 'wrapKey' | 'unwrapKey';
+
 function getCloudflareApiBase(env: Env): string {
-  return env.CF_API_BASE ?? 'https://api.cloudflare.com/client/v4';
+  const rawBase = env.CF_API_BASE?.trim();
+  if (env.CF_API_BASE === undefined) {
+    return 'https://api.cloudflare.com/client/v4';
+  }
+
+  if (!rawBase) {
+    throw new Error('CF_API_BASE cannot be empty');
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(rawBase);
+  } catch {
+    throw new Error('CF_API_BASE must be a valid URL');
+  }
+
+  const allowedHosts = new Set(['api.cloudflare.com', 'localhost', '127.0.0.1', '::1']);
+  if (!allowedHosts.has(parsed.hostname)) {
+    throw new Error('CF_API_BASE override is only allowed for api.cloudflare.com or localhost-based test endpoints');
+  }
+
+  return parsed.toString().replace(/\/$/, '');
 }
 
 /**
@@ -516,7 +539,7 @@ const TOKEN_DERIVATION_SALT = new Uint8Array(32);
 
 async function deriveTokenKey(
   env: Env,
-  usages: KeyUsage[]
+  usages: CryptoKeyUsageValue[]
 ): Promise<CryptoKey> {
   const keyMaterial = await crypto.subtle.importKey(
     'raw',
@@ -542,7 +565,7 @@ async function deriveTokenKey(
 
 async function deriveLegacyTokenKey(
   env: Env,
-  usages: KeyUsage[]
+  usages: CryptoKeyUsageValue[]
 ): Promise<CryptoKey> {
   return crypto.subtle.importKey(
     'raw',

--- a/worker/src/services/cloudflare.ts
+++ b/worker/src/services/cloudflare.ts
@@ -6,6 +6,10 @@
 
 import type { Env } from '../types';
 
+function getCloudflareApiBase(env: Env): string {
+  return env.CF_API_BASE ?? 'https://api.cloudflare.com/client/v4';
+}
+
 /**
  * Tunnel creation result
  */
@@ -24,7 +28,7 @@ async function findTunnelByName(
   const tunnelName = `gitspace-${name}`;
 
   const response = await fetch(
-    `https://api.cloudflare.com/client/v4/accounts/${env.CF_ACCOUNT_ID}/cfd_tunnel?name=${encodeURIComponent(tunnelName)}`,
+    `${getCloudflareApiBase(env)}/accounts/${env.CF_ACCOUNT_ID}/cfd_tunnel?name=${encodeURIComponent(tunnelName)}`,
     {
       method: 'GET',
       headers: {
@@ -57,7 +61,7 @@ async function getTunnelToken(
   tunnelId: string
 ): Promise<string> {
   const response = await fetch(
-    `https://api.cloudflare.com/client/v4/accounts/${env.CF_ACCOUNT_ID}/cfd_tunnel/${tunnelId}/token`,
+    `${getCloudflareApiBase(env)}/accounts/${env.CF_ACCOUNT_ID}/cfd_tunnel/${tunnelId}/token`,
     {
       method: 'GET',
       headers: {
@@ -108,7 +112,7 @@ export async function createTunnel(
   const secret = btoa(String.fromCharCode(...secretBytes));
 
   const response = await fetch(
-    `https://api.cloudflare.com/client/v4/accounts/${env.CF_ACCOUNT_ID}/cfd_tunnel`,
+    `${getCloudflareApiBase(env)}/accounts/${env.CF_ACCOUNT_ID}/cfd_tunnel`,
     {
       method: 'POST',
       headers: {
@@ -157,7 +161,7 @@ export async function configureTunnelIngress(
   subdomain: string
 ): Promise<void> {
   const response = await fetch(
-    `https://api.cloudflare.com/client/v4/accounts/${env.CF_ACCOUNT_ID}/cfd_tunnel/${tunnelId}/configurations`,
+    `${getCloudflareApiBase(env)}/accounts/${env.CF_ACCOUNT_ID}/cfd_tunnel/${tunnelId}/configurations`,
     {
       method: 'PUT',
       headers: {
@@ -197,7 +201,7 @@ export async function configureTunnelIngress(
 export async function deleteTunnel(env: Env, tunnelId: string): Promise<void> {
   // First, clean up the tunnel connections
   await fetch(
-    `https://api.cloudflare.com/client/v4/accounts/${env.CF_ACCOUNT_ID}/cfd_tunnel/${tunnelId}/connections`,
+    `${getCloudflareApiBase(env)}/accounts/${env.CF_ACCOUNT_ID}/cfd_tunnel/${tunnelId}/connections`,
     {
       method: 'DELETE',
       headers: {
@@ -208,7 +212,7 @@ export async function deleteTunnel(env: Env, tunnelId: string): Promise<void> {
 
   // Then delete the tunnel
   const response = await fetch(
-    `https://api.cloudflare.com/client/v4/accounts/${env.CF_ACCOUNT_ID}/cfd_tunnel/${tunnelId}`,
+    `${getCloudflareApiBase(env)}/accounts/${env.CF_ACCOUNT_ID}/cfd_tunnel/${tunnelId}`,
     {
       method: 'DELETE',
       headers: {
@@ -233,7 +237,7 @@ async function findDNSRecord(
   const fullName = name.endsWith('.gitspace.sh') ? name : `${name}.gitspace.sh`;
 
   const response = await fetch(
-    `https://api.cloudflare.com/client/v4/zones/${env.CF_ZONE_ID}/dns_records?name=${encodeURIComponent(fullName)}`,
+    `${getCloudflareApiBase(env)}/zones/${env.CF_ZONE_ID}/dns_records?name=${encodeURIComponent(fullName)}`,
     {
       method: 'GET',
       headers: {
@@ -269,7 +273,7 @@ async function updateDNSRecord(
   comment: string
 ): Promise<void> {
   const response = await fetch(
-    `https://api.cloudflare.com/client/v4/zones/${env.CF_ZONE_ID}/dns_records/${recordId}`,
+    `${getCloudflareApiBase(env)}/zones/${env.CF_ZONE_ID}/dns_records/${recordId}`,
     {
       method: 'PUT',
       headers: {
@@ -320,8 +324,8 @@ export async function createDNSRecords(
     }
 
     // Create new record
-    const response = await fetch(
-      `https://api.cloudflare.com/client/v4/zones/${env.CF_ZONE_ID}/dns_records`,
+      const response = await fetch(
+      `${getCloudflareApiBase(env)}/zones/${env.CF_ZONE_ID}/dns_records`,
       {
         method: 'POST',
         headers: {
@@ -365,7 +369,7 @@ export async function deleteDNSRecords(
 ): Promise<void> {
   for (const recordId of recordIds) {
     await fetch(
-      `https://api.cloudflare.com/client/v4/zones/${env.CF_ZONE_ID}/dns_records/${recordId}`,
+      `${getCloudflareApiBase(env)}/zones/${env.CF_ZONE_ID}/dns_records/${recordId}`,
       {
         method: 'DELETE',
         headers: {
@@ -403,7 +407,7 @@ export async function createCustomHostname(
   const hostname = `${subdomain}.gitspace.sh`;
 
   const response = await fetch(
-    `https://api.cloudflare.com/client/v4/zones/${env.CF_ZONE_ID}/custom_hostnames`,
+    `${getCloudflareApiBase(env)}/zones/${env.CF_ZONE_ID}/custom_hostnames`,
     {
       method: 'POST',
       headers: {
@@ -456,7 +460,7 @@ export async function deleteCustomHostname(
   customHostnameId: string
 ): Promise<void> {
   const response = await fetch(
-    `https://api.cloudflare.com/client/v4/zones/${env.CF_ZONE_ID}/custom_hostnames/${customHostnameId}`,
+    `${getCloudflareApiBase(env)}/zones/${env.CF_ZONE_ID}/custom_hostnames/${customHostnameId}`,
     {
       method: 'DELETE',
       headers: {
@@ -479,7 +483,7 @@ export async function getCustomHostnameStatus(
   customHostnameId: string
 ): Promise<{ status: string; sslStatus: string }> {
   const response = await fetch(
-    `https://api.cloudflare.com/client/v4/zones/${env.CF_ZONE_ID}/custom_hostnames/${customHostnameId}`,
+    `${getCloudflareApiBase(env)}/zones/${env.CF_ZONE_ID}/custom_hostnames/${customHostnameId}`,
     {
       method: 'GET',
       headers: {

--- a/worker/src/types.ts
+++ b/worker/src/types.ts
@@ -14,6 +14,9 @@ export interface Env {
   CF_ACCOUNT_ID: string;
   CF_ZONE_ID: string;
   ENCRYPTION_KEY: string;
+  GITHUB_OAUTH_BASE?: string;
+  GITHUB_API_BASE?: string;
+  CF_API_BASE?: string;
 }
 
 /**
@@ -71,6 +74,16 @@ export interface Session {
   expires_at: number;
   ip_address: string | null;
   user_agent: string | null;
+}
+
+export interface IdentityBackupRecord {
+  user_id: string;
+  version: number;
+  kind: string;
+  owner_user_root_id: string;
+  envelope_json: string;
+  created_at: number;
+  updated_at: number;
 }
 
 /**

--- a/worker/tests/auth-device.test.ts
+++ b/worker/tests/auth-device.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import type { WorkerHarness } from './helpers/worker-harness';
+import { createWorkerHarness } from './helpers/worker-harness';
+
+let harness: WorkerHarness;
+
+beforeEach(async () => {
+  harness = await createWorkerHarness();
+});
+
+afterEach(async () => {
+  await harness?.dispose();
+});
+
+describe('worker auth routes', () => {
+  test('protects bare /me and returns profile for a device-bound token', async () => {
+    const unauthenticated = await harness.request('/me');
+    expect(unauthenticated.status).toBe(401);
+
+    const session = await harness.createDeviceSession();
+    const me = await harness.request('/me', { headers: session.headers });
+
+    expect(me.status).toBe(200);
+    await expect(me.json()).resolves.toMatchObject({
+      github_username: 'octocat',
+      email: 'octocat@example.com',
+    });
+  });
+
+  test('rejects requests missing the bound device fingerprint', async () => {
+    const session = await harness.createDeviceSession();
+    const response = await harness.request('/me', {
+      headers: { Authorization: session.headers.Authorization },
+    });
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toMatchObject({
+      error: 'Missing device fingerprint',
+    });
+  });
+});

--- a/worker/tests/auth-portal.test.ts
+++ b/worker/tests/auth-portal.test.ts
@@ -30,17 +30,30 @@ describe('worker portal auth routes', () => {
     expect(url.origin).toBe(harness.upstream.githubOauthBase);
     expect(url.pathname).toBe('/login/oauth/authorize');
     expect(url.searchParams.get('client_id')).toBe('github-client-id');
-    expect(url.searchParams.get('redirect_uri')).toBe('https://api.gitspace.sh/auth/github/callback');
+    const redirectUri = new URL(url.searchParams.get('redirect_uri')!);
+    expect(redirectUri.pathname).toBe('/auth/github/callback');
+    expect(redirectUri.origin).toMatch(/^http:\/\/127\.0\.0\.1:\d+$/);
     expect(url.searchParams.get('scope')).toBe('read:user user:email');
     expect(url.searchParams.get('state')).toBeTruthy();
+    expect(response.headers.get('Set-Cookie')).toContain('gitspace_oauth_state=');
   });
 
   test('callback creates a session cookie and logout clears it', async () => {
-    const callback = await harness.request('/auth/github/callback?code=test-code', {
+    const start = await harness.request('/auth/github', { redirect: 'manual' });
+    const location = start.headers.get('Location');
+    expect(location).toBeTruthy();
+    const state = new URL(location!).searchParams.get('state');
+    expect(state).toBeTruthy();
+    const oauthCookie = start.headers.get('Set-Cookie');
+    expect(oauthCookie).toContain('gitspace_oauth_state=');
+    const oauthCookieHeader = oauthCookie!.split(';', 1)[0]!;
+
+    const callback = await harness.request(`/auth/github/callback?code=test-code&state=${state}`, {
       redirect: 'manual',
       headers: {
         'CF-Connecting-IP': '127.0.0.1',
         'User-Agent': 'worker-test-agent',
+        Cookie: oauthCookieHeader,
       },
     });
 

--- a/worker/tests/auth-portal.test.ts
+++ b/worker/tests/auth-portal.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import type { WorkerHarness } from './helpers/worker-harness';
+import { createWorkerHarness } from './helpers/worker-harness';
+
+let harness: WorkerHarness;
+
+function getSessionIdFromCookie(setCookie: string | null): string | null {
+  const match = setCookie?.match(/session=([^;]+)/);
+  return match?.[1] ?? null;
+}
+
+beforeEach(async () => {
+  harness = await createWorkerHarness();
+});
+
+afterEach(async () => {
+  await harness?.dispose();
+});
+
+describe('worker portal auth routes', () => {
+  test('starts GitHub OAuth with expected redirect parameters', async () => {
+    const response = await harness.request('/auth/github', { redirect: 'manual' });
+
+    expect(response.status).toBe(302);
+
+    const location = response.headers.get('Location');
+    expect(location).toBeTruthy();
+
+    const url = new URL(location!);
+    expect(url.origin).toBe(harness.upstream.githubOauthBase);
+    expect(url.pathname).toBe('/login/oauth/authorize');
+    expect(url.searchParams.get('client_id')).toBe('github-client-id');
+    expect(url.searchParams.get('redirect_uri')).toBe('https://api.gitspace.sh/auth/github/callback');
+    expect(url.searchParams.get('scope')).toBe('read:user user:email');
+    expect(url.searchParams.get('state')).toBeTruthy();
+  });
+
+  test('callback creates a session cookie and logout clears it', async () => {
+    const callback = await harness.request('/auth/github/callback?code=test-code', {
+      redirect: 'manual',
+      headers: {
+        'CF-Connecting-IP': '127.0.0.1',
+        'User-Agent': 'worker-test-agent',
+      },
+    });
+
+    expect(callback.status).toBe(302);
+    expect(callback.headers.get('Location')).toBe('https://gitspace.sh/dashboard');
+
+    const setCookie = callback.headers.get('Set-Cookie');
+    expect(setCookie).toContain('session=');
+    expect(setCookie).toContain('HttpOnly');
+    expect(setCookie).toContain('Secure');
+
+    const sessionId = getSessionIdFromCookie(setCookie);
+    expect(sessionId).toBeTruthy();
+    const resolvedSessionId = sessionId!;
+
+    const db = await harness.mf.getD1Database('DB');
+    const session = await db
+      .prepare('SELECT id, ip_address, user_agent FROM sessions WHERE id = ?')
+      .bind(resolvedSessionId)
+      .first<{ id: string; ip_address: string | null; user_agent: string | null }>();
+
+    expect(session).not.toBeNull();
+    expect(session?.id).toBe(resolvedSessionId);
+    expect(session?.ip_address).toBe('127.0.0.1');
+    expect(session?.user_agent).toBe('worker-test-agent');
+
+    const logout = await harness.request('/auth/logout', {
+      method: 'POST',
+      headers: {
+        Cookie: `session=${resolvedSessionId}`,
+      },
+    });
+
+    expect(logout.status).toBe(200);
+    expect(logout.headers.get('Set-Cookie')).toContain('Max-Age=0');
+
+    const deleted = await db
+      .prepare('SELECT id FROM sessions WHERE id = ?')
+      .bind(resolvedSessionId)
+      .first();
+    expect(deleted).toBeNull();
+  });
+});

--- a/worker/tests/auth-portal.test.ts
+++ b/worker/tests/auth-portal.test.ts
@@ -60,6 +60,13 @@ describe('worker portal auth routes', () => {
     expect(callback.status).toBe(302);
     expect(callback.headers.get('Location')).toBe('https://gitspace.sh/dashboard');
 
+    expect(harness.upstream.getLastGithubOauthTokenRequest()).toMatchObject({
+      client_id: 'github-client-id',
+      client_secret: 'github-client-secret',
+      code: 'test-code',
+      redirect_uri: expect.stringMatching(/^http:\/\/127\.0\.0\.1:\d+\/auth\/github\/callback$/),
+    });
+
     const setCookie = callback.headers.get('Set-Cookie');
     expect(setCookie).toContain('session=');
     expect(setCookie).toContain('HttpOnly');
@@ -95,5 +102,21 @@ describe('worker portal auth routes', () => {
       .bind(resolvedSessionId)
       .first();
     expect(deleted).toBeNull();
+  });
+
+  test('callback validates the exact OAuth state cookie name', async () => {
+    const start = await harness.request('/auth/github', { redirect: 'manual' });
+    const location = start.headers.get('Location');
+    const state = new URL(location!).searchParams.get('state');
+
+    const callback = await harness.request(`/auth/github/callback?code=test-code&state=${state}`, {
+      redirect: 'manual',
+      headers: {
+        Cookie: `not_gitspace_oauth_state=${state}`,
+      },
+    });
+
+    expect(callback.status).toBe(302);
+    expect(callback.headers.get('Location')).toBe('https://gitspace.sh?error=invalid_state');
   });
 });

--- a/worker/tests/helpers/mock-upstream.ts
+++ b/worker/tests/helpers/mock-upstream.ts
@@ -1,0 +1,169 @@
+import type { Server } from 'bun';
+
+export interface MockUpstream {
+  server: Server<any>;
+  githubApiBase: string;
+  githubOauthBase: string;
+  cloudflareApiBase: string;
+  close: () => void;
+}
+
+interface TunnelRecord {
+  id: string;
+  name: string;
+  token: string;
+}
+
+export function startMockUpstream(): MockUpstream {
+  const tunnels = new Map<string, TunnelRecord>();
+  const dnsRecords = new Map<string, { id: string; name: string; content: string }>();
+  const customHostnames = new Map<string, { id: string; hostname: string; status: string }>();
+
+  const server = Bun.serve({
+    port: 0,
+    hostname: '127.0.0.1',
+    fetch(request) {
+      const url = new URL(request.url);
+      const path = url.pathname;
+
+      if (path === '/login/oauth/access_token' && request.method === 'POST') {
+        return Response.json({ access_token: 'github-access-token' });
+      }
+
+      if (path === '/user' && request.method === 'GET') {
+        return Response.json({
+          id: 12345,
+          login: 'octocat',
+          name: 'The Octocat',
+          email: 'octocat@example.com',
+          avatar_url: 'https://avatars.example.com/octocat',
+        });
+      }
+
+      if (path === '/user/emails' && request.method === 'GET') {
+        return Response.json([
+          { email: 'octocat@example.com', primary: true, verified: true },
+        ]);
+      }
+
+      if (path.includes('/cfd_tunnel') && request.method === 'GET' && path.endsWith('/token')) {
+        const tunnelId = path.split('/').at(-2) ?? '';
+        const tunnel = Array.from(tunnels.values()).find((entry) => entry.id === tunnelId);
+        if (!tunnel) {
+          return new Response('Not found', { status: 404 });
+        }
+        return Response.json({ success: true, result: tunnel.token });
+      }
+
+      if (path.endsWith('/cfd_tunnel') && request.method === 'GET') {
+        const name = url.searchParams.get('name');
+        const result = name && tunnels.has(name) ? [tunnels.get(name)] : [];
+        return Response.json({ success: true, result });
+      }
+
+      if (path.endsWith('/cfd_tunnel') && request.method === 'POST') {
+        return request.json().then((body: any) => {
+          const name = body?.name ?? 'tunnel';
+          const tunnel = {
+            id: crypto.randomUUID(),
+            name,
+            token: `token-${name}-${crypto.randomUUID()}`,
+          };
+          tunnels.set(name, tunnel);
+          return Response.json({ success: true, result: { id: tunnel.id, token: tunnel.token } });
+        });
+      }
+
+      if (path.includes('/cfd_tunnel/') && path.endsWith('/configurations') && request.method === 'PUT') {
+        return Response.json({ success: true });
+      }
+
+      if (path.includes('/cfd_tunnel/') && path.endsWith('/connections') && request.method === 'DELETE') {
+        return Response.json({ success: true });
+      }
+
+      if (path.includes('/cfd_tunnel/') && request.method === 'DELETE') {
+        const tunnelId = path.split('/').at(-1) ?? '';
+        const existing = Array.from(tunnels.entries()).find(([, tunnel]) => tunnel.id === tunnelId);
+        if (existing) {
+          tunnels.delete(existing[0]);
+        }
+        return Response.json({ success: true });
+      }
+
+      if (path.endsWith('/dns_records') && request.method === 'GET') {
+        const name = url.searchParams.get('name') ?? '';
+        const matches = Array.from(dnsRecords.values()).filter((record) => record.name === name);
+        return Response.json({ success: true, result: matches });
+      }
+
+      if (path.endsWith('/dns_records') && request.method === 'POST') {
+        return request.json().then((body: any) => {
+          const record = {
+            id: crypto.randomUUID(),
+            name: `${body.name}.gitspace.sh`,
+            content: body.content,
+          };
+          dnsRecords.set(record.id, record);
+          return Response.json({ success: true, result: { id: record.id } });
+        });
+      }
+
+      if (path.includes('/dns_records/') && request.method === 'PUT') {
+        const recordId = path.split('/').at(-1) ?? '';
+        return request.json().then((body: any) => {
+          dnsRecords.set(recordId, {
+            id: recordId,
+            name: `${body.name}.gitspace.sh`,
+            content: body.content,
+          });
+          return Response.json({ success: true, result: { id: recordId } });
+        });
+      }
+
+      if (path.includes('/dns_records/') && request.method === 'DELETE') {
+        const recordId = path.split('/').at(-1) ?? '';
+        dnsRecords.delete(recordId);
+        return Response.json({ success: true });
+      }
+
+      if (path.endsWith('/custom_hostnames') && request.method === 'POST') {
+        return request.json().then((body: any) => {
+          const record = {
+            id: crypto.randomUUID(),
+            hostname: body.hostname,
+            status: 'pending',
+          };
+          customHostnames.set(record.id, record);
+          return Response.json({ success: true, result: record });
+        });
+      }
+
+      if (path.includes('/custom_hostnames/') && request.method === 'GET') {
+        const id = path.split('/').at(-1) ?? '';
+        const record = customHostnames.get(id);
+        if (!record) {
+          return new Response('Not found', { status: 404 });
+        }
+        return Response.json({ success: true, result: { ...record, ssl: { status: 'pending' } } });
+      }
+
+      if (path.includes('/custom_hostnames/') && request.method === 'DELETE') {
+        const id = path.split('/').at(-1) ?? '';
+        customHostnames.delete(id);
+        return Response.json({ success: true });
+      }
+
+      return new Response(`Unhandled upstream route: ${request.method} ${path}`, { status: 404 });
+    },
+  });
+
+  const base = `http://127.0.0.1:${server.port}`;
+  return {
+    server,
+    githubApiBase: base,
+    githubOauthBase: base,
+    cloudflareApiBase: `${base}/client/v4`,
+    close: () => server.stop(true),
+  };
+}

--- a/worker/tests/helpers/mock-upstream.ts
+++ b/worker/tests/helpers/mock-upstream.ts
@@ -5,6 +5,7 @@ export interface MockUpstream {
   githubApiBase: string;
   githubOauthBase: string;
   cloudflareApiBase: string;
+  registerGitHubUser: (token: string, user: { id: number; login: string; name: string; email: string; avatar_url: string }) => void;
   close: () => void;
 }
 
@@ -18,6 +19,15 @@ export function startMockUpstream(): MockUpstream {
   const tunnels = new Map<string, TunnelRecord>();
   const dnsRecords = new Map<string, { id: string; name: string; content: string }>();
   const customHostnames = new Map<string, { id: string; hostname: string; status: string }>();
+  const githubUsers = new Map<string, { id: number; login: string; name: string; email: string; avatar_url: string }>();
+
+  githubUsers.set('github-access-token', {
+    id: 12345,
+    login: 'octocat',
+    name: 'The Octocat',
+    email: 'octocat@example.com',
+    avatar_url: 'https://avatars.example.com/octocat',
+  });
 
   const server = Bun.serve({
     port: 0,
@@ -31,18 +41,24 @@ export function startMockUpstream(): MockUpstream {
       }
 
       if (path === '/user' && request.method === 'GET') {
-        return Response.json({
-          id: 12345,
-          login: 'octocat',
-          name: 'The Octocat',
-          email: 'octocat@example.com',
-          avatar_url: 'https://avatars.example.com/octocat',
-        });
+        const token = request.headers.get('Authorization')?.replace(/^Bearer\s+/i, '') ?? '';
+        const user = githubUsers.get(token);
+        if (!user) {
+          return new Response('Unauthorized', { status: 401 });
+        }
+
+        return Response.json(user);
       }
 
       if (path === '/user/emails' && request.method === 'GET') {
+        const token = request.headers.get('Authorization')?.replace(/^Bearer\s+/i, '') ?? '';
+        const user = githubUsers.get(token);
+        if (!user) {
+          return new Response('Unauthorized', { status: 401 });
+        }
+
         return Response.json([
-          { email: 'octocat@example.com', primary: true, verified: true },
+          { email: user.email, primary: true, verified: true },
         ]);
       }
 
@@ -164,6 +180,9 @@ export function startMockUpstream(): MockUpstream {
     githubApiBase: base,
     githubOauthBase: base,
     cloudflareApiBase: `${base}/client/v4`,
+    registerGitHubUser: (token, user) => {
+      githubUsers.set(token, user);
+    },
     close: () => server.stop(true),
   };
 }

--- a/worker/tests/helpers/mock-upstream.ts
+++ b/worker/tests/helpers/mock-upstream.ts
@@ -6,6 +6,7 @@ export interface MockUpstream {
   githubOauthBase: string;
   cloudflareApiBase: string;
   getLastGithubOauthTokenRequest: () => Record<string, unknown> | null;
+  failNextTunnelCreate: (tunnelName: string, status?: number, body?: string) => void;
   registerGitHubUser: (token: string, user: { id: number; login: string; name: string; email: string; avatar_url: string }) => void;
   close: () => void;
 }
@@ -22,6 +23,7 @@ export function startMockUpstream(): MockUpstream {
   const customHostnames = new Map<string, { id: string; hostname: string; status: string }>();
   const githubUsers = new Map<string, { id: number; login: string; name: string; email: string; avatar_url: string }>();
   let lastGithubOauthTokenRequest: Record<string, unknown> | null = null;
+  const failingTunnelCreates = new Map<string, { status: number; body: string }>();
 
   githubUsers.set('github-access-token', {
     id: 12345,
@@ -85,6 +87,12 @@ export function startMockUpstream(): MockUpstream {
       if (path.endsWith('/cfd_tunnel') && request.method === 'POST') {
         return request.json().then((body: any) => {
           const name = body?.name ?? 'tunnel';
+          const configuredFailure = failingTunnelCreates.get(name);
+          if (configuredFailure) {
+            failingTunnelCreates.delete(name);
+            return new Response(configuredFailure.body, { status: configuredFailure.status });
+          }
+
           const tunnel = {
             id: crypto.randomUUID(),
             name,
@@ -186,6 +194,9 @@ export function startMockUpstream(): MockUpstream {
     githubOauthBase: base,
     cloudflareApiBase: `${base}/client/v4`,
     getLastGithubOauthTokenRequest: () => lastGithubOauthTokenRequest,
+    failNextTunnelCreate: (tunnelName, status = 500, body = 'tunnel create failed') => {
+      failingTunnelCreates.set(tunnelName, { status, body });
+    },
     registerGitHubUser: (token, user) => {
       githubUsers.set(token, user);
     },

--- a/worker/tests/helpers/mock-upstream.ts
+++ b/worker/tests/helpers/mock-upstream.ts
@@ -5,6 +5,7 @@ export interface MockUpstream {
   githubApiBase: string;
   githubOauthBase: string;
   cloudflareApiBase: string;
+  getLastGithubOauthTokenRequest: () => Record<string, unknown> | null;
   registerGitHubUser: (token: string, user: { id: number; login: string; name: string; email: string; avatar_url: string }) => void;
   close: () => void;
 }
@@ -20,6 +21,7 @@ export function startMockUpstream(): MockUpstream {
   const dnsRecords = new Map<string, { id: string; name: string; content: string }>();
   const customHostnames = new Map<string, { id: string; hostname: string; status: string }>();
   const githubUsers = new Map<string, { id: number; login: string; name: string; email: string; avatar_url: string }>();
+  let lastGithubOauthTokenRequest: Record<string, unknown> | null = null;
 
   githubUsers.set('github-access-token', {
     id: 12345,
@@ -37,7 +39,10 @@ export function startMockUpstream(): MockUpstream {
       const path = url.pathname;
 
       if (path === '/login/oauth/access_token' && request.method === 'POST') {
-        return Response.json({ access_token: 'github-access-token' });
+        return request.json().then((body: any) => {
+          lastGithubOauthTokenRequest = body && typeof body === 'object' ? body : null;
+          return Response.json({ access_token: 'github-access-token' });
+        });
       }
 
       if (path === '/user' && request.method === 'GET') {
@@ -180,6 +185,7 @@ export function startMockUpstream(): MockUpstream {
     githubApiBase: base,
     githubOauthBase: base,
     cloudflareApiBase: `${base}/client/v4`,
+    getLastGithubOauthTokenRequest: () => lastGithubOauthTokenRequest,
     registerGitHubUser: (token, user) => {
       githubUsers.set(token, user);
     },

--- a/worker/tests/helpers/worker-harness.ts
+++ b/worker/tests/helpers/worker-harness.ts
@@ -11,7 +11,7 @@ const SCHEMA_PATH = join(WORKER_DIR, 'schema.sql');
 
 let bundlePathPromise: Promise<string> | null = null;
 
-async function applySchema(db: D1Database): Promise<void> {
+async function applySchema(db: any): Promise<void> {
   const sql = readFileSync(SCHEMA_PATH, 'utf8');
   const statements = sql
     .split('\n')
@@ -57,8 +57,11 @@ export interface WorkerHarness {
   mf: Miniflare;
   upstream: MockUpstream;
   dispose: () => Promise<void>;
-  request: (path: string, init?: RequestInit) => Promise<Response>;
-  createDeviceSession: () => Promise<{ token: string; fingerprint: string; headers: Record<string, string> }>;
+  request: (path: string, init?: RequestInit) => Promise<any>;
+  createDeviceSession: (options?: {
+    githubToken?: string;
+    githubUser?: { id: number; login: string; name: string; email: string; avatar_url: string };
+  }) => Promise<{ token: string; fingerprint: string; headers: Record<string, string> }>;
 }
 
 export async function createWorkerHarness(): Promise<WorkerHarness> {
@@ -98,8 +101,13 @@ export async function createWorkerHarness(): Promise<WorkerHarness> {
   return {
     mf,
     upstream,
-    request: (path, init) => mf.dispatchFetch(`http://worker${path}`, init),
-    createDeviceSession: async () => {
+    request: (path, init) => mf.dispatchFetch(`http://worker${path}`, init as any),
+    createDeviceSession: async (options = {}) => {
+      const githubToken = options.githubToken ?? 'github-access-token';
+      if (options.githubUser) {
+        upstream.registerGitHubUser(githubToken, options.githubUser);
+      }
+
       const privateKey = ed25519.utils.randomPrivateKey();
       const publicKey = ed25519.getPublicKey(privateKey);
       const timestamp = Date.now();
@@ -112,7 +120,7 @@ export async function createWorkerHarness(): Promise<WorkerHarness> {
         method: 'POST',
         headers: { 'content-type': 'application/json' },
         body: JSON.stringify({
-          github_token: 'github-access-token',
+          github_token: githubToken,
           machine_pubkey: Buffer.from(publicKey).toString('base64'),
           device_name: 'Worker Test Device',
           auth_timestamp: timestamp,

--- a/worker/tests/helpers/worker-harness.ts
+++ b/worker/tests/helpers/worker-harness.ts
@@ -1,0 +1,144 @@
+import { mkdirSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { Miniflare } from 'miniflare';
+import { ed25519 } from '@noble/curves/ed25519';
+import { startMockUpstream, type MockUpstream } from './mock-upstream';
+
+const WORKER_DIR = dirname(dirname(import.meta.dir));
+const SRC_ENTRY = join(WORKER_DIR, 'src', 'index.ts');
+const SCHEMA_PATH = join(WORKER_DIR, 'schema.sql');
+
+let bundlePathPromise: Promise<string> | null = null;
+
+async function applySchema(db: D1Database): Promise<void> {
+  const sql = readFileSync(SCHEMA_PATH, 'utf8');
+  const statements = sql
+    .split('\n')
+    .filter((line) => !line.trim().startsWith('--'))
+    .join('\n')
+    .split(';')
+    .map((statement) => statement.trim())
+    .filter(Boolean);
+
+  for (const statement of statements) {
+    await db.prepare(statement).run();
+  }
+}
+
+async function buildWorkerBundle(): Promise<string> {
+  if (!bundlePathPromise) {
+    bundlePathPromise = (async () => {
+      const outdir = join(WORKER_DIR, '.mf-build');
+      rmSync(outdir, { recursive: true, force: true });
+      mkdirSync(outdir, { recursive: true });
+      const result = await Bun.build({
+        entrypoints: [SRC_ENTRY],
+        outdir,
+        target: 'browser',
+        format: 'esm',
+        naming: 'index.js',
+        minify: false,
+        sourcemap: 'none',
+      });
+
+      if (!result.success) {
+        throw new Error(`Worker build failed: ${result.logs.map((log) => log.message).join('; ')}`);
+      }
+
+      return join(outdir, 'index.js');
+    })();
+  }
+
+  return bundlePathPromise;
+}
+
+export interface WorkerHarness {
+  mf: Miniflare;
+  upstream: MockUpstream;
+  dispose: () => Promise<void>;
+  request: (path: string, init?: RequestInit) => Promise<Response>;
+  createDeviceSession: () => Promise<{ token: string; fingerprint: string; headers: Record<string, string> }>;
+}
+
+export async function createWorkerHarness(): Promise<WorkerHarness> {
+  const upstream = startMockUpstream();
+  const bundlePath = await buildWorkerBundle();
+  const persistDir = mkdtempSync(join(tmpdir(), 'gitspace-worker-mf-'));
+
+  const mf = new Miniflare({
+    scriptPath: bundlePath,
+    modules: true,
+    modulesRules: [{ type: 'ESModule', include: ['**/*.js'] }],
+    compatibilityDate: '2024-12-01',
+    cf: false,
+    d1Databases: { DB: crypto.randomUUID() },
+    bindings: {
+      PORTAL_URL: 'https://gitspace.sh',
+      MAX_ACCOUNTS: '99',
+      GITHUB_CLIENT_ID: 'github-client-id',
+      GITHUB_CLIENT_SECRET: 'github-client-secret',
+      CF_API_TOKEN: 'cf-api-token',
+      CF_ACCOUNT_ID: 'cf-account-id',
+      CF_ZONE_ID: 'cf-zone-id',
+      ENCRYPTION_KEY: 'worker-test-encryption-key',
+      GITHUB_OAUTH_BASE: upstream.githubOauthBase,
+      GITHUB_API_BASE: upstream.githubApiBase,
+      CF_API_BASE: upstream.cloudflareApiBase,
+    },
+    cachePersist: false,
+    kvPersist: false,
+    durableObjectsPersist: false,
+    d1Persist: persistDir,
+  });
+
+  const db = await mf.getD1Database('DB');
+  await applySchema(db);
+
+  return {
+    mf,
+    upstream,
+    request: (path, init) => mf.dispatchFetch(`http://worker${path}`, init),
+    createDeviceSession: async () => {
+      const privateKey = ed25519.utils.randomPrivateKey();
+      const publicKey = ed25519.getPublicKey(privateKey);
+      const timestamp = Date.now();
+      const signature = ed25519.sign(
+        new TextEncoder().encode(`gitspace-device-auth:${timestamp}`),
+        privateKey,
+      );
+
+      const response = await mf.dispatchFetch('http://worker/auth/github/device', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          github_token: 'github-access-token',
+          machine_pubkey: Buffer.from(publicKey).toString('base64'),
+          device_name: 'Worker Test Device',
+          auth_timestamp: timestamp,
+          auth_signature: Buffer.from(signature).toString('base64'),
+        }),
+      });
+
+      if (!response.ok) {
+        throw new Error(`Failed to create device session: ${await response.text()}`);
+      }
+
+      const payload = await response.json() as { token: string };
+      const fingerprint = Buffer.from(publicKey).toString('base64');
+      return {
+        token: payload.token,
+        fingerprint,
+        headers: {
+          Authorization: `Bearer ${payload.token}`,
+          'X-Device-Fingerprint': fingerprint,
+        },
+      };
+    },
+    dispose: async () => {
+      upstream.close();
+      await mf.dispose();
+      rmSync(persistDir, { recursive: true, force: true });
+    },
+  };
+}

--- a/worker/tests/identity-backup.test.ts
+++ b/worker/tests/identity-backup.test.ts
@@ -48,17 +48,26 @@ describe('identity backup routes', () => {
     });
     expect(putResponse.status).toBe(200);
 
+    const putBody = await putResponse.json() as { success: boolean; backup: typeof backupPayload };
+    expect(putBody.success).toBe(true);
+    expect(putBody.backup.createdAt).toBeGreaterThan(0);
+    expect(putBody.backup.updatedAt).toBeGreaterThanOrEqual(putBody.backup.createdAt);
+
     const getResponse = await harness.request('/identity/backup', { headers: session.headers });
     expect(getResponse.status).toBe(200);
-    await expect(getResponse.json()).resolves.toEqual(backupPayload);
+    const storedBackup = await getResponse.json() as typeof backupPayload;
+    expect(storedBackup.ownerUserRootId).toBe(backupPayload.ownerUserRootId);
+    expect(storedBackup.envelope).toEqual(backupPayload.envelope);
+    expect(storedBackup.createdAt).toBe(putBody.backup.createdAt);
+    expect(storedBackup.updatedAt).toBe(putBody.backup.updatedAt);
 
     const statusAfter = await harness.request('/identity/backup/status', { headers: session.headers });
     expect(statusAfter.status).toBe(200);
     await expect(statusAfter.json()).resolves.toEqual({
       enabled: true,
       ownerUserRootId: backupPayload.ownerUserRootId,
-      createdAt: backupPayload.createdAt,
-      updatedAt: backupPayload.updatedAt,
+      createdAt: putBody.backup.createdAt,
+      updatedAt: putBody.backup.updatedAt,
     });
 
     const deleteResponse = await harness.request('/identity/backup', {
@@ -74,5 +83,41 @@ describe('identity backup routes', () => {
   test('requires auth for identity backup routes', async () => {
     const response = await harness.request('/identity/backup/status');
     expect(response.status).toBe(401);
+  });
+
+  test('isolates identity backups across accounts', async () => {
+    const ownerSession = await harness.createDeviceSession();
+    const otherSession = await harness.createDeviceSession({
+      githubToken: 'github-access-token-other',
+      githubUser: {
+        id: 67890,
+        login: 'spacecat',
+        name: 'Space Cat',
+        email: 'spacecat@example.com',
+        avatar_url: 'https://avatars.example.com/spacecat',
+      },
+    });
+
+    const putResponse = await harness.request('/identity/backup', {
+      method: 'PUT',
+      headers: {
+        ...ownerSession.headers,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(backupPayload),
+    });
+    expect(putResponse.status).toBe(200);
+
+    const otherGet = await harness.request('/identity/backup', { headers: otherSession.headers });
+    expect(otherGet.status).toBe(404);
+
+    const otherDelete = await harness.request('/identity/backup', {
+      method: 'DELETE',
+      headers: otherSession.headers,
+    });
+    expect(otherDelete.status).toBe(404);
+
+    const ownerGet = await harness.request('/identity/backup', { headers: ownerSession.headers });
+    expect(ownerGet.status).toBe(200);
   });
 });

--- a/worker/tests/identity-backup.test.ts
+++ b/worker/tests/identity-backup.test.ts
@@ -85,6 +85,42 @@ describe('identity backup routes', () => {
     expect(response.status).toBe(401);
   });
 
+  test('rejects unsupported backup envelope algorithms and iteration counts', async () => {
+    const session = await harness.createDeviceSession();
+
+    const badAlgorithm = await harness.request('/identity/backup', {
+      method: 'PUT',
+      headers: {
+        ...session.headers,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        ...backupPayload,
+        envelope: {
+          ...backupPayload.envelope,
+          algorithm: 'PBKDF2-AES-CBC',
+        },
+      }),
+    });
+    expect(badAlgorithm.status).toBe(400);
+
+    const weakIterations = await harness.request('/identity/backup', {
+      method: 'PUT',
+      headers: {
+        ...session.headers,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        ...backupPayload,
+        envelope: {
+          ...backupPayload.envelope,
+          iterations: 1,
+        },
+      }),
+    });
+    expect(weakIterations.status).toBe(400);
+  });
+
   test('isolates identity backups across accounts', async () => {
     const ownerSession = await harness.createDeviceSession();
     const otherSession = await harness.createDeviceSession({

--- a/worker/tests/identity-backup.test.ts
+++ b/worker/tests/identity-backup.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import type { WorkerHarness } from './helpers/worker-harness';
+import { createWorkerHarness } from './helpers/worker-harness';
+
+let harness: WorkerHarness;
+
+const backupPayload = {
+  version: 1,
+  kind: 'user-root-mnemonic',
+  ownerUserRootId: 'gssh-user:owner-test',
+  envelope: {
+    version: 1,
+    algorithm: 'PBKDF2-AES-GCM',
+    iterations: 210000,
+    salt: 'salt-b64',
+    iv: 'iv-b64',
+    ciphertext: 'ciphertext-b64',
+    createdAt: 1000,
+    updatedAt: 2000,
+  },
+  createdAt: 1000,
+  updatedAt: 2000,
+};
+
+beforeEach(async () => {
+  harness = await createWorkerHarness();
+});
+
+afterEach(async () => {
+  await harness?.dispose();
+});
+
+describe('identity backup routes', () => {
+  test('stores, returns, reports, and deletes encrypted identity backups', async () => {
+    const session = await harness.createDeviceSession();
+
+    const statusBefore = await harness.request('/identity/backup/status', { headers: session.headers });
+    expect(statusBefore.status).toBe(200);
+    await expect(statusBefore.json()).resolves.toEqual({ enabled: false });
+
+    const putResponse = await harness.request('/identity/backup', {
+      method: 'PUT',
+      headers: {
+        ...session.headers,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(backupPayload),
+    });
+    expect(putResponse.status).toBe(200);
+
+    const getResponse = await harness.request('/identity/backup', { headers: session.headers });
+    expect(getResponse.status).toBe(200);
+    await expect(getResponse.json()).resolves.toEqual(backupPayload);
+
+    const statusAfter = await harness.request('/identity/backup/status', { headers: session.headers });
+    expect(statusAfter.status).toBe(200);
+    await expect(statusAfter.json()).resolves.toEqual({
+      enabled: true,
+      ownerUserRootId: backupPayload.ownerUserRootId,
+      createdAt: backupPayload.createdAt,
+      updatedAt: backupPayload.updatedAt,
+    });
+
+    const deleteResponse = await harness.request('/identity/backup', {
+      method: 'DELETE',
+      headers: session.headers,
+    });
+    expect(deleteResponse.status).toBe(200);
+
+    const missingResponse = await harness.request('/identity/backup', { headers: session.headers });
+    expect(missingResponse.status).toBe(404);
+  });
+
+  test('requires auth for identity backup routes', async () => {
+    const response = await harness.request('/identity/backup/status');
+    expect(response.status).toBe(401);
+  });
+});

--- a/worker/tests/subdomains.test.ts
+++ b/worker/tests/subdomains.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import type { WorkerHarness } from './helpers/worker-harness';
+import { createWorkerHarness } from './helpers/worker-harness';
+
+let harness: WorkerHarness;
+
+beforeEach(async () => {
+  harness = await createWorkerHarness();
+});
+
+afterEach(async () => {
+  await harness?.dispose();
+});
+
+describe('subdomain routes', () => {
+  test('protects bare /subdomains and provisions companion serve token data', async () => {
+    const unauthenticated = await harness.request('/subdomains');
+    expect(unauthenticated.status).toBe(401);
+
+    const session = await harness.createDeviceSession();
+    const createResponse = await harness.request('/subdomains', {
+      method: 'POST',
+      headers: {
+        ...session.headers,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ subdomain: 'brad' }),
+    });
+
+    expect(createResponse.status).toBe(200);
+    const created = await createResponse.json() as {
+      subdomain: string;
+      serveSubdomain?: string;
+      tunnelToken?: string;
+      serveTunnelToken?: string;
+      isPrimary: boolean;
+    };
+    expect(created.subdomain).toBe('brad');
+    expect(created.serveSubdomain).toBe('brad.serve');
+    expect(created.tunnelToken).toBeTruthy();
+    expect(created.serveTunnelToken).toBeTruthy();
+    expect(created.isPrimary).toBe(true);
+
+    const listResponse = await harness.request('/subdomains', { headers: session.headers });
+    expect(listResponse.status).toBe(200);
+    const subdomains = await listResponse.json() as Array<{ subdomain: string }>;
+    expect(subdomains.map((entry) => entry.subdomain)).toEqual(['brad']);
+
+    const serveTokenResponse = await harness.request('/subdomains/brad.serve/token', {
+      headers: session.headers,
+    });
+    expect(serveTokenResponse.status).toBe(200);
+    await expect(serveTokenResponse.json()).resolves.toMatchObject({
+      tunnelToken: created.serveTunnelToken,
+    });
+  });
+
+  test('deleting a primary subdomain also removes its companion serve subdomain', async () => {
+    const session = await harness.createDeviceSession();
+
+    await harness.request('/subdomains', {
+      method: 'POST',
+      headers: {
+        ...session.headers,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ subdomain: 'brad' }),
+    });
+
+    const deleteResponse = await harness.request('/subdomains/brad', {
+      method: 'DELETE',
+      headers: session.headers,
+    });
+    expect(deleteResponse.status).toBe(200);
+
+    const serveTokenResponse = await harness.request('/subdomains/brad.serve/token', {
+      headers: session.headers,
+    });
+    expect(serveTokenResponse.status).toBe(404);
+  });
+});

--- a/worker/tests/subdomains.test.ts
+++ b/worker/tests/subdomains.test.ts
@@ -78,4 +78,79 @@ describe('subdomain routes', () => {
     });
     expect(serveTokenResponse.status).toBe(404);
   });
+
+  test('reuses an existing active subdomain instead of tearing it down first', async () => {
+    const session = await harness.createDeviceSession();
+
+    const firstCreate = await harness.request('/subdomains', {
+      method: 'POST',
+      headers: {
+        ...session.headers,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ subdomain: 'brad' }),
+    });
+    expect(firstCreate.status).toBe(200);
+    const firstBody = await firstCreate.json() as {
+      tunnelToken: string;
+      serveTunnelToken: string;
+      isPrimary: boolean;
+    };
+
+    const secondCreate = await harness.request('/subdomains', {
+      method: 'POST',
+      headers: {
+        ...session.headers,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ subdomain: 'brad' }),
+    });
+    expect(secondCreate.status).toBe(200);
+    const secondBody = await secondCreate.json() as {
+      tunnelToken: string;
+      serveTunnelToken: string;
+      isPrimary: boolean;
+    };
+
+    expect(secondBody.tunnelToken).toBe(firstBody.tunnelToken);
+    expect(secondBody.serveTunnelToken).toBe(firstBody.serveTunnelToken);
+    expect(secondBody.isPrimary).toBe(true);
+
+    const listResponse = await harness.request('/subdomains', { headers: session.headers });
+    const subdomains = await listResponse.json() as Array<{ subdomain: string; is_primary: number }>;
+    expect(subdomains).toHaveLength(1);
+    expect(subdomains[0]?.subdomain).toBe('brad');
+  });
+
+  test('keeps the current primary when replacement provisioning fails', async () => {
+    const session = await harness.createDeviceSession();
+
+    const firstCreate = await harness.request('/subdomains', {
+      method: 'POST',
+      headers: {
+        ...session.headers,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ subdomain: 'brad' }),
+    });
+    expect(firstCreate.status).toBe(200);
+
+    harness.upstream.failNextTunnelCreate('gitspace-alice.serve');
+    const failedCreate = await harness.request('/subdomains', {
+      method: 'POST',
+      headers: {
+        ...session.headers,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ subdomain: 'alice', isPrimary: true }),
+    });
+    expect(failedCreate.status).toBe(500);
+
+    const listResponse = await harness.request('/subdomains', { headers: session.headers });
+    expect(listResponse.status).toBe(200);
+    const subdomains = await listResponse.json() as Array<{ subdomain: string; is_primary: number }>;
+    expect(subdomains).toHaveLength(1);
+    expect(subdomains[0]?.subdomain).toBe('brad');
+    expect(subdomains[0]?.is_primary).toBe(1);
+  });
 });

--- a/worker/tsconfig.json
+++ b/worker/tsconfig.json
@@ -5,7 +5,7 @@
     "moduleResolution": "bundler",
     "strict": true,
     "skipLibCheck": true,
-    "lib": ["ESNext"],
+    "lib": ["ESNext", "DOM", "WebWorker"],
     "types": ["@cloudflare/workers-types"],
     "noEmit": true,
     "isolatedModules": true

--- a/worker/tsconfig.json
+++ b/worker/tsconfig.json
@@ -5,7 +5,7 @@
     "moduleResolution": "bundler",
     "strict": true,
     "skipLibCheck": true,
-    "lib": ["ESNext", "DOM", "WebWorker"],
+    "lib": ["ESNext"],
     "types": ["@cloudflare/workers-types"],
     "noEmit": true,
     "isolatedModules": true


### PR DESCRIPTION
## Summary
- add relay trust verification, cloud identity backup/recovery, cloud-safe relay persistence, and worker identity backup coverage on top of `develop`
- add `--password-stdin` for client and cloud connect flows so the real connect path can run non-interactively
- cover the new behavior with command, cloud lifecycle, relay vault/unlock, worker, and hermetic cloud-connect integration tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches security-critical areas (relay trust verification/pinning, identity recovery/backup encryption, and cloud bootstrap relay selection), where mistakes could enable MITM, lock users out, or misdirect bootstrap traffic.
> 
> **Overview**
> **Strengthens identity + trust flows across client, serve, relay, and cloud commands.** Client operations now probe relay `/health`, enforce TOFU/explicit `--relay-pubkey` trust with mismatch hard-fail, and add `--yes`/`--password-stdin` for scripted usage.
> 
> **Makes hosted/cloud setup more deterministic and fail-closed.** `auth login` now reuses a shared device-password context, runs `syncHostConfig()` that returns structured readiness diagnostics, prints a post-login hosted readiness summary, and adds `gssh user host doctor`. `relay start` gains `--mode auto|hosted|local` (hosted mode no silent downgrade) and binds/repairs relay vault owner metadata during startup.
> 
> **Improves cloud bootstrap correctness and UX.** `cloud launch` supports machine-first launches (repo/branch optional, `--branch` requires `--repo`), prefers a saved *cloud-reachable* relay URL, rehydrates pinned relay identity from trusted relays when needed, and fails when only local/private relay URLs are available. Adds `gssh cloud connect <workspaceId>` with workspace status validation and strict relay pubkey requirements for overrides; `cloud list` now prints machine IDs and suggested connect commands.
> 
> **Adds cloud identity backup features + tests.** Introduces encrypted cloud backup management commands (`identity backup enable|status|disable|rotate-password`) and `identity recover --cloud`, plus new crypto, trust, cloud-connect, relay-owner-repair, and CLI wiring tests; also updates `getGitspaceDir()` to respect `HOME` overrides and ignores Cloudflare worker build artifacts.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cec0fea6b59e13142a560329f77f3effe456d610. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * gssh cloud connect (workspace→machine), host doctor, identity cloud backup/recover, companion .serve subdomains, relay start --mode, new CLI flags: --yes, --password-stdin, --relay-pubkey.
* **Bug Fixes**
  * Clearer host sync readiness summaries and earlier failure with missing tunnel tooling.
* **Documentation**
  * Detailed design docs for hosted relay, deterministic startup, trust pinning, token hardening, non‑interactive flows, and UX improvements.
* **Chores**
  * Worker identity backup API, DB schema, test harness, and test scripts added.
* **Tests**
  * Large suite of unit, integration, and E2E tests for relay, backup, trust, cloud, and CLI flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->