### PR TITLE
feat: relay background default, owner takeover, and login identity bootstrap

### DIFF
--- a/src/cli/commands/relay.ts
+++ b/src/cli/commands/relay.ts
@@ -42,13 +42,15 @@ export function registerRelayCommands(parent: Command): void {
 
   cmd
     .command('start')
-    .description('Start relay server (auto-binds account host tunnel when available)')
+    .description('Start relay server in background (auto-binds account host tunnel when available)')
     .option('--port <port>', 'Port to listen on', '4480')
     .option('--bind <address>', 'Address to bind to', '0.0.0.0')
     .option('--hostname <host>', 'Only serve requests for this domain (optional)')
     .option('--mode <mode>', 'Startup mode: auto, hosted, local', 'auto')
     .option('--label <label>', 'Human-readable label for this relay')
     .option('-y, --yes', 'Auto-confirm prompts')
+    .option('--foreground', "Run in foreground (don't daemonize)")
+    .option('--takeover', 'Clear persisted relay owner state so the current identity can take over')
     .action(withErrorHandler(async (options) => {
       const { startRelay } = await import('../../commands/relay.js');
       await startRelay({
@@ -58,6 +60,8 @@ export function registerRelayCommands(parent: Command): void {
         mode: parseRelayStartMode(options.mode),
         label: options.label,
         yes: options.yes,
+        foreground: options.foreground,
+        takeover: options.takeover,
       });
     }, { skipSetupCheck: true }));
 

--- a/src/commands/__tests__/auth-login-identity-bootstrap.test.ts
+++ b/src/commands/__tests__/auth-login-identity-bootstrap.test.ts
@@ -1,0 +1,152 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+
+describe('authLogin identity bootstrap', () => {
+  const originalStdoutIsTTY = process.stdout.isTTY;
+  const originalStdinIsTTY = process.stdin.isTTY;
+  const originalSshClient = process.env.SSH_CLIENT;
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    Object.defineProperty(process.stdout, 'isTTY', { value: true, configurable: true });
+    Object.defineProperty(process.stdin, 'isTTY', { value: true, configurable: true });
+    process.env.SSH_CLIENT = '1';
+  });
+
+  afterEach(() => {
+    Object.defineProperty(process.stdout, 'isTTY', { value: originalStdoutIsTTY, configurable: true });
+    Object.defineProperty(process.stdin, 'isTTY', { value: originalStdinIsTTY, configurable: true });
+    if (originalSshClient === undefined) {
+      delete process.env.SSH_CLIENT;
+    } else {
+      process.env.SSH_CLIENT = originalSshClient;
+    }
+    globalThis.fetch = originalFetch;
+    mock.restore();
+  });
+
+  test('creates a missing user root identity after login and offers cloud backup', async () => {
+    const ensureDeviceIdentityPasswordMock = mock(async () => 'device-password');
+    const loadKeypairMock = mock(async () => ({ signing: { secretKey: new Uint8Array(64) } }));
+    const signMock = mock(() => new Uint8Array([1, 2, 3]));
+    const serializeIdentityMock = mock(() => ({ signingPublicKey: 'device-pubkey' }));
+    const setSecretMock = mock(async () => undefined);
+    const syncHostConfigMock = mock(async () => ({ ok: true }));
+    const printHostSyncReportMock = mock(() => undefined);
+    const loadUserRootIdentityMock = mock(async () => null);
+    const initFromMnemonicMock = mock(async () => ({
+      id: 'user-root-1',
+      signing: { publicKey: new Uint8Array(32) },
+      keyExchange: { publicKey: new Uint8Array(32) },
+      createdAt: Date.now(),
+    }));
+    const getCloudIdentityBackupStatusMock = mock(async () => ({ enabled: false }));
+    const backupCurrentUserRootToCloudMock = mock(async () => ({
+      ownerUserRootId: 'user-root-1',
+      updatedAt: Date.now(),
+    }));
+    const promptConfirmMock = mock(async () => true);
+    const promptPasswordMock = mock(async () => 'backup-password');
+
+    mock.module('../../utils/secrets.js', () => ({
+      getSecret: mock(async () => null),
+      setSecret: setSecretMock,
+      deleteSecret: mock(async () => true),
+    }));
+
+    mock.module('../../core/identity.js', () => ({
+      loadKeypair: loadKeypairMock,
+      getPublicKeyWithoutPassword: mock(() => null),
+    }));
+
+    mock.module('../../lib/tmux-lite/crypto/identity.js', () => ({
+      sign: signMock,
+      serializeIdentity: serializeIdentityMock,
+    }));
+
+    mock.module('../host.js', () => ({
+      syncHostConfig: syncHostConfigMock,
+      printHostSyncReport: printHostSyncReportMock,
+    }));
+
+    mock.module('../device-identity-password.js', () => ({
+      createDeviceIdentityPasswordContext: mock(() => ({ passwordStdin: false })),
+      ensureDeviceIdentityPassword: ensureDeviceIdentityPasswordMock,
+    }));
+
+    mock.module('../../core/user-identity.js', () => ({
+      formatFingerprint: mock(() => 'aa:bb:cc:dd'),
+      generateNewMnemonic: mock(() => 'alpha beta gamma delta epsilon zeta eta theta iota kappa lambda mu nu xi omicron pi rho sigma tau upsilon phi chi psi omega'),
+      initFromMnemonic: initFromMnemonicMock,
+      loadUserRootIdentity: loadUserRootIdentityMock,
+    }));
+
+    mock.module('../../core/identity-backup.js', () => ({
+      getCloudIdentityBackupStatus: getCloudIdentityBackupStatusMock,
+      backupCurrentUserRootToCloud: backupCurrentUserRootToCloudMock,
+    }));
+
+    mock.module('../../lib/tmux-lite/crypto/user-identity.js', () => ({
+      formatUserRootPublicKey: mock(() => 'gssh-user:PUBLICKEY'),
+    }));
+
+    mock.module('../identity.js', () => ({
+      logRecoveryPhrase: mock(() => undefined),
+      logIdentityInfo: mock(() => undefined),
+    }));
+
+    mock.module('../../utils/prompts.js', () => ({
+      promptConfirm: promptConfirmMock,
+      promptPassword: promptPasswordMock,
+    }));
+
+    globalThis.fetch = mock(async (input: string | URL | Request) => {
+      const url = typeof input === 'string'
+        ? input
+        : input instanceof URL
+          ? input.toString()
+          : input.url;
+
+      if (url.endsWith('/config')) {
+        return Response.json({ github_client_id: 'client-id' });
+      }
+
+      if (url === 'https://github.com/login/device/code') {
+        return Response.json({
+          device_code: 'device-code',
+          user_code: 'CODE-1234',
+          verification_uri: 'https://github.com/login/device',
+          expires_in: 900,
+          interval: 0,
+        });
+      }
+
+      if (url === 'https://github.com/login/oauth/access_token') {
+        return Response.json({ access_token: 'github-token' });
+      }
+
+      if (url.endsWith('/auth/github/device')) {
+        return Response.json({
+          token: 'gitspace-token',
+          user: {
+            id: 'user-1',
+            github_username: 'bradleat',
+            email: 'bradleat@example.com',
+            name: 'Brad',
+            avatar_url: null,
+          },
+        });
+      }
+
+      throw new Error(`Unexpected fetch: ${url}`);
+    }) as unknown as typeof fetch;
+
+    const { authLogin } = await import(`../auth.js?test=${Date.now()}`);
+
+    await authLogin({ yes: false, interactiveHostSync: false, showHostSyncSummary: false });
+
+    expect(initFromMnemonicMock).toHaveBeenCalledTimes(1);
+    expect(backupCurrentUserRootToCloudMock).toHaveBeenCalledWith('backup-password');
+    expect(syncHostConfigMock).toHaveBeenCalledWith(false);
+    expect(setSecretMock).toHaveBeenCalledWith('GITSPACE_TOKEN', 'gitspace-token');
+  });
+});

--- a/src/commands/__tests__/relay-owner-repair.test.ts
+++ b/src/commands/__tests__/relay-owner-repair.test.ts
@@ -2,8 +2,8 @@ import { describe, expect, test } from 'bun:test';
 import { existsSync, mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { ensureControlStore, getVaultMeta, setVaultMeta, upsertVaultMachine } from '../../relay/control/store.js';
-import { assertRelayOwnerRepairIsSafe, bindRelayOwnerForStartup } from '../relay.js';
+import { ensureControlStore, getVaultMeta, listVaultMachines, setVaultMeta, upsertVaultMachine } from '../../relay/control/store.js';
+import { assertRelayOwnerRepairIsSafe, bindRelayOwnerForStartup, takeOverRelayOwnerForStartup } from '../relay.js';
 
 let envLock: Promise<void> = Promise.resolve();
 
@@ -113,5 +113,27 @@ describe('bindRelayOwnerForStartup', () => {
       expect(getVaultMeta('vault_salt')).toBeUndefined();
       expect(getVaultMeta('vault_key_check')).toBeUndefined();
     }, { initializeVault: false });
+  });
+
+  test('can explicitly take over relay ownership by clearing persisted control state', async () => {
+    await withIsolatedEnv(async () => {
+      setVaultMeta('owner_user_root_id', 'owner-b');
+      upsertVaultMachine({
+        machineId: 'machine-a',
+        ownerUserRootId: 'owner-b',
+        signingKey: 'signing-a',
+        keyExchangeKey: 'kex-a',
+      });
+
+      const result = takeOverRelayOwnerForStartup('owner-a');
+
+      expect(result).toEqual({
+        repairedOwnerBinding: true,
+        missingVaultInitialization: true,
+      });
+      expect(getVaultMeta('owner_user_root_id')).toBe('owner-a');
+      expect(getVaultMeta('vault_initialized')).toBeUndefined();
+      expect(listVaultMachines()).toHaveLength(0);
+    });
   });
 });

--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -11,18 +11,100 @@ import {
   loadKeypair,
   getPublicKeyWithoutPassword,
 } from '../core/identity.js';
+import {
+  generateNewMnemonic,
+  initFromMnemonic,
+  loadUserRootIdentity,
+} from '../core/user-identity.js';
+import { logRecoveryPhrase, logIdentityInfo } from './identity.js';
+import {
+  backupCurrentUserRootToCloud,
+  getCloudIdentityBackupStatus,
+} from '../core/identity-backup.js';
 import { sign, serializeIdentity } from '../lib/tmux-lite/crypto/identity.js';
+
 import { logger } from '../utils/logger.js';
 import { SpacesError } from '../types/errors.js';
 import { printHostSyncReport, syncHostConfig } from './host.js';
+import { promptConfirm, promptPassword } from '../utils/prompts.js';
 import {
   createDeviceIdentityPasswordContext,
   ensureDeviceIdentityPassword,
   type DeviceIdentityPasswordContext,
 } from './device-identity-password.js';
+import type { UserRootIdentity } from '../types/identity.js';
 
 // API Configuration
 const API_BASE = process.env.GITSPACE_API_URL || 'https://api.gitspace.sh';
+
+function canPromptInteractively(): boolean {
+  return Boolean(process.stdin.isTTY && process.stdout.isTTY);
+}
+
+async function maybeBootstrapUserRootIdentityAfterLogin(): Promise<UserRootIdentity | null> {
+  const existingIdentity = await loadUserRootIdentity();
+  if (existingIdentity) {
+    return existingIdentity;
+  }
+
+  if (!canPromptInteractively()) {
+    logger.warning('No user root identity found. Run `gssh user identity init` to create one.');
+    return null;
+  }
+
+  logger.log('');
+  logger.info('No user root identity found. Creating one now...');
+
+  const mnemonic = generateNewMnemonic();
+  const identity = await initFromMnemonic(mnemonic);
+  logRecoveryPhrase(mnemonic);
+  logger.log('');
+  logIdentityInfo(identity, 'Identity created and stored in keychain');
+  return identity;
+}
+
+async function maybeOfferIdentityBackupAfterLogin(options: {
+  userRootIdentity: UserRootIdentity | null;
+  yes?: boolean;
+}): Promise<void> {
+  if (!options.userRootIdentity) {
+    return;
+  }
+
+  const backupStatus = await getCloudIdentityBackupStatus();
+  if (backupStatus.enabled) {
+    return;
+  }
+
+  if (!canPromptInteractively()) {
+    logger.dim('Run `gssh user identity backup enable` to create an encrypted cloud backup.');
+    return;
+  }
+
+  const shouldBackup = options.yes || await promptConfirm(
+    'Back up your identity to GitSpace cloud now?',
+    true,
+  );
+  if (!shouldBackup) {
+    logger.dim('Run `gssh user identity backup enable` any time to create an encrypted cloud backup.');
+    return;
+  }
+
+  const backupPassword = await promptPassword('Create identity backup password:');
+  if (!backupPassword) {
+    logger.info('Skipped cloud identity backup setup');
+    return;
+  }
+
+  const confirmPassword = await promptPassword('Confirm identity backup password:');
+  if (backupPassword !== confirmPassword) {
+    throw new SpacesError('Password confirmation does not match.', 'USER_ERROR', 1);
+  }
+
+  const record = await backupCurrentUserRootToCloud(backupPassword);
+  logger.success('Encrypted identity backup saved to GitSpace cloud');
+  logger.log(`  Owner ID: ${record.ownerUserRootId}`);
+}
 
 /**
  * Fetch GitHub Client ID from the API
@@ -208,6 +290,19 @@ export async function authLogin(
   logger.success('Authentication complete');
   logger.success(`Logged in as ${user.github_username}`);
   logger.success('Token saved to keychain');
+
+  try {
+    const userRootIdentity = await maybeBootstrapUserRootIdentityAfterLogin();
+    await maybeOfferIdentityBackupAfterLogin({
+      userRootIdentity,
+      yes: options.yes,
+    });
+  } catch (error) {
+    logger.warning(
+      `Could not finish identity setup after login: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    logger.dim('Run `gssh user identity init` or `gssh user identity backup enable` to finish setup.');
+  }
 
   // Step 6: Sync host config (fetches existing subdomains from API)
   // Interactive mode will prompt user to select primary or reserve a subdomain

--- a/src/commands/identity.ts
+++ b/src/commands/identity.ts
@@ -31,6 +31,54 @@ import {
 } from '../core/identity-backup.js';
 import { formatUserRootPublicKey } from '../lib/tmux-lite/crypto/user-identity.js';
 import { SpacesError } from '../types/errors.js';
+import type { UserRootIdentity } from '../types/identity.js';
+
+// ============================================================================
+// Shared display helpers (used by identity commands and auth login bootstrap)
+// ============================================================================
+
+/**
+ * Display a 24-word recovery phrase in a formatted 4-column grid.
+ */
+export function logRecoveryPhrase(mnemonic: string): void {
+  logger.log('');
+  logger.bold('=== YOUR 24-WORD RECOVERY PHRASE ===');
+  logger.log('');
+
+  const words = mnemonic.split(' ');
+  for (let row = 0; row < 6; row++) {
+    const cols = [0, 6, 12, 18].map((base) => {
+      const idx = base + row;
+      const num = String(idx + 1).padStart(2, ' ');
+      return `${num}. ${(words[idx] ?? '').padEnd(10)}`;
+    });
+    logger.log(`  ${cols.join('  ')}`);
+  }
+
+  logger.log('');
+  logger.bold('=== WRITE THIS DOWN AND STORE IT SAFELY ===');
+  logger.log('');
+  logger.dim('This phrase is the ONLY way to recover your identity on a new device.');
+  logger.dim('It will NOT be shown again after this step.');
+  logger.dim('The mnemonic is stored in your OS keychain on this machine.');
+}
+
+/**
+ * Display identity information (ID, fingerprint, public key).
+ */
+export function logIdentityInfo(identity: UserRootIdentity, successMessage: string): void {
+  const publicKeyString = formatUserRootPublicKey(identity);
+  const fingerprint = formatFingerprint(identity.signing.publicKey);
+
+  logger.success(successMessage);
+  logger.log('');
+  logger.bold('Identity Information:');
+  logger.log(`  ID:          ${identity.id}`);
+  logger.log(`  Fingerprint: ${fingerprint}`);
+  logger.log('');
+  logger.bold('Public Key:');
+  logger.log(`  ${publicKeyString}`);
+}
 
 // ============================================================================
 // gssh user identity init
@@ -73,42 +121,9 @@ export async function initIdentity(options: { force?: boolean } = {}): Promise<v
   logger.info('Generating identity from new mnemonic...');
   const identity = await initFromMnemonic(mnemonic, options.force ?? false);
 
-  const publicKeyString = formatUserRootPublicKey(identity);
-  const fingerprint = formatFingerprint(identity.signing.publicKey);
-
-  // Display mnemonic (one-time only)
+  logRecoveryPhrase(mnemonic);
   logger.log('');
-  logger.bold('=== YOUR 24-WORD RECOVERY PHRASE ===');
-  logger.log('');
-
-  const words = mnemonic.split(' ');
-  // Display in 4 columns of 6 words
-  for (let row = 0; row < 6; row++) {
-    const cols = [0, 6, 12, 18].map((base) => {
-      const idx = base + row;
-      const num = String(idx + 1).padStart(2, ' ');
-      return `${num}. ${words[idx].padEnd(10)}`;
-    });
-    logger.log(`  ${cols.join('  ')}`);
-  }
-
-  logger.log('');
-  logger.bold('=== WRITE THIS DOWN AND STORE IT SAFELY ===');
-  logger.log('');
-  logger.dim('This phrase is the ONLY way to recover your identity on a new device.');
-  logger.dim('It will NOT be shown again after this step.');
-  logger.dim('The mnemonic is stored in your OS keychain on this machine.');
-  logger.log('');
-
-  // Display identity info
-  logger.success('Identity created and stored in keychain');
-  logger.log('');
-  logger.bold('Identity Information:');
-  logger.log(`  ID:          ${identity.id}`);
-  logger.log(`  Fingerprint: ${fingerprint}`);
-  logger.log('');
-  logger.bold('Public Key:');
-  logger.log(`  ${publicKeyString}`);
+  logIdentityInfo(identity, 'Identity created and stored in keychain');
 }
 
 // ============================================================================
@@ -212,7 +227,7 @@ export async function recoverIdentity(
   // Derive and store
   logger.info('Deriving identity from mnemonic...');
   const identity = await initFromMnemonic(normalized, options.force ?? exists ?? false);
-  logIdentityRecovered(identity, 'Identity recovered and stored in keychain');
+  logIdentityInfo(identity, 'Identity recovered and stored in keychain');
 }
 
 export async function recoverIdentityFromCloud(options: { force?: boolean; yes?: boolean } = {}): Promise<void> {
@@ -248,22 +263,10 @@ export async function recoverIdentityFromCloud(options: { force?: boolean; yes?:
     force: options.force ?? exists ?? false,
   });
 
-  logIdentityRecovered(identity, 'Identity recovered from cloud backup and stored in keychain');
+  logIdentityInfo(identity, 'Identity recovered from cloud backup and stored in keychain');
 }
 
-function logIdentityRecovered(identity: Awaited<ReturnType<typeof initFromMnemonic>>, successMessage: string): void {
-  const publicKeyString = formatUserRootPublicKey(identity);
-  const fingerprint = formatFingerprint(identity.signing.publicKey);
 
-  logger.success(successMessage);
-  logger.log('');
-  logger.bold('Identity Information:');
-  logger.log(`  ID:          ${identity.id}`);
-  logger.log(`  Fingerprint: ${fingerprint}`);
-  logger.log('');
-  logger.bold('Public Key:');
-  logger.log(`  ${publicKeyString}`);
-}
 
 // ============================================================================
 // gssh user identity export

--- a/src/commands/relay.ts
+++ b/src/commands/relay.ts
@@ -12,6 +12,7 @@ import { SpacesError } from "../types/errors.js";
 import chalk from "chalk";
 import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
+import { pathToFileURL } from "node:url";
 import {
   loadOrCreateRelayIdentity,
   formatRelayFingerprint,
@@ -27,13 +28,14 @@ import {
   listVaultMachines,
   listVaultMachinesForOwner,
   removeVaultMachineForOwner,
+  resetControlStore,
 } from "../relay/control/store.js";
 import {
   ensureSubdomainTunnelToken,
   readHostConfig,
   resolveRelaySubdomains,
 } from "./host.js";
-import { selectOne } from "../utils/prompts.js";
+import { promptConfirm, selectOne } from "../utils/prompts.js";
 import { isCloudflaredInstalled, trackCloudflaredOutput } from "../utils/cloudflared.js";
 import { ensureUserRootIdentityWithRecovery } from "./identity-recovery.js";
 
@@ -41,8 +43,10 @@ import { ensureUserRootIdentityWithRecovery } from "./identity-recovery.js";
 const DEFAULT_PORT = 4480;
 const RELAY_RUNTIME_DIR = ".relay/runtime";
 const RELAY_STATE_FILE = "relay-state.json";
+const RELAY_LOG_FILE = "relay.log";
 const CLOUDFLARED_STARTUP_DELAY_MS = 1200;
 const CLOUDFLARED_EARLY_EXIT_RACE_MS = 100;
+const RELAY_DAEMON_STARTUP_TIMEOUT_MS = 5000;
 
 export function assertRelayOwnerRepairIsSafe(ownerUserRootId: string): void {
   const machineOwners = new Set(listVaultMachines().map((machine) => machine.ownerUserRootId));
@@ -70,7 +74,8 @@ export function bindRelayOwnerForStartup(ownerUserRootId: string): {
     throw new SpacesError(
       `Relay is already owned by a different user root identity.\n`
       + `  Existing owner: ${existingOwner.slice(0, 8)}...\n`
-      + `  Current user:   ${ownerUserRootId.slice(0, 8)}...`,
+      + `  Current user:   ${ownerUserRootId.slice(0, 8)}...\n\n`
+      + 'Recover the original identity, or re-run with `gssh relay start --takeover` to clear persisted relay control state and rebind ownership.',
       "USER_ERROR",
       1,
     );
@@ -91,6 +96,19 @@ export function bindRelayOwnerForStartup(ownerUserRootId: string): {
     repairedOwnerBinding: !existingOwner,
     missingVaultInitialization: !vaultInitialized,
   };
+}
+
+export function takeOverRelayOwnerForStartup(ownerUserRootId: string): {
+  repairedOwnerBinding: boolean;
+  missingVaultInitialization: boolean;
+} {
+  resetControlStore();
+  return bindRelayOwnerForStartup(ownerUserRootId);
+}
+
+function isRelayOwnerMismatchError(error: unknown): boolean {
+  return error instanceof SpacesError
+    && error.message.includes('Relay is already owned by a different user root identity.');
 }
 
 interface RelayRuntimeState {
@@ -126,6 +144,22 @@ function getRelayRuntimeDir(): string {
 
 function getRelayStatePath(): string {
   return join(getRelayRuntimeDir(), RELAY_STATE_FILE);
+}
+
+function getRelayLogPath(): string {
+  return join(getRelayRuntimeDir(), RELAY_LOG_FILE);
+}
+
+async function waitForRelayRunning(timeoutMs: number): Promise<RelayStatusSnapshot> {
+  const deadline = Date.now() + timeoutMs;
+  let snapshot = getRelayStatusSnapshot();
+
+  while (!snapshot.running && Date.now() < deadline) {
+    await Bun.sleep(100);
+    snapshot = getRelayStatusSnapshot();
+  }
+
+  return snapshot;
 }
 
 function isProcessRunning(pid: number): boolean {
@@ -210,7 +244,8 @@ function isOwnedProcessCommand(command: string, kind: RelayProcessKind): boolean
       && normalizedCommand.includes("run");
   }
 
-  return normalizedCommand.includes("relay start");
+  return normalizedCommand.includes("relay start")
+    || (normalizedCommand.includes("commands/relay.ts") && normalizedCommand.includes("startrelay"));
 }
 
 function isOwnedProcess(pid: number, kind: RelayProcessKind): boolean {
@@ -366,7 +401,73 @@ export async function startRelay(options: {
   mode?: RelayStartMode;
   label?: string;
   yes?: boolean;
+  foreground?: boolean;
+  takeover?: boolean;
 }): Promise<void> {
+  if (!options.foreground) {
+    logger.log("Starting relay daemon...");
+
+    const isCompiled = !process.execPath.endsWith("bun");
+    const relayArgs = ["relay", "start", "--foreground"];
+    if (options.port) relayArgs.push("--port", String(options.port));
+    if (options.bind) relayArgs.push("--bind", options.bind);
+    if (options.hostname) relayArgs.push("--hostname", options.hostname);
+    if (options.mode) relayArgs.push("--mode", options.mode);
+    if (options.label) relayArgs.push("--label", options.label);
+    if (options.yes) relayArgs.push("--yes");
+    if (options.takeover) {
+      relayArgs.push("--takeover");
+      // Auto-imply --yes for the daemon child: the user already explicitly
+      // requested --takeover in the parent, and the child process has no stdin
+      // to prompt for confirmation.
+      if (!options.yes) relayArgs.push("--yes");
+    }
+
+    const relayModuleUrl = pathToFileURL(join(import.meta.dir, "relay.ts")).href;
+    const foregroundOptions = JSON.stringify({ ...options, foreground: true });
+    const cmd = isCompiled
+      ? [process.execPath, ...relayArgs]
+      : [
+        "bun",
+        "--eval",
+        `const { startRelay } = await import(${JSON.stringify(relayModuleUrl)}); await startRelay(${foregroundOptions});`,
+      ];
+
+    const runtimeDir = getRelayRuntimeDir();
+    if (!existsSync(runtimeDir)) {
+      mkdirSync(runtimeDir, { recursive: true, mode: 0o700 });
+    }
+
+    const logFile = getRelayLogPath();
+    await Bun.write(logFile, `[${new Date().toISOString()}] Starting relay daemon...\n`);
+
+    // Clear stale state so polling only sees state written by the new child.
+    // Without this, a reused PID from an old relay-state.json could cause a
+    // false-positive "relay started" before the child even initializes.
+    clearRelayState();
+
+    Bun.spawn(cmd, {
+      stdin: "ignore",
+      stdout: Bun.file(logFile),
+      stderr: Bun.file(logFile),
+      env: process.env,
+    });
+
+    const snapshot = await waitForRelayRunning(RELAY_DAEMON_STARTUP_TIMEOUT_MS);
+    if (snapshot.running) {
+      logger.success(`relay daemon started${snapshot.pid ? ` (pid ${snapshot.pid})` : ""}`);
+      if (snapshot.publicRelayUrl) {
+        logger.log(`  Public URL: ${snapshot.publicRelayUrl}`);
+      }
+      process.exit(0);
+    }
+
+    const logContent = await Bun.file(logFile).text();
+    logger.error("Relay log:");
+    logger.log(logContent);
+    throw new SpacesError("Failed to start relay daemon. Check log above for details.", "SYSTEM_ERROR", 2);
+  }
+
   const existingState = readRelayState();
   if (existingState?.pid && isProcessRunning(existingState.pid)) {
     const existingCommand = getProcessCommand(existingState.pid);
@@ -490,7 +591,28 @@ export async function startRelay(options: {
       });
     if (userRoot) {
       ownerUserRootId = userRoot.id;
-      const ownerBinding = bindRelayOwnerForStartup(ownerUserRootId);
+      let ownerBinding;
+      try {
+        ownerBinding = bindRelayOwnerForStartup(ownerUserRootId);
+      } catch (error) {
+        if (!options.takeover || !isRelayOwnerMismatchError(error)) {
+          throw error;
+        }
+
+        if (!options.yes) {
+          const confirmed = await promptConfirm(
+            'Relay ownership belongs to a different identity. Clear persisted relay registrations, access lists, invites, and owner metadata so the current identity can take over?',
+            false,
+          );
+          if (!confirmed) {
+            throw new SpacesError('Cancelled', 'USER_ERROR', 1);
+          }
+        }
+
+        logger.warning('Clearing persisted relay control state and taking ownership with the current identity.');
+        ownerBinding = takeOverRelayOwnerForStartup(ownerUserRootId);
+      }
+
       if (ownerBinding.repairedOwnerBinding && !ownerBinding.missingVaultInitialization) {
         logger.info('Relay vault is initialized but owner metadata is missing; repairing owner binding from the current user root identity.');
       } else if (ownerBinding.missingVaultInitialization) {

--- a/src/relay/control/store.ts
+++ b/src/relay/control/store.ts
@@ -1,6 +1,6 @@
 import { Database } from 'bun:sqlite';
 import { createHash, randomBytes, randomUUID } from 'node:crypto';
-import { existsSync, mkdirSync } from 'node:fs';
+import { existsSync, mkdirSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { getSpacesDir } from '../../core/config.js';
 import { SpacesError } from '../../types/errors.js';
@@ -61,6 +61,13 @@ export function getControlDirPath(): string {
 
 export function getControlDbPath(): string {
   return join(getControlDirPath(), 'control.db');
+}
+
+export function resetControlStore(): void {
+  const controlDbPath = getControlDbPath();
+  rmSync(controlDbPath, { force: true });
+  rmSync(`${controlDbPath}-shm`, { force: true });
+  rmSync(`${controlDbPath}-wal`, { force: true });
 }
 
 function ensureControlDir(): void {


### PR DESCRIPTION
## Summary

- **Relay defaults to background**: `gssh relay start` now daemonizes by default; use `--foreground` for opt-in foreground mode
- **Relay owner takeover**: `gssh relay start --takeover` clears stale relay ownership when the relay says "already owned by a different identity"
- **Login identity bootstrap**: `gssh user auth login` now auto-creates a user identity and offers cloud backup, reducing manual setup steps

## Test coverage

- `relay-owner-repair.test.ts` — extended with takeover flow tests
- `auth-login-identity-bootstrap.test.ts` — new test for post-login identity creation + backup offer

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes relay startup semantics to daemonize by default and adds a `--takeover` path that wipes persisted control DB state, which can affect running processes and stored relay registrations. Also extends `authLogin` to create identities and prompt for cloud backup, impacting user onboarding and credential/secret handling flows.
> 
> **Overview**
> **Relay startup now daemonizes by default.** `gssh relay start` launches a background child process, writes logs to `relay.log`, polls `relay-state.json` for readiness, and adds `--foreground` to opt into the old foreground behavior.
> 
> **Adds relay ownership takeover and control-store reset.** `--takeover` lets startup clear the persisted control DB (machines/ACLs/invites/owner metadata) when ownership mismatches, with updated error messaging and new `resetControlStore()`/`takeOverRelayOwnerForStartup()` helpers.
> 
> **Auth login bootstraps user identity + optional cloud backup.** After successful `gssh user auth login`, the CLI can auto-create a missing user root identity (interactive only), display the recovery phrase/identity info via shared helpers moved into `identity.ts`, and optionally prompt to enable encrypted cloud backup; new tests cover both the login bootstrap and takeover flow.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6d186ed9ee183c385326c1ac0af8524b21349ed0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Relay start adds --foreground and --takeover, supports daemonized startup with startup logging and readiness wait.
  * Interactive post-login identity bootstrap with mnemonic display and optional encrypted cloud backup; improved identity info display.
  * Recovery helpers to reset relay control state and perform ownership takeover for recovery scenarios.

* **Tests**
  * New tests for auth identity bootstrap flow and relay ownership repair/recovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->