### PR TITLE
feat: web identity gate with GitHub OAuth + cloud backup recovery

### DIFF
--- a/src/app.web.tsx
+++ b/src/app.web.tsx
@@ -312,8 +312,7 @@ export default function App() {
     if (resolvedIdentity && relay.status === "disconnected") {
       relay.connect();
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [resolvedIdentity]);
+  }, [resolvedIdentity, relay.connect]);
 
   useEffect(() => {
     if (terminal.scriptState?.isRunning) {

--- a/src/app.web.tsx
+++ b/src/app.web.tsx
@@ -10,6 +10,8 @@ import {
 import { FloatingControls } from "./components/FloatingControls.web";
 import { useTerminal } from "./hooks/useTerminal.web";
 import { useRelayConnection } from "./hooks/useRelayConnection.web";
+import { IdentityGate } from "./components/IdentityGate.web";
+import type { Identity } from "./types/identity";
 import { useVisualViewport } from "./hooks/useVisualViewport.web";
 import { browserPreferencesService } from "./lib/preferences-service.web";
 import { Toaster, toast } from "./lib/sonner.web";
@@ -116,8 +118,11 @@ export default function App() {
     workspaceLabel?: string;
   } | null>(null);
 
+  // Identity state (resolved by IdentityGate before relay connection)
+  const [resolvedIdentity, setResolvedIdentity] = useState<Identity | null>(null);
+
   // Relay connection (for machine list)
-  const relay = useRelayConnection();
+  const relay = useRelayConnection({ identity: resolvedIdentity });
 
   // Terminal connection (for PTY)
   const terminal = useTerminal();
@@ -300,12 +305,12 @@ export default function App() {
     }
   }, []);
 
-  // Auto-connect on load (no token required for personal relays)
+  // Auto-connect when identity becomes available
   useEffect(() => {
-    if (relay.status === "disconnected") {
+    if (resolvedIdentity && relay.status === "disconnected") {
       relay.connect();
     }
-  }, []);
+  }, [resolvedIdentity]);
 
   useEffect(() => {
     if (terminal.scriptState?.isRunning) {
@@ -1430,6 +1435,11 @@ export default function App() {
 
   // ========== Machine List View ==========
   // This is now the main/default view - shows machines and your identity
+  // Show identity gate before allowing relay connection
+  if (!resolvedIdentity) {
+    return <IdentityGate onIdentityReady={setResolvedIdentity} />;
+  }
+
   return (
     <>
       <div className="h-screen w-screen flex flex-col bg-[#0d1117]">

--- a/src/app.web.tsx
+++ b/src/app.web.tsx
@@ -305,11 +305,14 @@ export default function App() {
     }
   }, []);
 
-  // Auto-connect when identity becomes available
+  // Auto-connect when identity becomes available.
+  // relay.status is intentionally omitted — including it would cause reconnect
+  // loops on every status transition. We only want to trigger on identity change.
   useEffect(() => {
     if (resolvedIdentity && relay.status === "disconnected") {
       relay.connect();
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [resolvedIdentity]);
 
   useEffect(() => {
@@ -1078,6 +1081,11 @@ export default function App() {
     return () => window.removeEventListener("keydown", handleKeyDown);
   }, [notifications.activeToast, notifications.attachToActiveToast, flow]);
 
+  // Show identity gate before any view (including review deep links)
+  if (!resolvedIdentity) {
+    return <IdentityGate onIdentityReady={setResolvedIdentity} />;
+  }
+
   // ========== Review View ==========
   if (view === 'review' && reviewWorkspace) {
     if (terminal.status === 'established') {
@@ -1435,10 +1443,7 @@ export default function App() {
 
   // ========== Machine List View ==========
   // This is now the main/default view - shows machines and your identity
-  // Show identity gate before allowing relay connection
-  if (!resolvedIdentity) {
-    return <IdentityGate onIdentityReady={setResolvedIdentity} />;
-  }
+  // (Identity gate is handled above, before any view rendering)
 
   return (
     <>

--- a/src/components/IdentityGate.web.tsx
+++ b/src/components/IdentityGate.web.tsx
@@ -150,6 +150,8 @@ export function IdentityGate({ onIdentityReady }: IdentityGateProps) {
         throw new Error('Decrypted data is not a valid mnemonic.');
       }
       pendingMnemonicRef.current = normalized;
+      setPasswordValue('');
+      setMnemonicValue('');
       setStep('create-pin');
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Decryption failed');
@@ -170,6 +172,8 @@ export function IdentityGate({ onIdentityReady }: IdentityGateProps) {
     }
 
     pendingMnemonicRef.current = normalized;
+    setMnemonicValue('');
+    setPasswordValue('');
     setStep('create-pin');
   }, [mnemonicValue]);
 
@@ -198,6 +202,8 @@ export function IdentityGate({ onIdentityReady }: IdentityGateProps) {
       await storeMnemonic(pendingMnemonicRef.current, newPinValue);
       // Clear sensitive data from memory
       pendingMnemonicRef.current = null;
+      setPasswordValue('');
+      setMnemonicValue('');
       setNewPinValue('');
       setConfirmPinValue('');
       completeWithIdentity();

--- a/src/components/IdentityGate.web.tsx
+++ b/src/components/IdentityGate.web.tsx
@@ -1,0 +1,449 @@
+/** @jsxImportSource react */
+/**
+ * Identity gate screen shown before relay connection.
+ *
+ * Handles the full identity bootstrap flow:
+ * - Returning user with stored mnemonic → PIN unlock
+ * - New user → GitHub OAuth → cloud backup recovery
+ * - Fallback → manual 24-word mnemonic entry
+ * - PIN creation for encrypting identity in localStorage
+ */
+
+import { useState, useEffect, useCallback, useRef } from 'react';
+import { useAuth } from '../hooks/useAuth.web';
+import {
+  fetchCloudBackup,
+  decryptBackupEnvelope,
+  type CloudBackup,
+} from '../lib/identity-backup.web';
+import {
+  hasStoredMnemonic,
+  unlockMnemonic,
+  storeMnemonic,
+  getUnlockedIdentity,
+} from '../lib/storage/identity-store.web';
+import {
+  isValidMnemonic,
+  normalizeMnemonic,
+} from '../session/crypto/identity.web';
+import type { Identity } from '../types/identity';
+
+type GateStep =
+  | 'checking'
+  | 'unlock-pin'
+  | 'login'
+  | 'fetching-backup'
+  | 'backup-password'
+  | 'no-backup'
+  | 'mnemonic-entry'
+  | 'create-pin'
+  | 'error';
+
+interface IdentityGateProps {
+  onIdentityReady: (identity: Identity) => void;
+}
+
+export function IdentityGate({ onIdentityReady }: IdentityGateProps) {
+  const auth = useAuth();
+  const [step, setStep] = useState<GateStep>('checking');
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  // Form values
+  const [pinValue, setPinValue] = useState('');
+  const [passwordValue, setPasswordValue] = useState('');
+  const [mnemonicValue, setMnemonicValue] = useState('');
+  const [newPinValue, setNewPinValue] = useState('');
+  const [confirmPinValue, setConfirmPinValue] = useState('');
+
+  // Backup data from cloud
+  const backupRef = useRef<CloudBackup | null>(null);
+  // Mnemonic ready to be stored with a PIN
+  const pendingMnemonicRef = useRef<string | null>(null);
+
+  // ================================================================
+  // Initial check: do we have a stored mnemonic or an auth token?
+  // ================================================================
+  useEffect(() => {
+    if (hasStoredMnemonic()) {
+      setStep('unlock-pin');
+      return;
+    }
+
+    if (auth.isLoggedIn) {
+      // Already have a token (e.g. just came back from OAuth redirect)
+      setStep('fetching-backup');
+      return;
+    }
+
+    setStep('login');
+  }, [auth.isLoggedIn]);
+
+  // ================================================================
+  // When step transitions to fetching-backup, auto-fetch
+  // ================================================================
+  useEffect(() => {
+    if (step !== 'fetching-backup' || !auth.token) return;
+
+    let cancelled = false;
+    (async () => {
+      try {
+        const backup = await fetchCloudBackup(auth.token!);
+        if (cancelled) return;
+
+        if (backup) {
+          backupRef.current = backup;
+          setStep('backup-password');
+        } else {
+          setStep('no-backup');
+        }
+      } catch (err) {
+        if (cancelled) return;
+        setError(err instanceof Error ? err.message : 'Failed to fetch backup');
+        setStep('error');
+      }
+    })();
+
+    return () => { cancelled = true; };
+  }, [step, auth.token]);
+
+  // ================================================================
+  // Handlers
+  // ================================================================
+
+  const completeWithIdentity = useCallback(() => {
+    const identity = getUnlockedIdentity('Browser Owner');
+    if (identity) {
+      onIdentityReady(identity);
+    } else {
+      setError('Failed to derive identity from mnemonic.');
+      setStep('error');
+    }
+  }, [onIdentityReady]);
+
+  const handleUnlockPin = useCallback(async () => {
+    if (!pinValue.trim()) return;
+    setLoading(true);
+    setError(null);
+
+    try {
+      await unlockMnemonic(pinValue);
+      completeWithIdentity();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Unlock failed');
+      setPinValue('');
+    } finally {
+      setLoading(false);
+    }
+  }, [pinValue, completeWithIdentity]);
+
+  const handleBackupPassword = useCallback(async () => {
+    if (!passwordValue.trim() || !backupRef.current) return;
+    setLoading(true);
+    setError(null);
+
+    try {
+      const mnemonic = await decryptBackupEnvelope(backupRef.current.envelope, passwordValue);
+      const normalized = normalizeMnemonic(mnemonic);
+      if (!isValidMnemonic(normalized)) {
+        throw new Error('Decrypted data is not a valid mnemonic.');
+      }
+      pendingMnemonicRef.current = normalized;
+      setStep('create-pin');
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Decryption failed');
+      setPasswordValue('');
+    } finally {
+      setLoading(false);
+    }
+  }, [passwordValue]);
+
+  const handleMnemonicEntry = useCallback(() => {
+    if (!mnemonicValue.trim()) return;
+    setError(null);
+
+    const normalized = normalizeMnemonic(mnemonicValue);
+    if (!isValidMnemonic(normalized)) {
+      setError('Invalid 24-word recovery phrase.');
+      return;
+    }
+
+    pendingMnemonicRef.current = normalized;
+    setStep('create-pin');
+  }, [mnemonicValue]);
+
+  const handleCreatePin = useCallback(async () => {
+    if (!newPinValue.trim()) {
+      setError('PIN is required.');
+      return;
+    }
+    if (newPinValue !== confirmPinValue) {
+      setError('PINs do not match.');
+      return;
+    }
+    if (!pendingMnemonicRef.current) {
+      setError('No mnemonic available.');
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      await storeMnemonic(pendingMnemonicRef.current, newPinValue);
+      completeWithIdentity();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to store identity');
+    } finally {
+      setLoading(false);
+    }
+  }, [newPinValue, confirmPinValue, completeWithIdentity]);
+
+  const handleKeyDown = useCallback((handler: () => void) => {
+    return (e: React.KeyboardEvent) => {
+      if (e.key === 'Enter' && !loading) {
+        handler();
+      }
+    };
+  }, [loading]);
+
+  // ================================================================
+  // Render
+  // ================================================================
+
+  return (
+    <div className="h-screen w-screen flex items-center justify-center bg-[#0d1117]">
+      <div className="w-full max-w-md mx-4">
+        {/* Header */}
+        <div className="text-center mb-8">
+          <h1 className="text-2xl font-bold text-[#e6edf3] mb-2">GitSpace</h1>
+          <p className="text-sm text-[#8b949e]">Secure terminal access</p>
+        </div>
+
+        {/* Card */}
+        <div className="bg-[#161b22] border border-[#30363d] rounded-lg p-6">
+          {step === 'checking' && (
+            <div className="text-center py-4">
+              <div className="text-[#8b949e]">Loading...</div>
+            </div>
+          )}
+
+          {step === 'unlock-pin' && (
+            <>
+              <h2 className="text-lg font-medium text-[#e6edf3] mb-4">Unlock Identity</h2>
+              <p className="text-sm text-[#8b949e] mb-4">
+                Enter your browser unlock PIN to continue.
+              </p>
+              <input
+                type="password"
+                value={pinValue}
+                onChange={(e) => setPinValue(e.target.value)}
+                onKeyDown={handleKeyDown(handleUnlockPin)}
+                placeholder="Enter PIN"
+                autoFocus
+                disabled={loading}
+                className="w-full p-3 text-base bg-[#0d1117] border border-[#30363d] rounded-lg text-[#e6edf3] placeholder:text-[#6e7681] focus:border-[#22c55e] focus:outline-none focus:shadow-glow transition-all disabled:opacity-50"
+              />
+              {error && (
+                <p className="mt-2 text-sm text-[#f85149]">{error}</p>
+              )}
+              <button
+                onClick={handleUnlockPin}
+                disabled={loading || !pinValue.trim()}
+                className="w-full mt-4 px-5 py-3 bg-[#22c55e] hover:bg-[#16a34a] active:bg-[#16a34a] text-[#0d1117] font-medium rounded-lg min-h-[48px] shadow-glow transition-all disabled:bg-[#21262d] disabled:border-[#30363d] disabled:text-[#6e7681] disabled:cursor-not-allowed disabled:shadow-none"
+              >
+                {loading ? 'Unlocking...' : 'Unlock'}
+              </button>
+              <button
+                onClick={() => {
+                  // Reset stored identity — user needs to re-import
+                  localStorage.removeItem('gssh.browser.identity.v1');
+                  setStep(auth.isLoggedIn ? 'fetching-backup' : 'login');
+                  setError(null);
+                  setPinValue('');
+                }}
+                className="w-full mt-2 px-5 py-2 text-sm text-[#8b949e] hover:text-[#e6edf3] transition-all"
+              >
+                Reset browser identity
+              </button>
+            </>
+          )}
+
+          {step === 'login' && (
+            <>
+              <h2 className="text-lg font-medium text-[#e6edf3] mb-4">Sign In</h2>
+              <p className="text-sm text-[#8b949e] mb-6">
+                Sign in with GitHub to recover your identity from the cloud, or enter your recovery phrase manually.
+              </p>
+              <button
+                onClick={auth.startLogin}
+                className="w-full px-5 py-3 bg-[#22c55e] hover:bg-[#16a34a] active:bg-[#16a34a] text-[#0d1117] font-medium rounded-lg min-h-[48px] shadow-glow transition-all"
+              >
+                Sign in with GitHub
+              </button>
+              <div className="flex items-center my-4">
+                <div className="flex-1 border-t border-[#30363d]" />
+                <span className="px-3 text-xs text-[#6e7681]">or</span>
+                <div className="flex-1 border-t border-[#30363d]" />
+              </div>
+              <button
+                onClick={() => { setStep('mnemonic-entry'); setError(null); }}
+                className="w-full px-5 py-3 bg-[#21262d] hover:bg-[#30363d] active:bg-[#161b22] text-[#e6edf3] border border-[#30363d] rounded-lg min-h-[48px] transition-all"
+              >
+                Enter recovery phrase
+              </button>
+            </>
+          )}
+
+          {step === 'fetching-backup' && (
+            <div className="text-center py-8">
+              <div className="text-[#8b949e] mb-2">Checking for cloud backup...</div>
+              <div className="text-xs text-[#6e7681]">This may take a moment</div>
+            </div>
+          )}
+
+          {step === 'backup-password' && (
+            <>
+              <h2 className="text-lg font-medium text-[#e6edf3] mb-2">Cloud Backup Found</h2>
+              <p className="text-sm text-[#8b949e] mb-4">
+                Enter your identity backup password to decrypt.
+              </p>
+              <input
+                type="password"
+                value={passwordValue}
+                onChange={(e) => setPasswordValue(e.target.value)}
+                onKeyDown={handleKeyDown(handleBackupPassword)}
+                placeholder="Backup password"
+                autoFocus
+                disabled={loading}
+                className="w-full p-3 text-base bg-[#0d1117] border border-[#30363d] rounded-lg text-[#e6edf3] placeholder:text-[#6e7681] focus:border-[#22c55e] focus:outline-none focus:shadow-glow transition-all disabled:opacity-50"
+              />
+              {error && (
+                <p className="mt-2 text-sm text-[#f85149]">{error}</p>
+              )}
+              <button
+                onClick={handleBackupPassword}
+                disabled={loading || !passwordValue.trim()}
+                className="w-full mt-4 px-5 py-3 bg-[#22c55e] hover:bg-[#16a34a] active:bg-[#16a34a] text-[#0d1117] font-medium rounded-lg min-h-[48px] shadow-glow transition-all disabled:bg-[#21262d] disabled:border-[#30363d] disabled:text-[#6e7681] disabled:cursor-not-allowed disabled:shadow-none"
+              >
+                {loading ? 'Decrypting...' : 'Decrypt'}
+              </button>
+              <button
+                onClick={() => { setStep('mnemonic-entry'); setError(null); setPasswordValue(''); }}
+                className="w-full mt-2 px-5 py-2 text-sm text-[#8b949e] hover:text-[#e6edf3] transition-all"
+              >
+                Enter recovery phrase instead
+              </button>
+            </>
+          )}
+
+          {step === 'no-backup' && (
+            <>
+              <h2 className="text-lg font-medium text-[#e6edf3] mb-2">No Cloud Backup</h2>
+              <p className="text-sm text-[#8b949e] mb-4">
+                No identity backup found for your account. You can enter your 24-word recovery phrase to set up this browser.
+              </p>
+              <p className="text-xs text-[#6e7681] mb-4">
+                To enable cloud backup, run <code className="text-[#3fb950] bg-[#0d1117] px-1 rounded">gssh user identity backup enable</code> from the CLI.
+              </p>
+              <button
+                onClick={() => { setStep('mnemonic-entry'); setError(null); }}
+                className="w-full px-5 py-3 bg-[#22c55e] hover:bg-[#16a34a] active:bg-[#16a34a] text-[#0d1117] font-medium rounded-lg min-h-[48px] shadow-glow transition-all"
+              >
+                Enter recovery phrase
+              </button>
+            </>
+          )}
+
+          {step === 'mnemonic-entry' && (
+            <>
+              <h2 className="text-lg font-medium text-[#e6edf3] mb-2">Recovery Phrase</h2>
+              <p className="text-sm text-[#8b949e] mb-4">
+                Enter your 24-word recovery phrase.
+              </p>
+              <textarea
+                value={mnemonicValue}
+                onChange={(e) => setMnemonicValue(e.target.value)}
+                placeholder="word1 word2 word3 ..."
+                rows={4}
+                autoFocus
+                className="w-full p-3 text-base bg-[#0d1117] border border-[#30363d] rounded-lg text-[#e6edf3] placeholder:text-[#6e7681] focus:border-[#22c55e] focus:outline-none focus:shadow-glow transition-all resize-none"
+              />
+              {error && (
+                <p className="mt-2 text-sm text-[#f85149]">{error}</p>
+              )}
+              <button
+                onClick={handleMnemonicEntry}
+                disabled={!mnemonicValue.trim()}
+                className="w-full mt-4 px-5 py-3 bg-[#22c55e] hover:bg-[#16a34a] active:bg-[#16a34a] text-[#0d1117] font-medium rounded-lg min-h-[48px] shadow-glow transition-all disabled:bg-[#21262d] disabled:border-[#30363d] disabled:text-[#6e7681] disabled:cursor-not-allowed disabled:shadow-none"
+              >
+                Continue
+              </button>
+              <button
+                onClick={() => { setStep(auth.isLoggedIn ? 'fetching-backup' : 'login'); setError(null); setMnemonicValue(''); }}
+                className="w-full mt-2 px-5 py-2 text-sm text-[#8b949e] hover:text-[#e6edf3] transition-all"
+              >
+                Back
+              </button>
+            </>
+          )}
+
+          {step === 'create-pin' && (
+            <>
+              <h2 className="text-lg font-medium text-[#e6edf3] mb-2">Create Browser PIN</h2>
+              <p className="text-sm text-[#8b949e] mb-4">
+                Create a PIN to unlock your identity on this browser. This is stored locally and protects your identity at rest.
+              </p>
+              <input
+                type="password"
+                value={newPinValue}
+                onChange={(e) => setNewPinValue(e.target.value)}
+                placeholder="Create PIN"
+                autoFocus
+                disabled={loading}
+                className="w-full p-3 text-base bg-[#0d1117] border border-[#30363d] rounded-lg text-[#e6edf3] placeholder:text-[#6e7681] focus:border-[#22c55e] focus:outline-none focus:shadow-glow transition-all disabled:opacity-50 mb-3"
+              />
+              <input
+                type="password"
+                value={confirmPinValue}
+                onChange={(e) => setConfirmPinValue(e.target.value)}
+                onKeyDown={handleKeyDown(handleCreatePin)}
+                placeholder="Confirm PIN"
+                disabled={loading}
+                className="w-full p-3 text-base bg-[#0d1117] border border-[#30363d] rounded-lg text-[#e6edf3] placeholder:text-[#6e7681] focus:border-[#22c55e] focus:outline-none focus:shadow-glow transition-all disabled:opacity-50"
+              />
+              {error && (
+                <p className="mt-2 text-sm text-[#f85149]">{error}</p>
+              )}
+              <button
+                onClick={handleCreatePin}
+                disabled={loading || !newPinValue.trim() || !confirmPinValue.trim()}
+                className="w-full mt-4 px-5 py-3 bg-[#22c55e] hover:bg-[#16a34a] active:bg-[#16a34a] text-[#0d1117] font-medium rounded-lg min-h-[48px] shadow-glow transition-all disabled:bg-[#21262d] disabled:border-[#30363d] disabled:text-[#6e7681] disabled:cursor-not-allowed disabled:shadow-none"
+              >
+                {loading ? 'Saving...' : 'Save & Continue'}
+              </button>
+            </>
+          )}
+
+          {step === 'error' && (
+            <>
+              <h2 className="text-lg font-medium text-[#f85149] mb-2">Error</h2>
+              <p className="text-sm text-[#8b949e] mb-4">{error}</p>
+              <button
+                onClick={() => { setStep('login'); setError(null); }}
+                className="w-full px-5 py-3 bg-[#21262d] hover:bg-[#30363d] active:bg-[#161b22] text-[#e6edf3] border border-[#30363d] rounded-lg min-h-[48px] transition-all"
+              >
+                Try again
+              </button>
+            </>
+          )}
+        </div>
+
+        {/* Footer */}
+        <div className="text-center mt-6 text-xs text-[#6e7681]">
+          E2E encrypted terminal access
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/IdentityGate.web.tsx
+++ b/src/components/IdentityGate.web.tsx
@@ -21,6 +21,7 @@ import {
   unlockMnemonic,
   storeMnemonic,
   getUnlockedIdentity,
+  clearStoredMnemonic,
 } from '../lib/storage/identity-store.web';
 import {
   isValidMnemonic,
@@ -177,6 +178,10 @@ export function IdentityGate({ onIdentityReady }: IdentityGateProps) {
       setError('PIN is required.');
       return;
     }
+    if (newPinValue.length < 4) {
+      setError('PIN must be at least 4 characters.');
+      return;
+    }
     if (newPinValue !== confirmPinValue) {
       setError('PINs do not match.');
       return;
@@ -191,6 +196,10 @@ export function IdentityGate({ onIdentityReady }: IdentityGateProps) {
 
     try {
       await storeMnemonic(pendingMnemonicRef.current, newPinValue);
+      // Clear sensitive data from memory
+      pendingMnemonicRef.current = null;
+      setNewPinValue('');
+      setConfirmPinValue('');
       completeWithIdentity();
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to store identity');
@@ -257,7 +266,7 @@ export function IdentityGate({ onIdentityReady }: IdentityGateProps) {
               <button
                 onClick={() => {
                   // Reset stored identity — user needs to re-import
-                  localStorage.removeItem('gssh.browser.identity.v1');
+                  clearStoredMnemonic();
                   setStep(auth.isLoggedIn ? 'fetching-backup' : 'login');
                   setError(null);
                   setPinValue('');

--- a/src/components/IdentityGate.web.tsx
+++ b/src/components/IdentityGate.web.tsx
@@ -66,6 +66,10 @@ export function IdentityGate({ onIdentityReady }: IdentityGateProps) {
   // Initial check: do we have a stored mnemonic or an auth token?
   // ================================================================
   useEffect(() => {
+    // Only run during the initial check phase — don't clobber user progress
+    // if auth state changes while they're mid-flow (e.g. at create-pin).
+    if (step !== 'checking') return;
+
     if (hasStoredMnemonic()) {
       setStep('unlock-pin');
       return;
@@ -78,7 +82,7 @@ export function IdentityGate({ onIdentityReady }: IdentityGateProps) {
     }
 
     setStep('login');
-  }, [auth.isLoggedIn]);
+  }, [auth.isLoggedIn, step]);
 
   // ================================================================
   // When step transitions to fetching-backup, auto-fetch

--- a/src/components/IdentityGate.web.tsx
+++ b/src/components/IdentityGate.web.tsx
@@ -287,9 +287,12 @@ export function IdentityGate({ onIdentityReady }: IdentityGateProps) {
               </button>
               <button
                 onClick={() => {
-                  // Reset stored identity — user needs to re-import
+                  // Full reset: clear stored identity and auth token so the
+                  // user re-authenticates with a fresh token instead of
+                  // hitting fetching-backup with a potentially expired one.
                   clearStoredMnemonic();
-                  setStep(auth.isLoggedIn ? 'fetching-backup' : 'login');
+                  auth.logout();
+                  setStep('login');
                   setError(null);
                   setPinValue('');
                 }}

--- a/src/components/IdentityGate.web.tsx
+++ b/src/components/IdentityGate.web.tsx
@@ -177,6 +177,18 @@ export function IdentityGate({ onIdentityReady }: IdentityGateProps) {
     setStep('create-pin');
   }, [mnemonicValue]);
 
+  const handleMnemonicBack = useCallback(() => {
+    setError(null);
+    setMnemonicValue('');
+
+    if (!auth.isLoggedIn) {
+      setStep('login');
+      return;
+    }
+
+    setStep(backupRef.current ? 'backup-password' : 'no-backup');
+  }, [auth.isLoggedIn]);
+
   const handleCreatePin = useCallback(async () => {
     if (!newPinValue.trim()) {
       setError('PIN is required.');
@@ -395,7 +407,7 @@ export function IdentityGate({ onIdentityReady }: IdentityGateProps) {
                 Continue
               </button>
               <button
-                onClick={() => { setStep(auth.isLoggedIn ? 'fetching-backup' : 'login'); setError(null); setMnemonicValue(''); }}
+                onClick={handleMnemonicBack}
                 className="w-full mt-2 px-5 py-2 text-sm text-[#8b949e] hover:text-[#e6edf3] transition-all"
               >
                 Back

--- a/src/hooks/useAuth.web.ts
+++ b/src/hooks/useAuth.web.ts
@@ -56,20 +56,25 @@ function consumeCallbackToken(): string | null {
   return token;
 }
 
-export function useAuth() {
-  const [state, setState] = useState<AuthState>({
-    token: getStoredToken(),
-    loading: false,
-  });
+/**
+ * Synchronously consume the OAuth callback token from the URL fragment
+ * and persist it BEFORE the first render, so that components see
+ * `isLoggedIn === true` on their initial render (no flash of login screen).
+ */
+function consumeAndPersistCallbackToken(): string | null {
+  const callbackToken = consumeCallbackToken();
+  if (callbackToken) {
+    localStorage.setItem(AUTH_TOKEN_KEY, callbackToken);
+    return callbackToken;
+  }
+  return getStoredToken();
+}
 
-  // On mount, check for OAuth callback token in URL fragment
-  useEffect(() => {
-    const callbackToken = consumeCallbackToken();
-    if (callbackToken) {
-      localStorage.setItem(AUTH_TOKEN_KEY, callbackToken);
-      setState({ token: callbackToken, loading: false });
-    }
-  }, []);
+export function useAuth() {
+  const [state, setState] = useState<AuthState>(() => ({
+    token: consumeAndPersistCallbackToken(),
+    loading: false,
+  }));
 
   /**
    * Start the GitHub OAuth redirect flow.

--- a/src/hooks/useAuth.web.ts
+++ b/src/hooks/useAuth.web.ts
@@ -15,6 +15,10 @@ import { useState, useCallback } from 'react';
 const AUTH_TOKEN_KEY = 'gssh.auth.token.v1';
 const API_BASE = 'https://api.gitspace.sh';
 
+function isValidToken(token: string): boolean {
+  return token.startsWith('gst_') && token.length >= 20;
+}
+
 export interface AuthState {
   /** The Bearer token, or null if not logged in */
   token: string | null;
@@ -28,7 +32,7 @@ export interface AuthState {
 function getStoredToken(): string | null {
   try {
     const token = localStorage.getItem(AUTH_TOKEN_KEY);
-    if (token && token.startsWith('gst_') && token.length >= 20) {
+    if (token && isValidToken(token)) {
       return token;
     }
     return null;
@@ -49,6 +53,7 @@ function consumeCallbackToken(): string | null {
   if (!match) return null;
 
   const token = match[1];
+  if (!isValidToken(token)) return null;
 
   // Clear the fragment from the URL without triggering navigation
   history.replaceState(null, '', window.location.pathname + window.location.search);
@@ -107,12 +112,12 @@ export function useAuth() {
       throw new Error('Not authenticated');
     }
 
+    const headers = new Headers(init?.headers);
+    headers.set('Authorization', `Bearer ${token}`);
+
     return fetch(`${API_BASE}${path}`, {
       ...init,
-      headers: {
-        ...init?.headers,
-        Authorization: `Bearer ${token}`,
-      },
+      headers,
     });
   }, [state.token]);
 

--- a/src/hooks/useAuth.web.ts
+++ b/src/hooks/useAuth.web.ts
@@ -10,7 +10,7 @@
  * The token is used for API calls (identity backup fetch, etc.).
  */
 
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useCallback } from 'react';
 
 const AUTH_TOKEN_KEY = 'gssh.auth.token.v1';
 const API_BASE = 'https://api.gitspace.sh';
@@ -64,7 +64,11 @@ function consumeCallbackToken(): string | null {
 function consumeAndPersistCallbackToken(): string | null {
   const callbackToken = consumeCallbackToken();
   if (callbackToken) {
-    localStorage.setItem(AUTH_TOKEN_KEY, callbackToken);
+    try {
+      localStorage.setItem(AUTH_TOKEN_KEY, callbackToken);
+    } catch {
+      return callbackToken;
+    }
     return callbackToken;
   }
   return getStoredToken();
@@ -80,7 +84,9 @@ export function useAuth() {
    * Start the GitHub OAuth redirect flow.
    */
   const startLogin = useCallback(() => {
-    const returnTo = encodeURIComponent(window.location.origin);
+    const returnTo = encodeURIComponent(
+      `${window.location.origin}${window.location.pathname}${window.location.search}`,
+    );
     window.location.href = `${API_BASE}/auth/github?return_to=${returnTo}`;
   }, []);
 
@@ -96,7 +102,7 @@ export function useAuth() {
    * Make an authenticated fetch request to the API.
    */
   const fetchWithAuth = useCallback(async (path: string, init?: RequestInit): Promise<Response> => {
-    const token = getStoredToken();
+    const token = state.token ?? getStoredToken();
     if (!token) {
       throw new Error('Not authenticated');
     }
@@ -108,7 +114,7 @@ export function useAuth() {
         Authorization: `Bearer ${token}`,
       },
     });
-  }, []);
+  }, [state.token]);
 
   return {
     token: state.token,

--- a/src/hooks/useAuth.web.ts
+++ b/src/hooks/useAuth.web.ts
@@ -22,8 +22,6 @@ function isValidToken(token: string): boolean {
 export interface AuthState {
   /** The Bearer token, or null if not logged in */
   token: string | null;
-  /** Whether we're currently processing a callback */
-  loading: boolean;
 }
 
 /**
@@ -82,7 +80,6 @@ function consumeAndPersistCallbackToken(): string | null {
 export function useAuth() {
   const [state, setState] = useState<AuthState>(() => ({
     token: consumeAndPersistCallbackToken(),
-    loading: false,
   }));
 
   /**
@@ -100,33 +97,13 @@ export function useAuth() {
    */
   const logout = useCallback(() => {
     localStorage.removeItem(AUTH_TOKEN_KEY);
-    setState({ token: null, loading: false });
+    setState({ token: null });
   }, []);
-
-  /**
-   * Make an authenticated fetch request to the API.
-   */
-  const fetchWithAuth = useCallback(async (path: string, init?: RequestInit): Promise<Response> => {
-    const token = state.token ?? getStoredToken();
-    if (!token) {
-      throw new Error('Not authenticated');
-    }
-
-    const headers = new Headers(init?.headers);
-    headers.set('Authorization', `Bearer ${token}`);
-
-    return fetch(`${API_BASE}${path}`, {
-      ...init,
-      headers,
-    });
-  }, [state.token]);
 
   return {
     token: state.token,
     isLoggedIn: state.token !== null,
-    loading: state.loading,
     startLogin,
     logout,
-    fetchWithAuth,
   };
 }

--- a/src/hooks/useAuth.web.ts
+++ b/src/hooks/useAuth.web.ts
@@ -1,0 +1,116 @@
+/**
+ * Browser authentication hook for gitspace.sh API.
+ *
+ * Manages the OAuth redirect flow:
+ * 1. startLogin() redirects to api.gitspace.sh/auth/github?return_to=<origin>
+ * 2. GitHub OAuth happens on github.com
+ * 3. Worker redirects back to <origin>/#token=gst_xxx
+ * 4. handleCallbackToken() reads token from URL fragment, stores in localStorage
+ *
+ * The token is used for API calls (identity backup fetch, etc.).
+ */
+
+import { useState, useEffect, useCallback } from 'react';
+
+const AUTH_TOKEN_KEY = 'gssh.auth.token.v1';
+const API_BASE = 'https://api.gitspace.sh';
+
+export interface AuthState {
+  /** The Bearer token, or null if not logged in */
+  token: string | null;
+  /** Whether we're currently processing a callback */
+  loading: boolean;
+}
+
+/**
+ * Read the stored auth token from localStorage.
+ */
+function getStoredToken(): string | null {
+  try {
+    const token = localStorage.getItem(AUTH_TOKEN_KEY);
+    if (token && token.startsWith('gst_') && token.length >= 20) {
+      return token;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Check the URL fragment for an OAuth callback token.
+ * Returns the token and cleans the fragment if found.
+ */
+function consumeCallbackToken(): string | null {
+  const hash = window.location.hash;
+  if (!hash) return null;
+
+  const match = hash.match(/^#\/?token=(gst_[a-f0-9]+)$/);
+  if (!match) return null;
+
+  const token = match[1];
+
+  // Clear the fragment from the URL without triggering navigation
+  history.replaceState(null, '', window.location.pathname + window.location.search);
+
+  return token;
+}
+
+export function useAuth() {
+  const [state, setState] = useState<AuthState>({
+    token: getStoredToken(),
+    loading: false,
+  });
+
+  // On mount, check for OAuth callback token in URL fragment
+  useEffect(() => {
+    const callbackToken = consumeCallbackToken();
+    if (callbackToken) {
+      localStorage.setItem(AUTH_TOKEN_KEY, callbackToken);
+      setState({ token: callbackToken, loading: false });
+    }
+  }, []);
+
+  /**
+   * Start the GitHub OAuth redirect flow.
+   */
+  const startLogin = useCallback(() => {
+    const returnTo = encodeURIComponent(window.location.origin);
+    window.location.href = `${API_BASE}/auth/github?return_to=${returnTo}`;
+  }, []);
+
+  /**
+   * Clear the stored token and log out.
+   */
+  const logout = useCallback(() => {
+    localStorage.removeItem(AUTH_TOKEN_KEY);
+    setState({ token: null, loading: false });
+  }, []);
+
+  /**
+   * Make an authenticated fetch request to the API.
+   */
+  const fetchWithAuth = useCallback(async (path: string, init?: RequestInit): Promise<Response> => {
+    const token = getStoredToken();
+    if (!token) {
+      throw new Error('Not authenticated');
+    }
+
+    return fetch(`${API_BASE}${path}`, {
+      ...init,
+      headers: {
+        ...init?.headers,
+        Authorization: `Bearer ${token}`,
+      },
+    });
+  }, []);
+
+  return {
+    token: state.token,
+    isLoggedIn: state.token !== null,
+    loading: state.loading,
+    startLogin,
+    logout,
+    fetchWithAuth,
+  };
+}

--- a/src/hooks/useRelayConnection.web.ts
+++ b/src/hooks/useRelayConnection.web.ts
@@ -26,10 +26,8 @@ interface UseRelayConnectionOptions {
 export function useRelayConnection(options?: UseRelayConnectionOptions) {
   const identityRef = useRef<Identity | null>(options?.identity ?? null);
 
-  // Keep ref in sync with prop
-  if (options?.identity) {
-    identityRef.current = options.identity;
-  }
+  // Keep ref in sync with prop (handle null transitions for logout)
+  identityRef.current = options?.identity ?? null;
 
   const machineDirectory = useMachineDirectory<
     WebSocket,

--- a/src/hooks/useRelayConnection.web.ts
+++ b/src/hooks/useRelayConnection.web.ts
@@ -60,7 +60,7 @@ export function useRelayConnection(options?: UseRelayConnectionOptions) {
 
   const connect = useCallback(async () => {
     await machineDirectory.connect();
-  }, [machineDirectory]);
+  }, [machineDirectory.connect]);
 
   return {
     status: machineDirectory.status,

--- a/src/hooks/useRelayConnection.web.ts
+++ b/src/hooks/useRelayConnection.web.ts
@@ -1,19 +1,15 @@
 /**
  * Hook for relay connection before terminal session.
+ *
+ * Identity is now resolved externally by IdentityGate and passed in.
+ * This hook no longer uses window.prompt() — it just takes the identity
+ * and wires up the relay connection.
  */
 
 import { useCallback, useRef } from 'react';
 import {
-  getUnlockedIdentity,
-  hasStoredMnemonic,
-  storeMnemonic,
-  unlockMnemonic,
-} from '../lib/storage/identity-store.web';
-import {
   createSelfSignedDeviceCertificate,
   exportUserRootPublicKey,
-  isValidMnemonic,
-  normalizeMnemonic,
 } from '../session/crypto/identity.web';
 import { signRelayMessage } from '../session/crypto/relay-signing.web';
 import type { Identity } from '../types/identity';
@@ -22,65 +18,18 @@ import {
 } from '../relay-client/useMachineDirectory.js';
 import { browserRelaySocketAdapter } from '../relay-client/adapters/browser.js';
 
-export function useRelayConnection() {
-  const unlockedIdentityRef = useRef<Identity | null>(null);
+interface UseRelayConnectionOptions {
+  /** Pre-resolved identity from IdentityGate */
+  identity: Identity | null;
+}
 
-  const resolveOwnerIdentity = useCallback(async (): Promise<Identity> => {
-    if (unlockedIdentityRef.current) {
-      return unlockedIdentityRef.current;
-    }
+export function useRelayConnection(options?: UseRelayConnectionOptions) {
+  const identityRef = useRef<Identity | null>(options?.identity ?? null);
 
-    const sessionIdentity = getUnlockedIdentity('Browser Owner');
-    if (sessionIdentity) {
-      unlockedIdentityRef.current = sessionIdentity;
-      return sessionIdentity;
-    }
-
-    if (hasStoredMnemonic()) {
-      const passphrase = window.prompt('Enter your browser unlock PIN/password:') ?? '';
-      if (!passphrase.trim()) {
-        throw new Error('Browser identity unlock cancelled.');
-      }
-
-      await unlockMnemonic(passphrase);
-      const unlocked = getUnlockedIdentity('Browser Owner');
-      if (!unlocked) {
-        throw new Error('Failed to unlock browser identity.');
-      }
-
-      unlockedIdentityRef.current = unlocked;
-      return unlocked;
-    }
-
-    const mnemonicInput = window.prompt('Enter your 24-word recovery phrase to authorize this browser:');
-    if (!mnemonicInput) {
-      throw new Error('Browser identity setup cancelled.');
-    }
-
-    const normalizedMnemonic = normalizeMnemonic(mnemonicInput);
-    if (!isValidMnemonic(normalizedMnemonic)) {
-      throw new Error('Invalid 24-word recovery phrase.');
-    }
-
-    const passphrase = window.prompt('Create a local unlock PIN/password for this browser:') ?? '';
-    if (!passphrase.trim()) {
-      throw new Error('Unlock PIN/password is required.');
-    }
-
-    const confirmPassphrase = window.prompt('Confirm your browser unlock PIN/password:') ?? '';
-    if (passphrase !== confirmPassphrase) {
-      throw new Error('Unlock PIN/password confirmation does not match.');
-    }
-
-    await storeMnemonic(normalizedMnemonic, passphrase);
-    const initialized = getUnlockedIdentity('Browser Owner');
-    if (!initialized) {
-      throw new Error('Failed to initialize browser identity.');
-    }
-
-    unlockedIdentityRef.current = initialized;
-    return initialized;
-  }, []);
+  // Keep ref in sync with prop
+  if (options?.identity) {
+    identityRef.current = options.identity;
+  }
 
   const machineDirectory = useMachineDirectory<
     WebSocket,
@@ -89,7 +38,11 @@ export function useRelayConnection() {
   >({
     socketAdapter: browserRelaySocketAdapter,
     resolveClientConfig: async () => {
-      const identity = await resolveOwnerIdentity();
+      const identity = identityRef.current;
+      if (!identity) {
+        throw new Error('No identity available. Complete identity setup first.');
+      }
+
       const publicKey = exportUserRootPublicKey(identity);
       const deviceCertificate = createSelfSignedDeviceCertificate(identity);
 

--- a/src/lib/browser-crypto.ts
+++ b/src/lib/browser-crypto.ts
@@ -1,0 +1,58 @@
+/**
+ * Shared browser crypto utilities for PBKDF2-AES-GCM operations.
+ *
+ * Centralizes base64 encoding, ArrayBuffer conversion, and AES key derivation
+ * used by both identity-store.web.ts (local PIN-encrypted storage)
+ * and identity-backup.web.ts (cloud backup decryption).
+ */
+
+export function base64ToBytes(input: string): Uint8Array {
+  const binary = atob(input);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes;
+}
+
+export function bytesToBase64(bytes: Uint8Array): string {
+  let binary = '';
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte);
+  }
+  return btoa(binary);
+}
+
+export function toArrayBuffer(bytes: Uint8Array): ArrayBuffer {
+  return bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength) as ArrayBuffer;
+}
+
+/**
+ * Derive an AES-256-GCM key from a passphrase using PBKDF2-SHA256.
+ */
+export async function deriveAesKey(
+  passphrase: string,
+  salt: Uint8Array,
+  iterations: number,
+): Promise<CryptoKey> {
+  const keyMaterial = await crypto.subtle.importKey(
+    'raw',
+    new TextEncoder().encode(passphrase),
+    'PBKDF2',
+    false,
+    ['deriveKey'],
+  );
+
+  return crypto.subtle.deriveKey(
+    {
+      name: 'PBKDF2',
+      salt: toArrayBuffer(salt),
+      iterations,
+      hash: 'SHA-256',
+    },
+    keyMaterial,
+    { name: 'AES-GCM', length: 256 },
+    false,
+    ['encrypt', 'decrypt'],
+  );
+}

--- a/src/lib/identity-backup.web.ts
+++ b/src/lib/identity-backup.web.ts
@@ -1,0 +1,140 @@
+/**
+ * Browser-side cloud identity backup recovery.
+ *
+ * Fetches the encrypted identity backup from api.gitspace.sh and decrypts it
+ * using Web Crypto API (PBKDF2 + AES-256-GCM), matching the server-side
+ * encryption in core/identity-backup.ts.
+ */
+
+const API_BASE = 'https://api.gitspace.sh';
+
+export interface CloudBackupEnvelope {
+  version: 1;
+  algorithm: 'PBKDF2-AES-GCM';
+  iterations: number;
+  salt: string;       // base64
+  iv: string;         // base64
+  ciphertext: string; // base64
+  createdAt: number;
+  updatedAt: number;
+}
+
+export interface CloudBackup {
+  version: number;
+  kind: string;
+  ownerUserRootId: string;
+  envelope: CloudBackupEnvelope;
+  createdAt: number;
+  updatedAt: number;
+}
+
+export interface BackupStatus {
+  enabled: boolean;
+  ownerUserRootId?: string;
+  createdAt?: number;
+  updatedAt?: number;
+}
+
+function base64ToBytes(input: string): Uint8Array {
+  const binary = atob(input);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes;
+}
+
+function toArrayBuffer(bytes: Uint8Array): ArrayBuffer {
+  return bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength) as ArrayBuffer;
+}
+
+/**
+ * Check if a cloud backup exists for the authenticated user.
+ */
+export async function fetchBackupStatus(token: string): Promise<BackupStatus> {
+  const res = await fetch(`${API_BASE}/identity/backup/status`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+
+  if (!res.ok) {
+    throw new Error(`Failed to check backup status: ${res.status}`);
+  }
+
+  return res.json() as Promise<BackupStatus>;
+}
+
+/**
+ * Fetch the encrypted identity backup from the cloud.
+ */
+export async function fetchCloudBackup(token: string): Promise<CloudBackup | null> {
+  const res = await fetch(`${API_BASE}/identity/backup`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+
+  if (res.status === 404) {
+    return null;
+  }
+
+  if (!res.ok) {
+    throw new Error(`Failed to fetch backup: ${res.status}`);
+  }
+
+  return res.json() as Promise<CloudBackup>;
+}
+
+/**
+ * Decrypt a cloud backup envelope with the user's backup password.
+ * Returns the plaintext mnemonic string.
+ *
+ * Uses the same PBKDF2-AES-GCM scheme as the server-side encryption:
+ * - PBKDF2 with SHA-256 to derive AES key from password + salt
+ * - AES-256-GCM to decrypt the mnemonic
+ */
+export async function decryptBackupEnvelope(
+  envelope: CloudBackupEnvelope,
+  password: string,
+): Promise<string> {
+  if (envelope.algorithm !== 'PBKDF2-AES-GCM') {
+    throw new Error(`Unsupported backup algorithm: ${envelope.algorithm}`);
+  }
+
+  const salt = base64ToBytes(envelope.salt);
+  const iv = base64ToBytes(envelope.iv);
+  const ciphertext = base64ToBytes(envelope.ciphertext);
+
+  // Derive AES key from password using PBKDF2
+  const keyMaterial = await crypto.subtle.importKey(
+    'raw',
+    new TextEncoder().encode(password),
+    'PBKDF2',
+    false,
+    ['deriveKey'],
+  );
+
+  const aesKey = await crypto.subtle.deriveKey(
+    {
+      name: 'PBKDF2',
+      salt: toArrayBuffer(salt),
+      iterations: envelope.iterations,
+      hash: 'SHA-256',
+    },
+    keyMaterial,
+    { name: 'AES-GCM', length: 256 },
+    false,
+    ['decrypt'],
+  );
+
+  // Decrypt
+  let plaintext: ArrayBuffer;
+  try {
+    plaintext = await crypto.subtle.decrypt(
+      { name: 'AES-GCM', iv: toArrayBuffer(iv) },
+      aesKey,
+      toArrayBuffer(ciphertext),
+    );
+  } catch {
+    throw new Error('Invalid backup password.');
+  }
+
+  return new TextDecoder().decode(plaintext);
+}

--- a/src/lib/identity-backup.web.ts
+++ b/src/lib/identity-backup.web.ts
@@ -132,7 +132,8 @@ export async function decryptBackupEnvelope(
       aesKey,
       toArrayBuffer(ciphertext),
     );
-  } catch {
+  } catch (err) {
+    console.debug('[identity-backup] Decryption failed:', err);
     throw new Error('Invalid backup password.');
   }
 

--- a/src/lib/identity-backup.web.ts
+++ b/src/lib/identity-backup.web.ts
@@ -7,6 +7,8 @@
  */
 
 const API_BASE = 'https://api.gitspace.sh';
+const PBKDF2_MIN_ACCEPTED_ITERATIONS = 100_000;
+const PBKDF2_MAX_ACCEPTED_ITERATIONS = 1_000_000;
 
 export interface CloudBackupEnvelope {
   version: 1;
@@ -96,6 +98,14 @@ export async function decryptBackupEnvelope(
 ): Promise<string> {
   if (envelope.algorithm !== 'PBKDF2-AES-GCM') {
     throw new Error(`Unsupported backup algorithm: ${envelope.algorithm}`);
+  }
+
+  if (
+    !Number.isSafeInteger(envelope.iterations)
+    || envelope.iterations < PBKDF2_MIN_ACCEPTED_ITERATIONS
+    || envelope.iterations > PBKDF2_MAX_ACCEPTED_ITERATIONS
+  ) {
+    throw new Error('Cloud backup payload uses unsupported key derivation parameters.');
   }
 
   const salt = base64ToBytes(envelope.salt);

--- a/src/lib/identity-backup.web.ts
+++ b/src/lib/identity-backup.web.ts
@@ -2,9 +2,12 @@
  * Browser-side cloud identity backup recovery.
  *
  * Fetches the encrypted identity backup from api.gitspace.sh and decrypts it
- * using Web Crypto API (PBKDF2 + AES-256-GCM), matching the server-side
- * encryption in core/identity-backup.ts.
+ * using the shared PBKDF2-AES-GCM primitives from browser-crypto.ts,
+ * matching the server-side encryption in core/identity-backup.ts.
  */
+
+import { base64ToBytes, toArrayBuffer, deriveAesKey } from './browser-crypto';
+import { SpacesError } from '../types/errors';
 
 const API_BASE = 'https://api.gitspace.sh';
 const PBKDF2_MIN_ACCEPTED_ITERATIONS = 100_000;
@@ -30,19 +33,6 @@ export interface CloudBackup {
   updatedAt: number;
 }
 
-function base64ToBytes(input: string): Uint8Array {
-  const binary = atob(input);
-  const bytes = new Uint8Array(binary.length);
-  for (let i = 0; i < binary.length; i++) {
-    bytes[i] = binary.charCodeAt(i);
-  }
-  return bytes;
-}
-
-function toArrayBuffer(bytes: Uint8Array): ArrayBuffer {
-  return bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength) as ArrayBuffer;
-}
-
 /**
  * Fetch the encrypted identity backup from the cloud.
  */
@@ -56,7 +46,8 @@ export async function fetchCloudBackup(token: string): Promise<CloudBackup | nul
   }
 
   if (!res.ok) {
-    throw new Error(`Failed to fetch backup: ${res.status}`);
+    console.error('[identity-backup] Failed to fetch backup:', res.status);
+    throw new SpacesError(`Failed to fetch backup: ${res.status}`, 'SERVICE_ERROR');
   }
 
   return res.json() as Promise<CloudBackup>;
@@ -75,7 +66,8 @@ export async function decryptBackupEnvelope(
   password: string,
 ): Promise<string> {
   if (envelope.algorithm !== 'PBKDF2-AES-GCM') {
-    throw new Error(`Unsupported backup algorithm: ${envelope.algorithm}`);
+    console.error('[identity-backup] Unsupported algorithm:', envelope.algorithm);
+    throw new SpacesError(`Unsupported backup algorithm: ${envelope.algorithm}`, 'SERVICE_ERROR');
   }
 
   if (
@@ -83,36 +75,16 @@ export async function decryptBackupEnvelope(
     || envelope.iterations < PBKDF2_MIN_ACCEPTED_ITERATIONS
     || envelope.iterations > PBKDF2_MAX_ACCEPTED_ITERATIONS
   ) {
-    throw new Error('Cloud backup payload uses unsupported key derivation parameters.');
+    console.error('[identity-backup] Invalid PBKDF2 iterations:', envelope.iterations);
+    throw new SpacesError('Cloud backup payload uses unsupported key derivation parameters.', 'SERVICE_ERROR');
   }
 
   const salt = base64ToBytes(envelope.salt);
   const iv = base64ToBytes(envelope.iv);
   const ciphertext = base64ToBytes(envelope.ciphertext);
 
-  // Derive AES key from password using PBKDF2
-  const keyMaterial = await crypto.subtle.importKey(
-    'raw',
-    new TextEncoder().encode(password),
-    'PBKDF2',
-    false,
-    ['deriveKey'],
-  );
+  const aesKey = await deriveAesKey(password, salt, envelope.iterations);
 
-  const aesKey = await crypto.subtle.deriveKey(
-    {
-      name: 'PBKDF2',
-      salt: toArrayBuffer(salt),
-      iterations: envelope.iterations,
-      hash: 'SHA-256',
-    },
-    keyMaterial,
-    { name: 'AES-GCM', length: 256 },
-    false,
-    ['decrypt'],
-  );
-
-  // Decrypt
   let plaintext: ArrayBuffer;
   try {
     plaintext = await crypto.subtle.decrypt(
@@ -122,7 +94,7 @@ export async function decryptBackupEnvelope(
     );
   } catch (err) {
     console.debug('[identity-backup] Decryption failed:', err);
-    throw new Error('Invalid backup password.');
+    throw new SpacesError('Invalid backup password.', 'USER_ERROR');
   }
 
   return new TextDecoder().decode(plaintext);

--- a/src/lib/identity-backup.web.ts
+++ b/src/lib/identity-backup.web.ts
@@ -30,13 +30,6 @@ export interface CloudBackup {
   updatedAt: number;
 }
 
-export interface BackupStatus {
-  enabled: boolean;
-  ownerUserRootId?: string;
-  createdAt?: number;
-  updatedAt?: number;
-}
-
 function base64ToBytes(input: string): Uint8Array {
   const binary = atob(input);
   const bytes = new Uint8Array(binary.length);
@@ -48,21 +41,6 @@ function base64ToBytes(input: string): Uint8Array {
 
 function toArrayBuffer(bytes: Uint8Array): ArrayBuffer {
   return bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength) as ArrayBuffer;
-}
-
-/**
- * Check if a cloud backup exists for the authenticated user.
- */
-export async function fetchBackupStatus(token: string): Promise<BackupStatus> {
-  const res = await fetch(`${API_BASE}/identity/backup/status`, {
-    headers: { Authorization: `Bearer ${token}` },
-  });
-
-  if (!res.ok) {
-    throw new Error(`Failed to check backup status: ${res.status}`);
-  }
-
-  return res.json() as Promise<BackupStatus>;
 }
 
 /**

--- a/src/lib/storage/identity-store.web.ts
+++ b/src/lib/storage/identity-store.web.ts
@@ -12,6 +12,12 @@ import {
   isValidMnemonic,
   normalizeMnemonic,
 } from '../../session/crypto/identity.web.js';
+import {
+  base64ToBytes,
+  bytesToBase64,
+  toArrayBuffer,
+  deriveAesKey,
+} from '../browser-crypto.js';
 
 const STORAGE_KEY = 'gssh.browser.identity.v1';
 const PBKDF2_ITERATIONS = 210_000;
@@ -29,32 +35,11 @@ interface EncryptedMnemonicBlob {
 
 let unlockedMnemonic: string | null = null;
 
-function bytesToBase64(bytes: Uint8Array): string {
-  let binary = '';
-  for (const byte of bytes) {
-    binary += String.fromCharCode(byte);
-  }
-  return btoa(binary);
-}
-
-function base64ToBytes(input: string): Uint8Array {
-  const binary = atob(input);
-  const bytes = new Uint8Array(binary.length);
-  for (let i = 0; i < binary.length; i += 1) {
-    bytes[i] = binary.charCodeAt(i);
-  }
-  return bytes;
-}
-
 function getCryptoApi(): Crypto {
   if (typeof window === 'undefined' || !window.crypto?.subtle) {
     throw new Error('Secure browser crypto APIs are unavailable.');
   }
   return window.crypto;
-}
-
-function toArrayBuffer(bytes: Uint8Array): ArrayBuffer {
-  return bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength) as ArrayBuffer;
 }
 
 function readBlob(): EncryptedMnemonicBlob | null {
@@ -83,39 +68,6 @@ function readBlob(): EncryptedMnemonicBlob | null {
 
 function writeBlob(blob: EncryptedMnemonicBlob): void {
   localStorage.setItem(STORAGE_KEY, JSON.stringify(blob));
-}
-
-async function deriveAesKey(
-  passphrase: string,
-  salt: Uint8Array,
-  iterations: number,
-): Promise<CryptoKey> {
-  const cryptoApi = getCryptoApi();
-  const encoder = new TextEncoder();
-
-  const keyMaterial = await cryptoApi.subtle.importKey(
-    'raw',
-    encoder.encode(passphrase),
-    'PBKDF2',
-    false,
-    ['deriveKey'],
-  );
-
-  return cryptoApi.subtle.deriveKey(
-    {
-      name: 'PBKDF2',
-      salt: toArrayBuffer(salt),
-      iterations,
-      hash: 'SHA-256',
-    },
-    keyMaterial,
-    {
-      name: 'AES-GCM',
-      length: 256,
-    },
-    false,
-    ['encrypt', 'decrypt'],
-  );
 }
 
 export function hasStoredMnemonic(): boolean {

--- a/worker/src/handlers/auth.ts
+++ b/worker/src/handlers/auth.ts
@@ -11,6 +11,25 @@ import { hashToken } from '../middleware/auth';
 
 const app = new Hono<{ Bindings: Env }>();
 const OAUTH_STATE_COOKIE = 'gitspace_oauth_state';
+const OAUTH_RETURN_TO_COOKIE = 'gitspace_oauth_return_to';
+
+/**
+ * Validate a return_to URL is a trusted origin (*.gitspace.sh or localhost dev).
+ * Returns the validated origin or null.
+ */
+function validateReturnTo(returnTo: string | undefined): string | null {
+  if (!returnTo) return null;
+  try {
+    const url = new URL(returnTo);
+    if (url.origin === 'http://localhost:5173') return url.origin;
+    if (url.protocol === 'https:' && /^[a-z0-9-]+\.gitspace\.sh$/.test(url.hostname)) {
+      return url.origin;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
 
 function getCookieValue(cookieHeader: string | undefined, name: string): string | null {
   if (!cookieHeader) {
@@ -53,13 +72,17 @@ app.get('/github', (c) => {
     state,
   });
 
-  return new Response(null, {
-    status: 302,
-    headers: {
-      Location: `${getGitHubOauthBase(c.env)}/login/oauth/authorize?${params}`,
-      'Set-Cookie': `${OAUTH_STATE_COOKIE}=${state}; Path=/auth/github; HttpOnly; Secure; SameSite=Lax; Max-Age=600`,
-    },
-  });
+  const headers = new Headers();
+  headers.set('Location', `${getGitHubOauthBase(c.env)}/login/oauth/authorize?${params}`);
+  headers.append('Set-Cookie', `${OAUTH_STATE_COOKIE}=${state}; Path=/auth/github; HttpOnly; Secure; SameSite=Lax; Max-Age=600`);
+
+  // If return_to is provided and valid, store it for the callback
+  const returnTo = validateReturnTo(c.req.query('return_to') ?? undefined);
+  if (returnTo) {
+    headers.append('Set-Cookie', `${OAUTH_RETURN_TO_COOKIE}=${encodeURIComponent(returnTo)}; Path=/auth/github; HttpOnly; Secure; SameSite=Lax; Max-Age=600`);
+  }
+
+  return new Response(null, { status: 302, headers });
 });
 
 /**
@@ -120,7 +143,45 @@ app.get('/github/callback', async (c) => {
       throw error;
     }
 
-    // Create session
+    // Check if this is a subdomain/client OAuth flow (return_to cookie set)
+    const returnToCookie = getCookieValue(c.req.header('Cookie') ?? undefined, OAUTH_RETURN_TO_COOKIE);
+    const returnTo = returnToCookie ? validateReturnTo(decodeURIComponent(returnToCookie)) : null;
+
+    if (returnTo) {
+      // ================================================================
+      // Client flow: create a Bearer token and redirect back to origin
+      // ================================================================
+      const now = Date.now();
+      const tokenPlain = `gst_${crypto.randomUUID().replace(/-/g, '')}`;
+      const tokenPrefix = tokenPlain.slice(0, 12);
+      const tokenHash = await hashToken(tokenPlain);
+      const tokenExpiresAt = now + 90 * 24 * 60 * 60 * 1000; // 90 days
+
+      await c.env.DB.prepare(
+        `INSERT INTO tokens (id, prefix, user_id, device_name, device_fingerprint, created_at, expires_at, last_used_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+      ).bind(
+        tokenHash,
+        tokenPrefix,
+        user.id,
+        'Browser',
+        null, // No device fingerprint for browser tokens
+        now,
+        tokenExpiresAt,
+        now,
+      ).run();
+
+      // Clear the return_to cookie and redirect with token in fragment
+      const headers = new Headers();
+      headers.set('Location', `${returnTo}/#token=${tokenPlain}`);
+      headers.append('Set-Cookie', `${OAUTH_RETURN_TO_COOKIE}=; Path=/auth/github; HttpOnly; Secure; SameSite=Lax; Max-Age=0`);
+      headers.append('Set-Cookie', `${OAUTH_STATE_COOKIE}=; Path=/auth/github; HttpOnly; Secure; SameSite=Lax; Max-Age=0`);
+      return new Response(null, { status: 302, headers });
+    }
+
+    // ================================================================
+    // Portal flow: create session cookie (existing behavior)
+    // ================================================================
     const sessionId = crypto.randomUUID();
     const expiresAt = Date.now() + 7 * 24 * 60 * 60 * 1000; // 7 days
 

--- a/worker/src/handlers/auth.ts
+++ b/worker/src/handlers/auth.ts
@@ -11,7 +11,6 @@ import { hashToken } from '../middleware/auth';
 
 const app = new Hono<{ Bindings: Env }>();
 const OAUTH_STATE_COOKIE = 'gitspace_oauth_state';
-const OAUTH_RETURN_TO_COOKIE = 'gitspace_oauth_return_to';
 
 /**
  * Validate a return_to URL is a trusted origin (*.gitspace.sh or localhost dev).
@@ -64,7 +63,13 @@ function getGitHubApiBase(env: Env): string {
  */
 app.get('/github', (c) => {
   const redirectUri = new URL('/auth/github/callback', c.req.url).toString();
-  const state = crypto.randomUUID();
+  const nonce = crypto.randomUUID();
+  const returnTo = validateReturnTo(c.req.query('return_to') ?? undefined);
+
+  // Encode return_to inside the state value so it's bound to this OAuth
+  // transaction via the CSRF cookie. Format: "nonce" or "nonce:return_to"
+  const state = returnTo ? `${nonce}:${returnTo}` : nonce;
+
   const params = new URLSearchParams({
     client_id: c.env.GITHUB_CLIENT_ID,
     redirect_uri: redirectUri,
@@ -72,17 +77,13 @@ app.get('/github', (c) => {
     state,
   });
 
-  const headers = new Headers();
-  headers.set('Location', `${getGitHubOauthBase(c.env)}/login/oauth/authorize?${params}`);
-  headers.append('Set-Cookie', `${OAUTH_STATE_COOKIE}=${state}; Path=/auth/github; HttpOnly; Secure; SameSite=Lax; Max-Age=600`);
-
-  // If return_to is provided and valid, store it for the callback
-  const returnTo = validateReturnTo(c.req.query('return_to') ?? undefined);
-  if (returnTo) {
-    headers.append('Set-Cookie', `${OAUTH_RETURN_TO_COOKIE}=${encodeURIComponent(returnTo)}; Path=/auth/github; HttpOnly; Secure; SameSite=Lax; Max-Age=600`);
-  }
-
-  return new Response(null, { status: 302, headers });
+  return new Response(null, {
+    status: 302,
+    headers: {
+      Location: `${getGitHubOauthBase(c.env)}/login/oauth/authorize?${params}`,
+      'Set-Cookie': `${OAUTH_STATE_COOKIE}=${encodeURIComponent(state)}; Path=/auth/github; HttpOnly; Secure; SameSite=Lax; Max-Age=600`,
+    },
+  });
 });
 
 /**
@@ -99,7 +100,8 @@ app.get('/github/callback', async (c) => {
     return c.redirect(`${c.env.PORTAL_URL}?error=missing_code`);
   }
 
-  if (!state || !stateCookie || state !== stateCookie) {
+  const decodedStateCookie = stateCookie ? decodeURIComponent(stateCookie) : null;
+  if (!state || !decodedStateCookie || state !== decodedStateCookie) {
     return c.redirect(`${c.env.PORTAL_URL}?error=invalid_state`);
   }
 
@@ -143,9 +145,9 @@ app.get('/github/callback', async (c) => {
       throw error;
     }
 
-    // Check if this is a subdomain/client OAuth flow (return_to cookie set)
-    const returnToCookie = getCookieValue(c.req.header('Cookie') ?? undefined, OAUTH_RETURN_TO_COOKIE);
-    const returnTo = returnToCookie ? validateReturnTo(decodeURIComponent(returnToCookie)) : null;
+    // Extract return_to from the state value (format: "nonce:return_to")
+    const colonIndex = state!.indexOf(':');
+    const returnTo = colonIndex >= 0 ? validateReturnTo(state!.slice(colonIndex + 1)) : null;
 
     if (returnTo) {
       // ================================================================
@@ -155,7 +157,7 @@ app.get('/github/callback', async (c) => {
       const tokenPlain = `gst_${crypto.randomUUID().replace(/-/g, '')}`;
       const tokenPrefix = tokenPlain.slice(0, 12);
       const tokenHash = await hashToken(tokenPlain);
-      const tokenExpiresAt = now + 90 * 24 * 60 * 60 * 1000; // 90 days
+      const tokenExpiresAt = now + 30 * 24 * 60 * 60 * 1000; // 30 days (browser tokens)
 
       await c.env.DB.prepare(
         `INSERT INTO tokens (id, prefix, user_id, device_name, device_fingerprint, created_at, expires_at, last_used_at)
@@ -171,12 +173,14 @@ app.get('/github/callback', async (c) => {
         now,
       ).run();
 
-      // Clear the return_to cookie and redirect with token in fragment
-      const headers = new Headers();
-      headers.set('Location', `${returnTo}/#token=${tokenPlain}`);
-      headers.append('Set-Cookie', `${OAUTH_RETURN_TO_COOKIE}=; Path=/auth/github; HttpOnly; Secure; SameSite=Lax; Max-Age=0`);
-      headers.append('Set-Cookie', `${OAUTH_STATE_COOKIE}=; Path=/auth/github; HttpOnly; Secure; SameSite=Lax; Max-Age=0`);
-      return new Response(null, { status: 302, headers });
+      // Clear the state cookie and redirect with token in fragment
+      return new Response(null, {
+        status: 302,
+        headers: {
+          Location: `${returnTo}/#token=${tokenPlain}`,
+          'Set-Cookie': `${OAUTH_STATE_COOKIE}=; Path=/auth/github; HttpOnly; Secure; SameSite=Lax; Max-Age=0`,
+        },
+      });
     }
 
     // ================================================================

--- a/worker/src/handlers/auth.ts
+++ b/worker/src/handlers/auth.ts
@@ -11,6 +11,7 @@ import { hashToken } from '../middleware/auth';
 
 const app = new Hono<{ Bindings: Env }>();
 const OAUTH_STATE_COOKIE = 'gitspace_oauth_state';
+const MAX_RETURN_TO_LENGTH = 1024;
 
 /**
  * Validate a return_to URL is a trusted web app URL.
@@ -24,7 +25,11 @@ function validateReturnTo(returnTo: string | undefined): string | null {
     const isGitspaceWeb = url.protocol === 'https:'
       && (url.hostname === 'gitspace.sh' || /^[a-z0-9-]+\.gitspace\.sh$/.test(url.hostname));
     if (isLocalDev || isGitspaceWeb) {
-      return `${url.origin}${url.pathname}${url.search}`;
+      const normalized = `${url.origin}${url.pathname}${url.search}`;
+      if (normalized.length > MAX_RETURN_TO_LENGTH) {
+        return null;
+      }
+      return normalized;
     }
     return null;
   } catch {
@@ -102,7 +107,14 @@ app.get('/github/callback', async (c) => {
     return c.redirect(`${c.env.PORTAL_URL}?error=missing_code`);
   }
 
-  const decodedStateCookie = stateCookie ? decodeURIComponent(stateCookie) : null;
+  let decodedStateCookie: string | null = null;
+  if (stateCookie) {
+    try {
+      decodedStateCookie = decodeURIComponent(stateCookie);
+    } catch {
+      return c.redirect(`${c.env.PORTAL_URL}?error=invalid_state`);
+    }
+  }
   if (!state || !decodedStateCookie || state !== decodedStateCookie) {
     return c.redirect(`${c.env.PORTAL_URL}?error=invalid_state`);
   }

--- a/worker/src/handlers/auth.ts
+++ b/worker/src/handlers/auth.ts
@@ -13,16 +13,18 @@ const app = new Hono<{ Bindings: Env }>();
 const OAUTH_STATE_COOKIE = 'gitspace_oauth_state';
 
 /**
- * Validate a return_to URL is a trusted origin (*.gitspace.sh or localhost dev).
- * Returns the validated origin or null.
+ * Validate a return_to URL is a trusted web app URL.
+ * Returns the validated URL without any hash fragment, or null.
  */
 function validateReturnTo(returnTo: string | undefined): string | null {
   if (!returnTo) return null;
   try {
     const url = new URL(returnTo);
-    if (url.origin === 'http://localhost:5173') return url.origin;
-    if (url.protocol === 'https:' && /^[a-z0-9-]+\.gitspace\.sh$/.test(url.hostname)) {
-      return url.origin;
+    const isLocalDev = url.origin === 'http://localhost:5173';
+    const isGitspaceWeb = url.protocol === 'https:'
+      && (url.hostname === 'gitspace.sh' || /^[a-z0-9-]+\.gitspace\.sh$/.test(url.hostname));
+    if (isLocalDev || isGitspaceWeb) {
+      return `${url.origin}${url.pathname}${url.search}`;
     }
     return null;
   } catch {
@@ -174,10 +176,12 @@ app.get('/github/callback', async (c) => {
       ).run();
 
       // Clear the state cookie and redirect with token in fragment
+      const returnToUrl = new URL(returnTo);
+      returnToUrl.hash = `token=${tokenPlain}`;
       return new Response(null, {
         status: 302,
         headers: {
-          Location: `${returnTo}/#token=${tokenPlain}`,
+          Location: returnToUrl.toString(),
           'Set-Cookie': `${OAUTH_STATE_COOKIE}=; Path=/auth/github; HttpOnly; Secure; SameSite=Lax; Max-Age=0`,
         },
       });

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -19,11 +19,18 @@ import subdomainHandlers from './handlers/subdomains';
 // Create app with typed bindings
 const app = new Hono<{ Bindings: Env; Variables: AuthContext }>();
 
-// CORS for portal and CLI
+// CORS for portal, CLI, and *.gitspace.sh subdomains
 app.use(
   '*',
   cors({
-    origin: ['https://gitspace.sh', 'http://localhost:5173'],
+    origin: (origin) => {
+      if (!origin) return 'https://gitspace.sh';
+      if (origin === 'https://gitspace.sh') return origin;
+      if (origin === 'http://localhost:5173') return origin;
+      // Allow any *.gitspace.sh subdomain (for web terminals)
+      if (/^https:\/\/[a-z0-9-]+\.gitspace\.sh$/.test(origin)) return origin;
+      return null;
+    },
     credentials: true,
     allowMethods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'],
     allowHeaders: ['Content-Type', 'Authorization', 'X-Device-Fingerprint'],


### PR DESCRIPTION
## Summary

Replaces the `window.prompt()` identity bootstrap flow in the web terminal with a proper React UI and GitHub OAuth integration.

**Problem**: When visiting `bradleat.gitspace.sh`, the web client showed raw `window.prompt()` dialogs asking for a 24-word recovery phrase. No cloud recovery, no OAuth, no proper UI.

**Solution**: 

### Worker changes (`worker/`)
- **Dynamic CORS**: Allow any `*.gitspace.sh` subdomain (was hardcoded to `gitspace.sh` + `localhost:5173`)
- **OAuth `return_to`**: `GET /auth/github?return_to=https://sub.gitspace.sh` stores the origin, and the callback creates a Bearer token + redirects back with `#token=gst_xxx` in the fragment
- Browser tokens have no `device_fingerprint` binding (column is nullable, middleware already skips the check when null)

### Web client changes (`src/`)
- **`IdentityGate.web.tsx`**: Full identity setup screen with multiple steps:
  - Returning user → PIN unlock
  - New user → "Sign in with GitHub" (primary) or "Enter recovery phrase" (secondary)
  - After OAuth → fetch cloud backup → prompt for backup password → decrypt
  - No backup → manual mnemonic entry
  - PIN creation to encrypt identity in localStorage
- **`useAuth.web.ts`**: Auth hook managing token in localStorage, OAuth redirect, callback token extraction from URL fragment
- **`identity-backup.web.ts`**: Cloud backup fetch + PBKDF2-AES-GCM decryption via Web Crypto API
- **`useRelayConnection.web.ts`**: Now accepts pre-resolved identity (no more `window.prompt()`)
- **`app.web.tsx`**: Shows `IdentityGate` before relay connection; auto-connects when identity is ready

### Flow
```
bradleat.gitspace.sh → IdentityGate → "Sign in with GitHub"
  → api.gitspace.sh/auth/github?return_to=https://bradleat.gitspace.sh
  → github.com OAuth
  → api.gitspace.sh/auth/github/callback → creates gst_ token
  → redirect to https://bradleat.gitspace.sh/#token=gst_xxx
  → fetch /identity/backup → decrypt with backup password
  → store encrypted in localStorage with PIN
  → relay connect
```

### Requires
- Worker deploy to apply CORS + OAuth changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> High risk because it introduces a new browser OAuth token issuance/redirect flow and changes the initial identity/relay bootstrap path, plus adds client-side decryption and storage logic for sensitive identity material.
> 
> **Overview**
> Adds a pre-connection **`IdentityGate`** UI that blocks all web terminal views until an identity is unlocked or created, supporting PIN unlock, GitHub OAuth, cloud-backup recovery, and manual mnemonic entry; `app.web.tsx` now waits for a resolved identity and only then auto-connects to the relay.
> 
> Introduces browser OAuth/token handling (`useAuth.web.ts`) and cloud backup recovery (`identity-backup.web.ts`), plus shared PBKDF2/AES-GCM helpers in `browser-crypto.ts`; `identity-store.web.ts` is refactored to use the shared crypto utilities.
> 
> Refactors `useRelayConnection.web.ts` to accept a pre-resolved `identity` (removing `window.prompt()` flows) and updates the worker to support the web OAuth return flow: validates `return_to`, encodes it into OAuth state, issues a `gst_` bearer token on callback, redirects back with `#token=...`, and expands CORS to allow `*.gitspace.sh` origins.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c51fc25b8317bc744cf6799c23fbb2c60bfedd5d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-step identity bootstrap UI with PIN, mnemonic entry, and cloud-recovery options
  * Cloud backup fetch and password-protected decryption for identity recovery
  * Browser GitHub OAuth flow that issues a short-lived client token for client login
  * App defers relay connection and main views until identity is resolved

* **Infrastructure**
  * CORS origin handling improved to support localhost and subdomain origins
<!-- end of auto-generated comment: release notes by coderabbit.ai -->