### PR TITLE
fix: keep hosted relays reachable over loopback

### DIFF
--- a/README.md
+++ b/README.md
@@ -465,6 +465,10 @@ When `--relay` is omitted, `gssh machine serve start` lets you choose from:
 - local relay (`ws://127.0.0.1:4480/ws`) if running
 - account relays (`*.gitspace.sh`) discovered from your host config/account
 
+`gssh relay start` always keeps the relay reachable locally. If account hosting is configured,
+`auto` and `hosted` modes add a `*.gitspace.sh` tunnel on top of the same local relay instead of
+replacing loopback access.
+
 ### Identity Management
 
 Every machine and client has a cryptographic identity (Ed25519 + X25519 keypair):

--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -307,6 +307,12 @@ Run your own relay for complete control:
 gssh relay start --port 8080
 ```
 
+Relay startup modes control whether GitSpace should also attach managed hosting:
+
+- `gssh relay start --mode local` keeps the relay local only.
+- `gssh relay start --mode hosted` requires gitspace.sh hosting and still keeps loopback access.
+- `gssh relay start --mode auto` keeps local access and adds hosted tunneling when available.
+
 ### Multiple Machines
 
 Each machine needs its own identity:

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -100,6 +100,10 @@ gssh machine enroll --invite "ws://localhost:4480/ws#<TOKEN>" --label "My Mac"
 gssh machine serve start --relay ws://localhost:4480/ws
 ```
 
+`gssh relay start` always exposes the relay locally at `ws://127.0.0.1:4480/ws`. If you also have
+gitspace.sh hosting configured, `auto` and `hosted` modes add the remote tunnel without disabling
+same-machine access.
+
 ### Connect from Another Device
 
 ```bash

--- a/src/cli/commands/relay.ts
+++ b/src/cli/commands/relay.ts
@@ -42,11 +42,11 @@ export function registerRelayCommands(parent: Command): void {
 
   cmd
     .command('start')
-    .description('Start relay server in background (auto-binds account host tunnel when available)')
+    .description('Start relay server in background (always reachable locally; auto/hosted also attach gitspace.sh when available)')
     .option('--port <port>', 'Port to listen on', '4480')
     .option('--bind <address>', 'Address to bind to', '0.0.0.0')
     .option('--hostname <host>', 'Only serve requests for this domain (optional)')
-    .option('--mode <mode>', 'Startup mode: auto, hosted, local', 'auto')
+    .option('--mode <mode>', 'Startup mode: auto (local + hosted if available), hosted (require tunnel, keep local), local (local only)', 'auto')
     .option('--label <label>', 'Human-readable label for this relay')
     .option('-y, --yes', 'Auto-confirm prompts')
     .option('--foreground', "Run in foreground (don't daemonize)")

--- a/src/commands/relay.ts
+++ b/src/commands/relay.ts
@@ -136,6 +136,21 @@ interface RelayStatusSnapshot {
   startedAt: number | null;
 }
 
+function formatRelayHostForUrl(host: string): string {
+  return host.includes(":") && !host.startsWith("[") ? `[${host}]` : host;
+}
+
+function getRecommendedLocalRelayHost(bind: string): string {
+  if (bind === "0.0.0.0" || bind === "::") {
+    return "127.0.0.1";
+  }
+  return bind;
+}
+
+function buildLocalRelayUrl(bind: string, port: number): string {
+  return `ws://${formatRelayHostForUrl(getRecommendedLocalRelayHost(bind))}:${port}/ws`;
+}
+
 export type RelayStartMode = "auto" | "hosted" | "local";
 
 function getRelayRuntimeDir(): string {
@@ -456,6 +471,9 @@ export async function startRelay(options: {
     const snapshot = await waitForRelayRunning(RELAY_DAEMON_STARTUP_TIMEOUT_MS);
     if (snapshot.running) {
       logger.success(`relay daemon started${snapshot.pid ? ` (pid ${snapshot.pid})` : ""}`);
+      if (snapshot.relayUrl) {
+        logger.log(`  Local URL:  ${snapshot.relayUrl}`);
+      }
       if (snapshot.publicRelayUrl) {
         logger.log(`  Public URL: ${snapshot.publicRelayUrl}`);
       }
@@ -657,7 +675,7 @@ export async function startRelay(options: {
   logger.log(`  Bind:     ${bind}`);
   logger.log(`  Mode:     ${mode}`);
   if (hostname) {
-    logger.log(`  Hostname: ${hostname} (only serving this domain)`);
+    logger.log(`  Hostname: ${hostname} (remote host; loopback still allowed)`);
   }
   if (tunnelSubdomain) {
     logger.log(`  Tunnel:   ${tunnelSubdomain}.gitspace.sh`);
@@ -692,7 +710,7 @@ export async function startRelay(options: {
       tunnelSubdomain,
     });
 
-    logger.success(`Relay listening on ws://${hostname || bind}:${port}`);
+    logger.success(`Local relay URL: ${buildLocalRelayUrl(bind, port)}`);
     if (tunnelSubdomain) {
       logger.success(`Public relay URL: wss://${tunnelSubdomain}.gitspace.sh/ws`);
     }
@@ -791,7 +809,7 @@ function getRelayStatusSnapshot(): RelayStatusSnapshot {
   const running = isProcessRunning(state.pid);
   const tunnelRunning = typeof state.tunnelPid === "number" && isProcessRunning(state.tunnelPid);
 
-  const relayUrl = `ws://${state.hostname || state.bind}:${state.port}`;
+  const relayUrl = buildLocalRelayUrl(state.bind, state.port);
   const publicRelayUrl = state.tunnelSubdomain
     ? `wss://${state.tunnelSubdomain}.gitspace.sh/ws`
     : null;
@@ -840,11 +858,11 @@ export async function relayStatus(options: { json?: boolean } = {}): Promise<voi
   logger.log("");
   logger.log(`  State:      ${chalk.green("running")}`);
   logger.log(`  PID:        ${snapshot.pid}`);
-  logger.log(`  Relay URL:  ${snapshot.relayUrl ?? "-"}`);
+  logger.log(`  Local URL:  ${snapshot.relayUrl ?? "-"}`);
   logger.log(`  Bind:       ${snapshot.bind ?? "-"}`);
   logger.log(`  Port:       ${snapshot.port ?? "-"}`);
   if (snapshot.hostname) {
-    logger.log(`  Hostname:   ${snapshot.hostname}`);
+    logger.log(`  Hostname:   ${snapshot.hostname} (loopback allowed)`);
   }
 
   if (snapshot.startedAt) {

--- a/src/commands/relay.ts
+++ b/src/commands/relay.ts
@@ -141,8 +141,11 @@ function formatRelayHostForUrl(host: string): string {
 }
 
 function getRecommendedLocalRelayHost(bind: string): string {
-  if (bind === "0.0.0.0" || bind === "::") {
+  if (bind === "0.0.0.0") {
     return "127.0.0.1";
+  }
+  if (bind === "::") {
+    return "::1";
   }
   return bind;
 }

--- a/src/relay/server.test.ts
+++ b/src/relay/server.test.ts
@@ -158,8 +158,39 @@ describe('relay basics', () => {
     const res = await fetch(`${relayHttpBase}/health`);
     expect(res.status).toBe(200);
     const body = await res.json();
+    expect(body.status).toBe('ok');
+    expect(body.configuredHostname).toBe(TEST_HOST);
+    expect(body.loopbackAllowed).toBe(true);
     expect(typeof body.machineCount).toBe('number');
     expect(typeof body.connectedClients).toBe('number');
+  });
+
+  test('allows loopback websocket upgrades when hosted hostname is configured', async () => {
+    const hostedRelay = startRelayServer({
+      bind: TEST_HOST,
+      hostname: 'myrelay.gitspace.sh',
+      disableRateLimit: true,
+      identity: generateRelayIdentity('hosted-loopback-relay'),
+    });
+
+    const ws = new WebSocket(`ws://${TEST_HOST}:${hostedRelay.port}/ws?role=client`);
+
+    try {
+      await new Promise<void>((resolve, reject) => {
+        const timeoutId = setTimeout(() => reject(new Error('Connection timeout')), 5000);
+        ws.onopen = () => {
+          clearTimeout(timeoutId);
+          resolve();
+        };
+        ws.onerror = () => {
+          clearTimeout(timeoutId);
+          reject(new Error('Client WebSocket connection failed'));
+        };
+      });
+    } finally {
+      ws.close();
+      hostedRelay.stop(true);
+    }
   });
 
   test('rejects unknown endpoint', async () => {

--- a/src/relay/server.ts
+++ b/src/relay/server.ts
@@ -243,6 +243,18 @@ function getClientIp(req: Request): string {
   return "unknown";
 }
 
+function normalizeHostname(hostname: string): string {
+  return hostname.toLowerCase().replace(/^\[/, "").replace(/\]$/, "").replace(/\.$/, "").split("%", 1)[0] ?? hostname.toLowerCase();
+}
+
+function isLoopbackHostname(hostname: string): boolean {
+  const normalized = normalizeHostname(hostname);
+  return normalized === "localhost"
+    || normalized === "127.0.0.1"
+    || normalized === "::1"
+    || normalized === "::ffff:127.0.0.1";
+}
+
 function consumeConnectionSlot(ip: string): boolean {
   const now = Date.now();
   const record = connectionRateLimits.get(ip);
@@ -599,6 +611,8 @@ export function createRelayServer(config: RelayConfig): Server<WebSocketData> {
         const clientCount = clientConnections.size;
         return Response.json({
           status: "ok",
+          configuredHostname: hostname ?? null,
+          loopbackAllowed: true,
           relayPublicKey: relayIdentity.signingPublicKey,
           relayFingerprint: formatRelayFingerprint(relayIdentity.signingPublicKey),
           relayLabel: relayIdentity.label ?? null,
@@ -607,11 +621,12 @@ export function createRelayServer(config: RelayConfig): Server<WebSocketData> {
         });
       }
 
-      // Check Host header if hostname is specified (after health check which is always allowed)
+      // When a hosted hostname is configured, keep that host reachable while also
+      // preserving same-machine loopback access for local clients and daemons.
       if (hostname) {
-        const hostHeader = req.headers.get("host");
-        const host = hostHeader?.split(":")[0]; // Remove port
-        if (host !== hostname) {
+        const requestHost = normalizeHostname(url.hostname);
+        const expectedHost = normalizeHostname(hostname);
+        if (requestHost !== expectedHost && !isLoopbackHostname(requestHost)) {
           return new Response("Not found", { status: 404 });
         }
       }

--- a/src/relay/server.ts
+++ b/src/relay/server.ts
@@ -247,12 +247,26 @@ function normalizeHostname(hostname: string): string {
   return hostname.toLowerCase().replace(/^\[/, "").replace(/\]$/, "").replace(/\.$/, "").split("%", 1)[0] ?? hostname.toLowerCase();
 }
 
-function isLoopbackHostname(hostname: string): boolean {
-  const normalized = normalizeHostname(hostname);
-  return normalized === "localhost"
-    || normalized === "127.0.0.1"
-    || normalized === "::1"
-    || normalized === "::ffff:127.0.0.1";
+function isIpv4Loopback(address: string): boolean {
+  const parts = address.split(".");
+  if (parts.length !== 4) {
+    return false;
+  }
+
+  const octets = parts.map((part) => Number.parseInt(part, 10));
+  return octets.every((octet) => Number.isInteger(octet) && octet >= 0 && octet <= 255)
+    && octets[0] === 127;
+}
+
+function isLoopbackIp(address: string | null | undefined): boolean {
+  if (!address) {
+    return false;
+  }
+
+  const normalized = normalizeHostname(address);
+  return normalized === "::1"
+    || isIpv4Loopback(normalized)
+    || (normalized.startsWith("::ffff:") && isIpv4Loopback(normalized.slice("::ffff:".length)));
 }
 
 function consumeConnectionSlot(ip: string): boolean {
@@ -626,7 +640,8 @@ export function createRelayServer(config: RelayConfig): Server<WebSocketData> {
       if (hostname) {
         const requestHost = normalizeHostname(url.hostname);
         const expectedHost = normalizeHostname(hostname);
-        if (requestHost !== expectedHost && !isLoopbackHostname(requestHost)) {
+        const requestIp = server.requestIP(req)?.address;
+        if (requestHost !== expectedHost && !isLoopbackIp(requestIp)) {
           return new Response("Not found", { status: 404 });
         }
       }

--- a/src/relay/types.ts
+++ b/src/relay/types.ts
@@ -51,7 +51,7 @@ export interface RelayConfig {
   port: number;
   /** Address to bind to (default: 0.0.0.0) */
   bind?: string;
-  /** Allowed hostname - only serve requests with matching Host header (optional) */
+  /** Preferred hosted hostname; loopback hosts remain allowed for local access (optional) */
   hostname?: string;
   /**
    * Disable best-effort in-memory connection rate limiting.


### PR DESCRIPTION
## Summary
- allow loopback websocket access when a relay is configured with a hosted hostname so the same relay stays reachable locally and through `*.gitspace.sh`
- report the local `/ws` relay URL clearly in CLI output/status and clarify relay mode behavior in the docs
- add relay regression coverage for hosted-hostname loopback upgrades and health metadata

## Testing
- bun test src/relay/server.test.ts
- bun run typecheck

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes request filtering for hosted relays to allow loopback connections even when a `hostname` is configured, which affects relay exposure and access behavior. Low code churn but touches network/WS ingress logic and should be reviewed for unintended bypass of hostname restrictions beyond loopback.
> 
> **Overview**
> Hosted relays configured with a `hostname` now continue to accept **loopback** HTTP/WS traffic, preventing same-machine clients/daemons from being blocked by the hostname filter; `/health` additionally reports `configuredHostname` and a `loopbackAllowed` flag.
> 
> CLI output/docs are updated to clarify `relay start` modes (`local`/`auto`/`hosted`) and to consistently surface the **local** relay URL (including IPv6-safe formatting) alongside any `*.gitspace.sh` public URL. Regression tests cover loopback WebSocket upgrades with a hosted hostname and the expanded health payload.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bf419c71e31dbbe2764115cc9fe1a1a1d799d1ea. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added and clarified guides explaining relay startup modes (local, hosted, auto) and that local loopback access is preserved when hosted tunneling is enabled.

* **New Features**
  * Relay status and CLI messages now explicitly show the local relay URL, configured hostname, and whether loopback access is allowed, ensuring local access remains available in hosted/auto modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->