### PR TITLE
fix: sync prerelease version bumps with bun.lock

### DIFF
--- a/.github/workflows/publish-prerelease.yml
+++ b/.github/workflows/publish-prerelease.yml
@@ -106,6 +106,8 @@ jobs:
         with:
           node-version: '24'
 
+      - uses: oven-sh/setup-bun@v2
+
       # Ensure npm is new enough for OIDC trusted publishing (requires 11.5.1+)
       - name: Update npm
         run: npm install -g npm@latest && npm --version
@@ -145,6 +147,12 @@ jobs:
           ' package.json > "$tmp"
           mv "$tmp" package.json
 
+      - name: Regenerate bun.lock for released version
+        run: bun install --lockfile-only --ignore-scripts
+
+      - name: Validate lockfile sync
+        run: bun run check:lockfile-sync
+
       - name: Publish platform packages
         run: |
           for target in darwin-arm64 darwin-x64 linux-x64 linux-arm64; do
@@ -170,7 +178,7 @@ jobs:
           # Create a branch and open a PR for the version bump
           BRANCH="chore/version-bump-v${VERSION}"
           git checkout -b "$BRANCH"
-          git add package.json
+          git add package.json bun.lock
           git commit -m "chore: bump version to v${VERSION}"
           git push origin "$BRANCH"
           gh pr create \

--- a/.github/workflows/publish-prerelease.yml
+++ b/.github/workflows/publish-prerelease.yml
@@ -147,12 +147,6 @@ jobs:
           ' package.json > "$tmp"
           mv "$tmp" package.json
 
-      - name: Regenerate bun.lock for released version
-        run: bun install --lockfile-only --ignore-scripts
-
-      - name: Validate lockfile sync
-        run: bun run check:lockfile-sync
-
       - name: Publish platform packages
         run: |
           for target in darwin-arm64 darwin-x64 linux-x64 linux-arm64; do
@@ -162,6 +156,12 @@ jobs:
 
       - name: Publish main package
         run: npm publish . --provenance --access public --tag ${{ inputs.dist_tag || 'latest' }}
+
+      - name: Regenerate bun.lock for released version
+        run: bun install --lockfile-only --ignore-scripts
+
+      - name: Validate lockfile sync
+        run: bun run check:lockfile-sync
 
       - name: Tag release and open version-bump PR
         env:

--- a/bun.lock
+++ b/bun.lock
@@ -41,10 +41,10 @@
         "typescript": "^5.9.3",
       },
       "optionalDependencies": {
-        "@gitspace/darwin-arm64": "0.2.0-rc.32",
-        "@gitspace/darwin-x64": "0.2.0-rc.32",
-        "@gitspace/linux-arm64": "0.2.0-rc.32",
-        "@gitspace/linux-x64": "0.2.0-rc.32",
+        "@gitspace/darwin-arm64": "0.2.0-rc.34",
+        "@gitspace/darwin-x64": "0.2.0-rc.34",
+        "@gitspace/linux-arm64": "0.2.0-rc.34",
+        "@gitspace/linux-x64": "0.2.0-rc.34",
       },
     },
   },
@@ -67,13 +67,13 @@
 
     "@fly/sprites": ["@fly/sprites@0.0.1-rc37", "", {}, "sha512-yzjJ8bsBl1XoECSols0iFvvmlqiog22ODO8F3Z+8mao44ZaMYiOVjRTuSd2g+rE0OFuj0u/ctlpPTHfVdpgWKA=="],
 
-    "@gitspace/darwin-arm64": ["@gitspace/darwin-arm64@0.2.0-rc.32", "", { "os": "darwin", "cpu": "arm64", "bin": { "gssh-darwin-arm64": "bin/gssh" } }, "sha512-VQgsN8Qktf+8KriLKXpfbYJoHkcXFtLzN+Sz3/SWJocd3HZebYrDxBUjTM+iwdtMzwpxoDmE1RS4hIqZJ5BmMg=="],
+    "@gitspace/darwin-arm64": ["@gitspace/darwin-arm64@0.2.0-rc.34", "", { "os": "darwin", "cpu": "arm64", "bin": { "gssh-darwin-arm64": "bin/gssh" } }, "sha512-HJqcg0/pc59Q3lzdCrU3R26SFBVM5jCzb9Fw6AOmP1reJRGWSjFmY7D92WtAu7cl81QONIFm5IPeSnNbIZKJvg=="],
 
-    "@gitspace/darwin-x64": ["@gitspace/darwin-x64@0.2.0-rc.32", "", { "os": "darwin", "cpu": "x64", "bin": { "gssh-darwin-x64": "bin/gssh" } }, "sha512-0qOGHOPki43Ry2jd1+1WESsiQHCGp0ph9nPIaQSK+ZDhEvzH0N1kZiIj5KsDkV60At4eGbSyV81ymnNTfJeXGA=="],
+    "@gitspace/darwin-x64": ["@gitspace/darwin-x64@0.2.0-rc.34", "", { "os": "darwin", "cpu": "x64", "bin": { "gssh-darwin-x64": "bin/gssh" } }, "sha512-/SvD0u8FU0F2rUqWtT9UZYEFJWykQ539w10Pu1bgS6usQWWgj5ReZEJlGFUlOlcqTBZlVnA/ujtU+rSBJEwaeg=="],
 
-    "@gitspace/linux-arm64": ["@gitspace/linux-arm64@0.2.0-rc.32", "", { "os": "linux", "cpu": "arm64", "bin": { "gssh-linux-arm64": "bin/gssh" } }, "sha512-RKwon3jH0TNOu3XPsPvHa1LSdhJWHVPwvgBfklMiiLLXs7AMExGZ9UFrg9woAbWwWyYxg0k6pxUeMeL+V7TG4Q=="],
+    "@gitspace/linux-arm64": ["@gitspace/linux-arm64@0.2.0-rc.34", "", { "os": "linux", "cpu": "arm64", "bin": { "gssh-linux-arm64": "bin/gssh" } }, "sha512-6J73fsWCeEQV47zYsOCSkE+TA4o9z9eG5kBCTUso/0KyQP3a36Tf6is30rtkBk7JRy0+Go29LawsRWCmVJmlZQ=="],
 
-    "@gitspace/linux-x64": ["@gitspace/linux-x64@0.2.0-rc.32", "", { "os": "linux", "cpu": "x64", "bin": { "gssh-linux-x64": "bin/gssh" } }, "sha512-v2PH2mRWMIkUpPYQWbPjzUSqVpKTARu+Boo+lTrhvXSCl7zIQBFivhqBBylDW7TyGN37UkL+raw2BCDyVUr0vw=="],
+    "@gitspace/linux-x64": ["@gitspace/linux-x64@0.2.0-rc.34", "", { "os": "linux", "cpu": "x64", "bin": { "gssh-linux-x64": "bin/gssh" } }, "sha512-6cFFik7Zt6p73+fv9R2BCqNfO61yy+ZhxCahyHR0KpeQZjGy8e1YWhCV4tHo3xWIkY6yKrAoYiu4pEyGenqhgA=="],
 
     "@graphql-typed-document-node/core": ["@graphql-typed-document-node/core@3.2.0", "", { "peerDependencies": { "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0" } }, "sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ=="],
 

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "type": "module",
   "scripts": {
     "dev": "bun src/index.ts",
+    "check:lockfile-sync": "bun scripts/check-lockfile-sync.ts",
     "typecheck": "tsc --noEmit",
     "lint": "eslint src/",
     "build:web": "cd web && bun install && bun run build",

--- a/scripts/check-lockfile-sync.ts
+++ b/scripts/check-lockfile-sync.ts
@@ -1,0 +1,64 @@
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { join } from 'path';
+
+const ROOT = join(fileURLToPath(new URL('.', import.meta.url)), '..');
+
+type PackageJson = {
+  version: string;
+  optionalDependencies?: Record<string, string>;
+};
+
+type BunLock = {
+  workspaces?: Record<string, { optionalDependencies?: Record<string, string> }>;
+  packages?: Record<string, [string, ...unknown[]]>;
+};
+
+function readJsonFile<T>(path: string): T {
+  return JSON.parse(readFileSync(path, 'utf-8')) as T;
+}
+
+function readBunLockFile(path: string): BunLock {
+  const raw = readFileSync(path, 'utf-8');
+  const normalized = raw.replace(/,\s*([}\]])/g, '$1');
+  return JSON.parse(normalized) as BunLock;
+}
+
+function fail(message: string): never {
+  console.error(`x ${message}`);
+  process.exit(1);
+}
+
+const pkg = readJsonFile<PackageJson>(join(ROOT, 'package.json'));
+const lock = readBunLockFile(join(ROOT, 'bun.lock'));
+
+const optionalDeps = pkg.optionalDependencies ?? {};
+const gitspaceOptionalDeps = Object.entries(optionalDeps).filter(([name]) =>
+  name.startsWith('@gitspace/')
+);
+
+if (gitspaceOptionalDeps.length === 0) {
+  fail('No @gitspace optionalDependencies found in package.json.');
+}
+
+const workspaceOptionalDeps = lock.workspaces?.['']?.optionalDependencies ?? {};
+
+for (const [name, version] of gitspaceOptionalDeps) {
+  if (version !== pkg.version) {
+    fail(`${name} in package.json should match package version ${pkg.version}, found ${version}.`);
+  }
+
+  const workspaceVersion = workspaceOptionalDeps[name];
+  if (workspaceVersion !== version) {
+    fail(`${name} in bun.lock workspace optionalDependencies should be ${version}, found ${workspaceVersion ?? 'missing'}.`);
+  }
+
+  const packageEntry = lock.packages?.[name];
+  const packageDescriptor = packageEntry?.[0];
+  const expectedDescriptor = `${name}@${version}`;
+  if (packageDescriptor !== expectedDescriptor) {
+    fail(`${name} in bun.lock packages should be ${expectedDescriptor}, found ${packageDescriptor ?? 'missing'}.`);
+  }
+}
+
+console.log(`✓ bun.lock @gitspace optionalDependencies match package.json version ${pkg.version}`);


### PR DESCRIPTION
## Summary
- regenerate `bun.lock` in the prerelease publish workflow after bumping `package.json`, and include it in the automated version-bump PR commit
- add `scripts/check-lockfile-sync.ts` plus `bun run check:lockfile-sync` so `package.json` and the `@gitspace/*` entries in `bun.lock` cannot silently drift apart
- refresh the committed `bun.lock` in tree so the current version bump state matches `package.json`

## Testing
- `bun run check:lockfile-sync`
- `bun run typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the prerelease publish GitHub Actions workflow and adds a new lockfile validation step; failures could block releases if the lockfile parsing/regen behaves unexpectedly in CI.
> 
> **Overview**
> Ensures prerelease version bumps update `bun.lock` alongside `package.json` so `@gitspace/*` optional dependency versions don’t drift.
> 
> The prerelease publish workflow now installs Bun, regenerates `bun.lock` for the released version, validates lockfile/version alignment via a new `check:lockfile-sync` script, and includes `bun.lock` in the automated version-bump PR commit. The committed `bun.lock` is also updated to reflect the current `0.2.0-rc.34` platform package versions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 46167745f646b567f8a67d8fb347b62bd1438872. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Publishing workflow now regenerates and validates the lockfile to ensure released packages match lockfile state.
  * Version bump releases include the lockfile alongside package metadata to keep commits consistent.
  * Added an automated check that verifies selected optional dependencies remain synchronized between package declarations and the lockfile.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->