### PR TITLE
add durable replay history across cli, tui, and web

### DIFF
--- a/src/app.tui.tsx
+++ b/src/app.tui.tsx
@@ -1130,7 +1130,7 @@ function App({ relayConfig, remoteIdentity, onQuit, keyboardMode }: AppProps) {
     dispatch({ type: 'SET_VIEW', view: 'events' });
   }, [localWorkspaces, requestLocalEvents]);
 
-  const handleOpenReplay = useCallback(async ({ replayId }: { replayId: string; workspaceId: string }) => {
+  const handleOpenReplay = useCallback(async (replayId: string) => {
     const replay = localReplays.find((item) => item.replayId === replayId);
     if (!replay) {
       flow.showMessage({

--- a/src/app.tui.tsx
+++ b/src/app.tui.tsx
@@ -301,6 +301,7 @@ function App({ relayConfig, remoteIdentity, onQuit, keyboardMode }: AppProps) {
   const [activeRemoteIdentity, setActiveRemoteIdentity] = useState<Identity | null>(null);
   const [activeReplay, setActiveReplay] = useState<ReplayInfo | null>(null);
   const [showDismissedReplays, setShowDismissedReplays] = useState(false);
+  const activeReplayDismissedRef = useRef(false);
 
   // View-only session state (true when attached to a running process session)
   const [isViewOnlySession, setIsViewOnlySession] = useState(false);
@@ -2136,8 +2137,9 @@ function App({ relayConfig, remoteIdentity, onQuit, keyboardMode }: AppProps) {
 
   const handleReplayDismiss = useCallback((replayId: string) => {
     try {
-      if (activeReplay?.dismissedAt) {
+      if (activeReplayDismissedRef.current) {
         undismissReplayOffline(replayId);
+        activeReplayDismissedRef.current = false;
         setActiveReplay((current) => current && current.replayId === replayId
           ? {
             ...current,
@@ -2149,6 +2151,7 @@ function App({ relayConfig, remoteIdentity, onQuit, keyboardMode }: AppProps) {
       }
 
       dismissReplayOffline(replayId);
+      activeReplayDismissedRef.current = true;
       return true;
     } catch (error) {
       flow.showMessage({
@@ -2160,7 +2163,11 @@ function App({ relayConfig, remoteIdentity, onQuit, keyboardMode }: AppProps) {
     } finally {
       void requestLocalReplays(undefined, showDismissedReplays);
     }
-  }, [activeReplay?.dismissedAt, flow, requestLocalReplays, showDismissedReplays]);
+  }, [flow, requestLocalReplays, showDismissedReplays]);
+
+  useEffect(() => {
+    activeReplayDismissedRef.current = Boolean(activeReplay?.dismissedAt);
+  }, [activeReplay?.dismissedAt]);
 
   if (state.view === 'replay' && activeReplay) {
     return (

--- a/src/app.tui.tsx
+++ b/src/app.tui.tsx
@@ -373,7 +373,6 @@ function App({ relayConfig, remoteIdentity, onQuit, keyboardMode }: AppProps) {
     startProcess: startLocalProcess,
     stopProcess: stopLocalProcess,
     requestEvents: requestLocalEvents,
-    getReplayText: getLocalReplayText,
     events: localEvents,
     liveEventIds: localLiveEventIds,
     savedEventFilters: localSavedEventFilters,

--- a/src/app.tui.tsx
+++ b/src/app.tui.tsx
@@ -2146,8 +2146,21 @@ function App({ relayConfig, remoteIdentity, onQuit, keyboardMode }: AppProps) {
             dispatch({ type: 'SET_VIEW', view: 'projects' });
           }}
           onDismiss={(replayId) => {
-            dismissReplayOffline(replayId);
-            void requestLocalReplays(undefined, showDismissedReplays);
+            try {
+              if (activeReplay?.dismissedAt) {
+                undismissReplayOffline(replayId);
+              } else {
+                dismissReplayOffline(replayId);
+              }
+            } catch (error) {
+              flow.showMessage({
+                title: 'Replay Update Failed',
+                message: error instanceof Error ? error.message : String(error),
+                variant: 'error',
+              });
+            } finally {
+              void requestLocalReplays(undefined, showDismissedReplays);
+            }
           }}
         />
         <FlowTUI flow={flow} />

--- a/src/app.tui.tsx
+++ b/src/app.tui.tsx
@@ -2149,9 +2149,22 @@ function App({ relayConfig, remoteIdentity, onQuit, keyboardMode }: AppProps) {
             try {
               if (activeReplay?.dismissedAt) {
                 undismissReplayOffline(replayId);
+                setActiveReplay((current) => current && current.replayId === replayId
+                  ? {
+                    ...current,
+                    dismissedAt: undefined,
+                    dismissedBy: undefined,
+                  }
+                  : current);
                 return false;
               } else {
                 dismissReplayOffline(replayId);
+                setActiveReplay((current) => current && current.replayId === replayId
+                  ? {
+                    ...current,
+                    dismissedAt: Date.now(),
+                  }
+                  : current);
                 return true;
               }
             } catch (error) {

--- a/src/app.tui.tsx
+++ b/src/app.tui.tsx
@@ -20,7 +20,12 @@ import { RemoteMachineScreen } from './components/RemoteMachineScreen.tui.js';
 import { ScriptTerminal } from './components/ScriptTerminal.tui.js';
 import { ReplayTerminal } from './components/ReplayTerminal.tui.js';
 import { ProjectOnboardingStepTUI } from './components/ProjectOnboardingStep.tui.js';
-import { getReplayAnsiBufferOffline, dismissReplayOffline, undismissReplayOffline } from './lib/tmux-lite/replay/service.js';
+import {
+  getReplayAnsiBufferOffline,
+  getReplayTimelineOffline,
+  dismissReplayOffline,
+  undismissReplayOffline,
+} from './lib/tmux-lite/replay/service.js';
 
 // Shared components and hooks
 import {
@@ -1140,6 +1145,58 @@ function App({ relayConfig, remoteIdentity, onQuit, keyboardMode }: AppProps) {
     dispatch({ type: 'SET_VIEW', view: 'replay' });
   }, [flow, localReplays]);
 
+  const handleReplayDismiss = useCallback((replayId: string) => {
+    try {
+      const replay = localReplays.find((item) => item.replayId === replayId) ?? activeReplay;
+      if (!activeReplayDismissedRef.current && replay?.status === 'running') {
+        flow.showMessage({
+          title: 'Replay Still Running',
+          message: 'Running replays cannot be dismissed.',
+          variant: 'info',
+        });
+        return false;
+      }
+
+      if (activeReplayDismissedRef.current) {
+        undismissReplayOffline(replayId);
+        activeReplayDismissedRef.current = false;
+        setActiveReplay((current) => current && current.replayId === replayId
+          ? {
+            ...current,
+            dismissedAt: undefined,
+            dismissedBy: undefined,
+          }
+          : current);
+        return false;
+      }
+
+      dismissReplayOffline(replayId);
+      activeReplayDismissedRef.current = true;
+      return true;
+    } catch (error) {
+      flow.showMessage({
+        title: 'Replay Update Failed',
+        message: error instanceof Error ? error.message : String(error),
+        variant: 'error',
+      });
+      return false;
+    } finally {
+      void requestLocalReplays(undefined, showDismissedReplays);
+    }
+  }, [activeReplay, flow, localReplays, requestLocalReplays, showDismissedReplays]);
+
+  useEffect(() => {
+    activeReplayDismissedRef.current = Boolean(activeReplay?.dismissedAt);
+  }, [activeReplay?.dismissedAt]);
+
+  const loadReplayAnsi = useCallback((replayId: string, target?: { atMs?: number; atSeq?: number }) => {
+    return getReplayAnsiBufferOffline(replayId, target);
+  }, []);
+
+  const loadReplayTimeline = useCallback((replayId: string) => {
+    return Promise.resolve(getReplayTimelineOffline(replayId));
+  }, []);
+
   // Spaces browser hook
   const spacesBrowserProps = useSpacesBrowser({
     workspaces: workspaceInfos,
@@ -1933,7 +1990,13 @@ function App({ relayConfig, remoteIdentity, onQuit, keyboardMode }: AppProps) {
             }
           } else if (selected?.type === 'replay') {
             try {
-              if (selected.replay.dismissedAt) {
+              if (!selected.replay.dismissedAt && selected.replay.status === 'running') {
+                flow.showMessage({
+                  title: 'Replay Still Running',
+                  message: 'Running replays cannot be dismissed.',
+                  variant: 'info',
+                });
+              } else if (selected.replay.dismissedAt) {
                 undismissReplayOffline(selected.replay.replayId);
               } else {
                 dismissReplayOffline(selected.replay.replayId);
@@ -2135,52 +2198,19 @@ function App({ relayConfig, remoteIdentity, onQuit, keyboardMode }: AppProps) {
     );
   }
 
-  const handleReplayDismiss = useCallback((replayId: string) => {
-    try {
-      if (activeReplayDismissedRef.current) {
-        undismissReplayOffline(replayId);
-        activeReplayDismissedRef.current = false;
-        setActiveReplay((current) => current && current.replayId === replayId
-          ? {
-            ...current,
-            dismissedAt: undefined,
-            dismissedBy: undefined,
-          }
-          : current);
-        return false;
-      }
-
-      dismissReplayOffline(replayId);
-      activeReplayDismissedRef.current = true;
-      return true;
-    } catch (error) {
-      flow.showMessage({
-        title: 'Replay Update Failed',
-        message: error instanceof Error ? error.message : String(error),
-        variant: 'error',
-      });
-      return false;
-    } finally {
-      void requestLocalReplays(undefined, showDismissedReplays);
-    }
-  }, [flow, requestLocalReplays, showDismissedReplays]);
-
-  useEffect(() => {
-    activeReplayDismissedRef.current = Boolean(activeReplay?.dismissedAt);
-  }, [activeReplay?.dismissedAt]);
-
   if (state.view === 'replay' && activeReplay) {
     return (
       <Fragment>
         <Toaster position="top-right" />
         <ReplayTerminal
           replay={activeReplay}
-          loadReplayAnsi={(replayId) => getReplayAnsiBufferOffline(replayId)}
+          loadReplayAnsi={loadReplayAnsi}
+          loadReplayTimeline={loadReplayTimeline}
           onBack={() => {
             setActiveReplay(null);
             dispatch({ type: 'SET_VIEW', view: 'projects' });
           }}
-          onDismiss={handleReplayDismiss}
+          onDismiss={activeReplay.status === 'running' ? undefined : handleReplayDismiss}
         />
         <FlowTUI flow={flow} />
       </Fragment>

--- a/src/app.tui.tsx
+++ b/src/app.tui.tsx
@@ -2149,8 +2149,10 @@ function App({ relayConfig, remoteIdentity, onQuit, keyboardMode }: AppProps) {
             try {
               if (activeReplay?.dismissedAt) {
                 undismissReplayOffline(replayId);
+                return false;
               } else {
                 dismissReplayOffline(replayId);
+                return true;
               }
             } catch (error) {
               flow.showMessage({
@@ -2158,6 +2160,7 @@ function App({ relayConfig, remoteIdentity, onQuit, keyboardMode }: AppProps) {
                 message: error instanceof Error ? error.message : String(error),
                 variant: 'error',
               });
+              return false;
             } finally {
               void requestLocalReplays(undefined, showDismissedReplays);
             }

--- a/src/app.tui.tsx
+++ b/src/app.tui.tsx
@@ -1932,12 +1932,20 @@ function App({ relayConfig, remoteIdentity, onQuit, keyboardMode }: AppProps) {
               handleDeleteWorkspace(workspace);
             }
           } else if (selected?.type === 'replay') {
-            if (selected.replay.dismissedAt) {
-              undismissReplayOffline(selected.replay.replayId);
-            } else {
-              dismissReplayOffline(selected.replay.replayId);
+            try {
+              if (selected.replay.dismissedAt) {
+                undismissReplayOffline(selected.replay.replayId);
+              } else {
+                dismissReplayOffline(selected.replay.replayId);
+              }
+              void requestLocalReplays(undefined, showDismissedReplays);
+            } catch (error) {
+              flow.showMessage({
+                title: 'Replay Update Failed',
+                message: error instanceof Error ? error.message : String(error),
+                variant: 'error',
+              });
             }
-            void requestLocalReplays(undefined, showDismissedReplays);
           }
         } else if (command === 'kill') {
           // Kill session or stop running process
@@ -1969,7 +1977,11 @@ function App({ relayConfig, remoteIdentity, onQuit, keyboardMode }: AppProps) {
             });
           }
         } else if (command === 'toggle-hidden') {
-          setShowDismissedReplays((value) => !value);
+          setShowDismissedReplays((value) => {
+            const next = !value;
+            void requestLocalReplays(undefined, next);
+            return next;
+          });
         } else if (command === 'back') {
           dispatch({ type: 'SET_PANEL_FOCUS', focus: 'projects' });
         }

--- a/src/app.tui.tsx
+++ b/src/app.tui.tsx
@@ -2134,6 +2134,34 @@ function App({ relayConfig, remoteIdentity, onQuit, keyboardMode }: AppProps) {
     );
   }
 
+  const handleReplayDismiss = useCallback((replayId: string) => {
+    try {
+      if (activeReplay?.dismissedAt) {
+        undismissReplayOffline(replayId);
+        setActiveReplay((current) => current && current.replayId === replayId
+          ? {
+            ...current,
+            dismissedAt: undefined,
+            dismissedBy: undefined,
+          }
+          : current);
+        return false;
+      }
+
+      dismissReplayOffline(replayId);
+      return true;
+    } catch (error) {
+      flow.showMessage({
+        title: 'Replay Update Failed',
+        message: error instanceof Error ? error.message : String(error),
+        variant: 'error',
+      });
+      return false;
+    } finally {
+      void requestLocalReplays(undefined, showDismissedReplays);
+    }
+  }, [activeReplay?.dismissedAt, flow, requestLocalReplays, showDismissedReplays]);
+
   if (state.view === 'replay' && activeReplay) {
     return (
       <Fragment>
@@ -2145,39 +2173,7 @@ function App({ relayConfig, remoteIdentity, onQuit, keyboardMode }: AppProps) {
             setActiveReplay(null);
             dispatch({ type: 'SET_VIEW', view: 'projects' });
           }}
-          onDismiss={(replayId) => {
-            try {
-              if (activeReplay?.dismissedAt) {
-                undismissReplayOffline(replayId);
-                setActiveReplay((current) => current && current.replayId === replayId
-                  ? {
-                    ...current,
-                    dismissedAt: undefined,
-                    dismissedBy: undefined,
-                  }
-                  : current);
-                return false;
-              } else {
-                dismissReplayOffline(replayId);
-                setActiveReplay((current) => current && current.replayId === replayId
-                  ? {
-                    ...current,
-                    dismissedAt: Date.now(),
-                  }
-                  : current);
-                return true;
-              }
-            } catch (error) {
-              flow.showMessage({
-                title: 'Replay Update Failed',
-                message: error instanceof Error ? error.message : String(error),
-                variant: 'error',
-              });
-              return false;
-            } finally {
-              void requestLocalReplays(undefined, showDismissedReplays);
-            }
-          }}
+          onDismiss={handleReplayDismiss}
         />
         <FlowTUI flow={flow} />
       </Fragment>

--- a/src/app.tui.tsx
+++ b/src/app.tui.tsx
@@ -18,7 +18,9 @@ import { Toaster } from '@opentui-ui/toast/react';
 import { SessionTerminal } from './components/SessionTerminal.tui.js';
 import { RemoteMachineScreen } from './components/RemoteMachineScreen.tui.js';
 import { ScriptTerminal } from './components/ScriptTerminal.tui.js';
+import { ReplayTerminal } from './components/ReplayTerminal.tui.js';
 import { ProjectOnboardingStepTUI } from './components/ProjectOnboardingStep.tui.js';
+import { getReplayAnsiBufferOffline, dismissReplayOffline, undismissReplayOffline } from './lib/tmux-lite/replay/service.js';
 
 // Shared components and hooks
 import {
@@ -32,6 +34,7 @@ import {
   isFlowWizard,
   type MachineInfo,
   type ProjectInfo,
+  type ReplayInfo,
 } from './components/index.js';
 import { FlowTUI } from './components/Flow.tui.js';
 import { MachineListTUI } from './components/MachineList.tui.js';
@@ -296,6 +299,8 @@ function App({ relayConfig, remoteIdentity, onQuit, keyboardMode }: AppProps) {
   // Events view state
   const [eventsWorkspaceId, setEventsWorkspaceId] = useState<string | null>(null);
   const [activeRemoteIdentity, setActiveRemoteIdentity] = useState<Identity | null>(null);
+  const [activeReplay, setActiveReplay] = useState<ReplayInfo | null>(null);
+  const [showDismissedReplays, setShowDismissedReplays] = useState(false);
 
   // View-only session state (true when attached to a running process session)
   const [isViewOnlySession, setIsViewOnlySession] = useState(false);
@@ -333,6 +338,7 @@ function App({ relayConfig, remoteIdentity, onQuit, keyboardMode }: AppProps) {
     listLinearIssues: listLocalLinearIssues,
     requestWorkspaces: requestLocalWorkspaces,
     requestSessions: requestLocalSessions,
+    requestReplays: requestLocalReplays,
     createProject: createLocalProject,
     prepareProjectCreation: prepareLocalProjectCreation,
     finalizeProjectCreation: finalizeLocalProjectCreation,
@@ -353,6 +359,7 @@ function App({ relayConfig, remoteIdentity, onQuit, keyboardMode }: AppProps) {
     projects: localProjects,
     workspaces: localWorkspaces,
     sessions: localSessions,
+    replays: localReplays,
     inbox: localInbox,
     inboxUnreadCount: localInboxUnreadCount,
     attachedSessionId: localAttachedSessionId,
@@ -366,6 +373,7 @@ function App({ relayConfig, remoteIdentity, onQuit, keyboardMode }: AppProps) {
     startProcess: startLocalProcess,
     stopProcess: stopLocalProcess,
     requestEvents: requestLocalEvents,
+    getReplayText: getLocalReplayText,
     events: localEvents,
     liveEventIds: localLiveEventIds,
     savedEventFilters: localSavedEventFilters,
@@ -534,8 +542,9 @@ function App({ relayConfig, remoteIdentity, onQuit, keyboardMode }: AppProps) {
     await Promise.all([
       requestLocalWorkspaces(),
       requestLocalSessions(),
+      requestLocalReplays(undefined, showDismissedReplays),
     ]);
-  }, [isLocalMachineContext, requestLocalSessions, requestLocalWorkspaces]);
+  }, [isLocalMachineContext, requestLocalReplays, requestLocalSessions, requestLocalWorkspaces, showDismissedReplays]);
 
   const bundleConfigFlow = useBundleConfigFlow({
     flow,
@@ -630,8 +639,12 @@ function App({ relayConfig, remoteIdentity, onQuit, keyboardMode }: AppProps) {
       const message = error instanceof Error ? error.message : String(error);
       console.error('[tui] Failed to refresh sessions after project select:', message);
     });
+    void requestLocalReplays(undefined, showDismissedReplays).catch((error) => {
+      const message = error instanceof Error ? error.message : String(error);
+      console.error('[tui] Failed to refresh replays after project select:', message);
+    });
     dispatch({ type: 'SET_PANEL_FOCUS', focus: 'workspaces' });
-  }, [requestLocalProjects, requestLocalSessions, requestLocalWorkspaces]);
+  }, [requestLocalProjects, requestLocalReplays, requestLocalSessions, requestLocalWorkspaces, showDismissedReplays]);
 
   // Delete project
   const handleDeleteProject = useCallback((project: ProjectInfo) => {
@@ -1031,6 +1044,10 @@ function App({ relayConfig, remoteIdentity, onQuit, keyboardMode }: AppProps) {
       )
     : [];
 
+  const replayInfos = currentProject
+    ? localReplays.filter((replay) => replay.projectName === currentProject)
+    : [];
+
   const inboxItems = localInbox as InboxItem[];
   const inboxUnreadCount = localInboxUnreadCount;
 
@@ -1108,12 +1125,32 @@ function App({ relayConfig, remoteIdentity, onQuit, keyboardMode }: AppProps) {
     dispatch({ type: 'SET_VIEW', view: 'events' });
   }, [localWorkspaces, requestLocalEvents]);
 
+  const handleOpenReplay = useCallback(async ({ replayId }: { replayId: string; workspaceId: string }) => {
+    const replay = localReplays.find((item) => item.replayId === replayId);
+    if (!replay) {
+      flow.showMessage({
+        title: 'Replay Missing',
+        message: 'That replay is no longer available.',
+        variant: 'error',
+      });
+      return;
+    }
+
+    setActiveReplay(replay);
+    dispatch({ type: 'SET_VIEW', view: 'replay' });
+  }, [flow, localReplays]);
+
   // Spaces browser hook
   const spacesBrowserProps = useSpacesBrowser({
     workspaces: workspaceInfos,
     sessions: sessionInfos,
-    onRequestSessions: () => {}, // Sessions already loaded
+    replays: replayInfos,
+    onRequestSessions: () => {
+      void requestLocalSessions();
+      void requestLocalReplays();
+    },
     onAttachSession: handleAttachSession,
+    onOpenReplay: handleOpenReplay,
     onEditProcesses: handleEditProcesses,
     onManageBundleConfig: handleManageBundleConfig,
     onStartProcess: handleStartProcess,
@@ -1122,6 +1159,9 @@ function App({ relayConfig, remoteIdentity, onQuit, keyboardMode }: AppProps) {
     onProcessDisabled: handleProcessDisabled,
     onOpenEvents: handleOpenEvents,
     onRefresh: refreshWorkspaces,
+    onRefreshSessions: async () => {
+      await Promise.all([requestLocalSessions(), requestLocalReplays()]);
+    },
     onBack: () => dispatch({ type: 'SET_PANEL_FOCUS', focus: 'projects' }),
     onCreateWorkspace: handleNewWorkspaceFlow,
     machineName: currentProject || undefined,
@@ -1463,7 +1503,7 @@ function App({ relayConfig, remoteIdentity, onQuit, keyboardMode }: AppProps) {
     }
 
     // Don't handle keys when in terminal view (Terminal component handles input)
-    if (state.view === 'terminal') {
+    if (state.view === 'terminal' || state.view === 'replay') {
       return;
     }
 
@@ -1874,7 +1914,7 @@ function App({ relayConfig, remoteIdentity, onQuit, keyboardMode }: AppProps) {
           const selected = spacesBrowserProps.selectedItem;
           const workspaceId = selected?.type === 'workspace'
             ? selected.workspace.id
-            : selected && 'workspaceId' in selected
+            : selected && 'workspaceId' in selected && selected.type !== 'replay'
               ? selected.workspaceId
               : null;
           if (workspaceId) {
@@ -1888,6 +1928,13 @@ function App({ relayConfig, remoteIdentity, onQuit, keyboardMode }: AppProps) {
             if (workspace) {
               handleDeleteWorkspace(workspace);
             }
+          } else if (selected?.type === 'replay') {
+            if (selected.replay.dismissedAt) {
+              undismissReplayOffline(selected.replay.replayId);
+            } else {
+              dismissReplayOffline(selected.replay.replayId);
+            }
+            void requestLocalReplays(undefined, showDismissedReplays);
           }
         } else if (command === 'kill') {
           // Kill session or stop running process
@@ -1918,6 +1965,8 @@ function App({ relayConfig, remoteIdentity, onQuit, keyboardMode }: AppProps) {
               variant: 'error',
             });
           }
+        } else if (command === 'toggle-hidden') {
+          setShowDismissedReplays((value) => !value);
         } else if (command === 'back') {
           dispatch({ type: 'SET_PANEL_FOCUS', focus: 'projects' });
         }
@@ -2067,6 +2116,27 @@ function App({ relayConfig, remoteIdentity, onQuit, keyboardMode }: AppProps) {
         <EventsTui {...eventsProps} />
         <FlowTUI flow={flow} />
         <StatusBar hint="[Esc/q] Back  [j/k] Navigate" rightHint={keyboardModeHint} />
+      </Fragment>
+    );
+  }
+
+  if (state.view === 'replay' && activeReplay) {
+    return (
+      <Fragment>
+        <Toaster position="top-right" />
+        <ReplayTerminal
+          replay={activeReplay}
+          loadReplayAnsi={(replayId) => getReplayAnsiBufferOffline(replayId)}
+          onBack={() => {
+            setActiveReplay(null);
+            dispatch({ type: 'SET_VIEW', view: 'projects' });
+          }}
+          onDismiss={(replayId) => {
+            dismissReplayOffline(replayId);
+            void requestLocalReplays(undefined, showDismissedReplays);
+          }}
+        />
+        <FlowTUI flow={flow} />
       </Fragment>
     );
   }
@@ -2436,7 +2506,13 @@ function SettingsFlowModal({ flow }: { flow: SettingsFlowState }) {
 
 function getWorkspacesPanelHint(selectedItem: TreeItem | null | undefined): string {
   if (selectedItem?.type === 'session') {
-    return '[Tab] Switch  [Enter] Attach  [x] Kill  [b] Bundle  [n] New Workspace  [d] Delete  [,] Settings  [?] Help  [q] Quit';
+    return '[Tab] Switch  [Enter] Attach  [x] Kill  [b] Bundle  [n] New Workspace  [h] Hidden  [d] Delete  [,] Settings  [?] Help  [q] Quit';
+  }
+  if (selectedItem?.type === 'replay') {
+    return '[Tab] Switch  [Enter] Open  [d] Dismiss/Restore  [h] Hidden  [,] Settings  [?] Help  [q] Quit';
+  }
+  if (selectedItem?.type === 'replay-section' || selectedItem?.type === 'orphaned-replay-section') {
+    return '[Tab] Switch  [Enter] Expand  [h] Hidden  [,] Settings  [?] Help  [q] Quit';
   }
   if (selectedItem?.type === 'process') {
     if (selectedItem.status === 'running') {

--- a/src/app.tui.tsx
+++ b/src/app.tui.tsx
@@ -1147,7 +1147,7 @@ function App({ relayConfig, remoteIdentity, onQuit, keyboardMode }: AppProps) {
     replays: replayInfos,
     onRequestSessions: () => {
       void requestLocalSessions();
-      void requestLocalReplays();
+      void requestLocalReplays(undefined, showDismissedReplays);
     },
     onAttachSession: handleAttachSession,
     onOpenReplay: handleOpenReplay,
@@ -1160,7 +1160,10 @@ function App({ relayConfig, remoteIdentity, onQuit, keyboardMode }: AppProps) {
     onOpenEvents: handleOpenEvents,
     onRefresh: refreshWorkspaces,
     onRefreshSessions: async () => {
-      await Promise.all([requestLocalSessions(), requestLocalReplays()]);
+      await Promise.all([
+        requestLocalSessions(),
+        requestLocalReplays(undefined, showDismissedReplays),
+      ]);
     },
     onBack: () => dispatch({ type: 'SET_PANEL_FOCUS', focus: 'projects' }),
     onCreateWorkspace: handleNewWorkspaceFlow,

--- a/src/app.web.tsx
+++ b/src/app.web.tsx
@@ -654,7 +654,7 @@ export default function App() {
     });
   }, [terminal]);
 
-  const handleOpenReplay = useCallback(async ({ replayId }: { replayId: string; workspaceId: string }) => {
+  const handleOpenReplay = useCallback(async (replayId: string) => {
     const replay = terminal.replays.find((item) => item.replayId === replayId);
     if (!replay) {
       flow.showMessage({ title: 'Replay Missing', message: 'Could not find replay metadata.', variant: 'error' });
@@ -1202,26 +1202,6 @@ export default function App() {
     toggleReplayDismissed,
     toggleShowDismissedReplayFilter,
   ]);
-
-  useEffect(() => {
-    if (view !== 'replay' || !activeReplay) {
-      return;
-    }
-
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) {
-        return;
-      }
-
-      if (e.key === 'h') {
-        e.preventDefault();
-        toggleShowDismissedReplayFilter();
-      }
-    };
-
-    window.addEventListener('keydown', handleKeyDown);
-    return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [activeReplay, toggleShowDismissedReplayFilter, view]);
 
   // Attached terminal mode keyboard handler (Shift+Esc to detach)
   useEffect(() => {

--- a/src/app.web.tsx
+++ b/src/app.web.tsx
@@ -1166,15 +1166,7 @@ export default function App() {
             },
           });
         } else if (selected?.type === 'replay') {
-          if (!selected.replay.dismissedAt && selected.replay.status === 'running') {
-            flow.showMessage({
-              title: 'Replay Still Running',
-              message: 'Running replays cannot be dismissed.',
-              variant: 'info',
-            });
-          } else {
-            void toggleReplayDismissed(selected.replay);
-          }
+          void toggleReplayDismissed(selected.replay);
         }
       } else if (command === 'toggle-hidden') {
         toggleShowDismissedReplayFilter();

--- a/src/app.web.tsx
+++ b/src/app.web.tsx
@@ -102,7 +102,6 @@ export default function App() {
     useState<NotificationConfig | null>(null);
   const [isViewOnlySession, setIsViewOnlySession] = useState(false);
   const [activeReplay, setActiveReplay] = useState<ReplayInfo | null>(null);
-  const [activeReplayAnsi, setActiveReplayAnsi] = useState<Uint8Array | null>(null);
   const [showDismissedReplays, setShowDismissedReplays] = useState(false);
   const showDismissedReplaysRef = useRef(showDismissedReplays);
   const pendingProcessEditWorkspacesRef = useRef<unknown[] | null>(null);
@@ -662,48 +661,60 @@ export default function App() {
       return;
     }
 
-    try {
-      const ansi = await terminal.getReplayAnsi(replayId);
-      setActiveReplay(replay);
-      setActiveReplayAnsi(ansi);
-      setView('replay');
-    } catch (error) {
-      flow.showMessage({
-        title: 'Replay Failed',
-        message: error instanceof Error ? error.message : String(error),
-        variant: 'error',
-      });
-    }
+    setActiveReplay(replay);
+    setView('replay');
   }, [flow, terminal]);
 
-  const toggleReplayDismissed = useCallback(async (replay: ReplayInfo) => {
+  const toggleReplayDismissed = useCallback(async (replay: ReplayInfo): Promise<boolean> => {
     try {
+      if (!replay.dismissedAt && replay.status === 'running') {
+        flow.showMessage({
+          title: 'Replay Still Running',
+          message: 'Running replays cannot be dismissed.',
+          variant: 'info',
+        });
+        return false;
+      }
+
       if (replay.dismissedAt) {
         await terminal.undismissReplay(replay.replayId);
-        if (activeReplay?.replayId === replay.replayId) {
-          setActiveReplay({
-            ...activeReplay,
+        setActiveReplay((current) => current && current.replayId === replay.replayId
+          ? {
+            ...current,
             dismissedAt: undefined,
             dismissedBy: undefined,
-          });
-        }
+          }
+          : current);
+        return false;
       } else {
         await terminal.dismissReplay(replay.replayId);
-        if (activeReplay?.replayId === replay.replayId) {
-          setActiveReplay(null);
-          setActiveReplayAnsi(null);
-          setView('terminal');
-        }
+        setActiveReplay((current) => current && current.replayId === replay.replayId
+          ? {
+            ...current,
+            dismissedAt: Date.now(),
+          }
+          : current);
+        return true;
       }
-      refreshReplayList();
     } catch (error) {
       flow.showMessage({
         title: replay.dismissedAt ? 'Restore Failed' : 'Dismiss Failed',
         message: error instanceof Error ? error.message : String(error),
         variant: 'error',
       });
+      return false;
+    } finally {
+      refreshReplayList();
     }
   }, [activeReplay?.replayId, flow, refreshReplayList, terminal]);
+
+  const loadReplayAnsi = useCallback((replayId: string, target?: { atMs?: number; atSeq?: number }) => {
+    return terminal.getReplayAnsi(replayId, target);
+  }, [terminal]);
+
+  const loadReplayTimeline = useCallback((replayId: string) => {
+    return terminal.getReplayTimeline(replayId);
+  }, [terminal]);
 
   // Spaces browser hook
   const spacesBrowserProps = useSpacesBrowser({
@@ -1155,7 +1166,15 @@ export default function App() {
             },
           });
         } else if (selected?.type === 'replay') {
-          void toggleReplayDismissed(selected.replay);
+          if (!selected.replay.dismissedAt && selected.replay.status === 'running') {
+            flow.showMessage({
+              title: 'Replay Still Running',
+              message: 'Running replays cannot be dismissed.',
+              variant: 'info',
+            });
+          } else {
+            void toggleReplayDismissed(selected.replay);
+          }
         }
       } else if (command === 'toggle-hidden') {
         toggleShowDismissedReplayFilter();
@@ -1194,15 +1213,7 @@ export default function App() {
         return;
       }
 
-      if (e.key === 'Escape' || e.key === 'q') {
-        e.preventDefault();
-        setView('terminal');
-        setActiveReplay(null);
-        setActiveReplayAnsi(null);
-      } else if (e.key === 'd') {
-        e.preventDefault();
-        void toggleReplayDismissed(activeReplay);
-      } else if (e.key === 'h') {
+      if (e.key === 'h') {
         e.preventDefault();
         toggleShowDismissedReplayFilter();
       }
@@ -1210,7 +1221,7 @@ export default function App() {
 
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [activeReplay, toggleReplayDismissed, toggleShowDismissedReplayFilter, view]);
+  }, [activeReplay, toggleShowDismissedReplayFilter, view]);
 
   // Attached terminal mode keyboard handler (Shift+Esc to detach)
   useEffect(() => {
@@ -1341,42 +1352,22 @@ export default function App() {
   if (view === 'replay' && activeReplay) {
     return (
       <>
-        <div className="w-screen h-screen flex flex-col bg-[#0d1117] overflow-hidden">
-          <div className="bg-[#161b22] px-4 py-2 flex items-center justify-between border-b border-[#30363d] min-h-[52px] gap-2 flex-shrink-0">
-            <div className="flex items-center gap-2 sm:gap-4 min-w-0 flex-1">
-              <button
-                onClick={() => {
-                  setView('terminal');
-                  setActiveReplay(null);
-                  setActiveReplayAnsi(null);
-                }}
-                className="text-sm text-[#8b949e] hover:text-[#e6edf3] py-2 pr-2 -ml-2 min-h-[44px] flex items-center flex-shrink-0"
-              >
-                ← <span className="hidden sm:inline ml-1">Workspaces</span>
-              </button>
-              <div className="text-sm text-[#8b949e] truncate">
-                <span className={activeReplay.status === 'crashed' ? 'text-[#ff7b72]' : 'text-[#79c0ff]'}>↺</span>{' '}
-                <span className="hidden sm:inline">{selectedMachine?.label || selectedMachine?.machineId}</span>
-                <span className="hidden sm:inline text-[#6e7681] mx-1">/</span>
-                <span className="text-[#e6edf3]">{activeReplay.sessionName}</span>
-                {activeReplay.workspaceName && (
-                  <span className="text-[#6e7681]"> · {activeReplay.workspaceName}</span>
-                )}
-              </div>
-            </div>
-            <div className="flex items-center gap-2 flex-shrink-0">
-              <button
-                onClick={() => void toggleReplayDismissed(activeReplay)}
-                className="px-3 py-2 text-sm bg-[#21262d] hover:bg-[#30363d] rounded text-[#e6edf3] min-h-[44px] border border-[#30363d]"
-              >
-                {activeReplay.dismissedAt ? 'Restore' : 'Dismiss'}
-              </button>
-            </div>
-          </div>
-          <div className="flex-1 min-h-0">
-            <ReplayTerminalWeb ansi={activeReplayAnsi} />
-          </div>
-        </div>
+        <ReplayTerminalWeb
+          replay={activeReplay}
+          machineLabel={selectedMachine?.label || selectedMachine?.machineId}
+          loadReplayAnsi={loadReplayAnsi}
+          loadReplayTimeline={loadReplayTimeline}
+          onBack={() => {
+            setView('terminal');
+            setActiveReplay(null);
+          }}
+          onDismiss={activeReplay.status === 'running'
+            ? undefined
+            : (replayId) => {
+              const replay = terminal.replays.find((item) => item.replayId === replayId) ?? activeReplay;
+              return toggleReplayDismissed(replay);
+            }}
+        />
         <FlowWeb flow={flow} />
         <Toaster theme="dark" position="top-right" richColors />
       </>

--- a/src/app.web.tsx
+++ b/src/app.web.tsx
@@ -643,8 +643,15 @@ export default function App() {
   }, [terminal, showDismissedReplays]);
 
   const toggleShowDismissedReplayFilter = useCallback(() => {
-    setShowDismissedReplays((value) => !value);
-  }, []);
+    setShowDismissedReplays((value) => {
+      const next = !value;
+      const isBrowsingView = view === 'terminal' && terminal.status === 'established' && terminal.mode === 'browsing';
+      if (!isBrowsingView) {
+        terminal.requestReplays(undefined, next);
+      }
+      return next;
+    });
+  }, [terminal, view]);
 
   const handleOpenReplay = useCallback(async ({ replayId }: { replayId: string; workspaceId: string }) => {
     const replay = terminal.replays.find((item) => item.replayId === replayId);

--- a/src/app.web.tsx
+++ b/src/app.web.tsx
@@ -642,6 +642,14 @@ export default function App() {
     terminal.requestReplays(undefined, showDismissedReplays);
   }, [terminal, showDismissedReplays]);
 
+  const toggleShowDismissedReplayFilter = useCallback(() => {
+    setShowDismissedReplays((value) => {
+      const next = !value;
+      terminal.requestReplays(undefined, next);
+      return next;
+    });
+  }, [terminal]);
+
   const handleOpenReplay = useCallback(async ({ replayId }: { replayId: string; workspaceId: string }) => {
     const replay = terminal.replays.find((item) => item.replayId === replayId);
     if (!replay) {
@@ -1130,7 +1138,7 @@ export default function App() {
           void toggleReplayDismissed(selected.replay);
         }
       } else if (command === 'toggle-hidden') {
-        setShowDismissedReplays((value) => !value);
+        toggleShowDismissedReplayFilter();
       } else if (command === 'open-inbox') {
         terminal.requestInbox();
         setShowInbox(true);
@@ -1175,13 +1183,13 @@ export default function App() {
         void toggleReplayDismissed(activeReplay);
       } else if (e.key === 'h') {
         e.preventDefault();
-        setShowDismissedReplays((value) => !value);
+        toggleShowDismissedReplayFilter();
       }
     };
 
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [activeReplay, toggleReplayDismissed, view]);
+  }, [activeReplay, toggleReplayDismissed, toggleShowDismissedReplayFilter, view]);
 
   // Attached terminal mode keyboard handler (Shift+Esc to detach)
   useEffect(() => {
@@ -1436,7 +1444,7 @@ export default function App() {
                 Replay history: <span className="text-[#e6edf3]">{showDismissedReplays ? 'showing dismissed' : 'hiding dismissed'}</span>
               </div>
               <button
-                onClick={() => setShowDismissedReplays((value) => !value)}
+                onClick={toggleShowDismissedReplayFilter}
                 className="px-3 py-2 text-xs bg-[#21262d] hover:bg-[#30363d] rounded text-[#e6edf3] min-h-[36px] border border-[#30363d]"
               >
                 {showDismissedReplays ? 'Hide Dismissed' : 'Show Dismissed'}

--- a/src/app.web.tsx
+++ b/src/app.web.tsx
@@ -675,6 +675,13 @@ export default function App() {
     try {
       if (replay.dismissedAt) {
         await terminal.undismissReplay(replay.replayId);
+        if (activeReplay?.replayId === replay.replayId) {
+          setActiveReplay({
+            ...activeReplay,
+            dismissedAt: undefined,
+            dismissedBy: undefined,
+          });
+        }
       } else {
         await terminal.dismissReplay(replay.replayId);
         if (activeReplay?.replayId === replay.replayId) {

--- a/src/app.web.tsx
+++ b/src/app.web.tsx
@@ -643,12 +643,8 @@ export default function App() {
   }, [terminal, showDismissedReplays]);
 
   const toggleShowDismissedReplayFilter = useCallback(() => {
-    setShowDismissedReplays((value) => {
-      const next = !value;
-      terminal.requestReplays(undefined, next);
-      return next;
-    });
-  }, [terminal]);
+    setShowDismissedReplays((value) => !value);
+  }, []);
 
   const handleOpenReplay = useCallback(async ({ replayId }: { replayId: string; workspaceId: string }) => {
     const replay = terminal.replays.find((item) => item.replayId === replayId);
@@ -919,7 +915,6 @@ export default function App() {
       terminal.requestProjects();
       terminal.requestWorkspaces();
       terminal.requestSessions();
-      terminal.requestReplays(undefined, showDismissedReplays);
       terminal.requestNotificationConfig();
     }
   }, [
@@ -929,8 +924,18 @@ export default function App() {
     terminal.requestProjects,
     terminal.requestWorkspaces,
     terminal.requestSessions,
-    terminal.requestReplays,
     terminal.requestNotificationConfig,
+  ]);
+
+  useEffect(() => {
+    if (view === "terminal" && terminal.status === "established" && terminal.mode === "browsing") {
+      terminal.requestReplays(undefined, showDismissedReplays);
+    }
+  }, [
+    view,
+    terminal.status,
+    terminal.mode,
+    terminal.requestReplays,
     showDismissedReplays,
   ]);
 
@@ -1168,6 +1173,7 @@ export default function App() {
     handleManageBundleConfig,
     deleteWorkspaceWithPrompt,
     toggleReplayDismissed,
+    toggleShowDismissedReplayFilter,
   ]);
 
   useEffect(() => {

--- a/src/app.web.tsx
+++ b/src/app.web.tsx
@@ -104,6 +104,7 @@ export default function App() {
   const [activeReplay, setActiveReplay] = useState<ReplayInfo | null>(null);
   const [activeReplayAnsi, setActiveReplayAnsi] = useState<Uint8Array | null>(null);
   const [showDismissedReplays, setShowDismissedReplays] = useState(false);
+  const showDismissedReplaysRef = useRef(showDismissedReplays);
   const pendingProcessEditWorkspacesRef = useRef<unknown[] | null>(null);
   const pendingProcessEditValidationArmedRef = useRef(false);
   const eventsKeyboardStateRef = useRef<{
@@ -642,16 +643,17 @@ export default function App() {
     terminal.requestReplays(undefined, showDismissedReplays);
   }, [terminal, showDismissedReplays]);
 
+  useEffect(() => {
+    showDismissedReplaysRef.current = showDismissedReplays;
+  }, [showDismissedReplays]);
+
   const toggleShowDismissedReplayFilter = useCallback(() => {
     setShowDismissedReplays((value) => {
       const next = !value;
-      const isBrowsingView = view === 'terminal' && terminal.status === 'established' && terminal.mode === 'browsing';
-      if (!isBrowsingView) {
-        terminal.requestReplays(undefined, next);
-      }
+      terminal.requestReplays(undefined, next);
       return next;
     });
-  }, [terminal, view]);
+  }, [terminal]);
 
   const handleOpenReplay = useCallback(async ({ replayId }: { replayId: string; workspaceId: string }) => {
     const replay = terminal.replays.find((item) => item.replayId === replayId);
@@ -936,14 +938,13 @@ export default function App() {
 
   useEffect(() => {
     if (view === "terminal" && terminal.status === "established" && terminal.mode === "browsing") {
-      terminal.requestReplays(undefined, showDismissedReplays);
+      terminal.requestReplays(undefined, showDismissedReplaysRef.current);
     }
   }, [
     view,
     terminal.status,
     terminal.mode,
     terminal.requestReplays,
-    showDismissedReplays,
   ]);
 
   // Reset view-only state when detached

--- a/src/app.web.tsx
+++ b/src/app.web.tsx
@@ -1,6 +1,7 @@
 /** @jsxImportSource react */
 import { useState, useEffect, useRef, useCallback, useMemo } from "react";
 import { SessionTerminal, type SessionTerminalHandle } from "./components/SessionTerminal.web";
+import { ReplayTerminalWeb } from './components/ReplayTerminal.web';
 import { ScriptTerminal } from "./components/ScriptTerminal.web";
 import {
   TerminalControls,
@@ -34,6 +35,7 @@ import {
   useFlow,
   getDefaultShortcuts,
   type MachineInfo,
+  type ReplayInfo,
   type WorkspaceInfo,
 } from "./components/index.js";
 import { MachineListWeb } from "./components/MachineList.web.js";
@@ -58,7 +60,7 @@ import {
   resolveSessionBrowserCommand,
 } from './app/input/sessionCommands.js';
 
-type View = "machines" | "terminal" | "review";
+type View = "machines" | "terminal" | "review" | 'replay';
 
 const PAGE_UP = '\x1b[5~';
 const PAGE_DOWN = '\x1b[6~';
@@ -99,6 +101,9 @@ export default function App() {
   const [localNotificationConfig, setLocalNotificationConfig] =
     useState<NotificationConfig | null>(null);
   const [isViewOnlySession, setIsViewOnlySession] = useState(false);
+  const [activeReplay, setActiveReplay] = useState<ReplayInfo | null>(null);
+  const [activeReplayAnsi, setActiveReplayAnsi] = useState<Uint8Array | null>(null);
+  const [showDismissedReplays, setShowDismissedReplays] = useState(false);
   const pendingProcessEditWorkspacesRef = useRef<unknown[] | null>(null);
   const pendingProcessEditValidationArmedRef = useRef(false);
   const eventsKeyboardStateRef = useRef<{
@@ -179,6 +184,7 @@ export default function App() {
     onApplied: async () => {
       terminal.requestWorkspaces();
       terminal.requestSessions();
+      terminal.requestReplays(undefined, showDismissedReplays);
     },
   });
 
@@ -243,6 +249,7 @@ export default function App() {
       setShowScriptTerminal(false);
       terminal.requestWorkspaces();
       terminal.requestSessions();
+      terminal.requestReplays(undefined, showDismissedReplays);
     },
     onDeleteCancelled: async () => {
       suppressDeleteScriptFailureModalRef.current = false;
@@ -624,12 +631,68 @@ export default function App() {
     [filteredWorkspaceIds, selectedProjectName, terminal.sessions]
   );
 
+  const filteredReplays = useMemo(
+    () => selectedProjectName
+      ? terminal.replays.filter((replay) => replay.projectName === selectedProjectName)
+      : [],
+    [selectedProjectName, terminal.replays]
+  );
+
+  const refreshReplayList = useCallback(() => {
+    terminal.requestReplays(undefined, showDismissedReplays);
+  }, [terminal, showDismissedReplays]);
+
+  const handleOpenReplay = useCallback(async ({ replayId }: { replayId: string; workspaceId: string }) => {
+    const replay = terminal.replays.find((item) => item.replayId === replayId);
+    if (!replay) {
+      flow.showMessage({ title: 'Replay Missing', message: 'Could not find replay metadata.', variant: 'error' });
+      return;
+    }
+
+    try {
+      const ansi = await terminal.getReplayAnsi(replayId);
+      setActiveReplay(replay);
+      setActiveReplayAnsi(ansi);
+      setView('replay');
+    } catch (error) {
+      flow.showMessage({
+        title: 'Replay Failed',
+        message: error instanceof Error ? error.message : String(error),
+        variant: 'error',
+      });
+    }
+  }, [flow, terminal]);
+
+  const toggleReplayDismissed = useCallback(async (replay: ReplayInfo) => {
+    try {
+      if (replay.dismissedAt) {
+        await terminal.undismissReplay(replay.replayId);
+      } else {
+        await terminal.dismissReplay(replay.replayId);
+        if (activeReplay?.replayId === replay.replayId) {
+          setActiveReplay(null);
+          setActiveReplayAnsi(null);
+          setView('terminal');
+        }
+      }
+      refreshReplayList();
+    } catch (error) {
+      flow.showMessage({
+        title: replay.dismissedAt ? 'Restore Failed' : 'Dismiss Failed',
+        message: error instanceof Error ? error.message : String(error),
+        variant: 'error',
+      });
+    }
+  }, [activeReplay?.replayId, flow, refreshReplayList, terminal]);
+
   // Spaces browser hook
   const spacesBrowserProps = useSpacesBrowser({
     workspaces: filteredWorkspaces,
     sessions: filteredSessions,
+    replays: filteredReplays,
     onRequestSessions: () => terminal.requestSessions(),
     onAttachSession: handleAttachSession,
+    onOpenReplay: handleOpenReplay,
     onEditProcesses: handleEditProcesses,
     onManageBundleConfig: handleManageBundleConfig,
     onStartProcess: (params) => processActions.handleStartProcess(params),
@@ -645,8 +708,8 @@ export default function App() {
         terminal.requestEvents(workspace.path, undefined, undefined, undefined);
       }
     },
-    onRefresh: terminal.requestWorkspaces,
-    onRefreshSessions: () => terminal.requestSessions(),
+    onRefresh: () => { terminal.requestWorkspaces(); refreshReplayList(); },
+    onRefreshSessions: () => { terminal.requestSessions(); refreshReplayList(); },
     onBack: handleBackToMachines,
     machineName: selectedProjectName
       ? `${selectedProjectName} - ${selectedMachine?.label || selectedMachine?.machineId || 'machine'}`
@@ -841,6 +904,7 @@ export default function App() {
       terminal.requestProjects();
       terminal.requestWorkspaces();
       terminal.requestSessions();
+      terminal.requestReplays(undefined, showDismissedReplays);
       terminal.requestNotificationConfig();
     }
   }, [
@@ -850,7 +914,9 @@ export default function App() {
     terminal.requestProjects,
     terminal.requestWorkspaces,
     terminal.requestSessions,
+    terminal.requestReplays,
     terminal.requestNotificationConfig,
+    showDismissedReplays,
   ]);
 
   // Reset view-only state when detached
@@ -1003,7 +1069,7 @@ export default function App() {
         const selected = spacesBrowserProps.selectedItem;
         const workspaceId = selected?.type === 'workspace'
           ? selected.workspace.id
-          : selected && 'workspaceId' in selected
+          : selected && 'workspaceId' in selected && selected.type !== 'replay'
             ? selected.workspaceId
             : null;
         if (workspaceId) {
@@ -1060,7 +1126,11 @@ export default function App() {
               });
             },
           });
+        } else if (selected?.type === 'replay') {
+          void toggleReplayDismissed(selected.replay);
         }
+      } else if (command === 'toggle-hidden') {
+        setShowDismissedReplays((value) => !value);
       } else if (command === 'open-inbox') {
         terminal.requestInbox();
         setShowInbox(true);
@@ -1082,7 +1152,36 @@ export default function App() {
     lifecycleController,
     handleManageBundleConfig,
     deleteWorkspaceWithPrompt,
+    toggleReplayDismissed,
   ]);
+
+  useEffect(() => {
+    if (view !== 'replay' || !activeReplay) {
+      return;
+    }
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) {
+        return;
+      }
+
+      if (e.key === 'Escape' || e.key === 'q') {
+        e.preventDefault();
+        setView('terminal');
+        setActiveReplay(null);
+        setActiveReplayAnsi(null);
+      } else if (e.key === 'd') {
+        e.preventDefault();
+        void toggleReplayDismissed(activeReplay);
+      } else if (e.key === 'h') {
+        e.preventDefault();
+        setShowDismissedReplays((value) => !value);
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [activeReplay, toggleReplayDismissed, view]);
 
   // Attached terminal mode keyboard handler (Shift+Esc to detach)
   useEffect(() => {
@@ -1210,6 +1309,51 @@ export default function App() {
     );
   }
 
+  if (view === 'replay' && activeReplay) {
+    return (
+      <>
+        <div className="w-screen h-screen flex flex-col bg-[#0d1117] overflow-hidden">
+          <div className="bg-[#161b22] px-4 py-2 flex items-center justify-between border-b border-[#30363d] min-h-[52px] gap-2 flex-shrink-0">
+            <div className="flex items-center gap-2 sm:gap-4 min-w-0 flex-1">
+              <button
+                onClick={() => {
+                  setView('terminal');
+                  setActiveReplay(null);
+                  setActiveReplayAnsi(null);
+                }}
+                className="text-sm text-[#8b949e] hover:text-[#e6edf3] py-2 pr-2 -ml-2 min-h-[44px] flex items-center flex-shrink-0"
+              >
+                ← <span className="hidden sm:inline ml-1">Workspaces</span>
+              </button>
+              <div className="text-sm text-[#8b949e] truncate">
+                <span className={activeReplay.status === 'crashed' ? 'text-[#ff7b72]' : 'text-[#79c0ff]'}>↺</span>{' '}
+                <span className="hidden sm:inline">{selectedMachine?.label || selectedMachine?.machineId}</span>
+                <span className="hidden sm:inline text-[#6e7681] mx-1">/</span>
+                <span className="text-[#e6edf3]">{activeReplay.sessionName}</span>
+                {activeReplay.workspaceName && (
+                  <span className="text-[#6e7681]"> · {activeReplay.workspaceName}</span>
+                )}
+              </div>
+            </div>
+            <div className="flex items-center gap-2 flex-shrink-0">
+              <button
+                onClick={() => void toggleReplayDismissed(activeReplay)}
+                className="px-3 py-2 text-sm bg-[#21262d] hover:bg-[#30363d] rounded text-[#e6edf3] min-h-[44px] border border-[#30363d]"
+              >
+                {activeReplay.dismissedAt ? 'Restore' : 'Dismiss'}
+              </button>
+            </div>
+          </div>
+          <div className="flex-1 min-h-0">
+            <ReplayTerminalWeb ansi={activeReplayAnsi} />
+          </div>
+        </div>
+        <FlowWeb flow={flow} />
+        <Toaster theme="dark" position="top-right" richColors />
+      </>
+    );
+  }
+
   // ========== Spaces Browser View (browsing mode) ==========
   if (
     view === 'terminal' &&
@@ -1286,7 +1430,19 @@ export default function App() {
               title={selectedMachine?.label || selectedMachine?.machineId || 'Projects'}
             />
           </div>
-          <div className="flex-1 min-h-0">
+          <div className="flex-1 min-h-0 flex flex-col">
+            <div className="px-3 py-2 border-b border-[#30363d] bg-[#11161d] flex items-center justify-between gap-2">
+              <div className="text-xs text-[#8b949e]">
+                Replay history: <span className="text-[#e6edf3]">{showDismissedReplays ? 'showing dismissed' : 'hiding dismissed'}</span>
+              </div>
+              <button
+                onClick={() => setShowDismissedReplays((value) => !value)}
+                className="px-3 py-2 text-xs bg-[#21262d] hover:bg-[#30363d] rounded text-[#e6edf3] min-h-[36px] border border-[#30363d]"
+              >
+                {showDismissedReplays ? 'Hide Dismissed' : 'Show Dismissed'}
+              </button>
+            </div>
+            <div className="flex-1 min-h-0">
             <SpacesBrowserWeb
               {...spacesBrowserProps}
               embedded={true}
@@ -1313,6 +1469,7 @@ export default function App() {
               onDeleteWorkspace={handleDeleteWorkspace}
               onDeleteSession={handleDeleteSession}
             />
+            </div>
           </div>
         </div>
         <FlowWeb flow={flow} />

--- a/src/app/input/sessionCommands.ts
+++ b/src/app/input/sessionCommands.ts
@@ -20,6 +20,7 @@ export type SessionUiCommand =
   | 'open-inbox'
   | 'bundle'
   | 'copy'
+  | 'toggle-hidden'
 
 function normalizeCommandKey(input: SessionCommandKeyInput): string | null {
   const key = input.key?.toLowerCase()
@@ -90,6 +91,7 @@ export function resolveSessionBrowserCommand(input: SessionCommandKeyInput): Ses
   if (key === '?') return 'help'
   if (key === 'x') return 'kill'
   if (key === 'd') return 'delete'
+  if (key === 'h') return 'toggle-hidden'
   if (key === 'i') return 'open-inbox'
   if (key === 'b') return 'bundle'
   return null

--- a/src/cli/commands/machine.ts
+++ b/src/cli/commands/machine.ts
@@ -9,6 +9,7 @@
 import type { Command } from 'commander';
 import { withErrorHandler } from '../error.js';
 import { configureTmuxSandbox } from '../tmux-sandbox.js';
+import { getTmuxLiteSandbox } from '../../lib/tmux-lite/protocol.js';
 
 export function registerMachineCommands(parent: Command): void {
   const cmd = parent
@@ -170,7 +171,7 @@ function registerMachineTmuxCommands(machine: Command): void {
     .option('--all', 'Include dismissed replays')
     .action(withErrorHandler(async (options) => {
       const { listTmuxReplays } = await import('../../commands/tmux.js');
-      listTmuxReplays({ all: options.all });
+      listTmuxReplays({ all: options.all, sandbox: getTmuxLiteSandbox() });
     }, { skipSetupCheck: true }));
 
   replay
@@ -183,6 +184,7 @@ function registerMachineTmuxCommands(machine: Command): void {
     .action(withErrorHandler(async (replayRef, options) => {
       const { showTmuxReplayText } = await import('../../commands/tmux.js');
       await showTmuxReplayText(replayRef, {
+        sandbox: getTmuxLiteSandbox(),
         atMs: options.atMs,
         scrollbackLines: options.scrollbackLines,
         includeScrollback: options.includeScrollback,
@@ -200,6 +202,7 @@ function registerMachineTmuxCommands(machine: Command): void {
     .action(withErrorHandler(async (replayRef, options) => {
       const { screenshotTmuxReplay } = await import('../../commands/tmux.js');
       await screenshotTmuxReplay(replayRef, {
+        sandbox: getTmuxLiteSandbox(),
         output: options.output,
         atMs: options.atMs,
         scrollbackLines: options.scrollbackLines,
@@ -213,7 +216,7 @@ function registerMachineTmuxCommands(machine: Command): void {
     .argument('<replay>', 'Replay ID, replay ID prefix, session ID, or session name')
     .action(withErrorHandler(async (replayRef) => {
       const { dismissTmuxReplay } = await import('../../commands/tmux.js');
-      dismissTmuxReplay(replayRef);
+      dismissTmuxReplay(replayRef, { sandbox: getTmuxLiteSandbox() });
     }, { skipSetupCheck: true }));
 
   replay
@@ -222,7 +225,7 @@ function registerMachineTmuxCommands(machine: Command): void {
     .argument('<replay>', 'Replay ID, replay ID prefix, session ID, or session name')
     .action(withErrorHandler(async (replayRef) => {
       const { undismissTmuxReplay } = await import('../../commands/tmux.js');
-      undismissTmuxReplay(replayRef);
+      undismissTmuxReplay(replayRef, { sandbox: getTmuxLiteSandbox() });
     }, { skipSetupCheck: true }));
 
   replay
@@ -231,6 +234,6 @@ function registerMachineTmuxCommands(machine: Command): void {
     .argument('<replay>', 'Replay ID, replay ID prefix, session ID, or session name')
     .action(withErrorHandler(async (replayRef) => {
       const { deleteTmuxReplay } = await import('../../commands/tmux.js');
-      deleteTmuxReplay(replayRef);
+      deleteTmuxReplay(replayRef, { sandbox: getTmuxLiteSandbox() });
     }, { skipSetupCheck: true }));
 }

--- a/src/cli/commands/machine.ts
+++ b/src/cli/commands/machine.ts
@@ -34,7 +34,7 @@ export function registerMachineCommands(parent: Command): void {
     }));
 
   // --------------------------------------------------------------------------
-  // gssh machine tmux [start|stop|status|list|new|attach|kill]
+  // gssh machine tmux [start|stop|status|list|new|attach|kill|replay]
   // --------------------------------------------------------------------------
   registerMachineTmuxCommands(cmd);
 }
@@ -157,5 +157,80 @@ function registerMachineTmuxCommands(machine: Command): void {
     .action(withErrorHandler(async (id) => {
       const { killTmux } = await import('../../commands/tmux.js');
       await killTmux(id);
+    }, { skipSetupCheck: true }));
+
+  const replay = tmux
+    .command('replay')
+    .description('Inspect saved tmux-lite replays');
+  configureTmuxSandbox(replay);
+
+  replay
+    .command('list')
+    .description('List captured replays')
+    .option('--all', 'Include dismissed replays')
+    .action(withErrorHandler(async (options) => {
+      const { listTmuxReplays } = await import('../../commands/tmux.js');
+      listTmuxReplays({ all: options.all });
+    }, { skipSetupCheck: true }));
+
+  replay
+    .command('text')
+    .description('Print replay terminal text')
+    .argument('<replay>', 'Replay ID, replay ID prefix, session ID, or session name')
+    .option('--at-ms <number>', 'Replay time offset in milliseconds', (value: string) => parseInt(value, 10))
+    .option('--scrollback-lines <number>', 'Scrollback lines to include', (value: string) => parseInt(value, 10))
+    .option('--include-scrollback', 'Include scrollback lines before the visible screen')
+    .action(withErrorHandler(async (replayRef, options) => {
+      const { showTmuxReplayText } = await import('../../commands/tmux.js');
+      await showTmuxReplayText(replayRef, {
+        atMs: options.atMs,
+        scrollbackLines: options.scrollbackLines,
+        includeScrollback: options.includeScrollback,
+      });
+    }, { skipSetupCheck: true }));
+
+  replay
+    .command('screenshot')
+    .description('Render a replay frame to PNG')
+    .argument('<replay>', 'Replay ID, replay ID prefix, session ID, or session name')
+    .option('--at-ms <number>', 'Replay time offset in milliseconds', (value: string) => parseInt(value, 10))
+    .option('--scrollback-lines <number>', 'Scrollback lines to include', (value: string) => parseInt(value, 10))
+    .option('--include-scrollback', 'Include scrollback lines before the visible screen')
+    .option('-o, --output <path>', 'Write PNG to this path')
+    .action(withErrorHandler(async (replayRef, options) => {
+      const { screenshotTmuxReplay } = await import('../../commands/tmux.js');
+      await screenshotTmuxReplay(replayRef, {
+        output: options.output,
+        atMs: options.atMs,
+        scrollbackLines: options.scrollbackLines,
+        includeScrollback: options.includeScrollback,
+      });
+    }, { skipSetupCheck: true }));
+
+  replay
+    .command('dismiss')
+    .description('Soft-hide a replay from default listing')
+    .argument('<replay>', 'Replay ID, replay ID prefix, session ID, or session name')
+    .action(withErrorHandler(async (replayRef) => {
+      const { dismissTmuxReplay } = await import('../../commands/tmux.js');
+      dismissTmuxReplay(replayRef);
+    }, { skipSetupCheck: true }));
+
+  replay
+    .command('undismiss')
+    .description('Restore a dismissed replay')
+    .argument('<replay>', 'Replay ID, replay ID prefix, session ID, or session name')
+    .action(withErrorHandler(async (replayRef) => {
+      const { undismissTmuxReplay } = await import('../../commands/tmux.js');
+      undismissTmuxReplay(replayRef);
+    }, { skipSetupCheck: true }));
+
+  replay
+    .command('delete')
+    .description('Permanently delete a replay from disk')
+    .argument('<replay>', 'Replay ID, replay ID prefix, session ID, or session name')
+    .action(withErrorHandler(async (replayRef) => {
+      const { deleteTmuxReplay } = await import('../../commands/tmux.js');
+      deleteTmuxReplay(replayRef);
     }, { skipSetupCheck: true }));
 }

--- a/src/cli/commands/machine.ts
+++ b/src/cli/commands/machine.ts
@@ -236,4 +236,22 @@ function registerMachineTmuxCommands(machine: Command): void {
       const { deleteTmuxReplay } = await import('../../commands/tmux.js');
       deleteTmuxReplay(replayRef, { sandbox: getTmuxLiteSandbox() });
     }, { skipSetupCheck: true }));
+
+  replay
+    .command('usage')
+    .description('Show replay storage disk usage')
+    .option('--json', 'Output as JSON')
+    .option('--top <n>', 'Show only the N largest replays', (v: string) => parseInt(v, 10))
+    .action(withErrorHandler(async (options) => {
+      const { showTmuxReplayUsage } = await import('../../commands/tmux.js');
+      showTmuxReplayUsage({ sandbox: getTmuxLiteSandbox(), json: options.json, top: options.top });
+    }, { skipSetupCheck: true }));
+
+  replay
+    .command('prune')
+    .description('Delete expired dismissed replays now')
+    .action(withErrorHandler(async () => {
+      const { pruneTmuxReplays } = await import('../../commands/tmux.js');
+      pruneTmuxReplays({ sandbox: getTmuxLiteSandbox() });
+    }, { skipSetupCheck: true }));
 }

--- a/src/commands/remove.ts
+++ b/src/commands/remove.ts
@@ -155,6 +155,10 @@ export async function removeWorkspace(
 		logger.info(`Killed ${result.sessionsKilled} active session(s)`)
 	}
 
+	if ((result.replaysDeleted ?? 0) > 0) {
+		logger.info(`Deleted ${result.replaysDeleted} replay artifact(s)`)
+	}
+
 	if (result.branchDeleted) {
 		logger.success(`Deleted branch: ${result.branch}`)
 	} else if (result.branch && !options.keepBranch) {
@@ -267,6 +271,10 @@ export async function removeProject(
 
 	if (result.sessionsKilled > 0) {
 		logger.info(`Killed ${result.sessionsKilled} active session(s)`)
+	}
+
+	if ((result.replaysDeleted ?? 0) > 0) {
+		logger.info(`Deleted ${result.replaysDeleted} replay artifact(s)`)
 	}
 
 	if (result.workspacesDeleted > 0) {

--- a/src/commands/tmux.ts
+++ b/src/commands/tmux.ts
@@ -39,6 +39,7 @@ import {
   screenshotReplayOffline,
   dismissReplayOffline,
   undismissReplayOffline,
+  deleteReplayOffline,
   type ReplayInfo,
 } from '../lib/tmux-lite/replay/service.js';
 
@@ -455,7 +456,6 @@ export function undismissTmuxReplay(ref: string, options: TmuxCommandOptions = {
 export function deleteTmuxReplay(ref: string, options: TmuxCommandOptions = {}): void {
   applyTmuxSandbox(options);
   const replay = resolveReplayOffline(ref, { includeDismissed: true });
-  const { deleteReplayOffline } = require('../lib/tmux-lite/replay/service.js') as typeof import('../lib/tmux-lite/replay/service.js');
   deleteReplayOffline(replay.replayId);
   logger.success(`Replay deleted: ${replay.sessionName || replay.replayId}`);
 }

--- a/src/commands/tmux.ts
+++ b/src/commands/tmux.ts
@@ -432,6 +432,7 @@ export async function screenshotTmuxReplay(
   const writtenPath = await screenshotReplayOffline(replay.replayId, {
     outputPath,
     atMs: options.atMs,
+    scrollbackLines: options.scrollbackLines,
     includeScrollback: options.includeScrollback,
   });
 

--- a/src/commands/tmux.ts
+++ b/src/commands/tmux.ts
@@ -31,6 +31,26 @@ import {
   PACKAGE_VERSION,
   type Session,
 } from "../lib/tmux-lite/cli.js";
+import { applyTmuxLiteSandboxEnvironment } from '../lib/tmux-lite/protocol.js';
+import {
+  listReplaysOffline,
+  resolveReplayOffline,
+  getReplayTextOffline,
+  screenshotReplayOffline,
+  dismissReplayOffline,
+  undismissReplayOffline,
+  type ReplayInfo,
+} from '../lib/tmux-lite/replay/service.js';
+
+interface TmuxCommandOptions {
+  sandbox?: string;
+}
+
+function applyTmuxSandbox(options?: TmuxCommandOptions): void {
+  if (options?.sandbox) {
+    applyTmuxLiteSandboxEnvironment(options.sandbox);
+  }
+}
 
 /**
  * Format uptime in human-readable format
@@ -43,10 +63,31 @@ function formatUptime(seconds: number): string {
   return `${hours}h ${mins}m`;
 }
 
+function formatAge(timestamp: number): string {
+  const age = Math.max(0, Math.floor((Date.now() - timestamp) / 1000));
+  if (age < 60) return `${age}s`;
+  if (age < 3600) return `${Math.floor(age / 60)}m`;
+  return `${Math.floor(age / 3600)}h`;
+}
+
+function formatDuration(durationMs: number): string {
+  const totalSeconds = Math.max(0, Math.floor(durationMs / 1000));
+  if (totalSeconds < 60) return `${totalSeconds}s`;
+  if (totalSeconds < 3600) return `${Math.floor(totalSeconds / 60)}m ${totalSeconds % 60}s`;
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  return `${hours}h ${minutes}m`;
+}
+
+function resolveReplay(ref: string): ReplayInfo {
+  return resolveReplayOffline(ref);
+}
+
 /**
  * Start the tmux-lite server daemon
  */
-export async function startTmux(): Promise<void> {
+export async function startTmux(options: TmuxCommandOptions = {}): Promise<void> {
+  applyTmuxSandbox(options);
   // Clean up any stale PID file first
   cleanupStalePidFile();
 
@@ -69,7 +110,8 @@ export async function startTmux(): Promise<void> {
 /**
  * Stop the tmux-lite server daemon
  */
-export async function stopTmux(options: { force?: boolean } = {}): Promise<void> {
+export async function stopTmux(options: { force?: boolean; sandbox?: string } = {}): Promise<void> {
+  applyTmuxSandbox(options);
   // Clean up any stale PID file first
   cleanupStalePidFile();
 
@@ -108,7 +150,8 @@ export async function stopTmux(options: { force?: boolean } = {}): Promise<void>
 /**
  * Show tmux-lite server status
  */
-export async function statusTmux(): Promise<void> {
+export async function statusTmux(options: TmuxCommandOptions = {}): Promise<void> {
+  applyTmuxSandbox(options);
   // Clean up any stale PID file first
   const wasStale = cleanupStalePidFile();
   if (wasStale) {
@@ -174,7 +217,8 @@ export async function statusTmux(): Promise<void> {
 /**
  * List tmux-lite sessions
  */
-export async function listTmux(): Promise<void> {
+export async function listTmux(options: TmuxCommandOptions = {}): Promise<void> {
+  applyTmuxSandbox(options);
   // Clean up any stale PID file first
   cleanupStalePidFile();
 
@@ -211,7 +255,8 @@ export async function listTmux(): Promise<void> {
 /**
  * Create and attach to a new tmux-lite session
  */
-export async function newTmux(name?: string, cwdOverride?: string): Promise<void> {
+export async function newTmux(name?: string, cwdOverride?: string, options: TmuxCommandOptions = {}): Promise<void> {
+  applyTmuxSandbox(options);
   // Check for nested session
   if (isNested()) {
     logger.error("Already inside a tmux-lite session");
@@ -247,7 +292,8 @@ export async function newTmux(name?: string, cwdOverride?: string): Promise<void
 /**
  * Attach to an existing tmux-lite session
  */
-export async function attachTmux(id: string, options: { force?: boolean } = {}): Promise<void> {
+export async function attachTmux(id: string, options: { force?: boolean; sandbox?: string } = {}): Promise<void> {
+  applyTmuxSandbox(options);
   // Check for nested session
   if (isNested()) {
     logger.error("Already inside a tmux-lite session");
@@ -295,7 +341,8 @@ export async function attachTmux(id: string, options: { force?: boolean } = {}):
 /**
  * Kill a tmux-lite session
  */
-export async function killTmux(id: string): Promise<void> {
+export async function killTmux(id: string, options: TmuxCommandOptions = {}): Promise<void> {
+  applyTmuxSandbox(options);
   // Clean up any stale PID file first
   cleanupStalePidFile();
 
@@ -315,4 +362,100 @@ export async function killTmux(id: string): Promise<void> {
 
   await killSession(session.id);
   logger.success(`Killed session: ${session.name} (id: ${session.id})`);
+}
+
+export function listTmuxReplays(options: TmuxCommandOptions & { all?: boolean } = {}): void {
+  applyTmuxSandbox(options);
+
+  const replays = listReplaysOffline({ includeDismissed: options.all ?? false });
+  if (replays.length === 0) {
+    logger.log(options.all ? 'No replays' : 'No replays (use --all to include dismissed)');
+    return;
+  }
+
+  logger.log('Replays:');
+  for (const replay of replays) {
+    const ended = replay.endedAt ? ` ${chalk.gray(`ended ${formatAge(replay.endedAt)} ago`)}` : '';
+    const status = replay.status === 'crashed'
+      ? chalk.red('crashed')
+      : replay.status === 'running'
+        ? chalk.green('running')
+        : chalk.yellow('closed');
+    const dismissed = replay.dismissedAt ? chalk.gray(' [dismissed]') : '';
+    const label = replay.sessionName || replay.sessionId;
+    const workspace = replay.workspaceName
+      ? chalk.gray(` [${replay.projectName}/${replay.workspaceName}]`)
+      : replay.projectName
+        ? chalk.gray(` [${replay.projectName}]`)
+        : '';
+    logger.log(`  ${chalk.cyan(replay.replayId.slice(0, 20))} ${label}${workspace} ${chalk.gray(`(${formatDuration(replay.durationMs)})`)} ${status}${ended}${dismissed}`);
+    logger.dim(`      ${replay.cwd}`);
+  }
+}
+
+export async function showTmuxReplayText(
+  ref: string,
+  options: {
+    atMs?: number;
+    scrollbackLines?: number;
+    includeScrollback?: boolean;
+    sandbox?: string;
+  } = {}
+): Promise<void> {
+  applyTmuxSandbox(options);
+
+  const replay = resolveReplay(ref);
+  const text = await getReplayTextOffline(replay.replayId, {
+    atMs: options.atMs,
+    scrollbackLines: options.scrollbackLines,
+    includeScrollback: options.includeScrollback,
+  });
+  logger.log(text);
+}
+
+export async function screenshotTmuxReplay(
+  ref: string,
+  options: {
+    output?: string;
+    atMs?: number;
+    scrollbackLines?: number;
+    includeScrollback?: boolean;
+    sandbox?: string;
+  } = {}
+): Promise<void> {
+  applyTmuxSandbox(options);
+
+  const replay = resolveReplay(ref);
+  const suffix = options.atMs !== undefined ? `${options.atMs}ms` : 'latest';
+  const outputPath = options.output ?? `replay-${replay.replayId}-${suffix}.png`;
+  const writtenPath = await screenshotReplayOffline(replay.replayId, {
+    outputPath,
+    atMs: options.atMs,
+    includeScrollback: options.includeScrollback,
+  });
+
+  logger.success(`Replay screenshot written: ${writtenPath}`);
+}
+
+export function dismissTmuxReplay(ref: string, options: TmuxCommandOptions = {}): void {
+  applyTmuxSandbox(options);
+  const replay = resolveReplay(ref);
+  dismissReplayOffline(replay.replayId);
+  logger.success(`Replay dismissed: ${replay.sessionName || replay.replayId}`);
+  logger.dim('Use `gssh machine tmux replay undismiss` to restore it.');
+}
+
+export function undismissTmuxReplay(ref: string, options: TmuxCommandOptions = {}): void {
+  applyTmuxSandbox(options);
+  const replay = resolveReplayOffline(ref, { includeDismissed: true });
+  undismissReplayOffline(replay.replayId);
+  logger.success(`Replay restored: ${replay.sessionName || replay.replayId}`);
+}
+
+export function deleteTmuxReplay(ref: string, options: TmuxCommandOptions = {}): void {
+  applyTmuxSandbox(options);
+  const replay = resolveReplayOffline(ref, { includeDismissed: true });
+  const { deleteReplayOffline } = require('../lib/tmux-lite/replay/service.js') as typeof import('../lib/tmux-lite/replay/service.js');
+  deleteReplayOffline(replay.replayId);
+  logger.success(`Replay deleted: ${replay.sessionName || replay.replayId}`);
 }

--- a/src/commands/tmux.ts
+++ b/src/commands/tmux.ts
@@ -40,6 +40,8 @@ import {
   dismissReplayOffline,
   undismissReplayOffline,
   deleteReplayOffline,
+  pruneExpiredReplaysOffline,
+  getReplayStorageSummaryOffline,
   type ReplayInfo,
 } from '../lib/tmux-lite/replay/service.js';
 
@@ -444,6 +446,7 @@ export function dismissTmuxReplay(ref: string, options: TmuxCommandOptions = {})
   const replay = resolveReplay(ref);
   dismissReplayOffline(replay.replayId);
   logger.success(`Replay dismissed: ${replay.sessionName || replay.replayId}`);
+  logger.dim('Replay will be permanently deleted in 7 days.');
   logger.dim('Use `gssh machine tmux replay undismiss` to restore it.');
 }
 
@@ -459,4 +462,60 @@ export function deleteTmuxReplay(ref: string, options: TmuxCommandOptions = {}):
   const replay = resolveReplayOffline(ref, { includeDismissed: true });
   deleteReplayOffline(replay.replayId);
   logger.success(`Replay deleted: ${replay.sessionName || replay.replayId}`);
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  if (bytes < 1024 * 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  return `${(bytes / (1024 * 1024 * 1024)).toFixed(2)} GB`;
+}
+
+export function showTmuxReplayUsage(options: TmuxCommandOptions & { json?: boolean; top?: number } = {}): void {
+  applyTmuxSandbox(options);
+
+  const summary = getReplayStorageSummaryOffline();
+  if (summary.replayCount === 0) {
+    logger.log('No replays stored.');
+    return;
+  }
+
+  if (options.json) {
+    logger.log(JSON.stringify(summary, null, 2));
+    return;
+  }
+
+  const limit = options.top && options.top > 0 ? options.top : summary.replays.length;
+  const shown = summary.replays.slice(0, limit);
+
+  logger.log(`Replay storage: ${chalk.bold(formatBytes(summary.totalBytes))} across ${summary.replayCount} replay(s)\n`);
+
+  for (const replay of shown) {
+    const status = replay.status === 'crashed'
+      ? chalk.red('crashed')
+      : replay.status === 'running'
+        ? chalk.green('running')
+        : chalk.yellow('closed');
+    const dismissed = replay.dismissedAt ? chalk.gray(' [dismissed]') : '';
+    const expires = replay.expiresAt
+      ? chalk.gray(` [deletes ${new Date(replay.expiresAt).toLocaleDateString()}]`)
+      : '';
+    const label = replay.sessionName || replay.replayId;
+    logger.log(`  ${chalk.cyan(replay.replayId.slice(0, 20))} ${label} ${status} ${chalk.bold(formatBytes(replay.totalBytes))}${dismissed}${expires}`);
+    logger.dim(`      events: ${formatBytes(replay.eventsBytes)}  checkpoints: ${formatBytes(replay.checkpointsBytes)}  manifest: ${formatBytes(replay.manifestBytes)}`);
+  }
+
+  if (limit < summary.replays.length) {
+    logger.dim(`\n  ... and ${summary.replays.length - limit} more replay(s)`);
+  }
+}
+
+export function pruneTmuxReplays(options: TmuxCommandOptions = {}): void {
+  applyTmuxSandbox(options);
+  const pruned = pruneExpiredReplaysOffline();
+  if (pruned === 0) {
+    logger.log('No expired replays to prune.');
+  } else {
+    logger.success(`Pruned ${pruned} expired replay(s).`);
+  }
 }

--- a/src/components/RemoteMachineScreen.tui.tsx
+++ b/src/components/RemoteMachineScreen.tui.tsx
@@ -26,6 +26,7 @@ import {
 } from '../app/input/sessionCommands.js';
 import { SessionTerminal } from './SessionTerminal.tui.js';
 import { ScriptTerminal } from './ScriptTerminal.tui.js';
+import { ReplayTerminal } from './ReplayTerminal.tui.js';
 import { getKeyboardInputChunk, normalizeInputText } from '../tui/input-text.js';
 import {
   applySearchableSelectPaste,
@@ -37,6 +38,7 @@ import { buildEditProcessesCommand } from '../lib/processes/editor.js';
 import { createLocalDeviceCertificate } from '../core/user-identity.js';
 import { writeCrashLog } from '../utils/crash-log.js';
 import { logger } from '../utils/logger.js';
+import type { ReplayInfo } from '../lib/tmux-lite/replay/index.js';
 
 const COLORS = {
   statusBar: '#333333',
@@ -93,10 +95,12 @@ export function RemoteMachineScreen({ machine, relayUrl, identity, onBack }: Rem
   const [isViewOnlySession, setIsViewOnlySession] = useState(false);
   const [scriptWorkspaceName, setScriptWorkspaceName] = useState('workspace');
   const [pendingProcessEditWorkspaceId, setPendingProcessEditWorkspaceId] = useState<string | null>(null);
+  const [activeReplay, setActiveReplay] = useState<ReplayInfo | null>(null);
   const pendingProcessEditWorkspacesRef = useRef<unknown[] | null>(null);
   const pendingProcessEditValidationArmedRef = useRef(false);
   const lastScriptWorkspaceIdRef = useRef<string | null>(null);
   const activeConnectKeyRef = useRef<string | null>(null);
+  const activeReplayDismissedRef = useRef(false);
   const connectRemoteRef = useRef(remote.connect);
   const disconnectRemoteRef = useRef(remote.disconnect);
   const flow = useFlow({
@@ -322,6 +326,12 @@ export function RemoteMachineScreen({ machine, relayUrl, identity, onBack }: Rem
     }
   }, [remote.mode]);
 
+  useEffect(() => {
+    if (remote.status !== 'established' || remote.mode !== 'browsing') {
+      setActiveReplay(null);
+    }
+  }, [remote.mode, remote.status]);
+
   const handleAttachSession = useCallback(async (params: { sessionId?: string; workspaceId?: string; viewOnly?: boolean }) => {
     setIsViewOnlySession(params.viewOnly ?? false);
     await attachController.attachFromSelection(params);
@@ -460,13 +470,73 @@ export function RemoteMachineScreen({ machine, relayUrl, identity, onBack }: Rem
     });
   }, [flow]);
 
-  const handleOpenReplay = useCallback(() => {
-    flow.showMessage({
-      title: 'Replay Unavailable',
-      message: 'Replay view is not available in this remote TUI screen yet.',
-      variant: 'info',
-    });
-  }, [flow]);
+  const handleOpenReplay = useCallback(async ({ replayId }: { replayId: string; workspaceId: string }) => {
+    const replay = remote.replays.find((item) => item.replayId === replayId);
+    if (!replay) {
+      flow.showMessage({
+        title: 'Replay Missing',
+        message: 'That replay is no longer available.',
+        variant: 'error',
+      });
+      return;
+    }
+
+    setShowInbox(false);
+    setShowScriptTerminal(false);
+    setActiveReplay(replay);
+  }, [flow, remote.replays]);
+
+  const handleReplayDismiss = useCallback(async (replayId: string) => {
+    try {
+      const replay = remote.replays.find((item) => item.replayId === replayId) ?? activeReplay;
+      if (!activeReplayDismissedRef.current && replay?.status === 'running') {
+        flow.showMessage({
+          title: 'Replay Still Running',
+          message: 'Running replays cannot be dismissed.',
+          variant: 'info',
+        });
+        return false;
+      }
+
+      if (activeReplayDismissedRef.current) {
+        await remote.undismissReplay(replayId);
+        activeReplayDismissedRef.current = false;
+        setActiveReplay((current) => current && current.replayId === replayId
+          ? {
+            ...current,
+            dismissedAt: undefined,
+            dismissedBy: undefined,
+          }
+          : current);
+        return false;
+      }
+
+      await remote.dismissReplay(replayId);
+      activeReplayDismissedRef.current = true;
+      return true;
+    } catch (error) {
+      flow.showMessage({
+        title: 'Replay Update Failed',
+        message: error instanceof Error ? error.message : String(error),
+        variant: 'error',
+      });
+      return false;
+    } finally {
+      remote.requestReplays();
+    }
+  }, [activeReplay, flow, remote]);
+
+  useEffect(() => {
+    activeReplayDismissedRef.current = Boolean(activeReplay?.dismissedAt);
+  }, [activeReplay?.dismissedAt]);
+
+  const loadReplayAnsi = useCallback((replayId: string, target?: { atMs?: number; atSeq?: number }) => {
+    return remote.getReplayAnsi(replayId, target).then((bytes) => Buffer.from(bytes));
+  }, [remote]);
+
+  const loadReplayTimeline = useCallback((replayId: string) => {
+    return remote.getReplayTimeline(replayId);
+  }, [remote]);
 
   const handleEditProcesses = useCallback(({ workspaceId }: { workspaceId: string }) => {
     pendingProcessEditValidationArmedRef.current = false;
@@ -655,6 +725,10 @@ export function RemoteMachineScreen({ machine, relayUrl, identity, onBack }: Rem
     }
 
     if (remote.mode === 'attached') {
+      return;
+    }
+
+    if (activeReplay) {
       return;
     }
 
@@ -885,6 +959,23 @@ export function RemoteMachineScreen({ machine, relayUrl, identity, onBack }: Rem
         <InboxTUI {...inboxProps} focused={true} />
         <FlowTUI flow={flow} />
         <StatusBar hint="[↑↓] Navigate  [Enter] Open/Attach  [x] Delete  [c] Clear  [Esc] Back" />
+      </Fragment>
+    );
+  }
+
+  if (activeReplay && remote.status === 'established' && remote.mode === 'browsing') {
+    return (
+      <Fragment>
+        <ReplayTerminal
+          replay={activeReplay}
+          loadReplayAnsi={loadReplayAnsi}
+          loadReplayTimeline={loadReplayTimeline}
+          onBack={() => {
+            setActiveReplay(null);
+          }}
+          onDismiss={activeReplay.status === 'running' ? undefined : handleReplayDismiss}
+        />
+        <FlowTUI flow={flow} />
       </Fragment>
     );
   }

--- a/src/components/RemoteMachineScreen.tui.tsx
+++ b/src/components/RemoteMachineScreen.tui.tsx
@@ -163,6 +163,7 @@ export function RemoteMachineScreen({ machine, relayUrl, identity, onBack }: Rem
     onApplied: async () => {
       remote.requestWorkspaces();
       remote.requestSessions();
+      remote.requestReplays();
     },
   });
 
@@ -215,6 +216,7 @@ export function RemoteMachineScreen({ machine, relayUrl, identity, onBack }: Rem
       setShowScriptTerminal(false);
       remote.requestWorkspaces();
       remote.requestSessions();
+      remote.requestReplays();
     },
     onDeleteError: async ({ message }) => {
       setShowScriptTerminal(false);
@@ -304,6 +306,7 @@ export function RemoteMachineScreen({ machine, relayUrl, identity, onBack }: Rem
     remote.requestProjects();
     remote.requestWorkspaces();
     remote.requestSessions();
+    remote.requestReplays();
     remote.requestNotificationConfig();
   }, [remote.mode, remote.status]);
 
@@ -495,7 +498,7 @@ export function RemoteMachineScreen({ machine, relayUrl, identity, onBack }: Rem
   const spacesBrowserProps = useSpacesBrowser({
     workspaces: remote.workspaces,
     sessions: remote.sessions,
-    replays: [],
+    replays: remote.replays,
     onRequestSessions: () => remote.requestSessions(),
     onAttachSession: handleAttachSession,
     onOpenReplay: handleOpenReplay,
@@ -507,7 +510,10 @@ export function RemoteMachineScreen({ machine, relayUrl, identity, onBack }: Rem
     onProcessDisabled: handleProcessDisabled,
     onOpenEvents: handleOpenEvents,
     onRefresh: remote.requestWorkspaces,
-    onRefreshSessions: () => remote.requestSessions(),
+    onRefreshSessions: () => {
+      remote.requestSessions();
+      remote.requestReplays();
+    },
     onBack,
     machineName: machine.label || machine.machineId,
   });

--- a/src/components/RemoteMachineScreen.tui.tsx
+++ b/src/components/RemoteMachineScreen.tui.tsx
@@ -470,7 +470,7 @@ export function RemoteMachineScreen({ machine, relayUrl, identity, onBack }: Rem
     });
   }, [flow]);
 
-  const handleOpenReplay = useCallback(async ({ replayId }: { replayId: string; workspaceId: string }) => {
+  const handleOpenReplay = useCallback(async (replayId: string) => {
     const replay = remote.replays.find((item) => item.replayId === replayId);
     if (!replay) {
       flow.showMessage({

--- a/src/components/RemoteMachineScreen.tui.tsx
+++ b/src/components/RemoteMachineScreen.tui.tsx
@@ -457,6 +457,14 @@ export function RemoteMachineScreen({ machine, relayUrl, identity, onBack }: Rem
     });
   }, [flow]);
 
+  const handleOpenReplay = useCallback(() => {
+    flow.showMessage({
+      title: 'Replay Unavailable',
+      message: 'Replay view is not available in this remote TUI screen yet.',
+      variant: 'info',
+    });
+  }, [flow]);
+
   const handleEditProcesses = useCallback(({ workspaceId }: { workspaceId: string }) => {
     pendingProcessEditValidationArmedRef.current = false;
     pendingProcessEditWorkspacesRef.current = remote.workspaces;
@@ -487,8 +495,10 @@ export function RemoteMachineScreen({ machine, relayUrl, identity, onBack }: Rem
   const spacesBrowserProps = useSpacesBrowser({
     workspaces: remote.workspaces,
     sessions: remote.sessions,
+    replays: [],
     onRequestSessions: () => remote.requestSessions(),
     onAttachSession: handleAttachSession,
+    onOpenReplay: handleOpenReplay,
     onEditProcesses: handleEditProcesses,
     onManageBundleConfig: handleManageBundleConfig,
     onStartProcess: handleStartProcess,

--- a/src/components/ReplayTerminal.tui.tsx
+++ b/src/components/ReplayTerminal.tui.tsx
@@ -44,7 +44,7 @@ export interface ReplayTerminalProps {
   /** Load replay as ANSI bytes (styled, for Ghostty rendering) */
   loadReplayAnsi: (replayId: string) => Promise<Buffer>;
   onBack: () => void;
-  onDismiss?: (replayId: string) => void;
+  onDismiss?: (replayId: string) => void | Promise<void>;
 }
 
 export function ReplayTerminal({ replay, loadReplayAnsi, onBack, onDismiss }: ReplayTerminalProps) {
@@ -85,8 +85,8 @@ export function ReplayTerminal({ replay, loadReplayAnsi, onBack, onDismiss }: Re
     return () => { process.removeListener('SIGWINCH', handleResize); };
   }, []);
 
-  const handleDismiss = useCallback(() => {
-    onDismiss?.(replay.replayId);
+  const handleDismiss = useCallback(async () => {
+    await onDismiss?.(replay.replayId);
     onBack();
   }, [onDismiss, onBack, replay.replayId]);
 
@@ -99,7 +99,7 @@ export function ReplayTerminal({ replay, loadReplayAnsi, onBack, onDismiss }: Re
       setReloadKey((k) => k + 1);
     }
     if (key.raw === 'd' && onDismiss) {
-      handleDismiss();
+      void handleDismiss();
     }
   });
 

--- a/src/components/ReplayTerminal.tui.tsx
+++ b/src/components/ReplayTerminal.tui.tsx
@@ -1,6 +1,11 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { extend, useKeyboard } from '@opentui/react';
 import { GhosttyTerminalRenderable } from 'ghostty-opentui/terminal-buffer';
+import type {
+  ReplayFrameTarget,
+  ReplayTimeline,
+  ReplayTimelineStep,
+} from '../lib/tmux-lite/replay/index.js';
 import type { ReplayInfo } from './SpacesBrowser.js';
 
 extend({ 'ghostty-terminal': GhosttyTerminalRenderable });
@@ -12,7 +17,15 @@ const COLORS = {
   textMuted: '#8b949e',
   error: '#ff7b72',
   crashed: '#ffa198',
+  loading: '#d29922',
+  playing: '#3fb950',
 };
+
+const PLAYBACK_SPEEDS = [0.25, 0.5, 1, 1.5, 2, 4] as const;
+const DEFAULT_PLAYBACK_SPEED_INDEX = 2;
+const FAST_SCRUB_STEP_COUNT = 5;
+const LOADING_REPLAY_BUFFER = Buffer.from('\x1b[2J\x1b[H\x1b[2;37mLoading replay...\x1b[0m');
+const EMPTY_REPLAY_BUFFER = Buffer.from('\x1b[2J\x1b[H\x1b[2;37m(empty replay)\x1b[0m');
 
 function formatAge(timestamp: number): string {
   const age = Math.max(0, Math.floor((Date.now() - timestamp) / 1000));
@@ -20,6 +33,24 @@ function formatAge(timestamp: number): string {
   if (age < 3600) return `${Math.floor(age / 60)}m ago`;
   if (age < 86400) return `${Math.floor(age / 3600)}h ago`;
   return `${Math.floor(age / 86400)}d ago`;
+}
+
+function formatReplayTime(timeMs: number): string {
+  const totalSeconds = Math.max(0, timeMs) / 1000;
+  if (totalSeconds < 60) {
+    return `${totalSeconds.toFixed(1)}s`;
+  }
+
+  const wholeSeconds = Math.floor(totalSeconds);
+  const seconds = wholeSeconds % 60;
+  const minutes = Math.floor(wholeSeconds / 60) % 60;
+  const hours = Math.floor(wholeSeconds / 3600);
+
+  if (hours > 0) {
+    return `${hours}:${String(minutes).padStart(2, '0')}:${String(seconds).padStart(2, '0')}`;
+  }
+
+  return `${minutes}:${String(seconds).padStart(2, '0')}`;
 }
 
 function getTerminalSize() {
@@ -39,51 +70,239 @@ function getTerminalSize() {
   };
 }
 
+function targetKey(target: ReplayFrameTarget | ReplayTimelineStep | null): string | null {
+  if (!target) {
+    return null;
+  }
+
+  const timeMs = 'timeMs' in target ? target.timeMs : target.atMs;
+  const seq = 'seq' in target ? target.seq : target.atSeq;
+  return `${timeMs ?? -1}:${seq ?? -1}`;
+}
+
+function toFrameTarget(step: ReplayTimelineStep | null, fallback: ReplayFrameTarget): ReplayFrameTarget {
+  if (!step) {
+    return fallback;
+  }
+
+  return {
+    atMs: step.timeMs,
+    atSeq: step.seq,
+  };
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
+function padLabel(value: string, width: number): string {
+  return value.padStart(width, ' ');
+}
+
 export interface ReplayTerminalProps {
   replay: ReplayInfo;
-  /** Load replay as ANSI bytes (styled, for Ghostty rendering) */
-  loadReplayAnsi: (replayId: string) => Promise<Buffer>;
+  loadReplayAnsi: (replayId: string, target?: ReplayFrameTarget) => Promise<Buffer>;
+  loadReplayTimeline: (replayId: string) => Promise<ReplayTimeline>;
   onBack: () => void;
   onDismiss?: (replayId: string) => boolean | void | Promise<boolean | void>;
 }
 
-export function ReplayTerminal({ replay, loadReplayAnsi, onBack, onDismiss }: ReplayTerminalProps) {
-  const [content, setContent] = useState<Buffer>(() => Buffer.from('\x1b[2J\x1b[HLoading replay...'));
+export function ReplayTerminal({
+  replay,
+  loadReplayAnsi,
+  loadReplayTimeline,
+  onBack,
+  onDismiss,
+}: ReplayTerminalProps) {
+  const latestFallbackTarget = useMemo<ReplayFrameTarget>(() => ({
+    atMs: replay.durationMs,
+    atSeq: replay.lastSeq,
+  }), [replay.durationMs, replay.lastSeq]);
+
+  const [content, setContent] = useState<Buffer | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [reloadKey, setReloadKey] = useState(0);
   const [termSize, setTermSize] = useState(getTerminalSize);
-  const loadingRef = useRef(false);
+  const [timeline, setTimeline] = useState<ReplayTimeline | null>(null);
+  const [currentStepIndex, setCurrentStepIndex] = useState(-1);
+  const [loadedTargetKey, setLoadedTargetKey] = useState<string | null>(null);
+  const [timelineLoading, setTimelineLoading] = useState(true);
+  const [frameLoading, setFrameLoading] = useState(true);
+  const [isPlaying, setIsPlaying] = useState(false);
+  const [playbackSpeedIndex, setPlaybackSpeedIndex] = useState(DEFAULT_PLAYBACK_SPEED_INDEX);
+  const contentRef = useRef<Buffer | null>(null);
+  const frameRequestIdRef = useRef(0);
+
+  useEffect(() => {
+    contentRef.current = content;
+  }, [content]);
+
+  const currentStep = timeline && currentStepIndex >= 0
+    ? timeline.steps[currentStepIndex] ?? null
+    : null;
+  const currentTarget = useMemo(
+    () => toFrameTarget(currentStep, latestFallbackTarget),
+    [currentStep, latestFallbackTarget],
+  );
+  const currentTargetKey = targetKey(currentTarget);
+  const playbackSpeed = PLAYBACK_SPEEDS[playbackSpeedIndex] ?? 1;
+
+  const loadFrame = useCallback(async (
+    target: ReplayFrameTarget,
+    options: { preserveContent: boolean },
+  ): Promise<void> => {
+    const requestId = ++frameRequestIdRef.current;
+    setFrameLoading(true);
+    setError(null);
+
+    if (!options.preserveContent && !contentRef.current) {
+      setContent(LOADING_REPLAY_BUFFER);
+    }
+
+    try {
+      const bytes = await loadReplayAnsi(replay.replayId, target);
+      if (frameRequestIdRef.current !== requestId) {
+        return;
+      }
+
+      setContent(bytes.length > 0 ? Buffer.from(bytes) : EMPTY_REPLAY_BUFFER);
+      setLoadedTargetKey(targetKey(target));
+      setError(null);
+    } catch (loadError) {
+      if (frameRequestIdRef.current !== requestId) {
+        return;
+      }
+
+      const message = loadError instanceof Error ? loadError.message : String(loadError);
+      setError(message);
+
+      if (!contentRef.current || !options.preserveContent) {
+        setContent(Buffer.from(`\x1b[2J\x1b[H\x1b[31mFailed to load replay\x1b[0m\r\n\r\n${message}`));
+      }
+    } finally {
+      if (frameRequestIdRef.current === requestId) {
+        setFrameLoading(false);
+      }
+    }
+  }, [loadReplayAnsi, replay.replayId]);
 
   useEffect(() => {
     let cancelled = false;
-    loadingRef.current = true;
+    frameRequestIdRef.current += 1;
+    setIsPlaying(false);
+    setPlaybackSpeedIndex(DEFAULT_PLAYBACK_SPEED_INDEX);
+    setTimeline(null);
+    setCurrentStepIndex(-1);
+    setLoadedTargetKey(null);
     setError(null);
-    setContent(Buffer.from('\x1b[2J\x1b[H\x1b[2;37mLoading replay...\x1b[0m'));
+    setContent(null);
+    setTimelineLoading(true);
+    setFrameLoading(true);
 
-    void loadReplayAnsi(replay.replayId)
-      .then((bytes) => {
-        if (cancelled) return;
-        loadingRef.current = false;
-        setContent(bytes.length > 0 ? bytes : Buffer.from('\x1b[2J\x1b[H\x1b[2;37m(empty replay)\x1b[0m'));
-      })
-      .catch((loadError) => {
-        if (cancelled) return;
-        loadingRef.current = false;
-        const message = loadError instanceof Error ? loadError.message : String(loadError);
-        setError(message);
-        setContent(Buffer.from(`\x1b[2J\x1b[H\x1b[31mFailed to load replay\x1b[0m\r\n\r\n${message}`));
-      });
+    void (async () => {
+      let nextTimeline: ReplayTimeline | null = null;
+
+      try {
+        nextTimeline = await loadReplayTimeline(replay.replayId);
+      } catch (timelineError) {
+        if (cancelled) {
+          return;
+        }
+        setError(timelineError instanceof Error ? timelineError.message : String(timelineError));
+      }
+
+      if (cancelled) {
+        return;
+      }
+
+      const initialStepIndex = nextTimeline && nextTimeline.steps.length > 0
+        ? nextTimeline.steps.length - 1
+        : -1;
+      const initialStep = nextTimeline && initialStepIndex >= 0
+        ? nextTimeline.steps[initialStepIndex] ?? null
+        : null;
+
+      await loadFrame(toFrameTarget(initialStep, latestFallbackTarget), { preserveContent: false });
+      if (cancelled) {
+        return;
+      }
+
+      setTimeline(nextTimeline);
+      setCurrentStepIndex(initialStepIndex);
+      setTimelineLoading(false);
+    })();
 
     return () => {
       cancelled = true;
+      frameRequestIdRef.current += 1;
     };
-  }, [loadReplayAnsi, reloadKey, replay.replayId]);
+  }, [latestFallbackTarget, loadFrame, loadReplayTimeline, reloadKey, replay.replayId]);
+
+  useEffect(() => {
+    if (!timeline || currentStepIndex < 0 || currentTargetKey === loadedTargetKey) {
+      return;
+    }
+
+    void loadFrame(currentTarget, { preserveContent: true });
+  }, [currentStepIndex, currentTarget, currentTargetKey, loadFrame, loadedTargetKey, timeline]);
 
   useEffect(() => {
     const handleResize = () => setTermSize(getTerminalSize());
     process.on('SIGWINCH', handleResize);
     return () => { process.removeListener('SIGWINCH', handleResize); };
   }, []);
+
+  useEffect(() => {
+    if (!isPlaying) {
+      return;
+    }
+
+    if (!timeline || timeline.steps.length === 0) {
+      setIsPlaying(false);
+      return;
+    }
+
+    if (currentStepIndex < 0) {
+      return;
+    }
+
+    if (currentStepIndex >= timeline.steps.length - 1) {
+      setIsPlaying(false);
+      return;
+    }
+
+    if (timelineLoading || frameLoading || currentTargetKey !== loadedTargetKey) {
+      return;
+    }
+
+    const current = timeline.steps[currentStepIndex];
+    const next = timeline.steps[currentStepIndex + 1];
+    if (!current || !next) {
+      setIsPlaying(false);
+      return;
+    }
+
+    const delayMs = Math.max(0, Math.round((next.timeMs - current.timeMs) / playbackSpeed));
+    const timer = setTimeout(() => {
+      setCurrentStepIndex((index) => {
+        if (!timeline) {
+          return index;
+        }
+        return clamp(index + 1, 0, timeline.steps.length - 1);
+      });
+    }, delayMs);
+
+    return () => clearTimeout(timer);
+  }, [
+    currentStepIndex,
+    currentTargetKey,
+    frameLoading,
+    isPlaying,
+    loadedTargetKey,
+    playbackSpeed,
+    timeline,
+    timelineLoading,
+  ]);
 
   const handleDismiss = useCallback(async () => {
     const shouldGoBack = await onDismiss?.(replay.replayId);
@@ -92,16 +311,84 @@ export function ReplayTerminal({ replay, loadReplayAnsi, onBack, onDismiss }: Re
     }
   }, [onDismiss, onBack, replay.replayId]);
 
+  const stepReplay = useCallback((direction: -1 | 1, count = 1) => {
+    if (!timeline || timeline.steps.length === 0) {
+      return;
+    }
+
+    setIsPlaying(false);
+    setCurrentStepIndex((index) => {
+      const resolvedIndex = index < 0 ? timeline.steps.length - 1 : index;
+      return clamp(resolvedIndex + (direction * count), 0, timeline.steps.length - 1);
+    });
+  }, [timeline]);
+
+  const adjustPlaybackSpeed = useCallback((direction: -1 | 1, count = 1) => {
+    setPlaybackSpeedIndex((index) => clamp(index + (direction * count), 0, PLAYBACK_SPEEDS.length - 1));
+  }, []);
+
+  const togglePlayback = useCallback(() => {
+    if (!timeline || timeline.steps.length === 0) {
+      return;
+    }
+
+    if (isPlaying) {
+      setIsPlaying(false);
+      return;
+    }
+
+    setCurrentStepIndex((index) => index >= timeline.steps.length - 1 ? 0 : Math.max(0, index));
+    setIsPlaying(true);
+  }, [isPlaying, timeline]);
+
+  const jumpToBoundary = useCallback((direction: 'start' | 'end') => {
+    if (!timeline || timeline.steps.length === 0) {
+      return;
+    }
+
+    setIsPlaying(false);
+    setCurrentStepIndex(direction === 'start' ? 0 : timeline.steps.length - 1);
+  }, [timeline]);
+
   useKeyboard((key) => {
     if (key.name === 'escape' || key.raw === 'q') {
       onBack();
       return;
     }
     if (key.raw === 'r') {
-      setReloadKey((k) => k + 1);
+      setReloadKey((value) => value + 1);
+      return;
     }
     if (key.raw === 'd' && onDismiss) {
       void handleDismiss();
+      return;
+    }
+    if (key.raw === ' ' || key.name === 'space') {
+      togglePlayback();
+      return;
+    }
+    if (key.name === 'home') {
+      jumpToBoundary('start');
+      return;
+    }
+    if (key.name === 'end') {
+      jumpToBoundary('end');
+      return;
+    }
+    if (key.name === 'left') {
+      if (isPlaying) {
+        adjustPlaybackSpeed(-1, key.shift ? 2 : 1);
+      } else {
+        stepReplay(-1, key.shift ? FAST_SCRUB_STEP_COUNT : 1);
+      }
+      return;
+    }
+    if (key.name === 'right') {
+      if (isPlaying) {
+        adjustPlaybackSpeed(1, key.shift ? 2 : 1);
+      } else {
+        stepReplay(1, key.shift ? FAST_SCRUB_STEP_COUNT : 1);
+      }
     }
   });
 
@@ -121,6 +408,23 @@ export function ReplayTerminal({ replay, loadReplayAnsi, onBack, onDismiss }: Re
   }, [replay]);
 
   const statusColor = replay.status === 'crashed' ? COLORS.crashed : COLORS.title;
+  const totalTimeMs = timeline?.latestTimeMs ?? replay.durationMs;
+  const activeTimeMs = currentTarget.atMs ?? totalTimeMs;
+  const totalSteps = timeline ? Math.max(0, timeline.steps.length - 1) : 0;
+  const visibleStepIndex = timeline && currentStepIndex >= 0
+    ? clamp(currentStepIndex, 0, Math.max(0, timeline.steps.length - 1))
+    : totalSteps;
+  const frame = content ?? LOADING_REPLAY_BUFFER;
+  const transportHint = isPlaying
+    ? '[Space] Pause  [←/→] Speed  [Shift+←/→] More  [Home/End] Jump'
+    : '[Space] Play  [←/→] Step  [Shift+←/→] Skip  [Home/End] Jump';
+  const speedLabel = `${playbackSpeed.toFixed(playbackSpeed < 1 ? 2 : 1)}x`;
+  const timeWidth = Math.max(formatReplayTime(totalTimeMs).length, formatReplayTime(0).length);
+  const timeLabel = `${padLabel(formatReplayTime(activeTimeMs), timeWidth)}/${formatReplayTime(totalTimeMs)}`;
+  const stepWidth = String(Math.max(0, totalSteps)).length;
+  const stepLabel = `${String(visibleStepIndex).padStart(stepWidth, ' ')}/${totalSteps}`;
+  const speedWidth = Math.max(...PLAYBACK_SPEEDS.map((value) => `${value.toFixed(value < 1 ? 2 : 1)}x`.length));
+  const paddedSpeedLabel = speedLabel.padStart(speedWidth, ' ');
 
   return (
     <box flexDirection="column" flexGrow={1}>
@@ -136,10 +440,15 @@ export function ReplayTerminal({ replay, loadReplayAnsi, onBack, onDismiss }: Re
           <text fg={statusColor}>{statusLabel.name}</text>
           <text fg={COLORS.textMuted}>{statusLabel.workspace}</text>
           <text fg={COLORS.textDim}> ({statusLabel.state}){statusLabel.age}</text>
+          <text fg={COLORS.textDim}>  {timeLabel}</text>
+          <text fg={COLORS.textDim}>  {stepLabel}</text>
+          <text fg={isPlaying ? COLORS.playing : COLORS.textMuted}>  {isPlaying ? '[playing]' : '[paused]'}</text>
+          <text fg={COLORS.loading}>  {paddedSpeedLabel}</text>
+          {(timelineLoading || frameLoading) && <text fg={COLORS.loading}> [loading]</text>}
           {error && <text fg={COLORS.error}> [error]</text>}
         </box>
         <text fg={COLORS.textDim}>
-          [r] Reload  {onDismiss ? `[d] ${replay.dismissedAt ? 'Restore' : 'Dismiss'}  ` : ''}[Esc/q] Back
+          {transportHint}  [r] Reload  {onDismiss ? `[d] ${replay.dismissedAt ? 'Restore' : 'Dismiss'}  ` : ''}[Esc/q] Back
         </text>
       </box>
       <scrollbox flexGrow={1} stickyStart="bottom">
@@ -148,7 +457,7 @@ export function ReplayTerminal({ replay, loadReplayAnsi, onBack, onDismiss }: Re
           showCursor={false}
           cols={termSize.cols}
           rows={termSize.rows}
-          ansi={content}
+          ansi={frame}
         />
       </scrollbox>
     </box>

--- a/src/components/ReplayTerminal.tui.tsx
+++ b/src/components/ReplayTerminal.tui.tsx
@@ -44,7 +44,7 @@ export interface ReplayTerminalProps {
   /** Load replay as ANSI bytes (styled, for Ghostty rendering) */
   loadReplayAnsi: (replayId: string) => Promise<Buffer>;
   onBack: () => void;
-  onDismiss?: (replayId: string) => void | Promise<void>;
+  onDismiss?: (replayId: string) => boolean | void | Promise<boolean | void>;
 }
 
 export function ReplayTerminal({ replay, loadReplayAnsi, onBack, onDismiss }: ReplayTerminalProps) {
@@ -86,8 +86,10 @@ export function ReplayTerminal({ replay, loadReplayAnsi, onBack, onDismiss }: Re
   }, []);
 
   const handleDismiss = useCallback(async () => {
-    await onDismiss?.(replay.replayId);
-    onBack();
+    const shouldGoBack = await onDismiss?.(replay.replayId);
+    if (shouldGoBack !== false) {
+      onBack();
+    }
   }, [onDismiss, onBack, replay.replayId]);
 
   useKeyboard((key) => {

--- a/src/components/ReplayTerminal.tui.tsx
+++ b/src/components/ReplayTerminal.tui.tsx
@@ -1,0 +1,150 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { extend, useKeyboard } from '@opentui/react';
+import { GhosttyTerminalRenderable } from 'ghostty-opentui/terminal-buffer';
+import type { ReplayInfo } from './SpacesBrowser.js';
+
+extend({ 'ghostty-terminal': GhosttyTerminalRenderable });
+
+const COLORS = {
+  statusBar: '#1a1f2e',
+  title: '#58a6ff',
+  textDim: '#6e7681',
+  textMuted: '#8b949e',
+  error: '#ff7b72',
+  crashed: '#ffa198',
+};
+
+function formatAge(timestamp: number): string {
+  const age = Math.max(0, Math.floor((Date.now() - timestamp) / 1000));
+  if (age < 60) return `${age}s ago`;
+  if (age < 3600) return `${Math.floor(age / 60)}m ago`;
+  if (age < 86400) return `${Math.floor(age / 3600)}h ago`;
+  return `${Math.floor(age / 86400)}d ago`;
+}
+
+function getTerminalSize() {
+  let cols = process.stdout.columns || 0;
+  let rows = process.stdout.rows || 0;
+  if (cols <= 0 || rows <= 0) {
+    const size = (process.stdout as { getWindowSize?: () => number[] }).getWindowSize?.();
+    if (Array.isArray(size) && size.length >= 2) {
+      cols = size[0];
+      rows = size[1];
+    }
+  }
+
+  return {
+    cols: cols > 0 ? cols : 80,
+    rows: Math.max(1, (rows > 0 ? rows : 24) - 1),
+  };
+}
+
+export interface ReplayTerminalProps {
+  replay: ReplayInfo;
+  /** Load replay as ANSI bytes (styled, for Ghostty rendering) */
+  loadReplayAnsi: (replayId: string) => Promise<Buffer>;
+  onBack: () => void;
+  onDismiss?: (replayId: string) => void;
+}
+
+export function ReplayTerminal({ replay, loadReplayAnsi, onBack, onDismiss }: ReplayTerminalProps) {
+  const [content, setContent] = useState<Buffer>(() => Buffer.from('\x1b[2J\x1b[HLoading replay...'));
+  const [error, setError] = useState<string | null>(null);
+  const [reloadKey, setReloadKey] = useState(0);
+  const [termSize, setTermSize] = useState(getTerminalSize);
+  const loadingRef = useRef(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    loadingRef.current = true;
+    setError(null);
+    setContent(Buffer.from('\x1b[2J\x1b[H\x1b[2;37mLoading replay...\x1b[0m'));
+
+    void loadReplayAnsi(replay.replayId)
+      .then((bytes) => {
+        if (cancelled) return;
+        loadingRef.current = false;
+        setContent(bytes.length > 0 ? bytes : Buffer.from('\x1b[2J\x1b[H\x1b[2;37m(empty replay)\x1b[0m'));
+      })
+      .catch((loadError) => {
+        if (cancelled) return;
+        loadingRef.current = false;
+        const message = loadError instanceof Error ? loadError.message : String(loadError);
+        setError(message);
+        setContent(Buffer.from(`\x1b[2J\x1b[H\x1b[31mFailed to load replay\x1b[0m\r\n\r\n${message}`));
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [loadReplayAnsi, reloadKey, replay.replayId]);
+
+  useEffect(() => {
+    const handleResize = () => setTermSize(getTerminalSize());
+    process.on('SIGWINCH', handleResize);
+    return () => { process.removeListener('SIGWINCH', handleResize); };
+  }, []);
+
+  const handleDismiss = useCallback(() => {
+    onDismiss?.(replay.replayId);
+    onBack();
+  }, [onDismiss, onBack, replay.replayId]);
+
+  useKeyboard((key) => {
+    if (key.name === 'escape' || key.raw === 'q') {
+      onBack();
+      return;
+    }
+    if (key.raw === 'r') {
+      setReloadKey((k) => k + 1);
+    }
+    if (key.raw === 'd' && onDismiss) {
+      handleDismiss();
+    }
+  });
+
+  const statusLabel = useMemo(() => {
+    const state = replay.status === 'crashed' ? 'crashed' : 'closed';
+    const workspace = replay.workspaceName
+      ? ` · ${replay.projectName}/${replay.workspaceName}`
+      : replay.projectName
+        ? ` · ${replay.projectName}`
+        : '';
+    const age = replay.endedAt ? `  ${formatAge(replay.endedAt)}` : '';
+    return { name: replay.sessionName, state, workspace, age };
+  }, [replay]);
+
+  const statusColor = replay.status === 'crashed' ? COLORS.crashed : COLORS.title;
+
+  return (
+    <box flexDirection="column" flexGrow={1}>
+      <box
+        height={1}
+        width="100%"
+        backgroundColor={COLORS.statusBar}
+        flexDirection="row"
+        paddingLeft={1}
+        paddingRight={1}
+      >
+        <box flexGrow={1} flexDirection="row">
+          <text fg={statusColor}>{statusLabel.name}</text>
+          <text fg={COLORS.textMuted}>{statusLabel.workspace}</text>
+          <text fg={COLORS.textDim}> ({statusLabel.state}){statusLabel.age}</text>
+          {error && <text fg={COLORS.error}> [error]</text>}
+        </box>
+        <text fg={COLORS.textDim}>
+          [r] Reload  {onDismiss ? '[d] Dismiss  ' : ''}[Esc/q] Back
+        </text>
+      </box>
+      <scrollbox flexGrow={1} stickyStart="bottom">
+        <ghostty-terminal
+          persistent={true}
+          showCursor={false}
+          cols={termSize.cols}
+          rows={termSize.rows}
+          ansi={content}
+        />
+      </scrollbox>
+    </box>
+  );
+}

--- a/src/components/ReplayTerminal.tui.tsx
+++ b/src/components/ReplayTerminal.tui.tsx
@@ -4,9 +4,17 @@ import { GhosttyTerminalRenderable } from 'ghostty-opentui/terminal-buffer';
 import type {
   ReplayFrameTarget,
   ReplayTimeline,
-  ReplayTimelineStep,
 } from '../lib/tmux-lite/replay/index.js';
 import type { ReplayInfo } from './SpacesBrowser.js';
+import {
+  PLAYBACK_SPEEDS,
+  DEFAULT_PLAYBACK_SPEED_INDEX,
+  FAST_SCRUB_STEP_COUNT,
+  formatReplayTime,
+  clamp,
+  targetKey,
+  toFrameTarget,
+} from './replay-utils.js';
 
 extend({ 'ghostty-terminal': GhosttyTerminalRenderable });
 
@@ -21,9 +29,6 @@ const COLORS = {
   playing: '#3fb950',
 };
 
-const PLAYBACK_SPEEDS = [0.25, 0.5, 1, 1.5, 2, 4] as const;
-const DEFAULT_PLAYBACK_SPEED_INDEX = 2;
-const FAST_SCRUB_STEP_COUNT = 5;
 const LOADING_REPLAY_BUFFER = Buffer.from('\x1b[2J\x1b[H\x1b[2;37mLoading replay...\x1b[0m');
 const EMPTY_REPLAY_BUFFER = Buffer.from('\x1b[2J\x1b[H\x1b[2;37m(empty replay)\x1b[0m');
 
@@ -33,24 +38,6 @@ function formatAge(timestamp: number): string {
   if (age < 3600) return `${Math.floor(age / 60)}m ago`;
   if (age < 86400) return `${Math.floor(age / 3600)}h ago`;
   return `${Math.floor(age / 86400)}d ago`;
-}
-
-function formatReplayTime(timeMs: number): string {
-  const totalSeconds = Math.max(0, timeMs) / 1000;
-  if (totalSeconds < 59.95) {
-    return `${totalSeconds.toFixed(1)}s`;
-  }
-
-  const wholeSeconds = Math.round(totalSeconds);
-  const seconds = wholeSeconds % 60;
-  const minutes = Math.floor(wholeSeconds / 60) % 60;
-  const hours = Math.floor(wholeSeconds / 3600);
-
-  if (hours > 0) {
-    return `${hours}:${String(minutes).padStart(2, '0')}:${String(seconds).padStart(2, '0')}`;
-  }
-
-  return `${minutes}:${String(seconds).padStart(2, '0')}`;
 }
 
 function getTerminalSize() {
@@ -68,31 +55,6 @@ function getTerminalSize() {
     cols: cols > 0 ? cols : 80,
     rows: Math.max(1, (rows > 0 ? rows : 24) - 1),
   };
-}
-
-function targetKey(target: ReplayFrameTarget | ReplayTimelineStep | null): string | null {
-  if (!target) {
-    return null;
-  }
-
-  const timeMs = 'timeMs' in target ? target.timeMs : target.atMs;
-  const seq = 'seq' in target ? target.seq : target.atSeq;
-  return `${timeMs ?? -1}:${seq ?? -1}`;
-}
-
-function toFrameTarget(step: ReplayTimelineStep | null, fallback: ReplayFrameTarget): ReplayFrameTarget {
-  if (!step) {
-    return fallback;
-  }
-
-  return {
-    atMs: step.timeMs,
-    atSeq: step.seq,
-  };
-}
-
-function clamp(value: number, min: number, max: number): number {
-  return Math.min(max, Math.max(min, value));
 }
 
 function padLabel(value: string, width: number): string {

--- a/src/components/ReplayTerminal.tui.tsx
+++ b/src/components/ReplayTerminal.tui.tsx
@@ -104,7 +104,11 @@ export function ReplayTerminal({ replay, loadReplayAnsi, onBack, onDismiss }: Re
   });
 
   const statusLabel = useMemo(() => {
-    const state = replay.status === 'crashed' ? 'crashed' : 'closed';
+    const state = replay.status === 'crashed'
+      ? 'crashed'
+      : replay.status === 'running'
+        ? 'running'
+        : 'closed';
     const workspace = replay.workspaceName
       ? ` · ${replay.projectName}/${replay.workspaceName}`
       : replay.projectName

--- a/src/components/ReplayTerminal.tui.tsx
+++ b/src/components/ReplayTerminal.tui.tsx
@@ -137,7 +137,7 @@ export function ReplayTerminal({ replay, loadReplayAnsi, onBack, onDismiss }: Re
           {error && <text fg={COLORS.error}> [error]</text>}
         </box>
         <text fg={COLORS.textDim}>
-          [r] Reload  {onDismiss ? '[d] Dismiss  ' : ''}[Esc/q] Back
+          [r] Reload  {onDismiss ? `[d] ${replay.dismissedAt ? 'Restore' : 'Dismiss'}  ` : ''}[Esc/q] Back
         </text>
       </box>
       <scrollbox flexGrow={1} stickyStart="bottom">

--- a/src/components/ReplayTerminal.tui.tsx
+++ b/src/components/ReplayTerminal.tui.tsx
@@ -37,11 +37,11 @@ function formatAge(timestamp: number): string {
 
 function formatReplayTime(timeMs: number): string {
   const totalSeconds = Math.max(0, timeMs) / 1000;
-  if (totalSeconds < 60) {
+  if (totalSeconds < 59.95) {
     return `${totalSeconds.toFixed(1)}s`;
   }
 
-  const wholeSeconds = Math.floor(totalSeconds);
+  const wholeSeconds = Math.round(totalSeconds);
   const seconds = wholeSeconds % 60;
   const minutes = Math.floor(wholeSeconds / 60) % 60;
   const hours = Math.floor(wholeSeconds / 3600);

--- a/src/components/ReplayTerminal.web.tsx
+++ b/src/components/ReplayTerminal.web.tsx
@@ -1,11 +1,16 @@
 /** @jsxImportSource react */
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import type { ReplayFrameTarget, ReplayInfo, ReplayTimeline, ReplayTimelineStep } from '../lib/tmux-lite/replay/index.js';
+import type { ReplayFrameTarget, ReplayInfo, ReplayTimeline } from '../lib/tmux-lite/replay/index.js';
 import { SessionTerminal } from './SessionTerminal.web';
-
-const PLAYBACK_SPEEDS = [0.25, 0.5, 1, 1.5, 2, 4] as const;
-const DEFAULT_PLAYBACK_SPEED_INDEX = 2;
-const FAST_SCRUB_STEP_COUNT = 5;
+import {
+  PLAYBACK_SPEEDS,
+  DEFAULT_PLAYBACK_SPEED_INDEX,
+  FAST_SCRUB_STEP_COUNT,
+  formatReplayTime,
+  clamp,
+  targetKey,
+  toFrameTarget,
+} from './replay-utils.js';
 
 function encodeAnsi(text: string): Uint8Array {
   return new TextEncoder().encode(text);
@@ -13,46 +18,6 @@ function encodeAnsi(text: string): Uint8Array {
 
 const LOADING_REPLAY_ANSI = encodeAnsi('\x1b[2J\x1b[H\x1b[2;37mLoading replay...\x1b[0m');
 const EMPTY_REPLAY_ANSI = encodeAnsi('\x1b[2J\x1b[H\x1b[2;37m(empty replay)\x1b[0m');
-
-function formatReplayTime(timeMs: number): string {
-  const totalSeconds = Math.max(0, timeMs) / 1000;
-  if (totalSeconds < 59.95) {
-    return `${totalSeconds.toFixed(1)}s`;
-  }
-
-  const wholeSeconds = Math.round(totalSeconds);
-  const seconds = wholeSeconds % 60;
-  const minutes = Math.floor(wholeSeconds / 60) % 60;
-  const hours = Math.floor(wholeSeconds / 3600);
-
-  if (hours > 0) {
-    return `${hours}:${String(minutes).padStart(2, '0')}:${String(seconds).padStart(2, '0')}`;
-  }
-
-  return `${minutes}:${String(seconds).padStart(2, '0')}`;
-}
-
-function clamp(value: number, min: number, max: number): number {
-  return Math.min(max, Math.max(min, value));
-}
-
-function targetKey(target: ReplayFrameTarget | ReplayTimelineStep | null): string | null {
-  if (!target) {
-    return null;
-  }
-
-  const timeMs = 'timeMs' in target ? target.timeMs : target.atMs;
-  const seq = 'seq' in target ? target.seq : target.atSeq;
-  return `${timeMs ?? -1}:${seq ?? -1}`;
-}
-
-function toFrameTarget(step: ReplayTimelineStep | null, fallback: ReplayFrameTarget): ReplayFrameTarget {
-  if (!step) {
-    return fallback;
-  }
-
-  return { atMs: step.timeMs, atSeq: step.seq };
-}
 
 export interface ReplayTerminalWebProps {
   replay: ReplayInfo;

--- a/src/components/ReplayTerminal.web.tsx
+++ b/src/components/ReplayTerminal.web.tsx
@@ -1,32 +1,488 @@
 /** @jsxImportSource react */
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import type { ReplayFrameTarget, ReplayInfo, ReplayTimeline, ReplayTimelineStep } from '../lib/tmux-lite/replay/index.js';
 import { SessionTerminal } from './SessionTerminal.web';
 
-interface ReplayTerminalProps {
-  ansi: Uint8Array | null;
+const PLAYBACK_SPEEDS = [0.25, 0.5, 1, 1.5, 2, 4] as const;
+const DEFAULT_PLAYBACK_SPEED_INDEX = 2;
+const FAST_SCRUB_STEP_COUNT = 5;
+
+function encodeAnsi(text: string): Uint8Array {
+  return new TextEncoder().encode(text);
 }
 
-export function ReplayTerminalWeb({ ansi }: ReplayTerminalProps) {
+const LOADING_REPLAY_ANSI = encodeAnsi('\x1b[2J\x1b[H\x1b[2;37mLoading replay...\x1b[0m');
+const EMPTY_REPLAY_ANSI = encodeAnsi('\x1b[2J\x1b[H\x1b[2;37m(empty replay)\x1b[0m');
+
+function formatReplayTime(timeMs: number): string {
+  const totalSeconds = Math.max(0, timeMs) / 1000;
+  if (totalSeconds < 60) {
+    return `${totalSeconds.toFixed(1)}s`;
+  }
+
+  const wholeSeconds = Math.floor(totalSeconds);
+  const seconds = wholeSeconds % 60;
+  const minutes = Math.floor(wholeSeconds / 60) % 60;
+  const hours = Math.floor(wholeSeconds / 3600);
+
+  if (hours > 0) {
+    return `${hours}:${String(minutes).padStart(2, '0')}:${String(seconds).padStart(2, '0')}`;
+  }
+
+  return `${minutes}:${String(seconds).padStart(2, '0')}`;
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
+function targetKey(target: ReplayFrameTarget | ReplayTimelineStep | null): string | null {
+  if (!target) {
+    return null;
+  }
+
+  const timeMs = 'timeMs' in target ? target.timeMs : target.atMs;
+  const seq = 'seq' in target ? target.seq : target.atSeq;
+  return `${timeMs ?? -1}:${seq ?? -1}`;
+}
+
+function toFrameTarget(step: ReplayTimelineStep | null, fallback: ReplayFrameTarget): ReplayFrameTarget {
+  if (!step) {
+    return fallback;
+  }
+
+  return { atMs: step.timeMs, atSeq: step.seq };
+}
+
+export interface ReplayTerminalWebProps {
+  replay: ReplayInfo;
+  machineLabel?: string;
+  loadReplayAnsi: (replayId: string, target?: ReplayFrameTarget) => Promise<Uint8Array>;
+  loadReplayTimeline: (replayId: string) => Promise<ReplayTimeline>;
+  onBack: () => void;
+  onDismiss?: (replayId: string) => boolean | void | Promise<boolean | void>;
+}
+
+export function ReplayTerminalWeb({
+  replay,
+  machineLabel,
+  loadReplayAnsi,
+  loadReplayTimeline,
+  onBack,
+  onDismiss,
+}: ReplayTerminalWebProps) {
+  const latestFallbackTarget = useMemo<ReplayFrameTarget>(() => ({
+    atMs: replay.durationMs,
+    atSeq: replay.lastSeq,
+  }), [replay.durationMs, replay.lastSeq]);
+
+  const [content, setContent] = useState<Uint8Array | null>(null);
   const [writer, setWriter] = useState<((data: Uint8Array) => void) | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [reloadKey, setReloadKey] = useState(0);
+  const [timeline, setTimeline] = useState<ReplayTimeline | null>(null);
+  const [currentStepIndex, setCurrentStepIndex] = useState(-1);
+  const [loadedTargetKey, setLoadedTargetKey] = useState<string | null>(null);
+  const [timelineLoading, setTimelineLoading] = useState(true);
+  const [frameLoading, setFrameLoading] = useState(true);
+  const [isPlaying, setIsPlaying] = useState(false);
+  const [playbackSpeedIndex, setPlaybackSpeedIndex] = useState(DEFAULT_PLAYBACK_SPEED_INDEX);
+  const contentRef = useRef<Uint8Array | null>(null);
+  const frameRequestIdRef = useRef(0);
+
+  useEffect(() => {
+    contentRef.current = content;
+  }, [content]);
+
+  useEffect(() => {
+    if (!writer || !content) {
+      return;
+    }
+    writer(content);
+  }, [content, writer]);
 
   const setWriteCallback = useCallback((fn: ((data: Uint8Array) => void) | null) => {
     setWriter(() => fn);
   }, []);
 
+  const currentStep = timeline && currentStepIndex >= 0
+    ? timeline.steps[currentStepIndex] ?? null
+    : null;
+  const currentTarget = useMemo(
+    () => toFrameTarget(currentStep, latestFallbackTarget),
+    [currentStep, latestFallbackTarget],
+  );
+  const currentTargetKey = targetKey(currentTarget);
+  const playbackSpeed = PLAYBACK_SPEEDS[playbackSpeedIndex] ?? 1;
+
+  const loadFrame = useCallback(async (
+    target: ReplayFrameTarget,
+    options: { preserveContent: boolean },
+  ): Promise<void> => {
+    const requestId = ++frameRequestIdRef.current;
+    setFrameLoading(true);
+    setError(null);
+
+    if (!options.preserveContent && !contentRef.current) {
+      setContent(LOADING_REPLAY_ANSI);
+    }
+
+    try {
+      const bytes = await loadReplayAnsi(replay.replayId, target);
+      if (frameRequestIdRef.current !== requestId) {
+        return;
+      }
+
+      setContent(bytes.length > 0 ? new Uint8Array(bytes) : EMPTY_REPLAY_ANSI);
+      setLoadedTargetKey(targetKey(target));
+      setError(null);
+    } catch (loadError) {
+      if (frameRequestIdRef.current !== requestId) {
+        return;
+      }
+
+      const message = loadError instanceof Error ? loadError.message : String(loadError);
+      setError(message);
+
+      if (!contentRef.current || !options.preserveContent) {
+        setContent(encodeAnsi(`\x1b[2J\x1b[H\x1b[31mFailed to load replay\x1b[0m\r\n\r\n${message}`));
+      }
+    } finally {
+      if (frameRequestIdRef.current === requestId) {
+        setFrameLoading(false);
+      }
+    }
+  }, [loadReplayAnsi, replay.replayId]);
+
   useEffect(() => {
-    if (!writer || !ansi) {
+    let cancelled = false;
+    frameRequestIdRef.current += 1;
+    setIsPlaying(false);
+    setPlaybackSpeedIndex(DEFAULT_PLAYBACK_SPEED_INDEX);
+    setTimeline(null);
+    setCurrentStepIndex(-1);
+    setLoadedTargetKey(null);
+    setError(null);
+    setContent(null);
+    setTimelineLoading(true);
+    setFrameLoading(true);
+
+    void (async () => {
+      let nextTimeline: ReplayTimeline | null = null;
+
+      try {
+        nextTimeline = await loadReplayTimeline(replay.replayId);
+      } catch (timelineError) {
+        if (cancelled) {
+          return;
+        }
+        setError(timelineError instanceof Error ? timelineError.message : String(timelineError));
+      }
+
+      if (cancelled) {
+        return;
+      }
+
+      const initialStepIndex = nextTimeline && nextTimeline.steps.length > 0
+        ? nextTimeline.steps.length - 1
+        : -1;
+      const initialStep = nextTimeline && initialStepIndex >= 0
+        ? nextTimeline.steps[initialStepIndex] ?? null
+        : null;
+
+      await loadFrame(toFrameTarget(initialStep, latestFallbackTarget), { preserveContent: false });
+      if (cancelled) {
+        return;
+      }
+
+      setTimeline(nextTimeline);
+      setCurrentStepIndex(initialStepIndex);
+      setTimelineLoading(false);
+    })();
+
+    return () => {
+      cancelled = true;
+      frameRequestIdRef.current += 1;
+    };
+  }, [latestFallbackTarget, loadFrame, loadReplayTimeline, reloadKey, replay.replayId]);
+
+  useEffect(() => {
+    if (!timeline || currentStepIndex < 0 || currentTargetKey === loadedTargetKey) {
       return;
     }
-    writer(ansi);
-  }, [writer, ansi]);
+
+    void loadFrame(currentTarget, { preserveContent: true });
+  }, [currentStepIndex, currentTarget, currentTargetKey, loadFrame, loadedTargetKey, timeline]);
+
+  useEffect(() => {
+    if (!isPlaying) {
+      return;
+    }
+
+    if (!timeline || timeline.steps.length === 0) {
+      setIsPlaying(false);
+      return;
+    }
+
+    if (currentStepIndex < 0) {
+      return;
+    }
+
+    if (currentStepIndex >= timeline.steps.length - 1) {
+      setIsPlaying(false);
+      return;
+    }
+
+    if (timelineLoading || frameLoading || currentTargetKey !== loadedTargetKey) {
+      return;
+    }
+
+    const current = timeline.steps[currentStepIndex];
+    const next = timeline.steps[currentStepIndex + 1];
+    if (!current || !next) {
+      setIsPlaying(false);
+      return;
+    }
+
+    const delayMs = Math.max(0, Math.round((next.timeMs - current.timeMs) / playbackSpeed));
+    const timer = window.setTimeout(() => {
+      setCurrentStepIndex((index) => {
+        if (!timeline) {
+          return index;
+        }
+        return clamp(index + 1, 0, timeline.steps.length - 1);
+      });
+    }, delayMs);
+
+    return () => window.clearTimeout(timer);
+  }, [
+    currentStepIndex,
+    currentTargetKey,
+    frameLoading,
+    isPlaying,
+    loadedTargetKey,
+    playbackSpeed,
+    timeline,
+    timelineLoading,
+  ]);
+
+  const stepReplay = useCallback((direction: -1 | 1, count = 1) => {
+    if (!timeline || timeline.steps.length === 0) {
+      return;
+    }
+
+    setIsPlaying(false);
+    setCurrentStepIndex((index) => {
+      const resolvedIndex = index < 0 ? timeline.steps.length - 1 : index;
+      return clamp(resolvedIndex + (direction * count), 0, timeline.steps.length - 1);
+    });
+  }, [timeline]);
+
+  const adjustPlaybackSpeed = useCallback((direction: -1 | 1, count = 1) => {
+    setPlaybackSpeedIndex((index) => clamp(index + (direction * count), 0, PLAYBACK_SPEEDS.length - 1));
+  }, []);
+
+  const togglePlayback = useCallback(() => {
+    if (!timeline || timeline.steps.length === 0) {
+      return;
+    }
+
+    if (isPlaying) {
+      setIsPlaying(false);
+      return;
+    }
+
+    setCurrentStepIndex((index) => index >= timeline.steps.length - 1 ? 0 : Math.max(0, index));
+    setIsPlaying(true);
+  }, [isPlaying, timeline]);
+
+  const jumpToBoundary = useCallback((direction: 'start' | 'end') => {
+    if (!timeline || timeline.steps.length === 0) {
+      return;
+    }
+
+    setIsPlaying(false);
+    setCurrentStepIndex(direction === 'start' ? 0 : timeline.steps.length - 1);
+  }, [timeline]);
+
+  const handleDismiss = useCallback(async () => {
+    const shouldGoBack = await onDismiss?.(replay.replayId);
+    if (shouldGoBack !== false) {
+      onBack();
+    }
+  }, [onBack, onDismiss, replay.replayId]);
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.target instanceof HTMLInputElement || event.target instanceof HTMLTextAreaElement) {
+        return;
+      }
+
+      if (event.key === 'Escape' || event.key === 'q') {
+        event.preventDefault();
+        onBack();
+        return;
+      }
+
+      if (event.key === 'd' && onDismiss) {
+        event.preventDefault();
+        void handleDismiss();
+        return;
+      }
+
+      if (event.key === 'r') {
+        event.preventDefault();
+        setReloadKey((value) => value + 1);
+        return;
+      }
+
+      if (event.key === ' ' || event.code === 'Space') {
+        event.preventDefault();
+        togglePlayback();
+        return;
+      }
+
+      if (event.key === 'Home') {
+        event.preventDefault();
+        jumpToBoundary('start');
+        return;
+      }
+
+      if (event.key === 'End') {
+        event.preventDefault();
+        jumpToBoundary('end');
+        return;
+      }
+
+      if (event.key === 'ArrowLeft') {
+        event.preventDefault();
+        if (isPlaying) {
+          adjustPlaybackSpeed(-1, event.shiftKey ? 2 : 1);
+        } else {
+          stepReplay(-1, event.shiftKey ? FAST_SCRUB_STEP_COUNT : 1);
+        }
+        return;
+      }
+
+      if (event.key === 'ArrowRight') {
+        event.preventDefault();
+        if (isPlaying) {
+          adjustPlaybackSpeed(1, event.shiftKey ? 2 : 1);
+        } else {
+          stepReplay(1, event.shiftKey ? FAST_SCRUB_STEP_COUNT : 1);
+        }
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [adjustPlaybackSpeed, handleDismiss, isPlaying, jumpToBoundary, onBack, onDismiss, stepReplay, togglePlayback]);
+
+  const totalTimeMs = timeline?.latestTimeMs ?? replay.durationMs;
+  const activeTimeMs = currentTarget.atMs ?? totalTimeMs;
+  const totalSteps = timeline ? Math.max(0, timeline.steps.length - 1) : 0;
+  const visibleStepIndex = timeline && currentStepIndex >= 0
+    ? clamp(currentStepIndex, 0, Math.max(0, timeline.steps.length - 1))
+    : totalSteps;
+  const speedLabel = `${playbackSpeed.toFixed(playbackSpeed < 1 ? 2 : 1)}x`;
+  const activeTimeLabel = formatReplayTime(activeTimeMs);
+  const totalTimeLabel = formatReplayTime(totalTimeMs);
+  const stepLabel = `${visibleStepIndex}/${totalSteps}`;
+  const transportHint = isPlaying
+    ? '[Space] Pause  [←/→] Speed  [Shift+←/→] More'
+    : '[Space] Play  [←/→] Step  [Shift+←/→] Skip';
 
   return (
-    <SessionTerminal
-      onData={() => {}}
-      setWriteCallback={setWriteCallback}
-      readOnly={true}
-      allowTapFocus={false}
-      allowTouchScroll={true}
-    />
+    <div className="w-screen h-screen flex flex-col bg-[#0d1117] overflow-hidden">
+      <div className="bg-[#161b22] px-4 py-2 flex items-center justify-between border-b border-[#30363d] min-h-[52px] gap-2 flex-shrink-0">
+        <div className="flex items-center gap-2 sm:gap-4 min-w-0 flex-1 overflow-hidden">
+          <button
+            onClick={onBack}
+            className="text-sm text-[#8b949e] hover:text-[#e6edf3] py-2 pr-2 -ml-2 min-h-[44px] flex items-center flex-shrink-0"
+          >
+            ← <span className="hidden sm:inline ml-1">Workspaces</span>
+          </button>
+          <div className="min-w-0 flex-1 overflow-hidden">
+            <div className="text-sm text-[#8b949e] truncate">
+              <span className={replay.status === 'crashed' ? 'text-[#ff7b72]' : 'text-[#79c0ff]'}>↺</span>{' '}
+              {machineLabel && <span className="hidden sm:inline">{machineLabel}</span>}
+              {machineLabel && <span className="hidden sm:inline text-[#6e7681] mx-1">/</span>}
+              <span className="text-[#e6edf3]">{replay.sessionName}</span>
+              {replay.workspaceName && <span className="text-[#6e7681]"> · {replay.workspaceName}</span>}
+            </div>
+            <div className="text-xs text-[#8b949e] font-mono tabular-nums flex items-center gap-3 overflow-x-auto whitespace-nowrap">
+              <span className="inline-flex min-w-[14ch] justify-end">
+                <span className="inline-block min-w-[6ch] text-right">{activeTimeLabel}</span>
+                <span>/</span>
+                <span>{totalTimeLabel}</span>
+              </span>
+              <span className="inline-flex min-w-[7ch] justify-end">{stepLabel}</span>
+              <span className={`inline-flex min-w-[9ch] justify-end ${isPlaying ? 'text-[#3fb950]' : 'text-[#8b949e]'}`}>
+                {isPlaying ? '[playing]' : '[paused]'}
+              </span>
+              <span className="inline-flex min-w-[6ch] justify-end text-[#d29922]">{speedLabel}</span>
+              {(timelineLoading || frameLoading) && <span className="text-[#d29922]">[loading]</span>}
+              {error && <span className="text-[#ff7b72] truncate">[error] {error}</span>}
+            </div>
+          </div>
+        </div>
+        <div className="flex items-center gap-2 flex-shrink-0">
+          <div className="hidden md:flex items-center gap-1">
+            <button
+              onClick={() => stepReplay(-1)}
+              className="px-2 py-2 text-xs bg-[#21262d] hover:bg-[#30363d] rounded text-[#e6edf3] min-h-[40px] border border-[#30363d]"
+              aria-label="Previous replay step"
+            >
+              ←
+            </button>
+            <button
+              onClick={togglePlayback}
+              className="px-3 py-2 text-xs bg-[#21262d] hover:bg-[#30363d] rounded text-[#e6edf3] min-h-[40px] border border-[#30363d]"
+            >
+              {isPlaying ? 'Pause' : 'Play'}
+            </button>
+            <button
+              onClick={() => stepReplay(1)}
+              className="px-2 py-2 text-xs bg-[#21262d] hover:bg-[#30363d] rounded text-[#e6edf3] min-h-[40px] border border-[#30363d]"
+              aria-label="Next replay step"
+            >
+              →
+            </button>
+            <button
+              onClick={() => adjustPlaybackSpeed(-1)}
+              className="px-2 py-2 text-xs bg-[#21262d] hover:bg-[#30363d] rounded text-[#e6edf3] min-h-[40px] border border-[#30363d]"
+              aria-label="Slower playback"
+            >
+              -
+            </button>
+            <button
+              onClick={() => adjustPlaybackSpeed(1)}
+              className="px-2 py-2 text-xs bg-[#21262d] hover:bg-[#30363d] rounded text-[#e6edf3] min-h-[40px] border border-[#30363d]"
+              aria-label="Faster playback"
+            >
+              +
+            </button>
+          </div>
+          <div className="hidden lg:block text-xs text-[#6e7681] font-mono whitespace-nowrap">{transportHint}</div>
+          {onDismiss && (
+            <button
+              onClick={() => void handleDismiss()}
+              className="px-3 py-2 text-sm bg-[#21262d] hover:bg-[#30363d] rounded text-[#e6edf3] min-h-[44px] border border-[#30363d]"
+            >
+              {replay.dismissedAt ? 'Restore' : 'Dismiss'}
+            </button>
+          )}
+        </div>
+      </div>
+      <div className="flex-1 min-h-0">
+        <SessionTerminal
+          onData={() => {}}
+          setWriteCallback={setWriteCallback}
+          readOnly={true}
+          allowTapFocus={false}
+          allowTouchScroll={true}
+        />
+      </div>
+    </div>
   );
 }

--- a/src/components/ReplayTerminal.web.tsx
+++ b/src/components/ReplayTerminal.web.tsx
@@ -1,0 +1,32 @@
+/** @jsxImportSource react */
+import { useCallback, useEffect, useState } from 'react';
+import { SessionTerminal } from './SessionTerminal.web';
+
+interface ReplayTerminalProps {
+  ansi: Uint8Array | null;
+}
+
+export function ReplayTerminalWeb({ ansi }: ReplayTerminalProps) {
+  const [writer, setWriter] = useState<((data: Uint8Array) => void) | null>(null);
+
+  const setWriteCallback = useCallback((fn: ((data: Uint8Array) => void) | null) => {
+    setWriter(() => fn);
+  }, []);
+
+  useEffect(() => {
+    if (!writer || !ansi) {
+      return;
+    }
+    writer(ansi);
+  }, [writer, ansi]);
+
+  return (
+    <SessionTerminal
+      onData={() => {}}
+      setWriteCallback={setWriteCallback}
+      readOnly={true}
+      allowTapFocus={false}
+      allowTouchScroll={true}
+    />
+  );
+}

--- a/src/components/ReplayTerminal.web.tsx
+++ b/src/components/ReplayTerminal.web.tsx
@@ -16,11 +16,11 @@ const EMPTY_REPLAY_ANSI = encodeAnsi('\x1b[2J\x1b[H\x1b[2;37m(empty replay)\x1b[
 
 function formatReplayTime(timeMs: number): string {
   const totalSeconds = Math.max(0, timeMs) / 1000;
-  if (totalSeconds < 60) {
+  if (totalSeconds < 59.95) {
     return `${totalSeconds.toFixed(1)}s`;
   }
 
-  const wholeSeconds = Math.floor(totalSeconds);
+  const wholeSeconds = Math.round(totalSeconds);
   const seconds = wholeSeconds % 60;
   const minutes = Math.floor(wholeSeconds / 60) % 60;
   const hours = Math.floor(wholeSeconds / 3600);

--- a/src/components/SpacesBrowser.tsx
+++ b/src/components/SpacesBrowser.tsx
@@ -7,6 +7,9 @@
 
 import { useState, useCallback, useMemo, useEffect } from 'react';
 import { normalizeProcessInstanceCount } from '../lib/processes/instances.js';
+import type { ReplayInfo } from '../lib/tmux-lite/replay/index.js';
+
+export type { ReplayInfo };
 
 // ============================================================================
 // Types
@@ -57,6 +60,9 @@ export type TreeItem =
   | { type: 'project'; name: string; workspaceCount: number }
   | { type: 'workspace'; workspace: WorkspaceInfo; expanded: boolean }
   | { type: 'session'; session: SessionInfo; workspaceId: string }
+  | { type: 'replay-section'; workspaceId: string; count: number; expanded: boolean }
+  | { type: 'orphaned-replay-section'; projectName: string; count: number; expanded: boolean }
+  | { type: 'replay'; replay: ReplayInfo; workspaceId: string }
   | { type: 'process'; processName: string; instance: number; workspaceId: string; status: 'running' | 'stopped' | 'failed'; ports?: WorkspaceProcessPort[]; serveDomain?: string }
   | { type: 'process-disabled'; processName: string; workspaceId: string; ports?: WorkspaceProcessPort[] }
   | { type: 'process-config-error'; workspaceId: string; error: string }
@@ -75,8 +81,10 @@ export type TreeItemWithState = TreeItem & {
 export interface UseSpacesBrowserProps {
   workspaces: WorkspaceInfo[];
   sessions: SessionInfo[];
+  replays: ReplayInfo[];
   onRequestSessions: (workspaceId?: string) => void;
   onAttachSession: (params: { sessionId?: string; workspaceId?: string; viewOnly?: boolean }) => void | Promise<void>;
+  onOpenReplay: (params: { replayId: string; workspaceId: string }) => void | Promise<void>;
   onStartProcess?: (params: { workspaceId: string; processName: string }) => void;
   onStartProcessAttach: (params: { workspaceId: string; processName: string; instance: number }) => void;
   onStopProcess?: (params: { workspaceId: string; processName: string }) => void;
@@ -116,6 +124,7 @@ export interface UseSpacesBrowserReturn {
   activateIndex: (index: number) => Promise<void>;
   /** Direct attach - bypasses state timing issues on mobile */
   attachSession: (params: { sessionId?: string; workspaceId?: string; viewOnly?: boolean }) => Promise<void>;
+  openReplay: (params: { replayId: string; workspaceId: string }) => Promise<void>;
   startProcessAttach: (params: { workspaceId: string; processName: string; instance: number }) => void;
   startProcess: (params: { workspaceId: string; processName: string }) => void;
   stopProcess: (params: { workspaceId: string; processName: string }) => void;
@@ -137,13 +146,20 @@ interface ProjectGroup {
   workspaces: WorkspaceInfo[];
 }
 
-function groupByProject(workspaces: WorkspaceInfo[]): ProjectGroup[] {
+function groupByProject(workspaces: WorkspaceInfo[], replays: ReplayInfo[]): ProjectGroup[] {
   const projectMap = new Map<string, WorkspaceInfo[]>();
 
   for (const ws of workspaces) {
     const list = projectMap.get(ws.projectName) || [];
     list.push(ws);
     projectMap.set(ws.projectName, list);
+  }
+
+  for (const replay of replays) {
+    const projectName = replay.projectName ?? 'Unknown';
+    if (!projectMap.has(projectName)) {
+      projectMap.set(projectName, []);
+    }
   }
 
   const groups: ProjectGroup[] = [];
@@ -157,13 +173,20 @@ function groupByProject(workspaces: WorkspaceInfo[]): ProjectGroup[] {
 function buildTree(
   workspaces: WorkspaceInfo[],
   sessions: SessionInfo[],
+  replays: ReplayInfo[],
   expandedWorkspaces: Set<string>,
+  expandedReplaySections: Set<string>,
   showProjectHeaders: boolean = true
 ): TreeItem[] {
   const items: TreeItem[] = [];
-  const projectGroups = groupByProject(workspaces);
+  const projectGroups = groupByProject(workspaces, replays);
 
   for (const group of projectGroups) {
+    const workspaceIds = new Set(group.workspaces.map((workspace) => workspace.id));
+    const orphanedProjectReplays = replays
+      .filter((replay) => (replay.projectName ?? 'Unknown') === group.name && !workspaceIds.has(replay.workspaceId ?? ''))
+      .sort((a, b) => b.startedAt - a.startedAt);
+
     // Project header (optional)
     if (showProjectHeaders) {
       items.push({
@@ -272,6 +295,30 @@ function buildTree(
           });
         }
 
+        const workspaceReplays = replays
+          .filter((replay) => replay.workspaceId === ws.id)
+          .sort((a, b) => b.startedAt - a.startedAt);
+
+        if (workspaceReplays.length > 0) {
+          const replaySectionExpanded = expandedReplaySections.has(ws.id);
+          items.push({
+            type: 'replay-section',
+            workspaceId: ws.id,
+            count: workspaceReplays.length,
+            expanded: replaySectionExpanded,
+          });
+
+          if (replaySectionExpanded) {
+            for (const replay of workspaceReplays) {
+              items.push({
+                type: 'replay',
+                replay,
+                workspaceId: ws.id,
+              });
+            }
+          }
+        }
+
         if (ws.processConfigError) {
           items.push({
             type: 'process-config-error',
@@ -305,6 +352,27 @@ function buildTree(
         });
       }
     }
+
+    if (orphanedProjectReplays.length > 0) {
+      const orphanKey = `orphan:${group.name}`;
+      const orphanExpanded = expandedReplaySections.has(orphanKey);
+      items.push({
+        type: 'orphaned-replay-section',
+        projectName: group.name,
+        count: orphanedProjectReplays.length,
+        expanded: orphanExpanded,
+      });
+
+      if (orphanExpanded) {
+        for (const replay of orphanedProjectReplays) {
+          items.push({
+            type: 'replay',
+            replay,
+            workspaceId: replay.workspaceId ?? orphanKey,
+          });
+        }
+      }
+    }
   }
 
   return items;
@@ -326,8 +394,10 @@ export function useSpacesBrowser(props: UseSpacesBrowserProps): UseSpacesBrowser
   const {
     workspaces,
     sessions,
+    replays,
     onRequestSessions,
     onAttachSession,
+    onOpenReplay,
     onStartProcess,
     onStartProcessAttach,
     onStopProcess,
@@ -346,11 +416,12 @@ export function useSpacesBrowser(props: UseSpacesBrowserProps): UseSpacesBrowser
   // Local UI state
   const [selectedIndex, setSelectedIndex] = useState(0);
   const [expandedWorkspaces, setExpandedWorkspaces] = useState<Set<string>>(new Set());
+  const [expandedReplaySections, setExpandedReplaySections] = useState<Set<string>>(new Set());
 
   // Build tree
   const tree = useMemo(
-    () => buildTree(workspaces, sessions, expandedWorkspaces, showProjectHeaders),
-    [workspaces, sessions, expandedWorkspaces, showProjectHeaders]
+    () => buildTree(workspaces, sessions, replays, expandedWorkspaces, expandedReplaySections, showProjectHeaders),
+    [workspaces, sessions, replays, expandedWorkspaces, expandedReplaySections, showProjectHeaders]
   );
 
   // Add selection state
@@ -413,15 +484,36 @@ export function useSpacesBrowser(props: UseSpacesBrowserProps): UseSpacesBrowser
     });
   }, [onRequestSessions]);
 
+  const toggleReplaySection = useCallback((workspaceId: string) => {
+    setExpandedReplaySections(prev => {
+      const next = new Set(prev);
+      if (next.has(workspaceId)) {
+        next.delete(workspaceId);
+      } else {
+        next.add(workspaceId);
+      }
+      return next;
+    });
+  }, []);
+
   const activateItem = useCallback(async (item: TreeItem | null) => {
     if (!item) return;
 
     if (item.type === 'workspace') {
       toggleWorkspace(item.workspace.id);
+    } else if (item.type === 'orphaned-replay-section') {
+      toggleReplaySection(`orphan:${item.projectName}`);
+    } else if (item.type === 'replay-section') {
+      toggleReplaySection(item.workspaceId);
     } else if (item.type === 'session') {
       await onAttachSession({
         sessionId: item.session.id,
         viewOnly: item.session.processName ? true : undefined,
+      });
+    } else if (item.type === 'replay') {
+      await onOpenReplay({
+        replayId: item.replay.replayId,
+        workspaceId: item.workspaceId,
       });
     } else if (item.type === 'process') {
       if (item.status === 'running') {
@@ -462,7 +554,7 @@ export function useSpacesBrowser(props: UseSpacesBrowserProps): UseSpacesBrowser
     } else if (item.type === 'new-session') {
       await onAttachSession({ workspaceId: item.workspaceId });
     }
-  }, [toggleWorkspace, onAttachSession, onStartProcessAttach, findSessionForProcess, onProcessDisabled, onEditProcesses, onManageBundleConfig, onOpenEvents]);
+  }, [toggleWorkspace, toggleReplaySection, onAttachSession, onOpenReplay, onStartProcessAttach, findSessionForProcess, onProcessDisabled, onEditProcesses, onManageBundleConfig, onOpenEvents]);
 
   const activateSelected = useCallback(async () => {
     await activateItem(selectedItem);
@@ -525,6 +617,9 @@ export function useSpacesBrowser(props: UseSpacesBrowserProps): UseSpacesBrowser
     activateIndex,
     attachSession: async (params) => {
       await onAttachSession(params);
+    },
+    openReplay: async (params) => {
+      await onOpenReplay(params);
     },
     startProcessAttach: (params) => onStartProcessAttach(params),
     startProcess: (params) => onStartProcess?.(params),

--- a/src/components/SpacesBrowser.tsx
+++ b/src/components/SpacesBrowser.tsx
@@ -84,7 +84,7 @@ export interface UseSpacesBrowserProps {
   replays: ReplayInfo[];
   onRequestSessions: (workspaceId?: string) => void;
   onAttachSession: (params: { sessionId?: string; workspaceId?: string; viewOnly?: boolean }) => void | Promise<void>;
-  onOpenReplay: (params: { replayId: string; workspaceId: string }) => void | Promise<void>;
+  onOpenReplay: (replayId: string) => void | Promise<void>;
   onStartProcess?: (params: { workspaceId: string; processName: string }) => void;
   onStartProcessAttach: (params: { workspaceId: string; processName: string; instance: number }) => void;
   onStopProcess?: (params: { workspaceId: string; processName: string }) => void;
@@ -124,7 +124,7 @@ export interface UseSpacesBrowserReturn {
   activateIndex: (index: number) => Promise<void>;
   /** Direct attach - bypasses state timing issues on mobile */
   attachSession: (params: { sessionId?: string; workspaceId?: string; viewOnly?: boolean }) => Promise<void>;
-  openReplay: (params: { replayId: string; workspaceId: string }) => Promise<void>;
+  openReplay: (replayId: string) => Promise<void>;
   startProcessAttach: (params: { workspaceId: string; processName: string; instance: number }) => void;
   startProcess: (params: { workspaceId: string; processName: string }) => void;
   stopProcess: (params: { workspaceId: string; processName: string }) => void;
@@ -511,10 +511,7 @@ export function useSpacesBrowser(props: UseSpacesBrowserProps): UseSpacesBrowser
         viewOnly: item.session.processName ? true : undefined,
       });
     } else if (item.type === 'replay') {
-      await onOpenReplay({
-        replayId: item.replay.replayId,
-        workspaceId: item.workspaceId,
-      });
+      await onOpenReplay(item.replay.replayId);
     } else if (item.type === 'process') {
       if (item.status === 'running') {
         const session = findSessionForProcess(
@@ -618,8 +615,8 @@ export function useSpacesBrowser(props: UseSpacesBrowserProps): UseSpacesBrowser
     attachSession: async (params) => {
       await onAttachSession(params);
     },
-    openReplay: async (params) => {
-      await onOpenReplay(params);
+    openReplay: async (replayId) => {
+      await onOpenReplay(replayId);
     },
     startProcessAttach: (params) => onStartProcessAttach(params),
     startProcess: (params) => onStartProcess?.(params),

--- a/src/components/SpacesBrowser.tui.tsx
+++ b/src/components/SpacesBrowser.tui.tsx
@@ -45,6 +45,19 @@ function getSpacesBrowserHint(selectedItem: TreeItem | null | undefined): string
   if (selectedItem?.type === 'session') {
     return '[↑↓] Navigate  [Enter] Attach  [x] Kill  [r] Refresh  [q] Back';
   }
+  if (selectedItem?.type === 'replay-section') {
+    return selectedItem.expanded
+      ? '[↑↓] Navigate  [Enter] Collapse  [h] Hidden  [r] Refresh  [q] Back'
+      : '[↑↓] Navigate  [Enter] Expand History  [h] Hidden  [r] Refresh  [q] Back';
+  }
+  if (selectedItem?.type === 'orphaned-replay-section') {
+    return selectedItem.expanded
+      ? '[↑↓] Navigate  [Enter] Collapse  [h] Hidden  [r] Refresh  [q] Back'
+      : '[↑↓] Navigate  [Enter] Expand Orphaned History  [h] Hidden  [r] Refresh  [q] Back';
+  }
+  if (selectedItem?.type === 'replay') {
+    return '[↑↓] Navigate  [Enter] Open  [d] Dismiss  [h] Hidden  [r] Refresh  [q] Back';
+  }
   if (selectedItem?.type === 'process') {
     return selectedItem.status === 'running'
       ? '[↑↓] Navigate  [Enter] View  [x] Stop  [r] Refresh  [q] Back'
@@ -175,6 +188,48 @@ export function SpacesBrowserTUI(props: SpacesBrowserTUIProps) {
                 <text fg={textColor}> {displayName}</text>
                 {session.processTitle && <text fg={COLORS.sessionAttached}>{processInfo}</text>}
                 <text fg={COLORS.textDim}> {timeInfo}</text>
+              </box>
+            );
+          }
+
+          if (item.type === 'replay-section') {
+            const textColor = isSelected ? COLORS.selected : '#8B949E';
+            const prefix = isSelected ? '>' : ' ';
+            const arrow = item.expanded ? '▾' : '▸';
+            return (
+              <box key={`replay-section-${item.workspaceId}`} flexDirection="row" height={1}>
+                <text fg={textColor}>{prefix}   {arrow} </text>
+                <text fg={textColor}>History</text>
+                <text fg={COLORS.textDim}> ({item.count})</text>
+              </box>
+            );
+          }
+
+          if (item.type === 'orphaned-replay-section') {
+            const textColor = isSelected ? COLORS.selected : '#D29922';
+            const prefix = isSelected ? '>' : ' ';
+            const arrow = item.expanded ? '▾' : '▸';
+            return (
+              <box key={`orphaned-replay-section-${item.projectName}`} flexDirection="row" height={1}>
+                <text fg={textColor}>{prefix}   {arrow} </text>
+                <text fg={textColor}>Orphaned History</text>
+                <text fg={COLORS.textDim}> ({item.count})</text>
+              </box>
+            );
+          }
+
+          if (item.type === 'replay') {
+            const replay = item.replay;
+            const textColor = isSelected ? COLORS.selected : replay.status === 'crashed' ? '#FF8888' : '#6CB6FF';
+            const prefix = isSelected ? '>' : ' ';
+            const statusLabel = replay.status === 'crashed' ? 'crashed' : 'replay';
+            const timeInfo = replay.endedAt ? formatTime(replay.endedAt) : formatTime(replay.startedAt);
+            const dismissedMark = replay.dismissedAt ? ' [hidden]' : '';
+
+            return (
+              <box key={`replay-${replay.replayId}`} flexDirection="row" height={1}>
+                <text fg={textColor}>{prefix}     ↺ {replay.sessionName}</text>
+                <text fg={COLORS.textDim}> ({statusLabel}, {timeInfo}{dismissedMark})</text>
               </box>
             );
           }

--- a/src/components/SpacesBrowser.web.tsx
+++ b/src/components/SpacesBrowser.web.tsx
@@ -293,6 +293,72 @@ export function SpacesBrowserWeb(props: SpacesBrowserWebProps) {
             );
           }
 
+          if (item.type === 'replay-section') {
+            const arrow = item.expanded ? '▾' : '▸';
+            return (
+              <div
+                key={`replay-section-${item.workspaceId}`}
+                ref={isSelected ? selectedRowRef : null}
+                onClick={(e) => { e.stopPropagation(); void activateIndex(index); }}
+                onKeyDown={(e) => { if (!isActivateKey(e.key)) return; e.preventDefault(); e.stopPropagation(); void activateIndex(index); }}
+                role="button"
+                tabIndex={0}
+                className={`pl-8 sm:pl-10 pr-4 py-2 cursor-pointer border-b border-[#30363d] flex items-center gap-2 min-h-[36px] ${isSelected ? 'bg-[#21262d] border-l-4 border-l-[#58a6ff]' : 'hover:bg-[#161b22]'}`}
+              >
+                <span className="text-[#6e7681] text-xs">{arrow}</span>
+                <span className="text-[#8b949e] text-xs font-medium">History</span>
+                <span className="text-[#6e7681] text-xs">({item.count})</span>
+              </div>
+            );
+          }
+
+          if (item.type === 'orphaned-replay-section') {
+            const arrow = item.expanded ? '▾' : '▸';
+            return (
+              <div
+                key={`orphaned-replay-section-${item.projectName}`}
+                ref={isSelected ? selectedRowRef : null}
+                onClick={(e) => { e.stopPropagation(); void activateIndex(index); }}
+                onKeyDown={(e) => { if (!isActivateKey(e.key)) return; e.preventDefault(); e.stopPropagation(); void activateIndex(index); }}
+                role="button"
+                tabIndex={0}
+                className={`pl-8 sm:pl-10 pr-4 py-2 cursor-pointer border-b border-[#30363d] flex items-center gap-2 min-h-[36px] ${isSelected ? 'bg-[#21262d] border-l-4 border-l-[#58a6ff]' : 'hover:bg-[#161b22]'}`}
+              >
+                <span className="text-[#d29922] text-xs">{arrow}</span>
+                <span className="text-[#d29922] text-xs font-medium">Orphaned History</span>
+                <span className="text-[#6e7681] text-xs">({item.count})</span>
+              </div>
+            );
+          }
+
+          if (item.type === 'replay') {
+            const replay = item.replay;
+            const tone = replay.status === 'crashed' ? 'text-[#ff7b72]' : 'text-[#79c0ff]';
+            const dismissed = replay.dismissedAt ? ' opacity-50' : '';
+            return (
+              <div
+                key={`replay-${replay.replayId}`}
+                ref={isSelected ? selectedRowRef : null}
+                onClick={(e) => { e.stopPropagation(); void activateIndex(index); }}
+                onKeyDown={(e) => { if (!isActivateKey(e.key)) return; e.preventDefault(); e.stopPropagation(); void activateIndex(index); }}
+                role="button"
+                tabIndex={0}
+                className={`pl-12 sm:pl-14 pr-4 py-3 cursor-pointer border-b border-[#30363d] flex items-center justify-between min-h-[48px] gap-3${dismissed} ${isSelected ? 'bg-[#21262d] border-l-4 border-l-[#58a6ff]' : 'hover:bg-[#161b22] active:bg-[#21262d]'}`}
+              >
+                <div className="flex items-center gap-3 min-w-0 flex-1">
+                  <span className={`${tone} flex-shrink-0 text-xs`}>↺</span>
+                  <div className="min-w-0 flex-1">
+                    <span className="text-[#8b949e] truncate block text-sm">{replay.sessionName}</span>
+                    <span className={`text-xs truncate block ${tone}`}>{replay.status === 'crashed' ? 'crashed' : 'replay'}</span>
+                  </div>
+                </div>
+                <div className="text-xs text-[#6e7681] hidden sm:block shrink-0">
+                  {formatTime(replay.endedAt ?? replay.startedAt)}
+                </div>
+              </div>
+            );
+          }
+
           if (item.type === 'process') {
             const statusIcon = item.status === 'running' ? '▶' : item.status === 'failed' ? '✗' : '■';
             const statusColor = item.status === 'running' ? 'text-[#3fb950]' : item.status === 'failed' ? 'text-[#f85149]' : 'text-[#8b949e]';
@@ -580,6 +646,27 @@ function getFooterHint(selectedItem: TreeItem | null, hasVisibleActions: boolean
     return {
       desktop: ['Enter Attach', 'Kill Session', 'i Inbox', '? Help'],
       mobile: 'Tap to attach • Use Kill to end a session',
+    };
+  }
+
+  if (selectedItem?.type === 'replay-section') {
+    return {
+      desktop: [selectedItem.expanded ? 'Enter Collapse' : 'Enter Expand', 'r Refresh', '? Help'],
+      mobile: selectedItem.expanded ? 'Tap to collapse history' : 'Tap to expand history',
+    };
+  }
+
+  if (selectedItem?.type === 'orphaned-replay-section') {
+    return {
+      desktop: [selectedItem.expanded ? 'Enter Collapse' : 'Enter Expand', 'h Hidden', 'r Refresh', '? Help'],
+      mobile: selectedItem.expanded ? 'Tap to collapse orphaned history' : 'Tap to expand orphaned history',
+    };
+  }
+
+  if (selectedItem?.type === 'replay') {
+    return {
+      desktop: ['Enter Open', 'd Dismiss', 'h Hidden', 'r Refresh', '? Help'],
+      mobile: 'Tap to open replay • Press d to dismiss',
     };
   }
 

--- a/src/components/__tests__/ReplayTerminal.tui.test.tsx
+++ b/src/components/__tests__/ReplayTerminal.tui.test.tsx
@@ -1,8 +1,9 @@
-import { afterEach, describe, expect, it, mock } from 'bun:test';
+import { afterEach, describe, expect, it, jest, mock } from 'bun:test';
 import { testRender } from '@opentui/react/test-utils';
-import { act } from 'react';
+import { act, useState } from 'react';
 import { ReplayTerminal } from '../ReplayTerminal.tui.js';
 import type { ReplayInfo } from '../SpacesBrowser.js';
+import type { ReplayFrameTarget, ReplayTimeline } from '../../lib/tmux-lite/replay/index.js';
 
 function makeReplay(overrides: Partial<ReplayInfo> = {}): ReplayInfo {
   return {
@@ -16,17 +17,53 @@ function makeReplay(overrides: Partial<ReplayInfo> = {}): ReplayInfo {
     startedAt: Date.now() - 120_000,
     endedAt: Date.now() - 60_000,
     status: 'closed',
-    durationMs: 60_000,
+    durationMs: 1_200,
     eventCount: 10,
     checkpointCount: 2,
-    lastSeq: 10,
+    lastSeq: 3,
     ...overrides,
   };
+}
+
+function makeTimeline(overrides: Partial<ReplayTimeline> = {}): ReplayTimeline {
+  return {
+    replayId: 'replay-1',
+    durationMs: 1_200,
+    latestTimeMs: 1_200,
+    steps: [
+      { timeMs: 0, seq: 0 },
+      { timeMs: 200, seq: 1 },
+      { timeMs: 500, seq: 2 },
+      { timeMs: 1_200, seq: 3 },
+    ],
+    checkpointSteps: [
+      { timeMs: 0, seq: 0 },
+      { timeMs: 500, seq: 2 },
+    ],
+    ...overrides,
+  };
+}
+
+function frameLabel(target?: ReplayFrameTarget): Buffer {
+  return Buffer.from(`frame:${target?.atMs ?? -1}:${target?.atSeq ?? -1}`);
+}
+
+async function renderAndFlush(renderOnce: () => Promise<void>) {
+  await act(async () => {
+    await renderOnce();
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+  await act(async () => {
+    await renderOnce();
+  });
 }
 
 let destroyRenderer: (() => void) | null = null;
 
 afterEach(async () => {
+  jest.useRealTimers();
+
   if (destroyRenderer) {
     await act(async () => {
       destroyRenderer?.();
@@ -37,21 +74,159 @@ afterEach(async () => {
 
 describe('ReplayTerminal TUI', () => {
   it('shows restore hint for dismissed replays', async () => {
+    const loadReplayAnsi = mock(async (replayId: string, target?: ReplayFrameTarget) => frameLabel(target));
+    const loadReplayTimeline = mock(async () => makeTimeline());
+
     const { renderer, renderOnce, captureCharFrame } = await testRender(
       <ReplayTerminal
         replay={makeReplay({ dismissedAt: Date.now() - 1_000, dismissedBy: 'tester' })}
-        loadReplayAnsi={mock(() => new Promise<Buffer>(() => {}))}
+        loadReplayAnsi={loadReplayAnsi}
+        loadReplayTimeline={loadReplayTimeline}
         onBack={mock(() => {})}
         onDismiss={mock(async () => {})}
       />,
-      { width: 100, height: 20 },
+      { width: 170, height: 20 },
     );
     destroyRenderer = () => renderer.destroy();
 
-    await renderOnce();
+    await renderAndFlush(renderOnce);
     const frame = captureCharFrame();
 
     expect(frame).toContain('[d] Restore');
     expect(frame).not.toContain('[d] Dismiss');
+  });
+
+  it('does not reload the replay on unrelated parent rerenders', async () => {
+    const loadReplayAnsi = mock(async (replayId: string, target?: ReplayFrameTarget) => frameLabel(target));
+    const loadReplayTimeline = mock(async () => makeTimeline());
+
+    let bump = () => {};
+
+    function Harness() {
+      const [, setTick] = useState(0);
+      bump = () => setTick((value) => value + 1);
+
+      return (
+        <ReplayTerminal
+          replay={makeReplay()}
+          loadReplayAnsi={loadReplayAnsi}
+          loadReplayTimeline={loadReplayTimeline}
+          onBack={mock(() => {})}
+        />
+      );
+    }
+
+    const { renderer, renderOnce, captureCharFrame } = await testRender(<Harness />, {
+      width: 170,
+      height: 20,
+    });
+    destroyRenderer = () => renderer.destroy();
+
+    await renderAndFlush(renderOnce);
+    expect(loadReplayAnsi).toHaveBeenCalledTimes(1);
+    expect(captureCharFrame()).toContain('frame:1200:3');
+
+    await act(async () => {
+      bump();
+    });
+    await renderAndFlush(renderOnce);
+
+    expect(loadReplayAnsi).toHaveBeenCalledTimes(1);
+    expect(captureCharFrame()).toContain('frame:1200:3');
+    expect(captureCharFrame()).not.toContain('Loading replay');
+  });
+
+  it('steps through replay points when paused', async () => {
+    const loadReplayAnsi = mock(async (replayId: string, target?: ReplayFrameTarget) => frameLabel(target));
+    const loadReplayTimeline = mock(async () => makeTimeline());
+
+    const { renderer, renderOnce, mockInput, captureCharFrame } = await testRender(
+      <ReplayTerminal
+        replay={makeReplay()}
+        loadReplayAnsi={loadReplayAnsi}
+        loadReplayTimeline={loadReplayTimeline}
+        onBack={mock(() => {})}
+      />,
+      { width: 170, height: 20 },
+    );
+    destroyRenderer = () => renderer.destroy();
+
+    await renderAndFlush(renderOnce);
+    expect(captureCharFrame()).toContain('frame:1200:3');
+
+    await act(async () => {
+      mockInput.pressArrow('left');
+    });
+    await renderAndFlush(renderOnce);
+    expect(captureCharFrame()).toContain('frame:500:2');
+
+    await act(async () => {
+      mockInput.pressArrow('left', { shift: true });
+    });
+    await renderAndFlush(renderOnce);
+    expect(captureCharFrame()).toContain('frame:0:0');
+
+    await act(async () => {
+      mockInput.pressArrow('right');
+    });
+    await renderAndFlush(renderOnce);
+    expect(captureCharFrame()).toContain('frame:200:1');
+
+    await act(async () => {
+      mockInput.pressArrow('right', { shift: true });
+    });
+    await renderAndFlush(renderOnce);
+    expect(captureCharFrame()).toContain('frame:1200:3');
+  });
+
+  it('plays in real time and lets arrows adjust playback speed while playing', async () => {
+    jest.useFakeTimers();
+
+    const loadReplayAnsi = mock(async (replayId: string, target?: ReplayFrameTarget) => frameLabel(target));
+    const loadReplayTimeline = mock(async () => makeTimeline());
+
+    const { renderer, renderOnce, mockInput, captureCharFrame } = await testRender(
+      <ReplayTerminal
+        replay={makeReplay()}
+        loadReplayAnsi={loadReplayAnsi}
+        loadReplayTimeline={loadReplayTimeline}
+        onBack={mock(() => {})}
+      />,
+      { width: 170, height: 20 },
+    );
+    destroyRenderer = () => renderer.destroy();
+
+    await renderAndFlush(renderOnce);
+    expect(captureCharFrame()).toContain('[paused]');
+    expect(captureCharFrame()).toContain('1.0x');
+
+    await act(async () => {
+      mockInput.pressKey(' ');
+    });
+    await renderAndFlush(renderOnce);
+    expect(captureCharFrame()).toContain('[playing]');
+    expect(captureCharFrame()).toContain('frame:0:0');
+
+    await act(async () => {
+      jest.advanceTimersByTime(200);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    await renderAndFlush(renderOnce);
+    expect(captureCharFrame()).toContain('frame:200:1');
+
+    await act(async () => {
+      mockInput.pressArrow('right');
+    });
+    await renderAndFlush(renderOnce);
+    expect(captureCharFrame()).toContain('1.5x');
+
+    await act(async () => {
+      jest.advanceTimersByTime(200);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    await renderAndFlush(renderOnce);
+    expect(captureCharFrame()).toContain('frame:500:2');
   });
 });

--- a/src/components/__tests__/ReplayTerminal.tui.test.tsx
+++ b/src/components/__tests__/ReplayTerminal.tui.test.tsx
@@ -1,0 +1,57 @@
+import { afterEach, describe, expect, it, mock } from 'bun:test';
+import { testRender } from '@opentui/react/test-utils';
+import { act } from 'react';
+import { ReplayTerminal } from '../ReplayTerminal.tui.js';
+import type { ReplayInfo } from '../SpacesBrowser.js';
+
+function makeReplay(overrides: Partial<ReplayInfo> = {}): ReplayInfo {
+  return {
+    replayId: 'replay-1',
+    sessionId: 'session-1',
+    sessionName: 'ghost-session',
+    cwd: '/tmp/workspace',
+    workspaceId: 'ws-1',
+    projectName: 'proj',
+    workspaceName: 'workspace',
+    startedAt: Date.now() - 120_000,
+    endedAt: Date.now() - 60_000,
+    status: 'closed',
+    durationMs: 60_000,
+    eventCount: 10,
+    checkpointCount: 2,
+    lastSeq: 10,
+    ...overrides,
+  };
+}
+
+let destroyRenderer: (() => void) | null = null;
+
+afterEach(async () => {
+  if (destroyRenderer) {
+    await act(async () => {
+      destroyRenderer?.();
+    });
+    destroyRenderer = null;
+  }
+});
+
+describe('ReplayTerminal TUI', () => {
+  it('shows restore hint for dismissed replays', async () => {
+    const { renderer, renderOnce, captureCharFrame } = await testRender(
+      <ReplayTerminal
+        replay={makeReplay({ dismissedAt: Date.now() - 1_000, dismissedBy: 'tester' })}
+        loadReplayAnsi={mock(() => new Promise<Buffer>(() => {}))}
+        onBack={mock(() => {})}
+        onDismiss={mock(async () => {})}
+      />,
+      { width: 100, height: 20 },
+    );
+    destroyRenderer = () => renderer.destroy();
+
+    await renderOnce();
+    const frame = captureCharFrame();
+
+    expect(frame).toContain('[d] Restore');
+    expect(frame).not.toContain('[d] Dismiss');
+  });
+});

--- a/src/components/__tests__/SpacesBrowser.test.ts
+++ b/src/components/__tests__/SpacesBrowser.test.ts
@@ -10,6 +10,7 @@ import { act, renderHook } from '@testing-library/react';
 import { Window } from 'happy-dom';
 import {
   useSpacesBrowser,
+  type ReplayInfo,
   type WorkspaceInfo,
   type SessionInfo,
   type UseSpacesBrowserProps,
@@ -66,8 +67,10 @@ function makeProps(overrides: Partial<UseSpacesBrowserProps> = {}): UseSpacesBro
   return {
     workspaces: [],
     sessions: [],
+    replays: [],
     onRequestSessions: mock(() => {}),
     onAttachSession: mock(async () => {}),
+    onOpenReplay: mock(async () => {}),
     onStartProcess: mock(() => {}),
     onStartProcessAttach: mock(() => {}),
     onStopProcess: mock(() => {}),
@@ -75,6 +78,26 @@ function makeProps(overrides: Partial<UseSpacesBrowserProps> = {}): UseSpacesBro
     onRefresh: mock(async () => {}),
     onBack: mock(() => {}),
     showProjectHeaders: false,
+    ...overrides,
+  };
+}
+
+function makeReplay(overrides: Partial<ReplayInfo> = {}): ReplayInfo {
+  return {
+    replayId: 'replay-1',
+    sessionId: 'sess-1',
+    sessionName: 'ghost-session',
+    cwd: '/home/user/gitspace/proj/workspaces/my-workspace',
+    workspaceId: 'ws-1',
+    projectName: 'proj',
+    workspaceName: 'my-workspace',
+    startedAt: Date.now() - 120000,
+    endedAt: Date.now() - 60000,
+    status: 'closed',
+    durationMs: 60000,
+    eventCount: 20,
+    checkpointCount: 2,
+    lastSeq: 20,
     ...overrides,
   };
 }
@@ -116,6 +139,34 @@ describe('useSpacesBrowser tree building', () => {
     expect(types).toContain('events');
     expect(types).toContain('bundle-config');
     expect(types).toContain('new-session');
+  });
+
+  it('shows replay-section row when expanded workspace has ghosts', () => {
+    const ws = makeWorkspace();
+    const replay = makeReplay();
+    const props = makeProps({ workspaces: [ws], replays: [replay] });
+    const { result } = renderHook(() => useSpacesBrowser(props));
+
+    act(() => { result.current.toggleWorkspace('ws-1'); });
+
+    // replay-section should appear but replays are collapsed by default
+    const sectionItem = result.current.items.find((item) => item.type === 'replay-section');
+    expect(sectionItem).toBeDefined();
+    if (sectionItem && sectionItem.type === 'replay-section') {
+      expect(sectionItem.count).toBe(1);
+      expect(sectionItem.expanded).toBe(false);
+    }
+
+    // expand the section via activateSelected
+    const sectionIndex = result.current.items.findIndex((item) => item.type === 'replay-section');
+    act(() => { result.current.selectIndex(sectionIndex); });
+    act(() => { void result.current.activateSelected(); });
+
+    const replayItem = result.current.items.find((item) => item.type === 'replay');
+    expect(replayItem).toBeDefined();
+    if (replayItem && replayItem.type === 'replay') {
+      expect(replayItem.replay.replayId).toBe('replay-1');
+    }
   });
 
   it('includes process items when workspace has processes configured', () => {
@@ -309,6 +360,28 @@ describe('useSpacesBrowser activateSelected', () => {
     await act(async () => { await result.current.activateSelected(); });
 
     expect(onOpenEvents).toHaveBeenCalledWith('ws-1');
+  });
+
+  it('opens replay when replay item is activated', async () => {
+    const ws = makeWorkspace();
+    const replay = makeReplay();
+    const onOpenReplay = mock(async () => {});
+    const props = makeProps({ workspaces: [ws], replays: [replay], onOpenReplay });
+    const { result } = renderHook(() => useSpacesBrowser(props));
+
+    act(() => { result.current.toggleWorkspace('ws-1'); });
+
+    // Expand the replay section first
+    const sectionIndex = result.current.items.findIndex((item) => item.type === 'replay-section');
+    act(() => { result.current.selectIndex(sectionIndex); });
+    act(() => { void result.current.activateSelected(); });
+
+    const replayIndex = result.current.items.findIndex((item) => item.type === 'replay');
+    act(() => { result.current.selectIndex(replayIndex); });
+
+    await act(async () => { await result.current.activateSelected(); });
+
+    expect(onOpenReplay).toHaveBeenCalledWith({ replayId: 'replay-1', workspaceId: 'ws-1' });
   });
 
   it('calls onEditProcesses when edit-processes item is activated', async () => {

--- a/src/components/__tests__/SpacesBrowser.test.ts
+++ b/src/components/__tests__/SpacesBrowser.test.ts
@@ -141,7 +141,7 @@ describe('useSpacesBrowser tree building', () => {
     expect(types).toContain('new-session');
   });
 
-  it('shows replay-section row when expanded workspace has ghosts', () => {
+  it('shows replay-section row when expanded workspace has ghosts', async () => {
     const ws = makeWorkspace();
     const replay = makeReplay();
     const props = makeProps({ workspaces: [ws], replays: [replay] });
@@ -160,7 +160,7 @@ describe('useSpacesBrowser tree building', () => {
     // expand the section via activateSelected
     const sectionIndex = result.current.items.findIndex((item) => item.type === 'replay-section');
     act(() => { result.current.selectIndex(sectionIndex); });
-    act(() => { void result.current.activateSelected(); });
+    await act(async () => { await result.current.activateSelected(); });
 
     const replayItem = result.current.items.find((item) => item.type === 'replay');
     expect(replayItem).toBeDefined();
@@ -396,7 +396,7 @@ describe('useSpacesBrowser activateSelected', () => {
     // Expand the replay section first
     const sectionIndex = result.current.items.findIndex((item) => item.type === 'replay-section');
     act(() => { result.current.selectIndex(sectionIndex); });
-    act(() => { void result.current.activateSelected(); });
+    await act(async () => { await result.current.activateSelected(); });
 
     const replayIndex = result.current.items.findIndex((item) => item.type === 'replay');
     act(() => { result.current.selectIndex(replayIndex); });

--- a/src/components/__tests__/SpacesBrowser.test.ts
+++ b/src/components/__tests__/SpacesBrowser.test.ts
@@ -169,6 +169,28 @@ describe('useSpacesBrowser tree building', () => {
     }
   });
 
+  it('shows orphaned replay section when project has replay history without workspace', () => {
+    const orphanedReplay = makeReplay({
+      replayId: 'replay-orphaned',
+      workspaceId: 'missing-workspace',
+      workspaceName: 'deleted-workspace',
+    });
+    const props = makeProps({ workspaces: [], replays: [orphanedReplay], showProjectHeaders: true });
+    const { result } = renderHook(() => useSpacesBrowser(props));
+
+    const types = result.current.items.map((item) => item.type);
+    expect(types).toContain('project');
+    expect(types).toContain('orphaned-replay-section');
+
+    const orphanedSection = result.current.items.find((item) => item.type === 'orphaned-replay-section');
+    expect(orphanedSection).toBeDefined();
+    if (orphanedSection && orphanedSection.type === 'orphaned-replay-section') {
+      expect(orphanedSection.projectName).toBe('proj');
+      expect(orphanedSection.count).toBe(1);
+      expect(orphanedSection.expanded).toBe(false);
+    }
+  });
+
   it('includes process items when workspace has processes configured', () => {
     const ws = makeWorkspace({
       sessionCount: 0,
@@ -382,6 +404,23 @@ describe('useSpacesBrowser activateSelected', () => {
     await act(async () => { await result.current.activateSelected(); });
 
     expect(onOpenReplay).toHaveBeenCalledWith({ replayId: 'replay-1', workspaceId: 'ws-1' });
+  });
+
+  it('opens orphaned replay when orphaned section is expanded', async () => {
+    const replay = makeReplay({ replayId: 'replay-orphaned', workspaceId: 'missing-workspace', workspaceName: 'deleted-ws' });
+    const onOpenReplay = mock(async () => {});
+    const props = makeProps({ workspaces: [], replays: [replay], onOpenReplay, showProjectHeaders: true });
+    const { result } = renderHook(() => useSpacesBrowser(props));
+
+    const orphanedIndex = result.current.items.findIndex((item) => item.type === 'orphaned-replay-section');
+    act(() => { result.current.selectIndex(orphanedIndex); });
+    await act(async () => { await result.current.activateSelected(); });
+
+    const replayIndex = result.current.items.findIndex((item) => item.type === 'replay');
+    act(() => { result.current.selectIndex(replayIndex); });
+    await act(async () => { await result.current.activateSelected(); });
+
+    expect(onOpenReplay).toHaveBeenCalledWith({ replayId: 'replay-orphaned', workspaceId: 'missing-workspace' });
   });
 
   it('calls onEditProcesses when edit-processes item is activated', async () => {

--- a/src/components/__tests__/SpacesBrowser.test.ts
+++ b/src/components/__tests__/SpacesBrowser.test.ts
@@ -403,7 +403,7 @@ describe('useSpacesBrowser activateSelected', () => {
 
     await act(async () => { await result.current.activateSelected(); });
 
-    expect(onOpenReplay).toHaveBeenCalledWith({ replayId: 'replay-1', workspaceId: 'ws-1' });
+    expect(onOpenReplay).toHaveBeenCalledWith('replay-1');
   });
 
   it('opens orphaned replay when orphaned section is expanded', async () => {
@@ -420,7 +420,7 @@ describe('useSpacesBrowser activateSelected', () => {
     act(() => { result.current.selectIndex(replayIndex); });
     await act(async () => { await result.current.activateSelected(); });
 
-    expect(onOpenReplay).toHaveBeenCalledWith({ replayId: 'replay-orphaned', workspaceId: 'missing-workspace' });
+    expect(onOpenReplay).toHaveBeenCalledWith('replay-orphaned');
   });
 
   it('calls onEditProcesses when edit-processes item is activated', async () => {

--- a/src/components/__tests__/SpacesBrowser.tui.test.tsx
+++ b/src/components/__tests__/SpacesBrowser.tui.test.tsx
@@ -30,6 +30,7 @@ function makeTuiProps(overrides: Partial<UseSpacesBrowserReturn> = {}): UseSpace
     activateSelected: mock(async () => {}),
     activateIndex: mock(async () => {}),
     attachSession: mock(async () => {}),
+    openReplay: mock(async () => {}),
     startProcessAttach: mock(() => {}),
     startProcess: mock(() => {}),
     stopProcess: mock(() => {}),
@@ -88,6 +89,31 @@ function makeNewSessionItem(): TreeItemWithState {
   };
 }
 
+function makeReplayItem(): TreeItemWithState {
+  return {
+    type: 'replay',
+    replay: {
+      replayId: 'replay-1',
+      sessionId: 'sess-ghost',
+      sessionName: 'ghost-session',
+      cwd: '/workspaces/my-workspace',
+      workspaceId: 'ws-1',
+      projectName: 'proj',
+      workspaceName: 'my-workspace',
+      startedAt: Date.now() - 120000,
+      endedAt: Date.now() - 60000,
+      status: 'closed',
+      durationMs: 60000,
+      eventCount: 20,
+      checkpointCount: 2,
+      lastSeq: 20,
+    },
+    workspaceId: 'ws-1',
+    isSelected: false,
+    index: 2,
+  };
+}
+
 // ============================================================================
 // Cleanup
 // ============================================================================
@@ -110,6 +136,7 @@ describe('SpacesBrowserTUI renderer', () => {
     const items: TreeItemWithState[] = [
       makeWorkspaceItem(),
       makeSessionItem(),
+      makeReplayItem(),
       makeNewSessionItem(),
     ];
 
@@ -128,6 +155,7 @@ describe('SpacesBrowserTUI renderer', () => {
     expect(frame).toContain('test-machine');
     // Should contain workspace name
     expect(frame).toContain('my-workspace');
+    expect(frame).toContain('ghost-session');
     // Should contain new session action
     expect(frame).toContain('New Session');
   });

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -31,6 +31,7 @@ export type {
   WorkspaceProcessPort,
   WorkspaceInfo,
   SessionInfo,
+  ReplayInfo,
   TreeItem,
   TreeItemWithState,
   UseSpacesBrowserProps,

--- a/src/components/replay-utils.ts
+++ b/src/components/replay-utils.ts
@@ -1,0 +1,71 @@
+/**
+ * Shared replay playback utilities used by both TUI and web replay terminals.
+ */
+
+import type {
+  ReplayFrameTarget,
+  ReplayTimelineStep,
+} from '../lib/tmux-lite/replay/index.js';
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+export const PLAYBACK_SPEEDS = [0.25, 0.5, 1, 1.5, 2, 4] as const;
+export const DEFAULT_PLAYBACK_SPEED_INDEX = 2;
+export const FAST_SCRUB_STEP_COUNT = 5;
+
+// ============================================================================
+// Formatting
+// ============================================================================
+
+export function formatReplayTime(timeMs: number): string {
+  const totalSeconds = Math.max(0, timeMs) / 1000;
+  if (totalSeconds < 59.95) {
+    return `${totalSeconds.toFixed(1)}s`;
+  }
+
+  const wholeSeconds = Math.round(totalSeconds);
+  const seconds = wholeSeconds % 60;
+  const minutes = Math.floor(wholeSeconds / 60) % 60;
+  const hours = Math.floor(wholeSeconds / 3600);
+
+  if (hours > 0) {
+    return `${hours}:${String(minutes).padStart(2, '0')}:${String(seconds).padStart(2, '0')}`;
+  }
+
+  return `${minutes}:${String(seconds).padStart(2, '0')}`;
+}
+
+// ============================================================================
+// Replay frame targeting
+// ============================================================================
+
+export function targetKey(target: ReplayFrameTarget | ReplayTimelineStep | null): string | null {
+  if (!target) {
+    return null;
+  }
+
+  const timeMs = 'timeMs' in target ? target.timeMs : target.atMs;
+  const seq = 'seq' in target ? target.seq : target.atSeq;
+  return `${timeMs ?? -1}:${seq ?? -1}`;
+}
+
+export function toFrameTarget(step: ReplayTimelineStep | null, fallback: ReplayFrameTarget): ReplayFrameTarget {
+  if (!step) {
+    return fallback;
+  }
+
+  return {
+    atMs: step.timeMs,
+    atSeq: step.seq,
+  };
+}
+
+// ============================================================================
+// Math
+// ============================================================================
+
+export function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}

--- a/src/core/workspace.ts
+++ b/src/core/workspace.ts
@@ -28,6 +28,10 @@ import {
   killSession,
   isServerRunning,
 } from '../lib/tmux-lite/cli.js';
+import {
+  deleteReplaysForProject,
+  deleteReplaysForWorkspace,
+} from '../lib/tmux-lite/replay/store.js';
 
 /**
  * Options for workspace deletion
@@ -68,6 +72,7 @@ export interface DeleteWorkspaceResult {
   branch?: string;
   branchDeleted: boolean;
   sessionsKilled: number;
+  replaysDeleted?: number;
   errorCode?: 'WORKSPACE_NOT_FOUND' | 'REMOVE_SCRIPT_FAILED' | 'WORKTREE_REMOVE_FAILED';
   error?: string;
   removeScriptError?: string;
@@ -95,6 +100,7 @@ export async function deleteWorkspaceCore(
     workspaceName,
     branchDeleted: false,
     sessionsKilled: 0,
+    replaysDeleted: 0,
   };
 
   // Validate workspace exists before attempting deletion
@@ -247,6 +253,15 @@ export async function deleteWorkspaceCore(
     logger.debug(`Failed to update bundle workspace metadata for ${workspaceName}: ${e}`);
   }
 
+  try {
+    result.replaysDeleted = deleteReplaysForWorkspace(`${projectName}:${workspaceName}`, {
+      projectName,
+      workspaceName,
+    });
+  } catch (e) {
+    logger.debug(`Failed to delete replay history for ${workspaceName}: ${e}`);
+  }
+
   return result;
 }
 
@@ -274,6 +289,7 @@ export interface DeleteProjectResult {
   projectName: string;
   workspacesDeleted: number;
   sessionsKilled: number;
+  replaysDeleted?: number;
   wasCurrentProject: boolean;
   errors: string[];
 }
@@ -297,6 +313,7 @@ export async function deleteProjectCore(
     projectName,
     workspacesDeleted: 0,
     sessionsKilled: 0,
+    replaysDeleted: 0,
     wasCurrentProject: false,
     errors: [],
   };
@@ -331,6 +348,7 @@ export async function deleteProjectCore(
       if (wsResult.success) {
         result.workspacesDeleted++;
         result.sessionsKilled += wsResult.sessionsKilled;
+        result.replaysDeleted = (result.replaysDeleted ?? 0) + (wsResult.replaysDeleted ?? 0);
       } else if (wsResult.error) {
         result.errors.push(`${workspaceName}: ${wsResult.error}`);
       }
@@ -349,6 +367,12 @@ export async function deleteProjectCore(
     const msg = e instanceof Error ? e.message : 'Failed to remove project directory';
     result.errors.push(msg);
     return result;
+  }
+
+  try {
+    result.replaysDeleted = (result.replaysDeleted ?? 0) + deleteReplaysForProject(projectName);
+  } catch (e) {
+    logger.debug(`Failed to delete replay history for project ${projectName}: ${e}`);
   }
 
   // Update global config if this was the current project

--- a/src/hooks/useLocalSession.tui.ts
+++ b/src/hooks/useLocalSession.tui.ts
@@ -252,7 +252,7 @@ export function useLocalSession(options: UseLocalSessionOptions = {}) {
   const requestReplays = useCallback(async (workspaceId?: string, includeDismissed?: boolean) => {
     await runWithBackend(async (sessionEngine) => {
       await sessionEngine.listReplays(backendKey, workspaceId, includeDismissed);
-    }, { strict: true });
+    });
   }, [backendKey, runWithBackend]);
 
   const createProject = useCallback(async (params: CreateProjectParams) => {

--- a/src/hooks/useLocalSession.tui.ts
+++ b/src/hooks/useLocalSession.tui.ts
@@ -249,6 +249,12 @@ export function useLocalSession(options: UseLocalSessionOptions = {}) {
     });
   }, [backendKey, runWithBackend]);
 
+  const requestReplays = useCallback(async (workspaceId?: string, includeDismissed?: boolean) => {
+    await runWithBackend(async (sessionEngine) => {
+      await sessionEngine.listReplays(backendKey, workspaceId, includeDismissed);
+    }, { strict: true });
+  }, [backendKey, runWithBackend]);
+
   const createProject = useCallback(async (params: CreateProjectParams) => {
     await runWithBackend(async (sessionEngine) => {
       await sessionEngine.createProject(backendKey, params);
@@ -491,6 +497,77 @@ export function useLocalSession(options: UseLocalSessionOptions = {}) {
     });
   }, [backendKey, runWithBackend]);
 
+  const createCheckpoint = useCallback(async (sessionId: string) => {
+    await runWithBackend(async (sessionEngine) => {
+      await sessionEngine.createCheckpoint(backendKey, sessionId);
+    }, { strict: true });
+  }, [backendKey, runWithBackend]);
+
+  const getReplaySnapshot = useCallback(async (replayId: string, atMs?: number, scrollbackLines?: number) => {
+    let snapshot = null;
+    await runWithBackend(async (sessionEngine) => {
+      snapshot = await sessionEngine.getReplaySnapshot(backendKey, replayId, atMs, scrollbackLines);
+    }, { strict: true });
+
+    if (!snapshot) {
+      throw new SpacesError('Replay snapshot unavailable', 'SYSTEM_ERROR', 2);
+    }
+
+    return snapshot;
+  }, [backendKey, runWithBackend]);
+
+  const getReplayText = useCallback(async (
+    replayId: string,
+    atMs?: number,
+    scrollbackLines?: number,
+    includeScrollback?: boolean,
+    trimTrailingBlankRows?: boolean,
+  ) => {
+    let text: string | null = null;
+    await runWithBackend(async (sessionEngine) => {
+      text = await sessionEngine.getReplayText(
+        backendKey,
+        replayId,
+        atMs,
+        scrollbackLines,
+        includeScrollback,
+        trimTrailingBlankRows,
+      );
+    }, { strict: true });
+
+    if (text === null) {
+      throw new SpacesError('Replay text unavailable', 'SYSTEM_ERROR', 2);
+    }
+
+    return text;
+  }, [backendKey, runWithBackend]);
+
+  const getReplayMarkdown = useCallback(async (
+    replayId: string,
+    atMs?: number,
+    scrollbackLines?: number,
+    includeScrollback?: boolean,
+    trimTrailingBlankRows?: boolean,
+  ) => {
+    let markdown: string | null = null;
+    await runWithBackend(async (sessionEngine) => {
+      markdown = await sessionEngine.getReplayMarkdown(
+        backendKey,
+        replayId,
+        atMs,
+        scrollbackLines,
+        includeScrollback,
+        trimTrailingBlankRows,
+      );
+    }, { strict: true });
+
+    if (markdown === null) {
+      throw new SpacesError('Replay markdown unavailable', 'SYSTEM_ERROR', 2);
+    }
+
+    return markdown;
+  }, [backendKey, runWithBackend]);
+
   const setWriteCallback = useCallback((fn: ((data: Uint8Array) => void) | null) => {
     writeCallbackRef.current = fn;
     backendRef.current?.setPtyOutputHandler(fn);
@@ -502,6 +579,7 @@ export function useLocalSession(options: UseLocalSessionOptions = {}) {
     projects: localState?.projects ?? [],
     workspaces: localState?.workspaces ?? [],
     sessions: localState?.sessions ?? [],
+    replays: localState?.replays ?? [],
     inbox: localState?.inbox ?? [],
     inboxUnreadCount: localState?.inboxUnreadCount ?? 0,
     notificationConfig: localState?.notificationConfig ?? null,
@@ -518,6 +596,7 @@ export function useLocalSession(options: UseLocalSessionOptions = {}) {
     listLinearIssues,
     requestWorkspaces,
     requestSessions,
+    requestReplays,
     createProject,
     prepareProjectCreation,
     finalizeProjectCreation,
@@ -541,6 +620,10 @@ export function useLocalSession(options: UseLocalSessionOptions = {}) {
     startProcess,
     stopProcess,
     requestEvents,
+    createCheckpoint,
+    getReplaySnapshot,
+    getReplayText,
+    getReplayMarkdown,
     send,
     resize,
     setWriteCallback,

--- a/src/lib/remote-session/__tests__/session-handler.test.ts
+++ b/src/lib/remote-session/__tests__/session-handler.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'bun:test';
+import { canAccessReplayForSession, filterReplaysForSessionAccess } from '../session-handler.js';
+
+describe('remote replay session access', () => {
+  it('allows full access to all replays', () => {
+    const replays = [
+      { replayId: 'r1', sessionId: 's1' },
+      { replayId: 'r2', sessionId: 's2' },
+    ];
+
+    expect(filterReplaysForSessionAccess('full', undefined, replays)).toEqual(replays);
+    expect(canAccessReplayForSession('full', undefined, { sessionId: 's1' })).toBe(true);
+  });
+
+  it('limits view access to the granted session only', () => {
+    const replays = [
+      { replayId: 'r1', sessionId: 's1' },
+      { replayId: 'r2', sessionId: 's2' },
+    ];
+
+    expect(filterReplaysForSessionAccess('view', 's2', replays)).toEqual([{ replayId: 'r2', sessionId: 's2' }]);
+    expect(canAccessReplayForSession('view', 's2', { sessionId: 's2' })).toBe(true);
+    expect(canAccessReplayForSession('view', 's2', { sessionId: 's1' })).toBe(false);
+  });
+
+  it('denies replay access when no session grant is present', () => {
+    const replays = [{ replayId: 'r1', sessionId: 's1' }];
+    expect(filterReplaysForSessionAccess('view', undefined, replays)).toEqual([]);
+    expect(canAccessReplayForSession('view', undefined, { sessionId: 's1' })).toBe(false);
+    expect(canAccessReplayForSession(undefined, undefined, { sessionId: 's1' })).toBe(false);
+  });
+});

--- a/src/lib/remote-session/protocol.ts
+++ b/src/lib/remote-session/protocol.ts
@@ -34,7 +34,7 @@ export type {
   ConfirmStepResult,
   SpacesBundle,
 } from '../../types/bundle.js';
-export type { ReplayInfo } from '../tmux-lite/replay/types.js';
+export type { ReplayFrameTarget, ReplayInfo, ReplayTimeline } from '../tmux-lite/replay/types.js';
 
 // Re-export attached mode control types from tmux-lite
 // These are used in attached mode for resize/detach/attach-init
@@ -67,6 +67,13 @@ export interface GetReplayAnsiRequest {
   type: 'get_replay_ansi';
   replayId: string;
   atMs?: number;
+  atSeq?: number;
+}
+
+/** Request replay timeline metadata for scrubbing and playback */
+export interface GetReplayTimelineRequest {
+  type: 'get_replay_timeline';
+  replayId: string;
 }
 
 /** Soft-hide a replay */
@@ -345,6 +352,13 @@ export interface ReplayAnsiResponse {
   encoding: 'base64';
 }
 
+/** Response with replay timeline metadata */
+export interface ReplayTimelineResponse {
+  type: 'replay_timeline';
+  replayId: string;
+  timeline: import('../tmux-lite/replay/types.js').ReplayTimeline;
+}
+
 /** Replay dismissed successfully */
 export interface ReplayDismissedResponse {
   type: 'replay_dismissed';
@@ -592,6 +606,7 @@ export type ClientToMachineMessage =
   | ListSessionsRequest
   | ListReplaysRequest
   | GetReplayAnsiRequest
+  | GetReplayTimelineRequest
   | DismissReplayRequest
   | UndismissReplayRequest
   | AttachSessionRequest
@@ -628,6 +643,7 @@ export type MachineToClientMessage =
   | SessionListResponse
   | ReplayListResponse
   | ReplayAnsiResponse
+  | ReplayTimelineResponse
   | ReplayDismissedResponse
   | ReplayUndismissedResponse
   | AttachedResponse
@@ -699,6 +715,7 @@ export function isBrowseMessage(msg: RemoteSessionMessage): msg is
   | ListSessionsRequest
   | ListReplaysRequest
   | GetReplayAnsiRequest
+  | GetReplayTimelineRequest
   | DismissReplayRequest
   | UndismissReplayRequest
   | AttachSessionRequest
@@ -720,6 +737,7 @@ export function isBrowseMessage(msg: RemoteSessionMessage): msg is
     "list_sessions",
     'list_replays',
     'get_replay_ansi',
+    'get_replay_timeline',
     'dismiss_replay',
     'undismiss_replay',
     "attach_session",

--- a/src/lib/remote-session/protocol.ts
+++ b/src/lib/remote-session/protocol.ts
@@ -718,6 +718,10 @@ export function isBrowseMessage(msg: RemoteSessionMessage): msg is
   return [
     "list_workspaces",
     "list_sessions",
+    'list_replays',
+    'get_replay_ansi',
+    'dismiss_replay',
+    'undismiss_replay',
     "attach_session",
     'cancel_pending_attach',
     "list_github_repos",

--- a/src/lib/remote-session/protocol.ts
+++ b/src/lib/remote-session/protocol.ts
@@ -34,6 +34,7 @@ export type {
   ConfirmStepResult,
   SpacesBundle,
 } from '../../types/bundle.js';
+export type { ReplayInfo } from '../tmux-lite/replay/types.js';
 
 // Re-export attached mode control types from tmux-lite
 // These are used in attached mode for resize/detach/attach-init
@@ -52,6 +53,32 @@ export interface ListWorkspacesRequest {
 export interface ListSessionsRequest {
   type: "list_sessions";
   workspaceId?: string;  // Filter by workspace, or all if omitted
+}
+
+/** Request list of saved replays, optionally filtered by workspace */
+export interface ListReplaysRequest {
+  type: 'list_replays';
+  workspaceId?: string;
+  includeDismissed?: boolean;
+}
+
+/** Request ANSI replay bytes for Ghostty/web rendering */
+export interface GetReplayAnsiRequest {
+  type: 'get_replay_ansi';
+  replayId: string;
+  atMs?: number;
+}
+
+/** Soft-hide a replay */
+export interface DismissReplayRequest {
+  type: 'dismiss_replay';
+  replayId: string;
+}
+
+/** Restore a previously dismissed replay */
+export interface UndismissReplayRequest {
+  type: 'undismiss_replay';
+  replayId: string;
 }
 
 /** Attach to a session (existing or new) */
@@ -304,6 +331,32 @@ export interface SessionListResponse {
   sessions: SessionInfo[];
 }
 
+/** Response with replay list */
+export interface ReplayListResponse {
+  type: 'replay_list';
+  replays: import('../tmux-lite/replay/types.js').ReplayInfo[];
+}
+
+/** Response with replay ANSI payload */
+export interface ReplayAnsiResponse {
+  type: 'replay_ansi';
+  replayId: string;
+  data: string;
+  encoding: 'base64';
+}
+
+/** Replay dismissed successfully */
+export interface ReplayDismissedResponse {
+  type: 'replay_dismissed';
+  replayId: string;
+}
+
+/** Replay restored successfully */
+export interface ReplayUndismissedResponse {
+  type: 'replay_undismissed';
+  replayId: string;
+}
+
 /** Session attached successfully - transitions to attached mode */
 export interface AttachedResponse {
   type: "attached";
@@ -537,6 +590,10 @@ export interface ProcessStoppedResponse {
 export type ClientToMachineMessage =
   | ListWorkspacesRequest
   | ListSessionsRequest
+  | ListReplaysRequest
+  | GetReplayAnsiRequest
+  | DismissReplayRequest
+  | UndismissReplayRequest
   | AttachSessionRequest
   | CancelPendingAttachRequest
   | ListProjectsRequest
@@ -569,6 +626,10 @@ export type ClientToMachineMessage =
 export type MachineToClientMessage =
   | WorkspaceListResponse
   | SessionListResponse
+  | ReplayListResponse
+  | ReplayAnsiResponse
+  | ReplayDismissedResponse
+  | ReplayUndismissedResponse
   | AttachedResponse
   | DetachedResponse
   | SessionExitedResponse
@@ -636,6 +697,10 @@ export function serializeRemoteMessage(msg: RemoteSessionMessage): string {
 export function isBrowseMessage(msg: RemoteSessionMessage): msg is
   | ListWorkspacesRequest
   | ListSessionsRequest
+  | ListReplaysRequest
+  | GetReplayAnsiRequest
+  | DismissReplayRequest
+  | UndismissReplayRequest
   | AttachSessionRequest
   | CancelPendingAttachRequest
   | ListGithubReposRequest

--- a/src/lib/remote-session/session-handler.ts
+++ b/src/lib/remote-session/session-handler.ts
@@ -150,8 +150,11 @@ export function filterReplaysForSessionAccess<T extends ReplaySessionAccessTarge
   grantedSessionId: string | undefined,
   replays: T[],
 ): T[] {
-  if (accessType !== 'view') {
+  if (accessType === 'full') {
     return replays;
+  }
+  if (accessType !== 'view') {
+    return [];
   }
   if (!grantedSessionId) {
     return [];

--- a/src/lib/remote-session/session-handler.ts
+++ b/src/lib/remote-session/session-handler.ts
@@ -27,6 +27,12 @@ import {
   markInboxRead,
   type Session,
 } from "../tmux-lite/cli";
+import {
+  listReplaysOffline,
+  getReplayAnsiBufferOffline,
+  dismissReplayOffline,
+  undismissReplayOffline,
+} from '../tmux-lite/replay/service.js';
 
 // Import project loading
 import { listProjectSummaries } from "../../core/project-catalog";
@@ -237,6 +243,22 @@ export class RemoteSessionHandler {
 
       case "list_sessions":
         await this.handleListSessions(session, msg.workspaceId, sendResponse);
+        break;
+
+      case 'list_replays':
+        await this.handleListReplays(session, msg.workspaceId, msg.includeDismissed, sendResponse);
+        break;
+
+      case 'get_replay_ansi':
+        await this.handleGetReplayAnsi(session, msg.replayId, msg.atMs, sendResponse);
+        break;
+
+      case 'dismiss_replay':
+        await this.handleDismissReplay(session, msg.replayId, sendResponse);
+        break;
+
+      case 'undismiss_replay':
+        await this.handleUndismissReplay(session, msg.replayId, sendResponse);
         break;
 
       case "attach_session":
@@ -662,6 +684,60 @@ export class RemoteSessionHandler {
       type: "session_list",
       sessions,
     });
+  }
+
+  private async handleListReplays(
+    session: RemoteClientSession,
+    workspaceId: string | undefined,
+    includeDismissed: boolean | undefined,
+    sendResponse: (data: Uint8Array) => void,
+  ): Promise<void> {
+    const replays = listReplaysOffline({ workspaceId, includeDismissed: includeDismissed ?? false });
+    await this.sendMessage(session, sendResponse, {
+      type: 'replay_list',
+      replays,
+    });
+  }
+
+  private async handleGetReplayAnsi(
+    session: RemoteClientSession,
+    replayId: string,
+    atMs: number | undefined,
+    sendResponse: (data: Uint8Array) => void,
+  ): Promise<void> {
+    const ansi = await getReplayAnsiBufferOffline(replayId, atMs);
+    await this.sendMessage(session, sendResponse, {
+      type: 'replay_ansi',
+      replayId,
+      data: Buffer.from(ansi).toString('base64'),
+      encoding: 'base64',
+    });
+  }
+
+  private async handleDismissReplay(
+    session: RemoteClientSession,
+    replayId: string,
+    sendResponse: (data: Uint8Array) => void,
+  ): Promise<void> {
+    if (!canManage(session.accessType)) {
+      await this.sendError(session, sendResponse, 'PERMISSION_DENIED', 'Requires full access to dismiss replays');
+      return;
+    }
+    dismissReplayOffline(replayId);
+    await this.sendMessage(session, sendResponse, { type: 'replay_dismissed', replayId });
+  }
+
+  private async handleUndismissReplay(
+    session: RemoteClientSession,
+    replayId: string,
+    sendResponse: (data: Uint8Array) => void,
+  ): Promise<void> {
+    if (!canManage(session.accessType)) {
+      await this.sendError(session, sendResponse, 'PERMISSION_DENIED', 'Requires full access to restore replays');
+      return;
+    }
+    undismissReplayOffline(replayId);
+    await this.sendMessage(session, sendResponse, { type: 'replay_undismissed', replayId });
   }
 
   private async handleCancelPendingAttach(

--- a/src/lib/remote-session/session-handler.ts
+++ b/src/lib/remote-session/session-handler.ts
@@ -825,6 +825,17 @@ export class RemoteSessionHandler {
       await this.sendError(session, sendResponse, 'PERMISSION_DENIED', 'Requires full access to restore replays');
       return;
     }
+
+    const manifest = readReplayManifest(replayId);
+    if (!manifest) {
+      await this.sendError(session, sendResponse, 'NOT_FOUND', `Replay not found: ${replayId}`);
+      return;
+    }
+    if (!canAccessReplayForSession(session.accessType, session.grantedSessionId, manifest)) {
+      await this.sendError(session, sendResponse, 'PERMISSION_DENIED', 'Not authorized to access this replay');
+      return;
+    }
+
     undismissReplayOffline(replayId);
     await this.sendMessage(session, sendResponse, { type: 'replay_undismissed', replayId });
   }

--- a/src/lib/remote-session/session-handler.ts
+++ b/src/lib/remote-session/session-handler.ts
@@ -33,6 +33,7 @@ import {
   dismissReplayOffline,
   undismissReplayOffline,
 } from '../tmux-lite/replay/service.js';
+import { readReplayManifest } from '../tmux-lite/replay/store.js';
 
 // Import project loading
 import { listProjectSummaries } from "../../core/project-catalog";
@@ -106,6 +107,10 @@ export interface RemoteClientSession {
   viewOnly?: boolean;
 }
 
+type ReplaySessionAccessTarget = {
+  sessionId: string;
+};
+
 // ============================================================================
 // Permission Helpers
 // ============================================================================
@@ -130,6 +135,28 @@ function canAttachSession(
     return grantedSessionId === targetSessionId;
   }
   return false;
+}
+
+export function canAccessReplayForSession(
+  accessType: AccessType | undefined,
+  grantedSessionId: string | undefined,
+  replay: ReplaySessionAccessTarget,
+): boolean {
+  return canAttachSession(accessType, grantedSessionId, replay.sessionId);
+}
+
+export function filterReplaysForSessionAccess<T extends ReplaySessionAccessTarget>(
+  accessType: AccessType | undefined,
+  grantedSessionId: string | undefined,
+  replays: T[],
+): T[] {
+  if (accessType !== 'view') {
+    return replays;
+  }
+  if (!grantedSessionId) {
+    return [];
+  }
+  return replays.filter((replay) => replay.sessionId === grantedSessionId);
 }
 
 const MUTATING_REVIEW_OPERATIONS = new Set<ReviewOperation['op']>([
@@ -692,7 +719,11 @@ export class RemoteSessionHandler {
     includeDismissed: boolean | undefined,
     sendResponse: (data: Uint8Array) => void,
   ): Promise<void> {
-    const replays = listReplaysOffline({ workspaceId, includeDismissed: includeDismissed ?? false });
+    const replays = filterReplaysForSessionAccess(
+      session.accessType,
+      session.grantedSessionId,
+      listReplaysOffline({ workspaceId, includeDismissed: includeDismissed ?? false }),
+    );
     await this.sendMessage(session, sendResponse, {
       type: 'replay_list',
       replays,
@@ -705,6 +736,17 @@ export class RemoteSessionHandler {
     atMs: number | undefined,
     sendResponse: (data: Uint8Array) => void,
   ): Promise<void> {
+    const manifest = readReplayManifest(replayId);
+    if (!manifest) {
+      await this.sendError(session, sendResponse, 'NOT_FOUND', `Replay not found: ${replayId}`);
+      return;
+    }
+
+    if (!canAccessReplayForSession(session.accessType, session.grantedSessionId, manifest)) {
+      await this.sendError(session, sendResponse, 'PERMISSION_DENIED', 'Not authorized to access this replay');
+      return;
+    }
+
     const ansi = await getReplayAnsiBufferOffline(replayId, atMs);
     await this.sendMessage(session, sendResponse, {
       type: 'replay_ansi',

--- a/src/lib/remote-session/session-handler.ts
+++ b/src/lib/remote-session/session-handler.ts
@@ -30,6 +30,7 @@ import {
 import {
   listReplaysOffline,
   getReplayAnsiBufferOffline,
+  getReplayTimelineOffline,
   dismissReplayOffline,
   undismissReplayOffline,
 } from '../tmux-lite/replay/service.js';
@@ -280,7 +281,11 @@ export class RemoteSessionHandler {
         break;
 
       case 'get_replay_ansi':
-        await this.handleGetReplayAnsi(session, msg.replayId, msg.atMs, sendResponse);
+        await this.handleGetReplayAnsi(session, msg.replayId, msg.atMs, msg.atSeq, sendResponse);
+        break;
+
+      case 'get_replay_timeline':
+        await this.handleGetReplayTimeline(session, msg.replayId, sendResponse);
         break;
 
       case 'dismiss_replay':
@@ -737,6 +742,7 @@ export class RemoteSessionHandler {
     session: RemoteClientSession,
     replayId: string,
     atMs: number | undefined,
+    atSeq: number | undefined,
     sendResponse: (data: Uint8Array) => void,
   ): Promise<void> {
     const manifest = readReplayManifest(replayId);
@@ -750,12 +756,36 @@ export class RemoteSessionHandler {
       return;
     }
 
-    const ansi = await getReplayAnsiBufferOffline(replayId, atMs);
+    const ansi = await getReplayAnsiBufferOffline(replayId, { atMs, atSeq });
     await this.sendMessage(session, sendResponse, {
       type: 'replay_ansi',
       replayId,
       data: Buffer.from(ansi).toString('base64'),
       encoding: 'base64',
+    });
+  }
+
+  private async handleGetReplayTimeline(
+    session: RemoteClientSession,
+    replayId: string,
+    sendResponse: (data: Uint8Array) => void,
+  ): Promise<void> {
+    const manifest = readReplayManifest(replayId);
+    if (!manifest) {
+      await this.sendError(session, sendResponse, 'NOT_FOUND', `Replay not found: ${replayId}`);
+      return;
+    }
+
+    if (!canAccessReplayForSession(session.accessType, session.grantedSessionId, manifest)) {
+      await this.sendError(session, sendResponse, 'PERMISSION_DENIED', 'Not authorized to access this replay');
+      return;
+    }
+
+    const timeline = getReplayTimelineOffline(replayId);
+    await this.sendMessage(session, sendResponse, {
+      type: 'replay_timeline',
+      replayId,
+      timeline,
     });
   }
 
@@ -768,6 +798,20 @@ export class RemoteSessionHandler {
       await this.sendError(session, sendResponse, 'PERMISSION_DENIED', 'Requires full access to dismiss replays');
       return;
     }
+    const manifest = readReplayManifest(replayId);
+    if (!manifest) {
+      await this.sendError(session, sendResponse, 'NOT_FOUND', `Replay not found: ${replayId}`);
+      return;
+    }
+    if (!canAccessReplayForSession(session.accessType, session.grantedSessionId, manifest)) {
+      await this.sendError(session, sendResponse, 'PERMISSION_DENIED', 'Not authorized to access this replay');
+      return;
+    }
+    if (manifest.status === 'running') {
+      await this.sendError(session, sendResponse, 'USER_ERROR', 'Running replays cannot be dismissed');
+      return;
+    }
+
     dismissReplayOffline(replayId);
     await this.sendMessage(session, sendResponse, { type: 'replay_dismissed', replayId });
   }

--- a/src/lib/tmux-lite/cli.ts
+++ b/src/lib/tmux-lite/cli.ts
@@ -27,6 +27,9 @@ import {
   type Session,
   type SessionEvent,
   type InboxItem,
+  type ReplayInfo,
+  type ReplayStatus,
+  type TerminalSnapshot,
   type SessionCreateHooks,
   encodeRouterMessage,
   decodeRouterMessages,
@@ -38,7 +41,7 @@ import {
 } from "./protocol";
 
 // Re-export types
-export type { Session, InboxItem, Command, Response };
+export type { Session, InboxItem, Command, Response, ReplayInfo, ReplayStatus, TerminalSnapshot };
 
 // Re-export constants
 export { PROTOCOL_VERSION, PACKAGE_VERSION, getRouterSocket, getPidFile };
@@ -331,6 +334,70 @@ export async function listSessions(): Promise<Session[]> {
   const res = await send({ type: "list" });
   if (res.type === "sessions") return res.sessions;
   throw new Error("Unexpected response");
+}
+
+export async function listReplays(options: {
+  workspaceId?: string;
+  sessionId?: string;
+  status?: ReplayStatus[];
+} = {}): Promise<ReplayInfo[]> {
+  await ensureServer();
+  const res = await send({ type: "list-replays", ...options });
+  if (res.type === "replays") return res.replays;
+  if (res.type === "error") throw new Error(res.message);
+  throw new Error("Unexpected response");
+}
+
+export async function getReplaySnapshot(
+  replayId: string,
+  options: {
+    atMs?: number;
+    scrollbackLines?: number;
+  } = {}
+): Promise<TerminalSnapshot> {
+  await ensureServer();
+  const res = await send({ type: "replay-snapshot", replayId, ...options });
+  if (res.type === "replay-snapshot") return res.snapshot;
+  if (res.type === "error") throw new Error(res.message);
+  throw new Error("Unexpected response");
+}
+
+export async function getReplayText(
+  replayId: string,
+  options: {
+    atMs?: number;
+    scrollbackLines?: number;
+    includeScrollback?: boolean;
+    trimTrailingBlankRows?: boolean;
+  } = {}
+): Promise<string> {
+  await ensureServer();
+  const res = await send({ type: "replay-text", replayId, ...options });
+  if (res.type === "replay-text") return res.text;
+  if (res.type === "error") throw new Error(res.message);
+  throw new Error("Unexpected response");
+}
+
+export async function getReplayMarkdown(
+  replayId: string,
+  options: {
+    atMs?: number;
+    scrollbackLines?: number;
+    includeScrollback?: boolean;
+    trimTrailingBlankRows?: boolean;
+  } = {}
+): Promise<string> {
+  await ensureServer();
+  const res = await send({ type: "replay-markdown", replayId, ...options });
+  if (res.type === "replay-markdown") return res.markdown;
+  if (res.type === "error") throw new Error(res.message);
+  throw new Error("Unexpected response");
+}
+
+export async function createCheckpoint(id: string): Promise<void> {
+  await ensureServer();
+  const res = await send({ type: "create-checkpoint", id });
+  if (res.type === "error") throw new Error(res.message);
 }
 
 export async function createSession(

--- a/src/lib/tmux-lite/protocol.ts
+++ b/src/lib/tmux-lite/protocol.ts
@@ -18,6 +18,7 @@ export interface TmuxLitePaths {
   routerSocket: string;
   pidFile: string;
   sessionDir: string;
+  replayDir: string;
 }
 
 function normalizeSessionDir(dir: string): string {
@@ -56,11 +57,13 @@ export function getTmuxLitePathsForSandbox(sandbox: string): TmuxLitePaths {
     routerSocket,
     pidFile: `${base}.pid`,
     sessionDir: base,
+    replayDir: `${base}/replays`,
   };
 }
 
 export function getTmuxLitePaths(): TmuxLitePaths {
   const explicitSessionDir = process.env.TMUX_LITE_SESSION_DIR?.trim();
+  const explicitReplayDir = process.env.TMUX_LITE_REPLAY_DIR?.trim();
   const explicitRouterSocket = process.env.TMUX_LITE_SOCKET?.trim();
   const explicitPidFile = process.env.TMUX_LITE_PID_FILE?.trim();
   const sandbox = getTmuxLiteSandbox();
@@ -73,6 +76,7 @@ export function getTmuxLitePaths(): TmuxLitePaths {
       routerSocket,
       pidFile: explicitPidFile || sandboxPaths.pidFile,
       sessionDir: normalizeSessionDir(explicitSessionDir || sandboxPaths.sessionDir),
+      replayDir: explicitReplayDir || sandboxPaths.replayDir,
     };
   }
 
@@ -83,6 +87,7 @@ export function getTmuxLitePaths(): TmuxLitePaths {
     routerSocket,
     pidFile: explicitPidFile || DEFAULT_PID_FILE,
     sessionDir,
+    replayDir: explicitReplayDir || `${sessionDir}/tmux-lite-replays`,
   };
 }
 
@@ -103,6 +108,9 @@ export function applyTmuxLiteSandboxEnvironment(
   if (!preserveExplicit || !process.env.TMUX_LITE_SESSION_DIR?.trim()) {
     process.env.TMUX_LITE_SESSION_DIR = paths.sessionDir;
   }
+  if (!preserveExplicit || !process.env.TMUX_LITE_REPLAY_DIR?.trim()) {
+    process.env.TMUX_LITE_REPLAY_DIR = paths.replayDir;
+  }
   return paths;
 }
 
@@ -116,6 +124,10 @@ export function getPidFile(): string {
 
 export function getSessionDir(): string {
   return getTmuxLitePaths().sessionDir;
+}
+
+export function getReplayDir(): string {
+  return getTmuxLitePaths().replayDir;
 }
 
 /**
@@ -197,8 +209,29 @@ export interface SessionCreateHooks {
   };
 }
 
+export type { ReplayInfo, ReplayStatus, TerminalSnapshot } from './replay/types.js';
+
 export type Command =
   | { type: "list" }
+  | { type: "list-replays"; workspaceId?: string; sessionId?: string; status?: import('./replay/types.js').ReplayStatus[] }
+  | { type: "replay-snapshot"; replayId: string; atMs?: number; scrollbackLines?: number }
+  | {
+      type: "replay-text";
+      replayId: string;
+      atMs?: number;
+      scrollbackLines?: number;
+      includeScrollback?: boolean;
+      trimTrailingBlankRows?: boolean;
+    }
+  | {
+      type: "replay-markdown";
+      replayId: string;
+      atMs?: number;
+      scrollbackLines?: number;
+      includeScrollback?: boolean;
+      trimTrailingBlankRows?: boolean;
+    }
+  | { type: "create-checkpoint"; id: string }
   | {
       type: "new";
       name?: string;
@@ -219,6 +252,10 @@ export type Command =
 
 export type Response =
   | { type: "sessions"; sessions: Session[] }
+  | { type: "replays"; replays: import('./replay/types.js').ReplayInfo[] }
+  | { type: "replay-snapshot"; snapshot: import('./replay/types.js').TerminalSnapshot }
+  | { type: "replay-text"; text: string }
+  | { type: "replay-markdown"; markdown: string }
   | { type: "session"; session: Session }
   | { type: "already-attached"; session: Session }
   | { type: "ok" }

--- a/src/lib/tmux-lite/replay.integration.test.ts
+++ b/src/lib/tmux-lite/replay.integration.test.ts
@@ -5,7 +5,16 @@ import { join } from "path";
 import { tmpdir } from "os";
 import { decodeRouterMessages, encodeRouterMessage } from "./protocol";
 import { findPngRasterizer, readPngDimensions, writeReplayScreenshot } from "./replay/screenshot.js";
-import { listReplayCheckpoints, listReplayInfos, readReplayEvents, readReplayManifest } from "./replay/store.js";
+import {
+  deleteReplay,
+  dismissReplay,
+  listReplayCheckpoints,
+  listReplayInfos,
+  readReplayEvents,
+  readReplayManifest,
+  undismissReplay,
+} from "./replay/store.js";
+import { getReplayTextOffline, listReplaysOffline, screenshotReplayOffline } from './replay/service.js';
 
 const SERVER_SCRIPT = join(import.meta.dir, "server.ts");
 
@@ -306,5 +315,75 @@ describe("tmux-lite replay capture", () => {
     } finally {
       rmSync(checkpointsDir, { recursive: true, force: true });
     }
+  }, 10000);
+
+  test.if(findPngRasterizer() !== null)('keeps replay history available after tmux-lite shutdown', async () => {
+    serverProc = await startServer(replayRoot);
+
+    const response = await sendRouterCommand({
+      type: 'new',
+      name: 'replay-offline-history',
+      cwd: join(import.meta.dir, '../../..'),
+      command: '/bin/sh',
+      args: ['-lc', "printf 'offline replay works'; exit 0"],
+    });
+
+    expect(response.type).toBe('session');
+    await waitFor(() => listReplayInfos().some((info) => info.sessionName === 'replay-offline-history' && info.status === 'closed'));
+
+    const replay = listReplayInfos().find((info) => info.sessionName === 'replay-offline-history');
+    expect(replay).toBeDefined();
+
+    await sendRouterCommand({ type: 'kill-server' });
+    await Bun.sleep(200);
+    serverProc = null;
+
+    const offlineList = listReplaysOffline();
+    expect(offlineList.some((info) => info.replayId === replay!.replayId)).toBe(true);
+
+    const offlineText = await getReplayTextOffline(replay!.replayId);
+    expect(offlineText).toContain('offline replay works');
+
+    const screenshotPath = await screenshotReplayOffline(replay!.replayId, {
+      outputPath: join(tmpdir(), `offline-replay-${Date.now()}.png`),
+    });
+    try {
+      expect(existsSync(screenshotPath)).toBe(true);
+      expect(statSync(screenshotPath).size).toBeGreaterThan(0);
+    } finally {
+      rmSync(screenshotPath, { force: true });
+    }
+  }, 10000);
+
+  test('dismisses, restores, and deletes replay lifecycle from durable store', async () => {
+    serverProc = await startServer(replayRoot);
+
+    const response = await sendRouterCommand({
+      type: 'new',
+      name: 'replay-dismiss-lifecycle',
+      cwd: join(import.meta.dir, '../../..'),
+      command: '/bin/sh',
+      args: ['-lc', "printf 'dismiss me'; exit 0"],
+    });
+
+    expect(response.type).toBe('session');
+    await waitFor(() => listReplayInfos().some((info) => info.sessionName === 'replay-dismiss-lifecycle' && info.status === 'closed'));
+
+    const replay = listReplayInfos().find((info) => info.sessionName === 'replay-dismiss-lifecycle');
+    expect(replay).toBeDefined();
+
+    dismissReplay(replay!.replayId, 'integration-test');
+    expect(listReplaysOffline().some((info) => info.replayId === replay!.replayId)).toBe(false);
+
+    const hidden = listReplaysOffline({ includeDismissed: true }).find((info) => info.replayId === replay!.replayId);
+    expect(hidden?.dismissedBy).toBe('integration-test');
+    expect(hidden?.dismissedAt).toBeDefined();
+
+    undismissReplay(replay!.replayId);
+    expect(listReplaysOffline().some((info) => info.replayId === replay!.replayId)).toBe(true);
+
+    deleteReplay(replay!.replayId);
+    expect(listReplaysOffline({ includeDismissed: true }).some((info) => info.replayId === replay!.replayId)).toBe(false);
+    expect(readReplayManifest(replay!.replayId)).toBeNull();
   }, 10000);
 });

--- a/src/lib/tmux-lite/replay.integration.test.ts
+++ b/src/lib/tmux-lite/replay.integration.test.ts
@@ -1,0 +1,310 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { spawn, type Subprocess } from "bun";
+import { existsSync, mkdtempSync, rmSync, statSync, unlinkSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { decodeRouterMessages, encodeRouterMessage } from "./protocol";
+import { findPngRasterizer, readPngDimensions, writeReplayScreenshot } from "./replay/screenshot.js";
+import { listReplayCheckpoints, listReplayInfos, readReplayEvents, readReplayManifest } from "./replay/store.js";
+
+const SERVER_SCRIPT = join(import.meta.dir, "server.ts");
+
+let testSocket = "/tmp/tmux-lite-test.sock";
+let testSessionDir = "/tmp/tmux-lite-test";
+let testPidFile = "/tmp/tmux-lite-test.pid";
+
+function cleanupSocketArtifacts(): void {
+  try { unlinkSync(testSocket); } catch {}
+  try { unlinkSync(testPidFile); } catch {}
+  try { rmSync(testSessionDir, { recursive: true, force: true }); } catch {}
+}
+
+async function waitFor(condition: () => boolean, timeoutMs = 5000, intervalMs = 50): Promise<void> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    if (condition()) {
+      return;
+    }
+    await Bun.sleep(intervalMs);
+  }
+  throw new Error("Timed out waiting for condition");
+}
+
+async function startServer(replayRoot: string): Promise<Subprocess> {
+  const proc = spawn({
+    cmd: ["bun", "run", SERVER_SCRIPT, "--test"],
+    stdout: "ignore",
+    stderr: "ignore",
+    env: {
+      ...process.env,
+      TMUX_LITE_SOCKET: testSocket,
+      TMUX_LITE_SESSION_DIR: testSessionDir,
+      TMUX_LITE_PID_FILE: testPidFile,
+      TMUX_LITE_REPLAY_DIR: replayRoot,
+    },
+  });
+
+  await waitFor(() => existsSync(testSocket));
+  return proc;
+}
+
+async function sendRouterCommand(command: Record<string, unknown>): Promise<any> {
+  return await new Promise((resolve, reject) => {
+    let buffer = Buffer.alloc(0);
+    let settled = false;
+    let socketRef: any;
+
+    const timeout = setTimeout(() => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      socketRef?.end();
+      reject(new Error(`Router timeout for command ${String(command.type)}`));
+    }, 3000);
+
+    const finish = (callback: () => void) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timeout);
+      socketRef?.end();
+      callback();
+    };
+
+    Bun.connect({
+      unix: testSocket,
+      socket: {
+        open(socket) {
+          socketRef = socket;
+          socket.write(encodeRouterMessage(command as any));
+        },
+        data(_socket, data) {
+          buffer = Buffer.concat([buffer, Buffer.from(data)]);
+          try {
+            const decoded = decodeRouterMessages(buffer);
+            buffer = Buffer.from(decoded.remaining as Buffer);
+            if (decoded.messages.length > 0) {
+              finish(() => resolve(decoded.messages[0]));
+            }
+          } catch (error) {
+            finish(() => reject(error));
+          }
+        },
+        close() {
+          finish(() => reject(new Error("Router socket closed before response")));
+        },
+        error(_socket, error) {
+          finish(() => reject(error));
+        },
+        connectError(_socket, error) {
+          finish(() => reject(error));
+        },
+        drain() {},
+      },
+    }).catch((error) => finish(() => reject(error)));
+  });
+}
+
+describe("tmux-lite replay capture", () => {
+  let replayRoot: string;
+  let serverProc: Subprocess | null = null;
+  const originalReplayDir = process.env.TMUX_LITE_REPLAY_DIR;
+
+  beforeEach(() => {
+    const runId = `${Date.now()}-${Math.round(Math.random() * 1_000_000)}`;
+    testSocket = `/tmp/tmux-lite-test-${runId}.sock`;
+    testSessionDir = `/tmp/tmux-lite-test-${runId}`;
+    testPidFile = `/tmp/tmux-lite-test-${runId}.pid`;
+    cleanupSocketArtifacts();
+    replayRoot = mkdtempSync(join(tmpdir(), "gitspace-replay-integration-"));
+    process.env.TMUX_LITE_REPLAY_DIR = replayRoot;
+  });
+
+  afterEach(async () => {
+    try {
+      if (existsSync(testSocket)) {
+        await sendRouterCommand({ type: "kill-server" });
+        await Bun.sleep(200);
+      }
+    } catch {}
+    try {
+      serverProc?.kill();
+    } catch {}
+    serverProc = null;
+
+    cleanupSocketArtifacts();
+    rmSync(replayRoot, { recursive: true, force: true });
+    if (originalReplayDir === undefined) {
+      delete process.env.TMUX_LITE_REPLAY_DIR;
+    } else {
+      process.env.TMUX_LITE_REPLAY_DIR = originalReplayDir;
+    }
+  });
+
+  test("captures replay output and exit metadata for completed sessions", async () => {
+    serverProc = await startServer(replayRoot);
+
+    const response = await sendRouterCommand({
+      type: "new",
+      name: "replay-test-session",
+      cwd: join(import.meta.dir, "../../.."),
+      command: "/bin/sh",
+      args: ["-lc", "printf 'hello replay'; exit 7"],
+    });
+
+    expect(response.type).toBe("session");
+
+    await waitFor(() => listReplayInfos().some((info) => info.status === "closed"), 5000);
+
+    const replayInfo = listReplayInfos()[0];
+    expect(replayInfo.status).toBe("closed");
+    expect(replayInfo.exitCode).toBe(7);
+
+    const manifest = readReplayManifest(replayInfo.replayId);
+    expect(manifest).not.toBeNull();
+    expect(manifest?.status).toBe("closed");
+    expect(manifest?.metadata.exitCode).toBe(7);
+    expect(manifest?.stats.eventCount).toBeGreaterThanOrEqual(2);
+    expect(manifest?.stats.checkpointCount).toBeGreaterThanOrEqual(1);
+    expect(listReplayCheckpoints(replayInfo.replayId).length).toBeGreaterThanOrEqual(1);
+
+    const replayListResponse = await sendRouterCommand({ type: 'list-replays' });
+    expect(replayListResponse.type).toBe('replays');
+    expect(replayListResponse.replays).toHaveLength(1);
+
+    const snapshotResponse = await sendRouterCommand({
+      type: 'replay-snapshot',
+      replayId: replayInfo.replayId,
+    });
+    expect(snapshotResponse.type).toBe('replay-snapshot');
+    expect(snapshotResponse.snapshot.screen.visible.some((line: string) => line.includes('hello replay'))).toBe(true);
+
+    const textResponse = await sendRouterCommand({
+      type: 'replay-text',
+      replayId: replayInfo.replayId,
+    });
+    expect(textResponse.type).toBe('replay-text');
+    expect(textResponse.text).toContain('hello replay');
+
+    const markdownResponse = await sendRouterCommand({
+      type: 'replay-markdown',
+      replayId: replayInfo.replayId,
+    });
+    expect(markdownResponse.type).toBe('replay-markdown');
+    expect(markdownResponse.markdown).toContain('```terminal');
+
+    const events = readReplayEvents(replayInfo.replayId);
+    const outputEvent = events.find((event) => event.type === "output");
+    const exitEvent = events.find((event) => event.type === "exit");
+    expect(outputEvent?.type).toBe("output");
+    expect(outputEvent && outputEvent.type === "output"
+      ? Buffer.from(outputEvent.data, "base64").toString("utf-8")
+      : "").toContain("hello replay");
+    expect(exitEvent).toEqual(expect.objectContaining({ type: "exit", code: 7 }));
+  }, 10000);
+
+  test("reconciles running replays as crashed after abrupt server termination", async () => {
+    serverProc = await startServer(replayRoot);
+
+    const response = await sendRouterCommand({
+      type: "new",
+      name: "replay-crash-session",
+      cwd: join(import.meta.dir, "../../.."),
+      command: "/bin/sh",
+      args: ["-lc", "printf 'still running'; sleep 30"],
+    });
+
+    expect(response.type).toBe("session");
+
+    await waitFor(() => listReplayInfos({ status: ["running"] }).length === 1, 5000);
+
+    const replayId = listReplayInfos({ status: ["running"] })[0].replayId;
+    process.kill(serverProc.pid, "SIGKILL");
+    serverProc = null;
+    await Bun.sleep(300);
+
+    const runningManifest = readReplayManifest(replayId);
+    expect(runningManifest?.status).toBe("running");
+
+    await startServer(replayRoot);
+    await waitFor(() => listReplayInfos({ status: ["crashed"] }).some((info) => info.replayId === replayId), 5000);
+
+    const reconciledManifest = readReplayManifest(replayId);
+    expect(reconciledManifest?.status).toBe("crashed");
+    expect(reconciledManifest?.endedAt).toBeDefined();
+  }, 10000);
+
+  test.if(findPngRasterizer() !== null)("captures replay text and png snapshots across timepoints", async () => {
+    serverProc = await startServer(replayRoot);
+
+    const response = await sendRouterCommand({
+      type: "new",
+      name: "replay-timeline-session",
+      cwd: join(import.meta.dir, "../../.."),
+      command: "/bin/sh",
+      args: [
+        "-lc",
+        "printf '\\033[2J\\033[Hframe zero'; sleep 0.35; printf '\\033[2J\\033[Hframe one'; sleep 0.35; printf '\\033[2J\\033[Hframe two'; exit 0",
+      ],
+    });
+
+    expect(response.type).toBe("session");
+
+    await waitFor(() => listReplayInfos().some((info) => info.status === "closed" && info.sessionName === "replay-timeline-session"), 5000);
+
+    const replayInfo = listReplayInfos().find((info) => info.sessionName === "replay-timeline-session");
+    expect(replayInfo).toBeDefined();
+
+    const checkpointsDir = mkdtempSync(join(tmpdir(), 'gitspace-replay-png-'));
+    try {
+      const earlyTextResponse = await sendRouterCommand({
+        type: 'replay-text',
+        replayId: replayInfo!.replayId,
+        atMs: 50,
+      });
+      expect(earlyTextResponse.type).toBe('replay-text');
+      expect(earlyTextResponse.text).toContain('frame zero');
+
+      const middleTextResponse = await sendRouterCommand({
+        type: 'replay-text',
+        replayId: replayInfo!.replayId,
+        atMs: 450,
+      });
+      expect(middleTextResponse.type).toBe('replay-text');
+      expect(middleTextResponse.text).toContain('frame one');
+
+      const lateTextResponse = await sendRouterCommand({
+        type: 'replay-text',
+        replayId: replayInfo!.replayId,
+        atMs: 800,
+      });
+      expect(lateTextResponse.type).toBe('replay-text');
+      expect(lateTextResponse.text).toContain('frame two');
+
+      const earlyPng = await writeReplayScreenshot(replayInfo!.replayId, {
+        outputPath: join(checkpointsDir, 'frame-zero.png'),
+        atMs: 50,
+      });
+      const middlePng = await writeReplayScreenshot(replayInfo!.replayId, {
+        outputPath: join(checkpointsDir, 'frame-one.png'),
+        atMs: 450,
+      });
+      const latePng = await writeReplayScreenshot(replayInfo!.replayId, {
+        outputPath: join(checkpointsDir, 'frame-two.png'),
+        atMs: 800,
+      });
+
+      for (const pngPath of [earlyPng, middlePng, latePng]) {
+        expect(existsSync(pngPath)).toBe(true);
+        expect(statSync(pngPath).size).toBeGreaterThan(0);
+        const dimensions = readPngDimensions(pngPath);
+        expect(dimensions.width).toBeGreaterThan(300);
+        expect(dimensions.height).toBeGreaterThan(60);
+      }
+    } finally {
+      rmSync(checkpointsDir, { recursive: true, force: true });
+    }
+  }, 10000);
+});

--- a/src/lib/tmux-lite/replay/index.ts
+++ b/src/lib/tmux-lite/replay/index.ts
@@ -1,0 +1,7 @@
+export * from './types.js';
+export * from './paths.js';
+export * from './store.js';
+export * from './reconstruct.js';
+export * from './snapshot.js';
+export * from './screenshot.js';
+export * from './service.js';

--- a/src/lib/tmux-lite/replay/paths.ts
+++ b/src/lib/tmux-lite/replay/paths.ts
@@ -1,0 +1,85 @@
+import { existsSync, mkdirSync } from 'fs';
+import { join } from 'path';
+import { getGitspaceDir } from '../../../core/config.js';
+import { getReplayDir as getTmuxLiteReplayDir } from '../protocol.js';
+
+const VALID_REPLAY_ID_PATTERN = /^[a-zA-Z0-9_-]+$/;
+
+function getConfiguredReplayRootDir(): string {
+  const configured = process.env.TMUX_LITE_REPLAY_DIR?.trim();
+  if (configured) {
+    return configured;
+  }
+  if (process.env.TMUX_LITE_SANDBOX?.trim()) {
+    return getTmuxLiteReplayDir();
+  }
+  return join(getGitspaceDir(), '.tmux-lite', 'replays');
+}
+
+export function assertValidReplayId(replayId: string): void {
+  if (!replayId || !VALID_REPLAY_ID_PATTERN.test(replayId)) {
+    throw new Error(`Invalid replay ID: ${replayId}`);
+  }
+}
+
+export function assertValidCheckpointId(checkpointId: string): void {
+  if (!checkpointId || !VALID_REPLAY_ID_PATTERN.test(checkpointId)) {
+    throw new Error(`Invalid checkpoint ID: ${checkpointId}`);
+  }
+}
+
+export function getReplayRootDir(): string {
+  return getConfiguredReplayRootDir();
+}
+
+export function ensureReplayRootDir(): string {
+  const dir = getReplayRootDir();
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true });
+  }
+  return dir;
+}
+
+export function getReplayDir(replayId: string): string {
+  assertValidReplayId(replayId);
+  return join(getReplayRootDir(), replayId);
+}
+
+export function ensureReplayDir(replayId: string): string {
+  ensureReplayRootDir();
+  const dir = getReplayDir(replayId);
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true });
+  }
+  return dir;
+}
+
+export function getReplayManifestPath(replayId: string): string {
+  return join(getReplayDir(replayId), 'manifest.json');
+}
+
+export function getReplayEventsPath(replayId: string): string {
+  return join(getReplayDir(replayId), 'events.ndjson');
+}
+
+export function getReplayCheckpointsDir(replayId: string): string {
+  return join(getReplayDir(replayId), 'checkpoints');
+}
+
+export function ensureReplayCheckpointsDir(replayId: string): string {
+  const dir = getReplayCheckpointsDir(replayId);
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true });
+  }
+  return dir;
+}
+
+export function getReplayCheckpointMetaPath(replayId: string, checkpointId: string): string {
+  assertValidCheckpointId(checkpointId);
+  return join(getReplayCheckpointsDir(replayId), `${checkpointId}.json`);
+}
+
+export function getReplayCheckpointAnsiPath(replayId: string, checkpointId: string): string {
+  assertValidCheckpointId(checkpointId);
+  return join(getReplayCheckpointsDir(replayId), `${checkpointId}.ansi`);
+}

--- a/src/lib/tmux-lite/replay/paths.ts
+++ b/src/lib/tmux-lite/replay/paths.ts
@@ -1,6 +1,8 @@
 import { existsSync, mkdirSync } from 'fs';
 import { join } from 'path';
 import { getGitspaceDir } from '../../../core/config.js';
+import { SpacesError } from '../../../types/errors.js';
+import { logger } from '../../../utils/logger.js';
 import { getReplayDir as getTmuxLiteReplayDir } from '../protocol.js';
 
 const VALID_REPLAY_ID_PATTERN = /^[a-zA-Z0-9_-]+$/;
@@ -18,13 +20,15 @@ function getConfiguredReplayRootDir(): string {
 
 export function assertValidReplayId(replayId: string): void {
   if (!replayId || !VALID_REPLAY_ID_PATTERN.test(replayId)) {
-    throw new Error(`Invalid replay ID: ${replayId}`);
+    logger.error(`[replay.paths] Invalid replay ID: ${String(replayId)}`);
+    throw new SpacesError(`Invalid replay ID: ${replayId}`, 'USER_ERROR', 1);
   }
 }
 
 export function assertValidCheckpointId(checkpointId: string): void {
   if (!checkpointId || !VALID_REPLAY_ID_PATTERN.test(checkpointId)) {
-    throw new Error(`Invalid checkpoint ID: ${checkpointId}`);
+    logger.error(`[replay.paths] Invalid checkpoint ID: ${String(checkpointId)}`);
+    throw new SpacesError(`Invalid checkpoint ID: ${checkpointId}`, 'USER_ERROR', 1);
   }
 }
 

--- a/src/lib/tmux-lite/replay/reconstruct.test.ts
+++ b/src/lib/tmux-lite/replay/reconstruct.test.ts
@@ -154,6 +154,16 @@ describe('replay reconstruction', () => {
     expect(buffer.getLine(1)?.translateToString(true)).toBe('world');
   });
 
+  it('clamps requested timestamps beyond available replay duration', async () => {
+    seedReplay();
+
+    const state = await reconstructReplayAt('replay_seed', 9999);
+
+    expect(state.timeMs).toBe(60);
+    expect(state.seq).toBe(5);
+    expect(state.exitCode).toBe(0);
+  });
+
   it('projects replay state to snapshot text and markdown', async () => {
     seedReplay();
 

--- a/src/lib/tmux-lite/replay/reconstruct.test.ts
+++ b/src/lib/tmux-lite/replay/reconstruct.test.ts
@@ -10,6 +10,7 @@ import {
 } from './store.js';
 import { reconstructReplayAt } from './reconstruct.js';
 import { getReplayMarkdown, getReplaySnapshot, getReplayText } from './snapshot.js';
+import { styledRowsToAnsi } from './service.js';
 import type { ReplayCheckpoint, ReplayManifest } from './types.js';
 
 describe('replay reconstruction', () => {
@@ -166,5 +167,95 @@ describe('replay reconstruction', () => {
     expect(text).toContain('hello\nworld');
     expect(markdown).toContain('```terminal');
     expect(markdown).toContain('Process: bun test');
+  });
+
+  it('uses latest event time for running replays by default', async () => {
+    const manifest: ReplayManifest = {
+      version: 1,
+      replayId: 'replay_running',
+      sessionId: 'session_running',
+      sessionName: 'project:workspace:1',
+      cwd: '/tmp/project/workspace',
+      workspaceId: 'project:workspace',
+      projectName: 'project',
+      workspaceName: 'workspace',
+      startedAt: 1000,
+      status: 'running',
+      initialTerminal: { cols: 80, rows: 24 },
+      metadata: {},
+      stats: {
+        lastSeq: 1,
+        eventCount: 1,
+        checkpointCount: 0,
+        durationMs: 0,
+      },
+    };
+
+    initializeReplay(manifest);
+    appendReplayEvent('replay_running', {
+      v: 1,
+      seq: 1,
+      t: 50,
+      type: 'output',
+      encoding: 'base64',
+      data: Buffer.from('latest-output').toString('base64'),
+    });
+
+    const state = await reconstructReplayAt('replay_running');
+    expect(state.timeMs).toBe(50);
+    expect(state.seq).toBe(1);
+    expect(state.xterm.buffer.active.getLine(0)?.translateToString(true)).toBe('latest-output');
+  });
+
+  it('tracks currentLine against the viewport when scrollback exists', async () => {
+    const manifest: ReplayManifest = {
+      version: 1,
+      replayId: 'replay_scrollback',
+      sessionId: 'session_scrollback',
+      sessionName: 'project:workspace:1',
+      cwd: '/tmp/project/workspace',
+      workspaceId: 'project:workspace',
+      projectName: 'project',
+      workspaceName: 'workspace',
+      startedAt: 1000,
+      endedAt: 1100,
+      status: 'closed',
+      initialTerminal: { cols: 80, rows: 2 },
+      metadata: {},
+      stats: { lastSeq: 1, eventCount: 1, checkpointCount: 0, durationMs: 100 },
+    };
+
+    initializeReplay(manifest);
+    appendReplayEvent('replay_scrollback', {
+      v: 1,
+      seq: 1,
+      t: 50,
+      type: 'output',
+      encoding: 'base64',
+      data: Buffer.from('line-1\r\nline-2\r\nline-3').toString('base64'),
+    });
+
+    const snapshot = await getReplaySnapshot('replay_scrollback');
+    expect(snapshot.screen.visible).toEqual(['line-2', 'line-3']);
+    expect(snapshot.screen.currentLine).toBe('line-3');
+  });
+
+  it('preserves unicode text when re-encoding styled rows to ansi', () => {
+    const buffer = styledRowsToAnsi([
+      [{
+        text: 'hello 你好 😀',
+        fg: '#ffffff',
+        bg: null,
+        bold: false,
+        italic: false,
+        underline: false,
+        dim: false,
+        strikethrough: false,
+      }],
+    ]);
+
+    const text = buffer.toString('utf8');
+    expect(text).toContain('你好');
+    expect(text).toContain('😀');
   });
 });

--- a/src/lib/tmux-lite/replay/reconstruct.test.ts
+++ b/src/lib/tmux-lite/replay/reconstruct.test.ts
@@ -1,0 +1,170 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { mkdtempSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import {
+  appendReplayEvent,
+  initializeReplay,
+  updateReplayManifest,
+  writeReplayCheckpoint,
+} from './store.js';
+import { reconstructReplayAt } from './reconstruct.js';
+import { getReplayMarkdown, getReplaySnapshot, getReplayText } from './snapshot.js';
+import type { ReplayCheckpoint, ReplayManifest } from './types.js';
+
+describe('replay reconstruction', () => {
+  let replayRoot: string;
+  const originalReplayDir = process.env.TMUX_LITE_REPLAY_DIR;
+
+  beforeEach(() => {
+    replayRoot = mkdtempSync(join(tmpdir(), 'gitspace-replay-reconstruct-'));
+    process.env.TMUX_LITE_REPLAY_DIR = replayRoot;
+  });
+
+  afterEach(() => {
+    rmSync(replayRoot, { recursive: true, force: true });
+    if (originalReplayDir === undefined) {
+      delete process.env.TMUX_LITE_REPLAY_DIR;
+    } else {
+      process.env.TMUX_LITE_REPLAY_DIR = originalReplayDir;
+    }
+  });
+
+  function seedReplay(): void {
+    const manifest: ReplayManifest = {
+      version: 1,
+      replayId: 'replay_seed',
+      sessionId: 'session_seed',
+      sessionName: 'project:workspace:1',
+      cwd: '/tmp/project/workspace',
+      workspaceId: 'project:workspace',
+      projectName: 'project',
+      workspaceName: 'workspace',
+      startedAt: 1000,
+      endedAt: 1060,
+      status: 'closed',
+      initialTerminal: {
+        cols: 80,
+        rows: 24,
+      },
+      metadata: {
+        processTitle: 'bun test',
+        exitCode: 0,
+      },
+      stats: {
+        lastSeq: 5,
+        eventCount: 5,
+        checkpointCount: 1,
+        durationMs: 60,
+      },
+    };
+
+    initializeReplay(manifest);
+
+    const checkpoint: ReplayCheckpoint = {
+      version: 1,
+      checkpointId: '000000',
+      seq: 1,
+      t: 10,
+      terminal: {
+        cols: 80,
+        rows: 24,
+      },
+      metadata: {},
+      serializer: {
+        kind: 'xterm-serialize',
+        scrollbackLines: 1000,
+      },
+      ansiPath: 'checkpoints/000000.ansi',
+    };
+    writeReplayCheckpoint('replay_seed', checkpoint, 'hello');
+
+    appendReplayEvent('replay_seed', {
+      v: 1,
+      seq: 2,
+      t: 20,
+      type: 'output',
+      encoding: 'base64',
+      data: Buffer.from('\r\nworld').toString('base64'),
+    });
+    appendReplayEvent('replay_seed', {
+      v: 1,
+      seq: 3,
+      t: 30,
+      type: 'resize',
+      cols: 100,
+      rows: 30,
+    });
+    appendReplayEvent('replay_seed', {
+      v: 1,
+      seq: 4,
+      t: 40,
+      type: 'process-title',
+      processTitle: 'bun test',
+    });
+    appendReplayEvent('replay_seed', {
+      v: 1,
+      seq: 5,
+      t: 50,
+      type: 'exit',
+      code: 0,
+    });
+
+    updateReplayManifest('replay_seed', (current) => ({
+      ...current,
+      stats: {
+        ...current.stats,
+        lastSeq: 5,
+        eventCount: 5,
+        checkpointCount: 1,
+        durationMs: 60,
+      },
+    }));
+  }
+
+  it('reconstructs latest replay state from checkpoints and events', async () => {
+    seedReplay();
+
+    const state = await reconstructReplayAt('replay_seed');
+
+    expect(state.seq).toBe(5);
+    expect(state.cols).toBe(100);
+    expect(state.rows).toBe(30);
+    expect(state.processTitle).toBe('bun test');
+    expect(state.exitCode).toBe(0);
+
+    const buffer = state.xterm.buffer.active;
+    expect(buffer.getLine(0)?.translateToString(true)).toBe('hello');
+    expect(buffer.getLine(1)?.translateToString(true)).toBe('world');
+  });
+
+  it('reconstructs earlier timestamps without later events', async () => {
+    seedReplay();
+
+    const state = await reconstructReplayAt('replay_seed', 25);
+
+    expect(state.seq).toBe(2);
+    expect(state.cols).toBe(80);
+    expect(state.rows).toBe(24);
+    expect(state.exitCode).toBeUndefined();
+
+    const buffer = state.xterm.buffer.active;
+    expect(buffer.getLine(0)?.translateToString(true)).toBe('hello');
+    expect(buffer.getLine(1)?.translateToString(true)).toBe('world');
+  });
+
+  it('projects replay state to snapshot text and markdown', async () => {
+    seedReplay();
+
+    const snapshot = await getReplaySnapshot('replay_seed');
+    const text = await getReplayText('replay_seed');
+    const markdown = await getReplayMarkdown('replay_seed');
+
+    expect(snapshot.metadata.processTitle).toBe('bun test');
+    expect(snapshot.screen.visible[0]).toBe('hello');
+    expect(snapshot.screen.visible[1]).toBe('world');
+    expect(text).toContain('hello\nworld');
+    expect(markdown).toContain('```terminal');
+    expect(markdown).toContain('Process: bun test');
+  });
+});

--- a/src/lib/tmux-lite/replay/reconstruct.test.ts
+++ b/src/lib/tmux-lite/replay/reconstruct.test.ts
@@ -254,7 +254,7 @@ describe('replay reconstruction', () => {
     const buffer = styledRowsToAnsi([
       [{
         text: 'hello 你好 😀',
-        cells: 'hello 你好 😀'.length,
+        cells: 13,
         fg: '#ffffff',
         bg: null,
         bold: false,

--- a/src/lib/tmux-lite/replay/reconstruct.test.ts
+++ b/src/lib/tmux-lite/replay/reconstruct.test.ts
@@ -254,6 +254,7 @@ describe('replay reconstruction', () => {
     const buffer = styledRowsToAnsi([
       [{
         text: 'hello 你好 😀',
+        cells: 'hello 你好 😀'.length,
         fg: '#ffffff',
         bg: null,
         bold: false,

--- a/src/lib/tmux-lite/replay/reconstruct.ts
+++ b/src/lib/tmux-lite/replay/reconstruct.ts
@@ -1,5 +1,7 @@
 import { Terminal as XTerminal } from '@xterm/headless';
 import { listReplayCheckpoints, readReplayCheckpoint, readReplayEvents, readReplayManifest } from './store.js';
+import { SpacesError } from '../../../types/errors.js';
+import { logger } from '../../../utils/logger.js';
 
 function getDefaultTargetTime(
   manifest: { status: string; stats: { durationMs: number } },
@@ -42,7 +44,8 @@ export async function reconstructReplayAt(
 ): Promise<ReconstructedTerminalState> {
   const manifest = readReplayManifest(replayId);
   if (!manifest) {
-    throw new Error(`Replay manifest not found: ${replayId}`);
+    logger.error(`[replay.reconstruct] Replay manifest not found: ${replayId}`);
+    throw new SpacesError(`Replay manifest not found: ${replayId}`, 'USER_ERROR', 1);
   }
 
   const checkpoints = listReplayCheckpoints(replayId);
@@ -57,8 +60,8 @@ export async function reconstructReplayAt(
     : null;
 
   const xterm = new XTerminal({
-    cols: checkpoint?.terminal.cols ?? manifest.initialTerminal.cols,
-    rows: checkpoint?.terminal.rows ?? manifest.initialTerminal.rows,
+    cols: checkpointRecord?.checkpoint.terminal.cols ?? manifest.initialTerminal.cols,
+    rows: checkpointRecord?.checkpoint.terminal.rows ?? manifest.initialTerminal.rows,
     scrollback: 10_000,
     allowProposedApi: true,
   });

--- a/src/lib/tmux-lite/replay/reconstruct.ts
+++ b/src/lib/tmux-lite/replay/reconstruct.ts
@@ -1,0 +1,116 @@
+import { Terminal as XTerminal } from '@xterm/headless';
+import { listReplayCheckpoints, readReplayCheckpoint, readReplayEvents, readReplayManifest } from './store.js';
+
+export interface ReconstructedTerminalState {
+  replayId: string;
+  sessionId: string;
+  workspaceId?: string;
+  timeMs: number;
+  seq: number;
+  cols: number;
+  rows: number;
+  title?: string;
+  processTitle?: string;
+  exitCode?: number;
+  checkpointId?: string;
+  xterm: XTerminal;
+}
+
+function writeToTerminal(xterm: XTerminal, data: string | Uint8Array): Promise<void> {
+  return new Promise((resolve) => {
+    xterm.write(data, () => resolve());
+  });
+}
+
+export async function reconstructReplayAt(
+  replayId: string,
+  atMs?: number
+): Promise<ReconstructedTerminalState> {
+  const manifest = readReplayManifest(replayId);
+  if (!manifest) {
+    throw new Error(`Replay manifest not found: ${replayId}`);
+  }
+
+  const targetTime = Math.max(0, atMs ?? manifest.stats.durationMs);
+  const checkpoints = listReplayCheckpoints(replayId);
+  const checkpoint = [...checkpoints]
+    .reverse()
+    .find((entry) => entry.t <= targetTime);
+  const checkpointRecord = checkpoint
+    ? readReplayCheckpoint(replayId, checkpoint.checkpointId)
+    : null;
+
+  const xterm = new XTerminal({
+    cols: checkpoint?.terminal.cols ?? manifest.initialTerminal.cols,
+    rows: checkpoint?.terminal.rows ?? manifest.initialTerminal.rows,
+    scrollback: 10_000,
+    allowProposedApi: true,
+  });
+
+  if (checkpointRecord) {
+    if (xterm.cols !== checkpointRecord.checkpoint.terminal.cols || xterm.rows !== checkpointRecord.checkpoint.terminal.rows) {
+      xterm.resize(checkpointRecord.checkpoint.terminal.cols, checkpointRecord.checkpoint.terminal.rows);
+    }
+    await writeToTerminal(xterm, '\x1bc\x1b[2J\x1b[H');
+    await writeToTerminal(xterm, checkpointRecord.ansi);
+  }
+
+  let seq = checkpointRecord?.checkpoint.seq ?? 0;
+  let title = checkpointRecord?.checkpoint.metadata.title;
+  let processTitle = checkpointRecord?.checkpoint.metadata.processTitle;
+  let exitCode = checkpointRecord?.checkpoint.metadata.exitCode;
+
+  const events = readReplayEvents(replayId);
+  for (const event of events) {
+    if (event.seq <= seq) {
+      continue;
+    }
+    if (event.t > targetTime) {
+      break;
+    }
+
+    switch (event.type) {
+      case 'output':
+        await writeToTerminal(xterm, Buffer.from(event.data, 'base64'));
+        break;
+      case 'input':
+      case 'marker':
+        break;
+      case 'resize':
+        xterm.resize(event.cols, event.rows);
+        break;
+      case 'title':
+        title = event.title;
+        break;
+      case 'process-title':
+        processTitle = event.processTitle;
+        break;
+      case 'exit':
+        exitCode = event.code;
+        break;
+    }
+
+    seq = event.seq;
+  }
+
+  if (targetTime >= manifest.stats.durationMs) {
+    title ??= manifest.metadata.title;
+    processTitle ??= manifest.metadata.processTitle;
+    exitCode ??= manifest.metadata.exitCode;
+  }
+
+  return {
+    replayId,
+    sessionId: manifest.sessionId,
+    workspaceId: manifest.workspaceId,
+    timeMs: targetTime,
+    seq,
+    cols: xterm.cols,
+    rows: xterm.rows,
+    title,
+    processTitle,
+    exitCode,
+    checkpointId: checkpointRecord?.checkpoint.checkpointId,
+    xterm,
+  };
+}

--- a/src/lib/tmux-lite/replay/reconstruct.ts
+++ b/src/lib/tmux-lite/replay/reconstruct.ts
@@ -1,6 +1,20 @@
 import { Terminal as XTerminal } from '@xterm/headless';
 import { listReplayCheckpoints, readReplayCheckpoint, readReplayEvents, readReplayManifest } from './store.js';
 
+function getDefaultTargetTime(
+  manifest: { status: string; stats: { durationMs: number } },
+  checkpoints: Array<{ t: number }>,
+  events: Array<{ t: number }>
+): number {
+  if (manifest.status !== 'running') {
+    return manifest.stats.durationMs;
+  }
+
+  const latestEventTime = events.length > 0 ? events[events.length - 1]?.t ?? 0 : 0;
+  const latestCheckpointTime = checkpoints.length > 0 ? checkpoints[checkpoints.length - 1]?.t ?? 0 : 0;
+  return Math.max(manifest.stats.durationMs, latestEventTime, latestCheckpointTime);
+}
+
 export interface ReconstructedTerminalState {
   replayId: string;
   sessionId: string;
@@ -31,8 +45,9 @@ export async function reconstructReplayAt(
     throw new Error(`Replay manifest not found: ${replayId}`);
   }
 
-  const targetTime = Math.max(0, atMs ?? manifest.stats.durationMs);
   const checkpoints = listReplayCheckpoints(replayId);
+  const events = readReplayEvents(replayId);
+  const targetTime = Math.max(0, atMs ?? getDefaultTargetTime(manifest, checkpoints, events));
   const checkpoint = [...checkpoints]
     .reverse()
     .find((entry) => entry.t <= targetTime);
@@ -60,7 +75,6 @@ export async function reconstructReplayAt(
   let processTitle = checkpointRecord?.checkpoint.metadata.processTitle;
   let exitCode = checkpointRecord?.checkpoint.metadata.exitCode;
 
-  const events = readReplayEvents(replayId);
   for (const event of events) {
     if (event.seq <= seq) {
       continue;

--- a/src/lib/tmux-lite/replay/reconstruct.ts
+++ b/src/lib/tmux-lite/replay/reconstruct.ts
@@ -47,7 +47,8 @@ export async function reconstructReplayAt(
 
   const checkpoints = listReplayCheckpoints(replayId);
   const events = readReplayEvents(replayId);
-  const targetTime = Math.max(0, atMs ?? getDefaultTargetTime(manifest, checkpoints, events));
+  const latestAvailableTime = getDefaultTargetTime(manifest, checkpoints, events);
+  const targetTime = Math.max(0, atMs === undefined ? latestAvailableTime : Math.min(atMs, latestAvailableTime));
   const checkpoint = [...checkpoints]
     .reverse()
     .find((entry) => entry.t <= targetTime);

--- a/src/lib/tmux-lite/replay/reconstruct.ts
+++ b/src/lib/tmux-lite/replay/reconstruct.ts
@@ -40,7 +40,8 @@ function writeToTerminal(xterm: XTerminal, data: string | Uint8Array): Promise<v
 
 export async function reconstructReplayAt(
   replayId: string,
-  atMs?: number
+  atMs?: number,
+  atSeq?: number,
 ): Promise<ReconstructedTerminalState> {
   const manifest = readReplayManifest(replayId);
   if (!manifest) {
@@ -54,7 +55,7 @@ export async function reconstructReplayAt(
   const targetTime = Math.max(0, atMs === undefined ? latestAvailableTime : Math.min(atMs, latestAvailableTime));
   const checkpoint = [...checkpoints]
     .reverse()
-    .find((entry) => entry.t <= targetTime);
+    .find((entry) => entry.t < targetTime || (entry.t === targetTime && (atSeq === undefined || entry.seq <= atSeq)));
   const checkpointRecord = checkpoint
     ? readReplayCheckpoint(replayId, checkpoint.checkpointId)
     : null;
@@ -84,6 +85,9 @@ export async function reconstructReplayAt(
       continue;
     }
     if (event.t > targetTime) {
+      break;
+    }
+    if (event.t === targetTime && atSeq !== undefined && event.seq > atSeq) {
       break;
     }
 

--- a/src/lib/tmux-lite/replay/screenshot.test.ts
+++ b/src/lib/tmux-lite/replay/screenshot.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { existsSync, rmSync, statSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import {
+  findPngRasterizer,
+  readPngDimensions,
+  renderTerminalSnapshotSvg,
+  writeTerminalSnapshotPng,
+} from './screenshot.js';
+import type { TerminalSnapshot } from './types.js';
+
+const tempPaths: string[] = [];
+
+afterEach(() => {
+  for (const filePath of tempPaths.splice(0)) {
+    rmSync(filePath, { force: true });
+  }
+});
+
+function makeSnapshot(): TerminalSnapshot {
+  return {
+    version: 1,
+    replayId: 'replay-demo',
+    sessionId: 'session-demo',
+    source: 'replay',
+    timeMs: 420,
+    seq: 3,
+    terminal: {
+      cols: 40,
+      rows: 4,
+      cursorX: 5,
+      cursorY: 1,
+      viewportY: 0,
+      baseY: 0,
+    },
+    metadata: {
+      processTitle: 'bun test',
+      exitCode: 0,
+    },
+    screen: {
+      visible: ['first line', 'second <line>', '', 'done'],
+      scrollbackTail: ['older line'],
+      currentLine: 'second <line>',
+    },
+  };
+}
+
+describe('replay screenshot rendering', () => {
+  test('renders terminal snapshot as svg markup', () => {
+    const svg = renderTerminalSnapshotSvg(makeSnapshot(), {
+      title: 'demo',
+      subtitle: 'frame 1',
+      includeScrollback: true,
+    });
+
+    expect(svg).toContain('<svg');
+    expect(svg).toContain('demo');
+    expect(svg).toContain('frame 1');
+    expect(svg).toContain('older line');
+    expect(svg).toContain('second &lt;line&gt;');
+  });
+
+  test.if(findPngRasterizer() !== null)('writes terminal snapshot png output', () => {
+    const outputPath = join(tmpdir(), `gitspace-replay-shot-${Date.now()}.png`);
+    tempPaths.push(outputPath);
+
+    const writtenPath = writeTerminalSnapshotPng(makeSnapshot(), outputPath, {
+      title: 'demo screenshot',
+    });
+
+    expect(writtenPath).toBe(outputPath);
+    expect(existsSync(outputPath)).toBe(true);
+    expect(statSync(outputPath).size).toBeGreaterThan(0);
+
+    const dimensions = readPngDimensions(outputPath);
+    expect(dimensions.width).toBeGreaterThan(200);
+    expect(dimensions.height).toBeGreaterThan(100);
+  });
+});

--- a/src/lib/tmux-lite/replay/screenshot.test.ts
+++ b/src/lib/tmux-lite/replay/screenshot.test.ts
@@ -63,11 +63,11 @@ describe('replay screenshot rendering', () => {
     expect(svg).toContain('second &lt;line&gt;');
   });
 
-  test.if(findPngRasterizer() !== null)('writes terminal snapshot png output', () => {
+  test.if(findPngRasterizer() !== null)('writes terminal snapshot png output', async () => {
     const outputPath = join(tmpdir(), `gitspace-replay-shot-${Date.now()}.png`);
     tempPaths.push(outputPath);
 
-    const writtenPath = writeTerminalSnapshotPng(makeSnapshot(), outputPath, {
+    const writtenPath = await writeTerminalSnapshotPng(makeSnapshot(), outputPath, {
       title: 'demo screenshot',
     });
 

--- a/src/lib/tmux-lite/replay/screenshot.test.ts
+++ b/src/lib/tmux-lite/replay/screenshot.test.ts
@@ -2,7 +2,9 @@ import { afterEach, describe, expect, test } from 'bun:test';
 import { existsSync, rmSync, statSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
+import { Terminal as XTerminal } from '@xterm/headless';
 import {
+  extractStyledRows,
   findPngRasterizer,
   readPngDimensions,
   renderTerminalSnapshotSvg,
@@ -76,5 +78,22 @@ describe('replay screenshot rendering', () => {
     const dimensions = readPngDimensions(outputPath);
     expect(dimensions.width).toBeGreaterThan(200);
     expect(dimensions.height).toBeGreaterThan(100);
+  });
+
+  test('extracts scrollback rows when requested', async () => {
+    const xterm = new XTerminal({ cols: 20, rows: 2, allowProposedApi: true, scrollback: 100 });
+    await new Promise<void>((resolve) => xterm.write('one\r\ntwo\r\nthree', () => resolve()));
+
+    const visibleRows = extractStyledRows(xterm, { trimTrailingBlank: true });
+    const scrollbackRows = extractStyledRows(xterm, {
+      trimTrailingBlank: true,
+      includeScrollback: true,
+      scrollbackLines: 5,
+    });
+
+    expect(visibleRows.map((row) => row.map((span) => span.text).join('').trimEnd())).toEqual(['two', 'three']);
+    expect(scrollbackRows.map((row) => row.map((span) => span.text).join('').trimEnd())).toEqual(['one', 'two', 'three']);
+
+    xterm.dispose();
   });
 });

--- a/src/lib/tmux-lite/replay/screenshot.ts
+++ b/src/lib/tmux-lite/replay/screenshot.ts
@@ -1,0 +1,498 @@
+import { spawnSync } from 'child_process';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { dirname, join, resolve } from 'path';
+import type { Terminal as XTerminal } from '@xterm/headless';
+import { reconstructReplayAt } from './reconstruct.js';
+import type { ReplaySnapshotOptions } from './snapshot.js';
+import { readReplayManifest } from './store.js';
+import type { TerminalSnapshot } from './types.js';
+
+// ============================================================================
+// PNG rasterizer detection
+// ============================================================================
+
+interface PngRasterizer {
+  kind: 'sips' | 'magick' | 'convert';
+  executable: string;
+}
+
+function pathCandidates(name: string): string[] {
+  const pathValue = process.env.PATH ?? '';
+  const segments = pathValue.split(process.platform === 'win32' ? ';' : ':').filter(Boolean);
+  const suffixes = process.platform === 'win32' ? ['', '.exe', '.cmd', '.bat'] : [''];
+  return segments.flatMap((segment) => suffixes.map((suffix) => join(segment, `${name}${suffix}`)));
+}
+
+function findExecutable(name: string): string | null {
+  for (const candidate of pathCandidates(name)) {
+    if (existsSync(candidate)) {
+      return candidate;
+    }
+  }
+  return null;
+}
+
+export function findPngRasterizer(): PngRasterizer | null {
+  const candidates = process.platform === 'darwin'
+    ? ['sips', 'magick', 'convert'] as const
+    : ['magick', 'convert', 'sips'] as const;
+
+  for (const candidate of candidates) {
+    const executable = findExecutable(candidate);
+    if (executable) {
+      return { kind: candidate, executable };
+    }
+  }
+
+  return null;
+}
+
+function rasterizeSvg(inputPath: string, outputPath: string, rasterizer: PngRasterizer): void {
+  const cmd = rasterizer.kind === 'sips'
+    ? [rasterizer.executable, '-s', 'format', 'png', inputPath, '--out', outputPath]
+    : [rasterizer.executable, inputPath, outputPath];
+
+  const [command, ...args] = cmd;
+  const result = spawnSync(command, args, { stdio: ['ignore', 'pipe', 'pipe'] });
+
+  if (result.status !== 0) {
+    const detail = Buffer.from(result.stderr ?? result.stdout ?? '').toString('utf-8').trim();
+    throw new Error(detail || `Failed to rasterize screenshot with ${rasterizer.kind}`);
+  }
+}
+
+// ============================================================================
+// Theme
+// ============================================================================
+
+const THEME = {
+  background: '#0d1117',
+  border: '#30363d',
+  header: '#161b22',
+  title: '#e6edf3',
+  subtitle: '#8b949e',
+  text: '#c9d1d9',
+  accent: '#58a6ff',
+};
+
+// ============================================================================
+// ANSI 256-color palette
+// ============================================================================
+
+// Base 16 ANSI colors matching our GitSpace dark theme
+const ANSI_BASE_COLORS: string[] = [
+  '#484f58', '#ff7b72', '#3fb950', '#d29922', '#58a6ff', '#bc8cff', '#39c5cf', '#b1bac4', // 0-7  normal
+  '#6e7681', '#ffa198', '#56d364', '#e3b341', '#79c0ff', '#d2a8ff', '#56d4dd', '#f0f6fc', // 8-15 bright
+];
+
+const ANSI_256_PALETTE: string[] = (() => {
+  const palette = [...ANSI_BASE_COLORS];
+
+  // 6x6x6 RGB cube (colors 16-231)
+  for (let r = 0; r < 6; r++) {
+    for (let g = 0; g < 6; g++) {
+      for (let b = 0; b < 6; b++) {
+        const rv = r === 0 ? 0 : 55 + r * 40;
+        const gv = g === 0 ? 0 : 55 + g * 40;
+        const bv = b === 0 ? 0 : 55 + b * 40;
+        palette.push(
+          `#${rv.toString(16).padStart(2, '0')}${gv.toString(16).padStart(2, '0')}${bv.toString(16).padStart(2, '0')}`,
+        );
+      }
+    }
+  }
+
+  // 24-step grayscale (colors 232-255)
+  for (let i = 0; i < 24; i++) {
+    const v = 8 + i * 10;
+    const hex = v.toString(16).padStart(2, '0');
+    palette.push(`#${hex}${hex}${hex}`);
+  }
+
+  return palette;
+})();
+
+const COLOR_MODE_DEFAULT = 0;
+const COLOR_MODE_P16 = 0x01000000;  // 16777216
+const COLOR_MODE_P256 = 0x02000000; // 33554432
+const COLOR_MODE_RGB = 0x03000000;  // 50331648
+
+function resolveXtermColor(mode: number, value: number, defaultColor: string): string {
+  switch (mode) {
+    case COLOR_MODE_P16:
+    case COLOR_MODE_P256:
+      return ANSI_256_PALETTE[value & 0xff] ?? defaultColor;
+    case COLOR_MODE_RGB:
+      return `#${((value >> 16) & 0xff).toString(16).padStart(2, '0')}${((value >> 8) & 0xff).toString(16).padStart(2, '0')}${(value & 0xff).toString(16).padStart(2, '0')}`;
+    default:
+      return defaultColor;
+  }
+}
+
+// ============================================================================
+// Styled span extraction from xterm buffer
+// ============================================================================
+
+export interface StyledSpan {
+  text: string;
+  fg: string;
+  bg: string | null;
+  bold: boolean;
+  italic: boolean;
+  underline: boolean;
+  dim: boolean;
+  strikethrough: boolean;
+}
+
+export type StyledRow = StyledSpan[];
+
+function spanStyleKey(span: StyledSpan): string {
+  return `${span.fg}|${span.bg ?? ''}|${span.bold ? 'b' : ''}${span.italic ? 'i' : ''}${span.underline ? 'u' : ''}${span.dim ? 'd' : ''}${span.strikethrough ? 's' : ''}`;
+}
+
+export function extractStyledRows(xterm: XTerminal, options: { trimTrailingBlank?: boolean } = {}): StyledRow[] {
+  const buffer = xterm.buffer.active;
+  const rows: StyledRow[] = [];
+  const nullCell = buffer.getNullCell();
+
+  const viewportStart = buffer.baseY;
+
+  for (let rowIndex = 0; rowIndex < xterm.rows; rowIndex++) {
+    const line = buffer.getLine(viewportStart + rowIndex);
+    if (!line) {
+      rows.push([]);
+      continue;
+    }
+
+    const spans: StyledSpan[] = [];
+    let currentKey = '';
+    let currentSpan: StyledSpan | null = null;
+
+    for (let colIndex = 0; colIndex < xterm.cols; colIndex++) {
+      const cell = line.getCell(colIndex, nullCell);
+      if (!cell) {
+        continue;
+      }
+
+      const char = cell.getChars() || ' ';
+      const inverse = cell.isInverse() !== 0;
+
+      let fg = resolveXtermColor(cell.getFgColorMode(), cell.getFgColor(), THEME.text);
+      let bg: string | null = cell.getBgColorMode() !== COLOR_MODE_DEFAULT
+        ? resolveXtermColor(cell.getBgColorMode(), cell.getBgColor(), THEME.background)
+        : null;
+
+      if (inverse) {
+        const resolvedBg = bg ?? THEME.background;
+        bg = fg;
+        fg = resolvedBg;
+      }
+
+      const span: StyledSpan = {
+        text: char,
+        fg,
+        bg,
+        bold: cell.isBold() !== 0,
+        italic: cell.isItalic() !== 0,
+        underline: cell.isUnderline() !== 0,
+        dim: cell.isDim() !== 0,
+        strikethrough: cell.isStrikethrough() !== 0,
+      };
+
+      const key = spanStyleKey(span);
+      if (currentSpan && key === currentKey) {
+        currentSpan.text += char;
+      } else {
+        currentSpan = { ...span };
+        currentKey = key;
+        spans.push(currentSpan);
+      }
+    }
+
+    rows.push(spans);
+  }
+
+  if (options.trimTrailingBlank) {
+    while (rows.length > 0) {
+      const lastRow = rows[rows.length - 1];
+      const rowText = lastRow.map((s) => s.text).join('').trimEnd();
+      if (rowText.length === 0) {
+        rows.pop();
+      } else {
+        break;
+      }
+    }
+  }
+
+  return rows;
+}
+
+// ============================================================================
+// Colored SVG renderer
+// ============================================================================
+
+function escapeXml(value: string): string {
+  return value
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&apos;');
+}
+
+function buildSvgDocument(width: number, height: number, body: string): string {
+  return [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}">`,
+    body,
+    '</svg>',
+  ].join('');
+}
+
+export interface RenderStyledSvgOptions {
+  title?: string;
+  subtitle?: string;
+  dimOpacity?: number;
+}
+
+export function renderStyledRowsSvg(
+  rows: StyledRow[],
+  cols: number,
+  options: RenderStyledSvgOptions = {},
+): string {
+  const paddingX = 20;
+  const paddingY = 16;
+  const headerHeight = 44;
+  const cellWidth = 8.4;
+  const cellHeight = 18;
+  const fontSize = 13;
+  const fontFamily = "Menlo, Monaco, 'SF Mono', 'Cascadia Code', monospace";
+  const dimOpacity = options.dimOpacity ?? 0.5;
+
+  const displayRows = Math.max(rows.length, 1);
+  const displayCols = Math.max(cols, 20);
+  const width = Math.round(paddingX * 2 + displayCols * cellWidth);
+  const height = headerHeight + paddingY * 2 + displayRows * cellHeight;
+
+  const title = options.title ?? '';
+  const subtitle = options.subtitle ?? '';
+
+  const bgRects: string[] = [];
+  const textElements: string[] = [];
+  const decorationLines: string[] = [];
+
+  // Underline sits 2px below the baseline; strikethrough sits at ~40% up from baseline
+  const underlineY = fontSize + 2;
+  const strikeY = Math.round(fontSize * 0.6);
+
+  for (let rowIndex = 0; rowIndex < rows.length; rowIndex++) {
+    const row = rows[rowIndex];
+    const rowY = headerHeight + paddingY + rowIndex * cellHeight;
+    const textY = rowY + fontSize;
+
+    let colX = paddingX;
+
+    for (const span of row) {
+      const spanWidth = span.text.length * cellWidth;
+
+      // Background rect for non-default backgrounds
+      if (span.bg !== null) {
+        bgRects.push(
+          `<rect x="${colX.toFixed(1)}" y="${rowY}" width="${spanWidth.toFixed(1)}" height="${cellHeight}" fill="${span.bg}" />`,
+        );
+      }
+
+      // Text span (skip all-whitespace spans with no bg)
+      const trimmedText = span.text.trimEnd();
+      if (trimmedText.length > 0 || span.bg !== null) {
+        const attrs: string[] = [
+          `x="${colX.toFixed(1)}"`,
+          `y="${textY}"`,
+          `fill="${span.fg}"`,
+        ];
+
+        if (span.bold) {
+          attrs.push('font-weight="bold"');
+        }
+        if (span.italic) {
+          attrs.push('font-style="italic"');
+        }
+        if (span.dim) {
+          attrs.push(`opacity="${dimOpacity}"`);
+        }
+
+        textElements.push(
+          `<text ${attrs.join(' ')} xml:space="preserve">${escapeXml(span.text)}</text>`,
+        );
+      }
+
+      // Explicit underline and strikethrough lines (SVG text-decoration is unreliable in sips)
+      if (span.underline && trimmedText.length > 0) {
+        const lineX2 = (colX + trimmedText.length * cellWidth).toFixed(1);
+        const opacity = span.dim ? dimOpacity : 1;
+        decorationLines.push(
+          `<line x1="${colX.toFixed(1)}" y1="${rowY + underlineY}" x2="${lineX2}" y2="${rowY + underlineY}" stroke="${span.fg}" stroke-width="1" opacity="${opacity}" />`,
+        );
+      }
+      if (span.strikethrough && trimmedText.length > 0) {
+        const lineX2 = (colX + trimmedText.length * cellWidth).toFixed(1);
+        const opacity = span.dim ? dimOpacity : 1;
+        decorationLines.push(
+          `<line x1="${colX.toFixed(1)}" y1="${rowY + strikeY}" x2="${lineX2}" y2="${rowY + strikeY}" stroke="${span.fg}" stroke-width="1" opacity="${opacity}" />`,
+        );
+      }
+
+      colX += spanWidth;
+    }
+  }
+
+  return buildSvgDocument(width, height, `
+    <rect width="100%" height="100%" rx="14" ry="14" fill="${THEME.background}" stroke="${THEME.border}" />
+    <rect x="1" y="1" width="${width - 2}" height="${headerHeight}" rx="14" ry="14" fill="${THEME.header}" />
+    <circle cx="18" cy="${headerHeight / 2}" r="5" fill="#ff5f57" />
+    <circle cx="34" cy="${headerHeight / 2}" r="5" fill="#febc2e" />
+    <circle cx="50" cy="${headerHeight / 2}" r="5" fill="#28c840" />
+    <text x="66" y="${headerHeight / 2 - 5}" fill="${THEME.title}" font-family="${fontFamily}" font-size="14" font-weight="600">${escapeXml(title)}</text>
+    <text x="66" y="${headerHeight / 2 + 9}" fill="${THEME.subtitle}" font-family="${fontFamily}" font-size="11">${escapeXml(subtitle)}</text>
+    <text x="${width - 16}" y="${headerHeight / 2 - 4}" text-anchor="end" fill="${THEME.accent}" font-family="${fontFamily}" font-size="11">${displayCols}x${displayRows}</text>
+    <rect x="0" y="${headerHeight}" width="${width}" height="${height - headerHeight}" fill="${THEME.background}" />
+    <g font-family="${fontFamily}" font-size="${fontSize}" style="font-variant-ligatures:none;">
+      ${bgRects.join('\n      ')}
+      ${textElements.join('\n      ')}
+      ${decorationLines.join('\n      ')}
+    </g>
+  `);
+}
+
+// ============================================================================
+// Legacy plain-text SVG renderer (kept for tests / fallback)
+// ============================================================================
+
+export interface RenderSnapshotSvgOptions {
+  title?: string;
+  subtitle?: string;
+  includeScrollback?: boolean;
+}
+
+export function renderTerminalSnapshotSvg(snapshot: TerminalSnapshot, options: RenderSnapshotSvgOptions = {}): string {
+  const includeScrollback = options.includeScrollback ?? false;
+  const lines = includeScrollback
+    ? [...snapshot.screen.scrollbackTail, ...snapshot.screen.visible]
+    : [...snapshot.screen.visible];
+
+  const paddingX = 20;
+  const paddingY = 16;
+  const headerHeight = 44;
+  const cellWidth = 8.4;
+  const cellHeight = 18;
+  const fontSize = 13;
+  const fontFamily = "Menlo, Monaco, 'SF Mono', 'Cascadia Code', monospace";
+  const cols = Math.max(snapshot.terminal.cols, 20);
+  const displayRows = Math.max(lines.length, snapshot.terminal.rows, 1);
+  const width = Math.round(paddingX * 2 + cols * cellWidth);
+  const height = headerHeight + paddingY * 2 + displayRows * cellHeight;
+  const title = options.title ?? snapshot.metadata.processTitle ?? snapshot.sessionId;
+  const subtitle = options.subtitle ?? `replay ${snapshot.replayId} - t=${snapshot.timeMs}ms`;
+
+  const textElements = (lines.length > 0 ? lines : ['']).map((line, index) => {
+    const y = headerHeight + paddingY + fontSize + index * cellHeight;
+    const content = line.length > 0 ? escapeXml(line) : '&#160;';
+    return `<text x="${paddingX}" y="${y}" xml:space="preserve">${content}</text>`;
+  }).join('');
+
+  return buildSvgDocument(width, height, `
+    <rect width="100%" height="100%" rx="14" ry="14" fill="${THEME.background}" stroke="${THEME.border}" />
+    <rect x="1" y="1" width="${width - 2}" height="${headerHeight}" rx="14" ry="14" fill="${THEME.header}" />
+    <circle cx="18" cy="${headerHeight / 2}" r="5" fill="#ff5f57" />
+    <circle cx="34" cy="${headerHeight / 2}" r="5" fill="#febc2e" />
+    <circle cx="50" cy="${headerHeight / 2}" r="5" fill="#28c840" />
+    <text x="66" y="${headerHeight / 2 - 5}" fill="${THEME.title}" font-family="${fontFamily}" font-size="14" font-weight="600">${escapeXml(title)}</text>
+    <text x="66" y="${headerHeight / 2 + 9}" fill="${THEME.subtitle}" font-family="${fontFamily}" font-size="11">${escapeXml(subtitle)}</text>
+    <text x="${width - 16}" y="${headerHeight / 2 - 4}" text-anchor="end" fill="${THEME.accent}" font-family="${fontFamily}" font-size="11">${snapshot.terminal.cols}x${snapshot.terminal.rows}</text>
+    <g fill="${THEME.text}" font-family="${fontFamily}" font-size="${fontSize}" style="font-variant-ligatures:none;">
+      ${textElements}
+    </g>
+  `);
+}
+
+// ============================================================================
+// PNG writing helpers
+// ============================================================================
+
+export interface ReplayScreenshotOptions extends ReplaySnapshotOptions {
+  outputPath: string;
+  includeScrollback?: boolean;
+}
+
+function writeSvgAsPng(svg: string, outputPath: string): string {
+  const rasterizer = findPngRasterizer();
+  if (!rasterizer) {
+    throw new Error('No PNG rasterizer found. Install ImageMagick or use a system with sips available.');
+  }
+
+  const absoluteOutputPath = resolve(outputPath);
+  mkdirSync(dirname(absoluteOutputPath), { recursive: true });
+
+  const tempDir = mkdtempSync(join(tmpdir(), 'gitspace-replay-shot-'));
+  const tempSvgPath = join(tempDir, 'snapshot.svg');
+
+  try {
+    writeFileSync(tempSvgPath, svg, 'utf-8');
+    rasterizeSvg(tempSvgPath, absoluteOutputPath, rasterizer);
+
+    if (!existsSync(absoluteOutputPath)) {
+      throw new Error(`Screenshot was not written: ${absoluteOutputPath}`);
+    }
+
+    const size = statSync(absoluteOutputPath).size;
+    if (size <= 0) {
+      throw new Error(`Screenshot is empty: ${absoluteOutputPath}`);
+    }
+
+    return absoluteOutputPath;
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+}
+
+// Legacy: write from TerminalSnapshot (plain text, no colors)
+export function writeTerminalSnapshotPng(
+  snapshot: TerminalSnapshot,
+  outputPath: string,
+  options: RenderSnapshotSvgOptions = {},
+): string {
+  return writeSvgAsPng(renderTerminalSnapshotSvg(snapshot, options), outputPath);
+}
+
+// Primary: write directly from replay, using colored xterm buffer extraction
+export async function writeReplayScreenshot(replayId: string, options: ReplayScreenshotOptions): Promise<string> {
+  const manifest = readReplayManifest(replayId);
+  if (!manifest) {
+    throw new Error(`Replay manifest not found: ${replayId}`);
+  }
+
+  const state = await reconstructReplayAt(replayId, options.atMs);
+  try {
+    const rows = extractStyledRows(state.xterm, { trimTrailingBlank: true });
+    const svg = renderStyledRowsSvg(rows, state.cols, {
+      title: manifest.sessionName || manifest.sessionId,
+      subtitle: `replay ${manifest.replayId.slice(0, 16)} · t=${state.timeMs}ms`,
+    });
+    return writeSvgAsPng(svg, options.outputPath);
+  } finally {
+    state.xterm.dispose();
+  }
+}
+
+export function readPngDimensions(pngPath: string): { width: number; height: number } {
+  const file = readFileSync(pngPath);
+  if (file.length < 24 || file.toString('ascii', 1, 4) !== 'PNG') {
+    throw new Error(`Invalid PNG file: ${pngPath}`);
+  }
+
+  return {
+    width: file.readUInt32BE(16),
+    height: file.readUInt32BE(20),
+  };
+}

--- a/src/lib/tmux-lite/replay/screenshot.ts
+++ b/src/lib/tmux-lite/replay/screenshot.ts
@@ -1,8 +1,10 @@
-import { spawnSync } from 'child_process';
+import { spawn } from 'child_process';
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
 import { dirname, join, resolve } from 'path';
 import type { Terminal as XTerminal } from '@xterm/headless';
+import { ReplayScreenshotError, SpacesError } from '../../../types/errors.js';
+import { logger } from '../../../utils/logger.js';
 import { reconstructReplayAt } from './reconstruct.js';
 import type { ReplaySnapshotOptions } from './snapshot.js';
 import { readReplayManifest } from './store.js';
@@ -48,18 +50,114 @@ export function findPngRasterizer(): PngRasterizer | null {
   return null;
 }
 
-function rasterizeSvg(inputPath: string, outputPath: string, rasterizer: PngRasterizer): void {
+const RASTERIZE_TIMEOUT_MS = 15_000;
+
+interface ScreenshotErrorContext {
+  replayId?: string;
+  outputPath?: string;
+  rasterizer?: string;
+}
+
+function formatScreenshotContext(context: ScreenshotErrorContext): string {
+  return [
+    context.replayId ? `replayId=${context.replayId}` : null,
+    context.outputPath ? `outputPath=${context.outputPath}` : null,
+    context.rasterizer ? `rasterizer=${context.rasterizer}` : null,
+  ].filter((value): value is string => value !== null).join(' ');
+}
+
+function logAndCreateScreenshotError(
+  message: string,
+  context: ScreenshotErrorContext,
+  error?: unknown,
+): ReplayScreenshotError {
+  const suffix = formatScreenshotContext(context);
+  const detail = error instanceof Error ? error.message : error ? String(error) : null;
+  logger.error(`[replay.screenshot] ${message}${suffix ? ` (${suffix})` : ''}${detail ? `: ${detail}` : ''}`);
+  return new ReplayScreenshotError(message);
+}
+
+function collectOutput(chunks: Buffer[]): string {
+  return Buffer.concat(chunks).toString('utf-8').trim();
+}
+
+function buildProcessFailureMessage(rasterizer: PngRasterizer, reason: string, stdout: string, stderr: string): string {
+  const output = [stderr, stdout].filter(Boolean).join('\n').trim();
+  return output.length > 0
+    ? `Failed to rasterize screenshot with ${rasterizer.kind}: ${reason}. ${output}`
+    : `Failed to rasterize screenshot with ${rasterizer.kind}: ${reason}`;
+}
+
+async function rasterizeSvg(
+  inputPath: string,
+  outputPath: string,
+  rasterizer: PngRasterizer,
+  context: ScreenshotErrorContext,
+): Promise<void> {
   const cmd = rasterizer.kind === 'sips'
     ? [rasterizer.executable, '-s', 'format', 'png', inputPath, '--out', outputPath]
     : [rasterizer.executable, inputPath, outputPath];
 
   const [command, ...args] = cmd;
-  const result = spawnSync(command, args, { stdio: ['ignore', 'pipe', 'pipe'] });
+  await new Promise<void>((resolvePromise, rejectPromise) => {
+    const stdoutChunks: Buffer[] = [];
+    const stderrChunks: Buffer[] = [];
+    const child = spawn(command, args, { stdio: ['ignore', 'pipe', 'pipe'] });
+    let settled = false;
 
-  if (result.status !== 0) {
-    const detail = Buffer.from(result.stderr ?? result.stdout ?? '').toString('utf-8').trim();
-    throw new Error(detail || `Failed to rasterize screenshot with ${rasterizer.kind}`);
-  }
+    const finish = (error?: ReplayScreenshotError) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timeout);
+      if (error) {
+        rejectPromise(error);
+      } else {
+        resolvePromise();
+      }
+    };
+
+    const timeout = setTimeout(() => {
+      child.kill('SIGKILL');
+      const stdout = collectOutput(stdoutChunks);
+      const stderr = collectOutput(stderrChunks);
+      finish(logAndCreateScreenshotError(
+        buildProcessFailureMessage(rasterizer, `timed out after ${RASTERIZE_TIMEOUT_MS}ms`, stdout, stderr),
+        { ...context, rasterizer: rasterizer.kind },
+      ));
+    }, RASTERIZE_TIMEOUT_MS);
+
+    child.stdout?.on('data', (chunk: Buffer | string) => {
+      stdoutChunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+    });
+    child.stderr?.on('data', (chunk: Buffer | string) => {
+      stderrChunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+    });
+
+    child.on('error', (error) => {
+      finish(logAndCreateScreenshotError(
+        `Failed to start screenshot rasterizer ${rasterizer.kind}`,
+        { ...context, rasterizer: rasterizer.kind },
+        error,
+      ));
+    });
+
+    child.on('close', (code, signal) => {
+      if (code === 0) {
+        finish();
+        return;
+      }
+
+      const stdout = collectOutput(stdoutChunks);
+      const stderr = collectOutput(stderrChunks);
+      const reason = signal ? `terminated by signal ${signal}` : `exited with code ${code ?? 'unknown'}`;
+      finish(logAndCreateScreenshotError(
+        buildProcessFailureMessage(rasterizer, reason, stdout, stderr),
+        { ...context, rasterizer: rasterizer.kind },
+      ));
+    });
+  });
 }
 
 // ============================================================================
@@ -443,51 +541,128 @@ export interface ReplayScreenshotOptions extends ReplaySnapshotOptions {
   includeScrollback?: boolean;
 }
 
-function writeSvgAsPng(svg: string, outputPath: string): string {
+async function writeSvgAsPng(svg: string, outputPath: string, replayId?: string): Promise<string> {
   const rasterizer = findPngRasterizer();
-  if (!rasterizer) {
-    throw new Error('No PNG rasterizer found. Install ImageMagick or use a system with sips available.');
-  }
-
   const absoluteOutputPath = resolve(outputPath);
-  mkdirSync(dirname(absoluteOutputPath), { recursive: true });
 
-  const tempDir = mkdtempSync(join(tmpdir(), 'gitspace-replay-shot-'));
-  const tempSvgPath = join(tempDir, 'snapshot.svg');
+  if (!rasterizer) {
+    throw logAndCreateScreenshotError(
+      'No PNG rasterizer found. Install ImageMagick or use a system with sips available.',
+      { replayId, outputPath: absoluteOutputPath },
+    );
+  }
 
   try {
-    writeFileSync(tempSvgPath, svg, 'utf-8');
-    rasterizeSvg(tempSvgPath, absoluteOutputPath, rasterizer);
+    mkdirSync(dirname(absoluteOutputPath), { recursive: true });
+  } catch (error) {
+    throw logAndCreateScreenshotError(
+      'Failed to prepare replay screenshot output directory.',
+      { replayId, outputPath: absoluteOutputPath, rasterizer: rasterizer.kind },
+      error,
+    );
+  }
+
+  let tempDir: string;
+  try {
+    tempDir = mkdtempSync(join(tmpdir(), 'gitspace-replay-shot-'));
+  } catch (error) {
+    throw logAndCreateScreenshotError(
+      'Failed to create temporary screenshot directory.',
+      { replayId, outputPath: absoluteOutputPath, rasterizer: rasterizer.kind },
+      error,
+    );
+  }
+  const tempSvgPath = join(tempDir, 'snapshot.svg');
+  let result: string | null = null;
+  let pendingError: Error | null = null;
+
+  try {
+    try {
+      writeFileSync(tempSvgPath, svg, 'utf-8');
+    } catch (error) {
+      throw logAndCreateScreenshotError(
+        'Failed to write temporary replay screenshot SVG.',
+        { replayId, outputPath: absoluteOutputPath, rasterizer: rasterizer.kind },
+        error,
+      );
+    }
+
+    await rasterizeSvg(tempSvgPath, absoluteOutputPath, rasterizer, {
+      replayId,
+      outputPath: absoluteOutputPath,
+    });
 
     if (!existsSync(absoluteOutputPath)) {
-      throw new Error(`Screenshot was not written: ${absoluteOutputPath}`);
+      throw logAndCreateScreenshotError(
+        `Screenshot was not written: ${absoluteOutputPath}`,
+        { replayId, outputPath: absoluteOutputPath, rasterizer: rasterizer.kind },
+      );
     }
 
-    const size = statSync(absoluteOutputPath).size;
+    let size: number;
+    try {
+      size = statSync(absoluteOutputPath).size;
+    } catch (error) {
+      throw logAndCreateScreenshotError(
+        'Failed to read replay screenshot output metadata.',
+        { replayId, outputPath: absoluteOutputPath, rasterizer: rasterizer.kind },
+        error,
+      );
+    }
+
     if (size <= 0) {
-      throw new Error(`Screenshot is empty: ${absoluteOutputPath}`);
+      throw logAndCreateScreenshotError(
+        `Screenshot is empty: ${absoluteOutputPath}`,
+        { replayId, outputPath: absoluteOutputPath, rasterizer: rasterizer.kind },
+      );
     }
 
-    return absoluteOutputPath;
+    result = absoluteOutputPath;
+  } catch (error) {
+    pendingError = error instanceof ReplayScreenshotError || error instanceof SpacesError
+      ? error
+      : logAndCreateScreenshotError(
+        'Unexpected replay screenshot failure.',
+        { replayId, outputPath: absoluteOutputPath, rasterizer: rasterizer.kind },
+        error,
+      );
   } finally {
-    rmSync(tempDir, { recursive: true, force: true });
+    try {
+      rmSync(tempDir, { recursive: true, force: true });
+    } catch (error) {
+      const cleanupFailure = logAndCreateScreenshotError(
+        'Failed to clean up temporary replay screenshot files.',
+        { replayId, outputPath: absoluteOutputPath, rasterizer: rasterizer.kind },
+        error,
+      );
+      if (!pendingError) {
+        pendingError = cleanupFailure;
+      }
+    }
   }
+
+  if (pendingError) {
+    throw pendingError;
+  }
+
+  return result as string;
 }
 
 // Legacy: write from TerminalSnapshot (plain text, no colors)
-export function writeTerminalSnapshotPng(
+export async function writeTerminalSnapshotPng(
   snapshot: TerminalSnapshot,
   outputPath: string,
   options: RenderSnapshotSvgOptions = {},
-): string {
-  return writeSvgAsPng(renderTerminalSnapshotSvg(snapshot, options), outputPath);
+): Promise<string> {
+  return writeSvgAsPng(renderTerminalSnapshotSvg(snapshot, options), outputPath, snapshot.replayId);
 }
 
 // Primary: write directly from replay, using colored xterm buffer extraction
 export async function writeReplayScreenshot(replayId: string, options: ReplayScreenshotOptions): Promise<string> {
   const manifest = readReplayManifest(replayId);
   if (!manifest) {
-    throw new Error(`Replay manifest not found: ${replayId}`);
+    logger.error(`[replay.screenshot] Replay manifest not found: replayId=${replayId} outputPath=${resolve(options.outputPath)}`);
+    throw new SpacesError(`Replay manifest not found: ${replayId}`, 'USER_ERROR', 1);
   }
 
   const state = await reconstructReplayAt(replayId, options.atMs);
@@ -501,16 +676,22 @@ export async function writeReplayScreenshot(replayId: string, options: ReplayScr
       title: manifest.sessionName || manifest.sessionId,
       subtitle: `replay ${manifest.replayId.slice(0, 16)} · t=${state.timeMs}ms`,
     });
-    return writeSvgAsPng(svg, options.outputPath);
+    return await writeSvgAsPng(svg, options.outputPath, replayId);
   } finally {
     state.xterm.dispose();
   }
 }
 
 export function readPngDimensions(pngPath: string): { width: number; height: number } {
-  const file = readFileSync(pngPath);
+  let file: Buffer;
+  try {
+    file = readFileSync(pngPath);
+  } catch (error) {
+    throw logAndCreateScreenshotError('Failed to read PNG file.', { outputPath: resolve(pngPath) }, error);
+  }
+
   if (file.length < 24 || file.toString('ascii', 1, 4) !== 'PNG') {
-    throw new Error(`Invalid PNG file: ${pngPath}`);
+    throw logAndCreateScreenshotError(`Invalid PNG file: ${pngPath}`, { outputPath: resolve(pngPath) });
   }
 
   return {

--- a/src/lib/tmux-lite/replay/screenshot.ts
+++ b/src/lib/tmux-lite/replay/screenshot.ts
@@ -151,14 +151,23 @@ function spanStyleKey(span: StyledSpan): string {
   return `${span.fg}|${span.bg ?? ''}|${span.bold ? 'b' : ''}${span.italic ? 'i' : ''}${span.underline ? 'u' : ''}${span.dim ? 'd' : ''}${span.strikethrough ? 's' : ''}`;
 }
 
-export function extractStyledRows(xterm: XTerminal, options: { trimTrailingBlank?: boolean } = {}): StyledRow[] {
+export function extractStyledRows(
+  xterm: XTerminal,
+  options: { trimTrailingBlank?: boolean; includeScrollback?: boolean; scrollbackLines?: number } = {}
+): StyledRow[] {
   const buffer = xterm.buffer.active;
   const rows: StyledRow[] = [];
   const nullCell = buffer.getNullCell();
 
-  const viewportStart = buffer.baseY;
+  const scrollbackLines = options.scrollbackLines ?? 80;
+  const viewportStart = options.includeScrollback
+    ? Math.max(0, buffer.baseY - scrollbackLines)
+    : buffer.baseY;
+  const rowCount = options.includeScrollback
+    ? Math.max(xterm.rows, buffer.baseY - viewportStart + xterm.rows)
+    : xterm.rows;
 
-  for (let rowIndex = 0; rowIndex < xterm.rows; rowIndex++) {
+  for (let rowIndex = 0; rowIndex < rowCount; rowIndex++) {
     const line = buffer.getLine(viewportStart + rowIndex);
     if (!line) {
       rows.push([]);
@@ -474,7 +483,11 @@ export async function writeReplayScreenshot(replayId: string, options: ReplayScr
 
   const state = await reconstructReplayAt(replayId, options.atMs);
   try {
-    const rows = extractStyledRows(state.xterm, { trimTrailingBlank: true });
+    const rows = extractStyledRows(state.xterm, {
+      trimTrailingBlank: true,
+      includeScrollback: options.includeScrollback,
+      scrollbackLines: options.scrollbackLines,
+    });
     const svg = renderStyledRowsSvg(rows, state.cols, {
       title: manifest.sessionName || manifest.sessionId,
       subtitle: `replay ${manifest.replayId.slice(0, 16)} · t=${state.timeMs}ms`,

--- a/src/lib/tmux-lite/replay/screenshot.ts
+++ b/src/lib/tmux-lite/replay/screenshot.ts
@@ -136,6 +136,7 @@ function resolveXtermColor(mode: number, value: number, defaultColor: string): s
 
 export interface StyledSpan {
   text: string;
+  cells: number;
   fg: string;
   bg: string | null;
   bold: boolean;
@@ -184,6 +185,11 @@ export function extractStyledRows(
         continue;
       }
 
+      const width = cell.getWidth();
+      if (width === 0) {
+        continue;
+      }
+
       const char = cell.getChars() || ' ';
       const inverse = cell.isInverse() !== 0;
 
@@ -200,6 +206,7 @@ export function extractStyledRows(
 
       const span: StyledSpan = {
         text: char,
+        cells: width,
         fg,
         bg,
         bold: cell.isBold() !== 0,
@@ -212,6 +219,7 @@ export function extractStyledRows(
       const key = spanStyleKey(span);
       if (currentSpan && key === currentKey) {
         currentSpan.text += char;
+        currentSpan.cells += width;
       } else {
         currentSpan = { ...span };
         currentKey = key;
@@ -303,7 +311,7 @@ export function renderStyledRowsSvg(
     let colX = paddingX;
 
     for (const span of row) {
-      const spanWidth = span.text.length * cellWidth;
+      const spanWidth = span.cells * cellWidth;
 
       // Background rect for non-default backgrounds
       if (span.bg !== null) {
@@ -338,14 +346,14 @@ export function renderStyledRowsSvg(
 
       // Explicit underline and strikethrough lines (SVG text-decoration is unreliable in sips)
       if (span.underline && trimmedText.length > 0) {
-        const lineX2 = (colX + trimmedText.length * cellWidth).toFixed(1);
+        const lineX2 = (colX + span.cells * cellWidth).toFixed(1);
         const opacity = span.dim ? dimOpacity : 1;
         decorationLines.push(
           `<line x1="${colX.toFixed(1)}" y1="${rowY + underlineY}" x2="${lineX2}" y2="${rowY + underlineY}" stroke="${span.fg}" stroke-width="1" opacity="${opacity}" />`,
         );
       }
       if (span.strikethrough && trimmedText.length > 0) {
-        const lineX2 = (colX + trimmedText.length * cellWidth).toFixed(1);
+        const lineX2 = (colX + span.cells * cellWidth).toFixed(1);
         const opacity = span.dim ? dimOpacity : 1;
         decorationLines.push(
           `<line x1="${colX.toFixed(1)}" y1="${rowY + strikeY}" x2="${lineX2}" y2="${rowY + strikeY}" stroke="${span.fg}" stroke-width="1" opacity="${opacity}" />`,

--- a/src/lib/tmux-lite/replay/screenshot.ts
+++ b/src/lib/tmux-lite/replay/screenshot.ts
@@ -161,10 +161,11 @@ export function extractStyledRows(
   const nullCell = buffer.getNullCell();
 
   const scrollbackLines = options.scrollbackLines ?? 80;
-  const viewportStart = options.includeScrollback
+  const includeScrollback = options.includeScrollback === true || (options.scrollbackLines ?? 0) > 0;
+  const viewportStart = includeScrollback
     ? Math.max(0, buffer.baseY - scrollbackLines)
     : buffer.baseY;
-  const rowCount = options.includeScrollback
+  const rowCount = includeScrollback
     ? Math.max(xterm.rows, buffer.baseY - viewportStart + xterm.rows)
     : xterm.rows;
 

--- a/src/lib/tmux-lite/replay/service.ts
+++ b/src/lib/tmux-lite/replay/service.ts
@@ -158,11 +158,6 @@ export function styledRowsToAnsi(rows: StyledRow[]): Buffer {
 
   for (const row of rows) {
     for (const span of row) {
-      if (span.text.trim() === '' && span.bg === null) {
-        // Whitespace with no bg — emit as-is (no SGR needed)
-        parts.push(span.text);
-        continue;
-      }
       parts.push(spanToSgr(span));
       parts.push(span.text);
     }

--- a/src/lib/tmux-lite/replay/service.ts
+++ b/src/lib/tmux-lite/replay/service.ts
@@ -15,12 +15,23 @@ import { getReplaySnapshot } from './snapshot.js';
 import { extractStyledRows, writeReplayScreenshot, type StyledRow, type StyledSpan } from './screenshot.js';
 import {
   listReplayInfos,
+  listReplayCheckpoints,
+  readReplayEvents,
+  readReplayManifest,
   dismissReplay,
   undismissReplay,
   deleteReplay,
+  pruneExpiredReplays,
+  getReplayStorageSummary,
   type ReplayListFilter,
 } from './store.js';
-import type { ReplayInfo, TerminalSnapshot } from './types.js';
+import type {
+  ReplayFrameTarget,
+  ReplayInfo,
+  ReplayTimeline,
+  ReplayTimelineStep,
+  TerminalSnapshot,
+} from './types.js';
 import { SpacesError } from '../../../types/errors.js';
 import { logger } from '../../../utils/logger.js';
 
@@ -43,6 +54,24 @@ export interface OfflineReplayScreenshotOptions {
   atMs?: number;
   scrollbackLines?: number;
   includeScrollback?: boolean;
+}
+
+function getLatestReplayTime(
+  durationMs: number,
+  checkpoints: Array<{ t: number }>,
+  events: Array<{ t: number }>,
+): number {
+  const latestEventTime = events.length > 0 ? events[events.length - 1]?.t ?? 0 : 0;
+  const latestCheckpointTime = checkpoints.length > 0 ? checkpoints[checkpoints.length - 1]?.t ?? 0 : 0;
+  return Math.max(durationMs, latestEventTime, latestCheckpointTime);
+}
+
+function appendUniqueStep(steps: ReplayTimelineStep[], next: ReplayTimelineStep): void {
+  const previous = steps[steps.length - 1];
+  if (previous && previous.timeMs === next.timeMs && previous.seq === next.seq) {
+    return;
+  }
+  steps.push(next);
 }
 
 // ============================================================================
@@ -83,6 +112,44 @@ export function resolveReplayOffline(ref: string, filter: ReplayListFilter = {})
   throw new SpacesError(`Replay not found: ${ref}`, 'USER_ERROR', 1);
 }
 
+export function getReplayTimelineOffline(replayId: string): ReplayTimeline {
+  const manifest = readReplayManifest(replayId);
+  if (!manifest) {
+    logger.error(`[replay.service] Replay manifest not found: ${replayId}`);
+    throw new SpacesError(`Replay manifest not found: ${replayId}`, 'USER_ERROR', 1);
+  }
+
+  const events = readReplayEvents(replayId);
+  const checkpoints = listReplayCheckpoints(replayId);
+  const latestTimeMs = getLatestReplayTime(manifest.stats.durationMs, checkpoints, events);
+
+  const steps: ReplayTimelineStep[] = [];
+  appendUniqueStep(steps, { timeMs: 0, seq: 0 });
+
+  for (const event of events) {
+    if (event.type === 'input' || event.type === 'marker') {
+      continue;
+    }
+    appendUniqueStep(steps, { timeMs: event.t, seq: event.seq });
+  }
+
+  appendUniqueStep(steps, {
+    timeMs: latestTimeMs,
+    seq: manifest.stats.lastSeq,
+  });
+
+  return {
+    replayId,
+    durationMs: manifest.stats.durationMs,
+    latestTimeMs,
+    steps,
+    checkpointSteps: checkpoints.map((checkpoint) => ({
+      timeMs: checkpoint.t,
+      seq: checkpoint.seq,
+    })),
+  };
+}
+
 // ============================================================================
 // Read
 // ============================================================================
@@ -117,8 +184,12 @@ export async function getReplaySnapshotOffline(
   return getReplaySnapshot(replayId, options);
 }
 
-export async function getReplayStyledRowsOffline(replayId: string, atMs?: number): Promise<StyledRow[]> {
-  const state = await reconstructReplayAt(replayId, atMs);
+export async function getReplayStyledRowsOffline(
+  replayId: string,
+  atMs?: number,
+  atSeq?: number,
+): Promise<StyledRow[]> {
+  const state = await reconstructReplayAt(replayId, atMs, atSeq);
   try {
     return extractStyledRows(state.xterm, { trimTrailingBlank: true });
   } finally {
@@ -177,8 +248,11 @@ export function styledRowsToAnsi(rows: StyledRow[]): Buffer {
   return Buffer.from(parts.join(''), 'utf8');
 }
 
-export async function getReplayAnsiBufferOffline(replayId: string, atMs?: number): Promise<Buffer> {
-  const state = await reconstructReplayAt(replayId, atMs);
+export async function getReplayAnsiBufferOffline(
+  replayId: string,
+  target: ReplayFrameTarget = {},
+): Promise<Buffer> {
+  const state = await reconstructReplayAt(replayId, target.atMs, target.atSeq);
   try {
     const rows = extractStyledRows(state.xterm, { trimTrailingBlank: true });
     return styledRowsToAnsi(rows);
@@ -212,4 +286,12 @@ export function undismissReplayOffline(replayId: string): void {
 
 export function deleteReplayOffline(replayId: string): void {
   deleteReplay(replayId);
+}
+
+export function pruneExpiredReplaysOffline(now?: number): number {
+  return pruneExpiredReplays(now);
+}
+
+export function getReplayStorageSummaryOffline(filter?: ReplayListFilter): import('./types.js').ReplayStorageSummary {
+  return getReplayStorageSummary(filter);
 }

--- a/src/lib/tmux-lite/replay/service.ts
+++ b/src/lib/tmux-lite/replay/service.ts
@@ -1,0 +1,236 @@
+/**
+ * Offline replay service.
+ *
+ * Reads replay artifacts directly from disk without requiring a live tmux-lite
+ * daemon. Use this for replay browsing, screenshot export, and dismissal flows
+ * so they remain usable after a daemon crash.
+ *
+ * The tmux-lite daemon path (cli.ts) is still available for operations that
+ * require live server state (e.g. creating new sessions). This module is
+ * specifically for historical replay access.
+ */
+
+import { reconstructReplayAt } from './reconstruct.js';
+import { getReplaySnapshot } from './snapshot.js';
+import { extractStyledRows, writeReplayScreenshot, type StyledRow, type StyledSpan } from './screenshot.js';
+import {
+  listReplayInfos,
+  readReplayManifest,
+  dismissReplay,
+  undismissReplay,
+  deleteReplay,
+  type ReplayListFilter,
+} from './store.js';
+import type { ReplayInfo, TerminalSnapshot } from './types.js';
+
+export type { ReplayInfo, TerminalSnapshot, ReplayListFilter, StyledRow, StyledSpan };
+
+export interface OfflineReplayTextOptions {
+  atMs?: number;
+  scrollbackLines?: number;
+  includeScrollback?: boolean;
+  trimTrailingBlankRows?: boolean;
+}
+
+export interface OfflineReplaySnapshotOptions {
+  atMs?: number;
+  scrollbackLines?: number;
+}
+
+export interface OfflineReplayScreenshotOptions {
+  outputPath: string;
+  atMs?: number;
+  includeScrollback?: boolean;
+}
+
+// ============================================================================
+// List
+// ============================================================================
+
+export function listReplaysOffline(filter: ReplayListFilter = {}): ReplayInfo[] {
+  return listReplayInfos(filter);
+}
+
+export function resolveReplayOffline(ref: string, filter: ReplayListFilter = {}): ReplayInfo {
+  const all = listReplayInfos({ ...filter, includeDismissed: true });
+
+  const exactMatches = all.filter(
+    (r) => r.replayId === ref || r.sessionId === ref || r.sessionName === ref,
+  );
+  if (exactMatches.length === 1) {
+    return exactMatches[0];
+  }
+  if (exactMatches.length > 1) {
+    throw new Error(`Replay reference is ambiguous: ${ref}`);
+  }
+
+  const prefixMatches = all.filter((r) => r.replayId.startsWith(ref));
+  if (prefixMatches.length === 1) {
+    return prefixMatches[0];
+  }
+  if (prefixMatches.length > 1) {
+    throw new Error(`Replay reference matches multiple replay IDs: ${ref}`);
+  }
+
+  throw new Error(`Replay not found: ${ref}`);
+}
+
+// ============================================================================
+// Read
+// ============================================================================
+
+export async function getReplayTextOffline(
+  replayId: string,
+  options: OfflineReplayTextOptions = {},
+): Promise<string> {
+  const snapshot = await getReplaySnapshot(replayId, {
+    atMs: options.atMs,
+    scrollbackLines: options.scrollbackLines,
+  });
+  const lines = options.includeScrollback
+    ? [...snapshot.screen.scrollbackTail, ...snapshot.screen.visible]
+    : [...snapshot.screen.visible];
+
+  if (options.trimTrailingBlankRows !== false) {
+    let end = lines.length;
+    while (end > 0 && lines[end - 1].trim() === '') {
+      end--;
+    }
+    return lines.slice(0, end).join('\n');
+  }
+
+  return lines.join('\n');
+}
+
+export async function getReplaySnapshotOffline(
+  replayId: string,
+  options: OfflineReplaySnapshotOptions = {},
+): Promise<TerminalSnapshot> {
+  return getReplaySnapshot(replayId, options);
+}
+
+export async function getReplayStyledRowsOffline(replayId: string, atMs?: number): Promise<StyledRow[]> {
+  const state = await reconstructReplayAt(replayId, atMs);
+  try {
+    return extractStyledRows(state.xterm, { trimTrailingBlank: true });
+  } finally {
+    state.xterm.dispose();
+  }
+}
+
+// ============================================================================
+// ANSI encoder — styled rows → escape sequences for Ghostty/TUI rendering
+// ============================================================================
+
+function hexColorToRgb(hex: string): [number, number, number] | null {
+  const match = /^#([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]{2})$/i.exec(hex);
+  if (!match) {
+    return null;
+  }
+  return [parseInt(match[1], 16), parseInt(match[2], 16), parseInt(match[3], 16)];
+}
+
+function spanToSgr(span: StyledSpan): string {
+  const codes: number[] = [0]; // always reset first
+
+  if (span.bold) codes.push(1);
+  if (span.dim) codes.push(2);
+  if (span.italic) codes.push(3);
+  if (span.underline) codes.push(4);
+  if (span.strikethrough) codes.push(9);
+
+  const fgRgb = hexColorToRgb(span.fg);
+  if (fgRgb) {
+    codes.push(38, 2, fgRgb[0], fgRgb[1], fgRgb[2]);
+  }
+
+  if (span.bg !== null) {
+    const bgRgb = hexColorToRgb(span.bg);
+    if (bgRgb) {
+      codes.push(48, 2, bgRgb[0], bgRgb[1], bgRgb[2]);
+    }
+  }
+
+  return `\x1b[${codes.join(';')}m`;
+}
+
+export function styledRowsToAnsi(rows: StyledRow[]): Buffer {
+  const parts: string[] = ['\x1b[2J\x1b[H']; // clear + cursor home
+
+  for (const row of rows) {
+    for (const span of row) {
+      if (span.text.trim() === '' && span.bg === null) {
+        // Whitespace with no bg — emit as-is (no SGR needed)
+        parts.push(span.text);
+        continue;
+      }
+      parts.push(spanToSgr(span));
+      parts.push(span.text);
+    }
+    parts.push('\x1b[0m\r\n');
+  }
+
+  parts.push('\x1b[0m');
+  return Buffer.from(parts.join(''), 'binary');
+}
+
+export async function getReplayAnsiBufferOffline(replayId: string, atMs?: number): Promise<Buffer> {
+  const state = await reconstructReplayAt(replayId, atMs);
+  try {
+    const rows = extractStyledRows(state.xterm, { trimTrailingBlank: true });
+    return styledRowsToAnsi(rows);
+  } finally {
+    state.xterm.dispose();
+  }
+}
+
+export async function getReplayAnsiOffline(replayId: string, atMs?: number): Promise<Buffer> {
+  const manifest = readReplayManifest(replayId);
+  if (!manifest) {
+    throw new Error(`Replay manifest not found: ${replayId}`);
+  }
+
+  // Concatenate the raw PTY output events up to atMs
+  const { readReplayEvents } = await import('./store.js');
+  const targetTime = atMs ?? manifest.stats.durationMs;
+  const events = readReplayEvents(replayId);
+
+  const chunks: Buffer[] = [];
+  for (const event of events) {
+    if (event.t > targetTime) {
+      break;
+    }
+    if (event.type === 'output') {
+      chunks.push(Buffer.from(event.data, 'base64'));
+    }
+  }
+
+  return Buffer.concat(chunks);
+}
+
+// ============================================================================
+// Screenshot
+// ============================================================================
+
+export async function screenshotReplayOffline(
+  replayId: string,
+  options: OfflineReplayScreenshotOptions,
+): Promise<string> {
+  return writeReplayScreenshot(replayId, options);
+}
+
+// ============================================================================
+// Lifecycle
+// ============================================================================
+
+export function dismissReplayOffline(replayId: string, dismissedBy?: string): void {
+  dismissReplay(replayId, dismissedBy);
+}
+
+export function undismissReplayOffline(replayId: string): void {
+  undismissReplay(replayId);
+}
+
+export function deleteReplayOffline(replayId: string): void {
+  deleteReplay(replayId);
+}

--- a/src/lib/tmux-lite/replay/service.ts
+++ b/src/lib/tmux-lite/replay/service.ts
@@ -54,7 +54,10 @@ export function listReplaysOffline(filter: ReplayListFilter = {}): ReplayInfo[] 
 }
 
 export function resolveReplayOffline(ref: string, filter: ReplayListFilter = {}): ReplayInfo {
-  const all = listReplayInfos({ ...filter, includeDismissed: true });
+  const all = listReplayInfos({
+    ...filter,
+    includeDismissed: filter.includeDismissed ?? false,
+  });
 
   const exactMatches = all.filter(
     (r) => r.replayId === ref || r.sessionId === ref || r.sessionName === ref,

--- a/src/lib/tmux-lite/replay/service.ts
+++ b/src/lib/tmux-lite/replay/service.ts
@@ -15,7 +15,6 @@ import { getReplaySnapshot } from './snapshot.js';
 import { extractStyledRows, writeReplayScreenshot, type StyledRow, type StyledSpan } from './screenshot.js';
 import {
   listReplayInfos,
-  readReplayManifest,
   dismissReplay,
   undismissReplay,
   deleteReplay,
@@ -171,7 +170,7 @@ export function styledRowsToAnsi(rows: StyledRow[]): Buffer {
   }
 
   parts.push('\x1b[0m');
-  return Buffer.from(parts.join(''), 'binary');
+  return Buffer.from(parts.join(''), 'utf8');
 }
 
 export async function getReplayAnsiBufferOffline(replayId: string, atMs?: number): Promise<Buffer> {
@@ -182,30 +181,6 @@ export async function getReplayAnsiBufferOffline(replayId: string, atMs?: number
   } finally {
     state.xterm.dispose();
   }
-}
-
-export async function getReplayAnsiOffline(replayId: string, atMs?: number): Promise<Buffer> {
-  const manifest = readReplayManifest(replayId);
-  if (!manifest) {
-    throw new Error(`Replay manifest not found: ${replayId}`);
-  }
-
-  // Concatenate the raw PTY output events up to atMs
-  const { readReplayEvents } = await import('./store.js');
-  const targetTime = atMs ?? manifest.stats.durationMs;
-  const events = readReplayEvents(replayId);
-
-  const chunks: Buffer[] = [];
-  for (const event of events) {
-    if (event.t > targetTime) {
-      break;
-    }
-    if (event.type === 'output') {
-      chunks.push(Buffer.from(event.data, 'base64'));
-    }
-  }
-
-  return Buffer.concat(chunks);
 }
 
 // ============================================================================

--- a/src/lib/tmux-lite/replay/service.ts
+++ b/src/lib/tmux-lite/replay/service.ts
@@ -21,6 +21,8 @@ import {
   type ReplayListFilter,
 } from './store.js';
 import type { ReplayInfo, TerminalSnapshot } from './types.js';
+import { SpacesError } from '../../../types/errors.js';
+import { logger } from '../../../utils/logger.js';
 
 export type { ReplayInfo, TerminalSnapshot, ReplayListFilter, StyledRow, StyledSpan };
 
@@ -39,6 +41,7 @@ export interface OfflineReplaySnapshotOptions {
 export interface OfflineReplayScreenshotOptions {
   outputPath: string;
   atMs?: number;
+  scrollbackLines?: number;
   includeScrollback?: boolean;
 }
 
@@ -60,7 +63,8 @@ export function resolveReplayOffline(ref: string, filter: ReplayListFilter = {})
     return exactMatches[0];
   }
   if (exactMatches.length > 1) {
-    throw new Error(`Replay reference is ambiguous: ${ref}`);
+    logger.error(`[replay.service] Replay reference is ambiguous: ${ref}`);
+    throw new SpacesError(`Replay reference is ambiguous: ${ref}`, 'USER_ERROR', 1);
   }
 
   const prefixMatches = all.filter((r) => r.replayId.startsWith(ref));
@@ -68,10 +72,12 @@ export function resolveReplayOffline(ref: string, filter: ReplayListFilter = {})
     return prefixMatches[0];
   }
   if (prefixMatches.length > 1) {
-    throw new Error(`Replay reference matches multiple replay IDs: ${ref}`);
+    logger.error(`[replay.service] Replay reference matches multiple replay IDs: ${ref}`);
+    throw new SpacesError(`Replay reference matches multiple replay IDs: ${ref}`, 'USER_ERROR', 1);
   }
 
-  throw new Error(`Replay not found: ${ref}`);
+  logger.error(`[replay.service] Replay not found: ${ref}`);
+  throw new SpacesError(`Replay not found: ${ref}`, 'USER_ERROR', 1);
 }
 
 // ============================================================================

--- a/src/lib/tmux-lite/replay/snapshot.ts
+++ b/src/lib/tmux-lite/replay/snapshot.ts
@@ -24,47 +24,51 @@ export async function getReplaySnapshot(
 ): Promise<TerminalSnapshot> {
   const { atMs, scrollbackLines = 80 } = options;
   const reconstructed = await reconstructReplayAt(replayId, atMs);
-  const buffer = reconstructed.xterm.buffer.active;
-  const viewportY = buffer.viewportY;
-  const visible: string[] = [];
-  for (let row = 0; row < reconstructed.rows; row++) {
-    visible.push(translateLine(buffer, viewportY + row));
-  }
+  try {
+    const buffer = reconstructed.xterm.buffer.active;
+    const viewportY = buffer.viewportY;
+    const visible: string[] = [];
+    for (let row = 0; row < reconstructed.rows; row++) {
+      visible.push(translateLine(buffer, viewportY + row));
+    }
 
-  const scrollbackStart = Math.max(0, viewportY - scrollbackLines);
-  const scrollbackTail: string[] = [];
-  for (let row = scrollbackStart; row < viewportY; row++) {
-    scrollbackTail.push(translateLine(buffer, row));
-  }
+    const scrollbackStart = Math.max(0, viewportY - scrollbackLines);
+    const scrollbackTail: string[] = [];
+    for (let row = scrollbackStart; row < viewportY; row++) {
+      scrollbackTail.push(translateLine(buffer, row));
+    }
 
-  return {
-    version: 1,
-    replayId: reconstructed.replayId,
-    sessionId: reconstructed.sessionId,
-    workspaceId: reconstructed.workspaceId,
-    source: 'replay',
-    timeMs: reconstructed.timeMs,
-    seq: reconstructed.seq,
-    terminal: {
-      cols: reconstructed.cols,
-      rows: reconstructed.rows,
-      cursorX: buffer.cursorX,
-      cursorY: buffer.cursorY,
-      viewportY,
-      baseY: buffer.baseY,
-    },
-    metadata: {
-      title: reconstructed.title,
-      processTitle: reconstructed.processTitle,
-      exitCode: reconstructed.exitCode,
-      checkpointId: reconstructed.checkpointId,
-    },
-    screen: {
-      visible,
-      scrollbackTail,
-      currentLine: translateLine(buffer, viewportY + buffer.cursorY),
-    },
-  };
+    return {
+      version: 1,
+      replayId: reconstructed.replayId,
+      sessionId: reconstructed.sessionId,
+      workspaceId: reconstructed.workspaceId,
+      source: 'replay',
+      timeMs: reconstructed.timeMs,
+      seq: reconstructed.seq,
+      terminal: {
+        cols: reconstructed.cols,
+        rows: reconstructed.rows,
+        cursorX: buffer.cursorX,
+        cursorY: buffer.cursorY,
+        viewportY,
+        baseY: buffer.baseY,
+      },
+      metadata: {
+        title: reconstructed.title,
+        processTitle: reconstructed.processTitle,
+        exitCode: reconstructed.exitCode,
+        checkpointId: reconstructed.checkpointId,
+      },
+      screen: {
+        visible,
+        scrollbackTail,
+        currentLine: translateLine(buffer, viewportY + buffer.cursorY),
+      },
+    };
+  } finally {
+    reconstructed.xterm.dispose();
+  }
 }
 
 export interface ReplayTextOptions extends ReplaySnapshotOptions {

--- a/src/lib/tmux-lite/replay/snapshot.ts
+++ b/src/lib/tmux-lite/replay/snapshot.ts
@@ -62,7 +62,7 @@ export async function getReplaySnapshot(
     screen: {
       visible,
       scrollbackTail,
-      currentLine: translateLine(buffer, buffer.cursorY),
+      currentLine: translateLine(buffer, viewportY + buffer.cursorY),
     },
   };
 }
@@ -89,8 +89,12 @@ export async function getReplayMarkdown(
   options: ReplayTextOptions = {}
 ): Promise<string> {
   const snapshot = await getReplaySnapshot(replayId, options);
-  const text = await getReplayText(replayId, options);
-  const lines = [
+  const lines = options.includeScrollback
+    ? [...snapshot.screen.scrollbackTail, ...snapshot.screen.visible]
+    : [...snapshot.screen.visible];
+  const output = options.trimTrailingBlankRows === false ? lines : trimTrailingBlankLines(lines);
+  const text = output.join('\n');
+  const metadataLines = [
     `Session: ${snapshot.sessionId}`,
     `Replay: ${snapshot.replayId}`,
     `Time: ${snapshot.timeMs}ms`,
@@ -98,11 +102,11 @@ export async function getReplayMarkdown(
   ];
 
   if (snapshot.metadata.processTitle) {
-    lines.push(`Process: ${snapshot.metadata.processTitle}`);
+    metadataLines.push(`Process: ${snapshot.metadata.processTitle}`);
   }
   if (snapshot.metadata.exitCode !== undefined) {
-    lines.push(`Exit: ${snapshot.metadata.exitCode}`);
+    metadataLines.push(`Exit: ${snapshot.metadata.exitCode}`);
   }
 
-  return `${lines.join('\n')}\n\n\`\`\`terminal\n${text}\n\`\`\``;
+  return `${metadataLines.join('\n')}\n\n\`\`\`terminal\n${text}\n\`\`\``;
 }

--- a/src/lib/tmux-lite/replay/snapshot.ts
+++ b/src/lib/tmux-lite/replay/snapshot.ts
@@ -1,0 +1,108 @@
+import type { TerminalSnapshot } from './types.js';
+import { reconstructReplayAt } from './reconstruct.js';
+
+function translateLine(buffer: { getLine(index: number): { translateToString(trimRight?: boolean): string } | undefined }, index: number): string {
+  return buffer.getLine(index)?.translateToString(true) ?? '';
+}
+
+function trimTrailingBlankLines(lines: string[]): string[] {
+  let end = lines.length;
+  while (end > 0 && lines[end - 1] === '') {
+    end--;
+  }
+  return lines.slice(0, end);
+}
+
+export interface ReplaySnapshotOptions {
+  atMs?: number;
+  scrollbackLines?: number;
+}
+
+export async function getReplaySnapshot(
+  replayId: string,
+  options: ReplaySnapshotOptions = {}
+): Promise<TerminalSnapshot> {
+  const { atMs, scrollbackLines = 80 } = options;
+  const reconstructed = await reconstructReplayAt(replayId, atMs);
+  const buffer = reconstructed.xterm.buffer.active;
+  const viewportY = buffer.viewportY;
+  const visible: string[] = [];
+  for (let row = 0; row < reconstructed.rows; row++) {
+    visible.push(translateLine(buffer, viewportY + row));
+  }
+
+  const scrollbackStart = Math.max(0, viewportY - scrollbackLines);
+  const scrollbackTail: string[] = [];
+  for (let row = scrollbackStart; row < viewportY; row++) {
+    scrollbackTail.push(translateLine(buffer, row));
+  }
+
+  return {
+    version: 1,
+    replayId: reconstructed.replayId,
+    sessionId: reconstructed.sessionId,
+    workspaceId: reconstructed.workspaceId,
+    source: 'replay',
+    timeMs: reconstructed.timeMs,
+    seq: reconstructed.seq,
+    terminal: {
+      cols: reconstructed.cols,
+      rows: reconstructed.rows,
+      cursorX: buffer.cursorX,
+      cursorY: buffer.cursorY,
+      viewportY,
+      baseY: buffer.baseY,
+    },
+    metadata: {
+      title: reconstructed.title,
+      processTitle: reconstructed.processTitle,
+      exitCode: reconstructed.exitCode,
+      checkpointId: reconstructed.checkpointId,
+    },
+    screen: {
+      visible,
+      scrollbackTail,
+      currentLine: translateLine(buffer, buffer.cursorY),
+    },
+  };
+}
+
+export interface ReplayTextOptions extends ReplaySnapshotOptions {
+  includeScrollback?: boolean;
+  trimTrailingBlankRows?: boolean;
+}
+
+export async function getReplayText(
+  replayId: string,
+  options: ReplayTextOptions = {}
+): Promise<string> {
+  const snapshot = await getReplaySnapshot(replayId, options);
+  const lines = options.includeScrollback
+    ? [...snapshot.screen.scrollbackTail, ...snapshot.screen.visible]
+    : [...snapshot.screen.visible];
+  const output = options.trimTrailingBlankRows === false ? lines : trimTrailingBlankLines(lines);
+  return output.join('\n');
+}
+
+export async function getReplayMarkdown(
+  replayId: string,
+  options: ReplayTextOptions = {}
+): Promise<string> {
+  const snapshot = await getReplaySnapshot(replayId, options);
+  const text = await getReplayText(replayId, options);
+  const lines = [
+    `Session: ${snapshot.sessionId}`,
+    `Replay: ${snapshot.replayId}`,
+    `Time: ${snapshot.timeMs}ms`,
+    `Size: ${snapshot.terminal.cols}x${snapshot.terminal.rows}`,
+  ];
+
+  if (snapshot.metadata.processTitle) {
+    lines.push(`Process: ${snapshot.metadata.processTitle}`);
+  }
+  if (snapshot.metadata.exitCode !== undefined) {
+    lines.push(`Exit: ${snapshot.metadata.exitCode}`);
+  }
+
+  return `${lines.join('\n')}\n\n\`\`\`terminal\n${text}\n\`\`\``;
+}

--- a/src/lib/tmux-lite/replay/store.test.ts
+++ b/src/lib/tmux-lite/replay/store.test.ts
@@ -9,6 +9,8 @@ import {
   deleteReplay,
   deleteReplaysForProject,
   deleteReplaysForWorkspace,
+  pruneExpiredReplays,
+  getReplayStorageSummary,
   initializeReplay,
   listReplayCheckpoints,
   listReplayInfos,
@@ -18,6 +20,7 @@ import {
   readReplayManifest,
   updateReplayManifest,
   writeReplayCheckpoint,
+  DISMISS_EXPIRY_TTL_MS,
 } from './store.js';
 import { existsSync } from 'fs';
 import type { ReplayCheckpoint, ReplayEvent, ReplayManifest } from './types.js';
@@ -203,7 +206,7 @@ describe('replay store', () => {
     expect(closed?.status).toBe('closed');
   });
 
-  it('soft-dismisses and restores a replay', () => {
+  it('soft-dismisses with expiry and restores a replay', () => {
     initializeReplay(makeManifest({ replayId: 'dismiss_replay', status: 'closed', endedAt: 2000 }));
 
     expect(listReplayInfos()).toHaveLength(1);
@@ -215,11 +218,68 @@ describe('replay store', () => {
     const info = listReplayInfos({ includeDismissed: true })[0];
     expect(info.dismissedAt).toBeDefined();
     expect(info.dismissedBy).toBe('user');
+    expect(info.expiresAt).toBeDefined();
+    expect(info.expiresAt! - info.dismissedAt!).toBe(DISMISS_EXPIRY_TTL_MS);
 
     undismissReplay('dismiss_replay');
     expect(listReplayInfos()).toHaveLength(1);
     const restored = listReplayInfos()[0];
     expect(restored.dismissedAt).toBeUndefined();
+    expect(restored.expiresAt).toBeUndefined();
+  });
+
+  it('rejects dismissing a running replay', () => {
+    initializeReplay(makeManifest({ replayId: 'running_replay', status: 'running' }));
+
+    expect(() => dismissReplay('running_replay', 'user')).toThrow('Cannot dismiss running replay');
+    expect(listReplayInfos()).toHaveLength(1);
+    expect(listReplayInfos({ includeDismissed: true })[0]?.dismissedAt).toBeUndefined();
+  });
+
+  it('prunes expired replays', () => {
+    const now = Date.now();
+    initializeReplay(makeManifest({ replayId: 'expired_replay', status: 'closed', endedAt: 1000, retention: { dismissedAt: now - 100_000, expiresAt: now - 1 } }));
+    initializeReplay(makeManifest({ replayId: 'future_replay', status: 'closed', endedAt: 2000, retention: { dismissedAt: now, expiresAt: now + 100_000 } }));
+    initializeReplay(makeManifest({ replayId: 'active_replay', status: 'closed', endedAt: 3000 }));
+
+    expect(listReplayInfos({ includeDismissed: true })).toHaveLength(3);
+
+    const pruned = pruneExpiredReplays(now);
+    expect(pruned).toBe(1);
+    expect(listReplayInfos({ includeDismissed: true }).map((r) => r.replayId).sort()).toEqual(['active_replay', 'future_replay']);
+  });
+
+  it('measures replay storage summary', () => {
+    initializeReplay(makeManifest({ replayId: 'storage_replay', status: 'closed', endedAt: 2000 }));
+    appendReplayEvent('storage_replay', makeEvent({ seq: 1, t: 10 }));
+
+    const summary = getReplayStorageSummary();
+    expect(summary.replayCount).toBe(1);
+    expect(summary.totalBytes).toBeGreaterThan(0);
+    expect(summary.replays[0].replayId).toBe('storage_replay');
+    expect(summary.replays[0].eventsBytes).toBeGreaterThan(0);
+    expect(summary.replays[0].manifestBytes).toBeGreaterThan(0);
+  });
+
+  it('reads both compressed and uncompressed checkpoint ANSI', () => {
+    const manifest = makeManifest({ replayId: 'checkpoint_gz', status: 'closed', endedAt: 2000 });
+    initializeReplay(manifest);
+
+    const checkpoint: ReplayCheckpoint = {
+      version: 1,
+      checkpointId: '000000',
+      seq: 0,
+      t: 0,
+      terminal: { cols: 80, rows: 24 },
+      metadata: {},
+      serializer: { kind: 'xterm-serialize', scrollbackLines: 100 },
+      ansiPath: 'checkpoints/000000.ansi',
+    };
+
+    writeReplayCheckpoint('checkpoint_gz', checkpoint, 'hello gzip world');
+    const record = readReplayCheckpoint('checkpoint_gz', '000000');
+    expect(record).not.toBeNull();
+    expect(record!.ansi).toBe('hello gzip world');
   });
 
   it('permanently deletes a replay from disk', () => {

--- a/src/lib/tmux-lite/replay/store.test.ts
+++ b/src/lib/tmux-lite/replay/store.test.ts
@@ -1,0 +1,279 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { mkdtempSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import {
+  appendReplayEvent,
+  dismissReplay,
+  undismissReplay,
+  deleteReplay,
+  deleteReplaysForProject,
+  deleteReplaysForWorkspace,
+  initializeReplay,
+  listReplayCheckpoints,
+  listReplayInfos,
+  reconcileRunningReplaysAsCrashed,
+  readReplayCheckpoint,
+  readReplayEvents,
+  readReplayManifest,
+  updateReplayManifest,
+  writeReplayCheckpoint,
+} from './store.js';
+import { existsSync } from 'fs';
+import type { ReplayCheckpoint, ReplayEvent, ReplayManifest } from './types.js';
+
+describe('replay store', () => {
+  let replayRoot: string;
+  const originalReplayDir = process.env.TMUX_LITE_REPLAY_DIR;
+
+  beforeEach(() => {
+    replayRoot = mkdtempSync(join(tmpdir(), 'gitspace-replay-store-'));
+    process.env.TMUX_LITE_REPLAY_DIR = replayRoot;
+  });
+
+  afterEach(() => {
+    rmSync(replayRoot, { recursive: true, force: true });
+    if (originalReplayDir === undefined) {
+      delete process.env.TMUX_LITE_REPLAY_DIR;
+    } else {
+      process.env.TMUX_LITE_REPLAY_DIR = originalReplayDir;
+    }
+  });
+
+  function makeManifest(overrides: Partial<ReplayManifest> = {}): ReplayManifest {
+    return {
+      version: 1,
+      replayId: 'replay_1',
+      sessionId: 'session_1',
+      sessionName: 'project:workspace:1',
+      cwd: '/tmp/project/workspace',
+      workspaceId: 'project:workspace',
+      projectName: 'project',
+      workspaceName: 'workspace',
+      startedAt: 1000,
+      status: 'running',
+      initialTerminal: {
+        cols: 120,
+        rows: 40,
+        termType: 'xterm-256color',
+      },
+      metadata: {},
+      stats: {
+        lastSeq: 0,
+        eventCount: 0,
+        checkpointCount: 0,
+        durationMs: 0,
+      },
+      ...overrides,
+    };
+  }
+
+  function makeEvent(overrides: Partial<ReplayEvent> = {}): ReplayEvent {
+    return {
+      v: 1,
+      seq: 1,
+      t: 50,
+      type: 'output',
+      encoding: 'base64',
+      data: Buffer.from('hello').toString('base64'),
+      ...overrides,
+    } as ReplayEvent;
+  }
+
+  function makeCheckpoint(overrides: Partial<ReplayCheckpoint> = {}): ReplayCheckpoint {
+    return {
+      version: 1,
+      checkpointId: 'checkpoint_0001',
+      seq: 12,
+      t: 500,
+      terminal: {
+        cols: 120,
+        rows: 40,
+      },
+      metadata: {
+        processTitle: 'npm test',
+      },
+      serializer: {
+        kind: 'xterm-serialize',
+        scrollbackLines: 1000,
+      },
+      ansiPath: 'checkpoints/checkpoint_0001.ansi',
+      ...overrides,
+    };
+  }
+
+  it('initializes and reads a replay manifest', () => {
+    const manifest = makeManifest();
+    initializeReplay(manifest);
+
+    const stored = readReplayManifest(manifest.replayId);
+    expect(stored).toEqual(manifest);
+  });
+
+  it('appends and reads replay events', () => {
+    const manifest = makeManifest();
+    initializeReplay(manifest);
+
+    appendReplayEvent(manifest.replayId, makeEvent({ seq: 1, t: 10 }));
+    appendReplayEvent(manifest.replayId, makeEvent({ seq: 2, t: 25, data: Buffer.from('world').toString('base64') }));
+
+    const events = readReplayEvents(manifest.replayId);
+    expect(events).toHaveLength(2);
+    expect(events[0].seq).toBe(1);
+    expect(events[1].seq).toBe(2);
+  });
+
+  it('writes and reads checkpoints', () => {
+    const manifest = makeManifest();
+    initializeReplay(manifest);
+
+    const checkpoint = makeCheckpoint();
+    writeReplayCheckpoint(manifest.replayId, checkpoint, '\u001bc\u001b[2J\u001b[Hhello');
+
+    const stored = readReplayCheckpoint(manifest.replayId, checkpoint.checkpointId);
+    expect(stored).not.toBeNull();
+    expect(stored?.checkpoint).toEqual(checkpoint);
+    expect(stored?.ansi).toContain('hello');
+    expect(listReplayCheckpoints(manifest.replayId)).toEqual([checkpoint]);
+  });
+
+  it('updates manifest data and lists replay infos with filters', () => {
+    initializeReplay(
+      makeManifest({
+        replayId: 'replay_a',
+        sessionId: 'session_a',
+        startedAt: 1000,
+        status: 'closed',
+        stats: {
+          lastSeq: 20,
+          eventCount: 20,
+          checkpointCount: 2,
+          durationMs: 1200,
+        },
+      })
+    );
+    initializeReplay(
+      makeManifest({
+        replayId: 'replay_b',
+        sessionId: 'session_b',
+        workspaceId: 'project:other',
+        workspaceName: 'other',
+        startedAt: 2000,
+        status: 'crashed',
+      })
+    );
+
+    const updated = updateReplayManifest('replay_b', (manifest) => ({
+      ...manifest,
+      metadata: {
+        ...manifest.metadata,
+        processTitle: 'bun test',
+      },
+      stats: {
+        ...manifest.stats,
+        durationMs: 900,
+      },
+    }));
+
+    expect(updated.metadata.processTitle).toBe('bun test');
+
+    const allInfos = listReplayInfos();
+    expect(allInfos).toHaveLength(2);
+    expect(allInfos[0].replayId).toBe('replay_b');
+    expect(allInfos[1].replayId).toBe('replay_a');
+
+    const filtered = listReplayInfos({ workspaceId: 'project:workspace', status: ['closed'] });
+    expect(filtered).toHaveLength(1);
+    expect(filtered[0].replayId).toBe('replay_a');
+  });
+
+  it('reconciles running replays as crashed', () => {
+    initializeReplay(makeManifest({ replayId: 'running_replay', startedAt: 1000 }));
+    initializeReplay(makeManifest({ replayId: 'closed_replay', status: 'closed', endedAt: 1500 }));
+
+    const reconciled = reconcileRunningReplaysAsCrashed(5000);
+    expect(reconciled).toHaveLength(1);
+    expect(reconciled[0].replayId).toBe('running_replay');
+
+    const running = readReplayManifest('running_replay');
+    const closed = readReplayManifest('closed_replay');
+    expect(running?.status).toBe('crashed');
+    expect(running?.endedAt).toBe(5000);
+    expect(running?.stats.durationMs).toBe(4000);
+    expect(closed?.status).toBe('closed');
+  });
+
+  it('soft-dismisses and restores a replay', () => {
+    initializeReplay(makeManifest({ replayId: 'dismiss_replay', status: 'closed', endedAt: 2000 }));
+
+    expect(listReplayInfos()).toHaveLength(1);
+
+    dismissReplay('dismiss_replay', 'user');
+    expect(listReplayInfos()).toHaveLength(0);
+    expect(listReplayInfos({ includeDismissed: true })).toHaveLength(1);
+
+    const info = listReplayInfos({ includeDismissed: true })[0];
+    expect(info.dismissedAt).toBeDefined();
+    expect(info.dismissedBy).toBe('user');
+
+    undismissReplay('dismiss_replay');
+    expect(listReplayInfos()).toHaveLength(1);
+    const restored = listReplayInfos()[0];
+    expect(restored.dismissedAt).toBeUndefined();
+  });
+
+  it('permanently deletes a replay from disk', () => {
+    initializeReplay(makeManifest({ replayId: 'delete_replay', status: 'closed', endedAt: 3000 }));
+    expect(listReplayInfos()).toHaveLength(1);
+
+    const { getReplayDir } = require('./paths.js') as typeof import('./paths.js');
+    const dir = getReplayDir('delete_replay');
+    expect(existsSync(dir)).toBe(true);
+
+    deleteReplay('delete_replay');
+    expect(existsSync(dir)).toBe(false);
+    expect(listReplayInfos()).toHaveLength(0);
+  });
+
+  it('deletes replay history for a workspace', () => {
+    initializeReplay(makeManifest({ replayId: 'ws_replay_1', status: 'closed', endedAt: 100 }));
+    initializeReplay(makeManifest({
+      replayId: 'ws_replay_2',
+      status: 'closed',
+      endedAt: 200,
+      retention: { dismissedAt: 150 },
+    }));
+    initializeReplay(makeManifest({
+      replayId: 'other_replay',
+      workspaceId: 'project:other',
+      workspaceName: 'other',
+      status: 'closed',
+      endedAt: 300,
+    }));
+
+    expect(deleteReplaysForWorkspace('project:workspace', { projectName: 'project', workspaceName: 'workspace' })).toBe(2);
+    expect(listReplayInfos({ includeDismissed: true }).map((replay) => replay.replayId)).toEqual(['other_replay']);
+  });
+
+  it('deletes replay history for a project', () => {
+    initializeReplay(makeManifest({ replayId: 'project_replay_1', status: 'closed', endedAt: 100 }));
+    initializeReplay(makeManifest({
+      replayId: 'project_replay_2',
+      workspaceId: 'project:other',
+      workspaceName: 'other',
+      status: 'closed',
+      endedAt: 200,
+    }));
+    initializeReplay(makeManifest({
+      replayId: 'foreign_replay',
+      projectName: 'foreign',
+      workspaceId: 'foreign:workspace',
+      workspaceName: 'workspace',
+      status: 'closed',
+      endedAt: 300,
+    }));
+
+    expect(deleteReplaysForProject('project')).toBe(2);
+    expect(listReplayInfos({ includeDismissed: true }).map((replay) => replay.replayId)).toEqual(['foreign_replay']);
+  });
+});

--- a/src/lib/tmux-lite/replay/store.ts
+++ b/src/lib/tmux-lite/replay/store.ts
@@ -4,6 +4,7 @@ import {
   mkdirSync,
   readFileSync,
   readdirSync,
+  renameSync,
   rmSync,
   writeFileSync,
 } from 'fs';
@@ -45,7 +46,9 @@ function readTextFile(path: string): string | null {
 }
 
 function writeJsonFile(path: string, value: unknown): void {
-  writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`, 'utf-8');
+  const tempPath = `${path}.tmp-${process.pid}-${Date.now()}`;
+  writeFileSync(tempPath, `${JSON.stringify(value, null, 2)}\n`, 'utf-8');
+  renameSync(tempPath, path);
 }
 
 function parseManifest(value: unknown): ReplayManifest | null {
@@ -360,6 +363,9 @@ export function updateReplayManifest(
     throw new Error(`Replay manifest not found: ${replayId}`);
   }
   const next = updater(manifest);
+  if (next.replayId !== manifest.replayId) {
+    throw new Error(`Replay manifest updater cannot change replay ID (${manifest.replayId} -> ${next.replayId})`);
+  }
   writeReplayManifest(next);
   return next;
 }
@@ -602,10 +608,9 @@ export function deleteReplaysForWorkspace(
 }
 
 export function deleteReplaysForProject(projectName: string): number {
-  const matches = listReplayInfos({
-    includeDismissed: true,
-    projectName,
-  });
+  const matches = listReplayInfos({ includeDismissed: true }).filter((replay) =>
+    replay.projectName === projectName || replay.workspaceId?.startsWith(`${projectName}:`) === true
+  );
 
   for (const replay of matches) {
     deleteReplay(replay.replayId);

--- a/src/lib/tmux-lite/replay/store.ts
+++ b/src/lib/tmux-lite/replay/store.ts
@@ -1,0 +1,615 @@
+import {
+  appendFileSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from 'fs';
+import { join } from 'path';
+import {
+  assertValidCheckpointId,
+  assertValidReplayId,
+  ensureReplayCheckpointsDir,
+  ensureReplayDir,
+  ensureReplayRootDir,
+  getReplayCheckpointAnsiPath,
+  getReplayCheckpointMetaPath,
+  getReplayDir,
+  getReplayEventsPath,
+  getReplayManifestPath,
+  getReplayRootDir,
+} from './paths.js';
+import type {
+  ReplayCheckpoint,
+  ReplayEvent,
+  ReplayInfo,
+  ReplayManifest,
+  ReplayStatus,
+} from './types.js';
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function readTextFile(path: string): string | null {
+  if (!existsSync(path)) {
+    return null;
+  }
+  try {
+    return readFileSync(path, 'utf-8');
+  } catch {
+    return null;
+  }
+}
+
+function writeJsonFile(path: string, value: unknown): void {
+  writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`, 'utf-8');
+}
+
+function parseManifest(value: unknown): ReplayManifest | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  const {
+    version,
+    replayId,
+    sessionId,
+    sessionName,
+    cwd,
+    workspaceId,
+    projectName,
+    workspaceName,
+    startedAt,
+    endedAt,
+    status,
+    initialTerminal,
+    metadata,
+    retention,
+    stats,
+  } = value;
+
+  if (version !== 1) {
+    return null;
+  }
+  if (typeof replayId !== 'string' || typeof sessionId !== 'string' || typeof sessionName !== 'string') {
+    return null;
+  }
+  if (typeof cwd !== 'string' || typeof startedAt !== 'number') {
+    return null;
+  }
+  if (endedAt !== undefined && typeof endedAt !== 'number') {
+    return null;
+  }
+  if (status !== 'running' && status !== 'closed' && status !== 'crashed') {
+    return null;
+  }
+  if (!isRecord(initialTerminal) || typeof initialTerminal.cols !== 'number' || typeof initialTerminal.rows !== 'number') {
+    return null;
+  }
+  if (!isRecord(metadata)) {
+    return null;
+  }
+  if (
+    !isRecord(stats) ||
+    typeof stats.lastSeq !== 'number' ||
+    typeof stats.eventCount !== 'number' ||
+    typeof stats.checkpointCount !== 'number' ||
+    typeof stats.durationMs !== 'number'
+  ) {
+    return null;
+  }
+
+  return {
+    version: 1,
+    replayId,
+    sessionId,
+    sessionName,
+    cwd,
+    workspaceId: typeof workspaceId === 'string' ? workspaceId : undefined,
+    projectName: typeof projectName === 'string' ? projectName : undefined,
+    workspaceName: typeof workspaceName === 'string' ? workspaceName : undefined,
+    startedAt,
+    endedAt,
+    status,
+    initialTerminal: {
+      cols: initialTerminal.cols,
+      rows: initialTerminal.rows,
+      termType: typeof initialTerminal.termType === 'string' ? initialTerminal.termType : undefined,
+    },
+    metadata: {
+      title: typeof metadata.title === 'string' ? metadata.title : undefined,
+      processTitle: typeof metadata.processTitle === 'string' ? metadata.processTitle : undefined,
+      exitCode: typeof metadata.exitCode === 'number' ? metadata.exitCode : undefined,
+    },
+    retention: isRecord(retention)
+      ? {
+          expiresAt: typeof retention.expiresAt === 'number' ? retention.expiresAt : undefined,
+          dismissedAt: typeof retention.dismissedAt === 'number' ? retention.dismissedAt : undefined,
+          dismissedBy: typeof retention.dismissedBy === 'string' ? retention.dismissedBy : undefined,
+        }
+      : undefined,
+    stats: {
+      lastSeq: stats.lastSeq,
+      eventCount: stats.eventCount,
+      checkpointCount: stats.checkpointCount,
+      durationMs: stats.durationMs,
+    },
+  };
+}
+
+function parseEvent(value: unknown): ReplayEvent | null {
+  if (!isRecord(value) || value.v !== 1 || typeof value.seq !== 'number' || typeof value.t !== 'number') {
+    return null;
+  }
+
+  switch (value.type) {
+    case 'output':
+      if (value.encoding !== 'base64' || typeof value.data !== 'string') {
+        return null;
+      }
+      return {
+        v: 1,
+        seq: value.seq,
+        t: value.t,
+        type: 'output',
+        encoding: 'base64',
+        data: value.data,
+      };
+    case 'input':
+      if (value.encoding !== 'base64' || typeof value.data !== 'string') {
+        return null;
+      }
+      return {
+        v: 1,
+        seq: value.seq,
+        t: value.t,
+        type: 'input',
+        encoding: 'base64',
+        data: value.data,
+      };
+    case 'resize':
+      if (typeof value.cols !== 'number' || typeof value.rows !== 'number') {
+        return null;
+      }
+      return {
+        v: 1,
+        seq: value.seq,
+        t: value.t,
+        type: 'resize',
+        cols: value.cols,
+        rows: value.rows,
+      };
+    case 'marker':
+      if (value.label !== undefined && typeof value.label !== 'string') {
+        return null;
+      }
+      return {
+        v: 1,
+        seq: value.seq,
+        t: value.t,
+        type: 'marker',
+        label: value.label,
+      };
+    case 'title':
+      if (typeof value.title !== 'string') {
+        return null;
+      }
+      return {
+        v: 1,
+        seq: value.seq,
+        t: value.t,
+        type: 'title',
+        title: value.title,
+      };
+    case 'process-title':
+      if (typeof value.processTitle !== 'string') {
+        return null;
+      }
+      return {
+        v: 1,
+        seq: value.seq,
+        t: value.t,
+        type: 'process-title',
+        processTitle: value.processTitle,
+      };
+    case 'exit':
+      if (typeof value.code !== 'number') {
+        return null;
+      }
+      return {
+        v: 1,
+        seq: value.seq,
+        t: value.t,
+        type: 'exit',
+        code: value.code,
+      };
+    default:
+      return null;
+  }
+}
+
+function parseCheckpoint(value: unknown): ReplayCheckpoint | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  if (
+    value.version !== 1 ||
+    typeof value.checkpointId !== 'string' ||
+    typeof value.seq !== 'number' ||
+    typeof value.t !== 'number' ||
+    !isRecord(value.terminal) ||
+    typeof value.terminal.cols !== 'number' ||
+    typeof value.terminal.rows !== 'number' ||
+    !isRecord(value.metadata) ||
+    !isRecord(value.serializer) ||
+    value.serializer.kind !== 'xterm-serialize' ||
+    typeof value.serializer.scrollbackLines !== 'number' ||
+    typeof value.ansiPath !== 'string'
+  ) {
+    return null;
+  }
+
+  return {
+    version: 1,
+    checkpointId: value.checkpointId,
+    seq: value.seq,
+    t: value.t,
+    terminal: {
+      cols: value.terminal.cols,
+      rows: value.terminal.rows,
+    },
+    metadata: {
+      title: typeof value.metadata.title === 'string' ? value.metadata.title : undefined,
+      processTitle: typeof value.metadata.processTitle === 'string' ? value.metadata.processTitle : undefined,
+      exitCode: typeof value.metadata.exitCode === 'number' ? value.metadata.exitCode : undefined,
+    },
+    serializer: {
+      kind: 'xterm-serialize',
+      scrollbackLines: value.serializer.scrollbackLines,
+    },
+    ansiPath: value.ansiPath,
+  };
+}
+
+function toReplayInfo(manifest: ReplayManifest): ReplayInfo {
+  return {
+    replayId: manifest.replayId,
+    sessionId: manifest.sessionId,
+    sessionName: manifest.sessionName,
+    cwd: manifest.cwd,
+    workspaceId: manifest.workspaceId,
+    projectName: manifest.projectName,
+    workspaceName: manifest.workspaceName,
+    startedAt: manifest.startedAt,
+    endedAt: manifest.endedAt,
+    status: manifest.status,
+    durationMs: manifest.stats.durationMs,
+    eventCount: manifest.stats.eventCount,
+    checkpointCount: manifest.stats.checkpointCount,
+    lastSeq: manifest.stats.lastSeq,
+    title: manifest.metadata.title,
+    processTitle: manifest.metadata.processTitle,
+    exitCode: manifest.metadata.exitCode,
+    dismissedAt: manifest.retention?.dismissedAt,
+    dismissedBy: manifest.retention?.dismissedBy,
+  };
+}
+
+export interface ReplayListFilter {
+  workspaceId?: string;
+  sessionId?: string;
+  projectName?: string;
+  workspaceName?: string;
+  status?: ReplayStatus[];
+  /** Include dismissed replays. Defaults to false (dismissed replays are hidden). */
+  includeDismissed?: boolean;
+}
+
+export interface ReplayCheckpointRecord {
+  checkpoint: ReplayCheckpoint;
+  ansi: string;
+}
+
+export interface ReplayReconciliationResult {
+  replayId: string;
+  previousDurationMs: number;
+  endedAt: number;
+}
+
+export function initializeReplay(manifest: ReplayManifest): void {
+  assertValidReplayId(manifest.replayId);
+  ensureReplayDir(manifest.replayId);
+  ensureReplayCheckpointsDir(manifest.replayId);
+  writeReplayManifest(manifest);
+  const eventsPath = getReplayEventsPath(manifest.replayId);
+  if (!existsSync(eventsPath)) {
+    writeFileSync(eventsPath, '', 'utf-8');
+  }
+}
+
+export function writeReplayManifest(manifest: ReplayManifest): void {
+  assertValidReplayId(manifest.replayId);
+  ensureReplayDir(manifest.replayId);
+  writeJsonFile(getReplayManifestPath(manifest.replayId), manifest);
+}
+
+export function readReplayManifest(replayId: string): ReplayManifest | null {
+  assertValidReplayId(replayId);
+  const raw = readTextFile(getReplayManifestPath(replayId));
+  if (!raw) {
+    return null;
+  }
+
+  try {
+    return parseManifest(JSON.parse(raw));
+  } catch {
+    return null;
+  }
+}
+
+export function updateReplayManifest(
+  replayId: string,
+  updater: (manifest: ReplayManifest) => ReplayManifest
+): ReplayManifest {
+  const manifest = readReplayManifest(replayId);
+  if (!manifest) {
+    throw new Error(`Replay manifest not found: ${replayId}`);
+  }
+  const next = updater(manifest);
+  writeReplayManifest(next);
+  return next;
+}
+
+export function appendReplayEvent(replayId: string, event: ReplayEvent): void {
+  assertValidReplayId(replayId);
+  ensureReplayDir(replayId);
+  appendFileSync(getReplayEventsPath(replayId), `${JSON.stringify(event)}\n`, 'utf-8');
+}
+
+export function readReplayEvents(replayId: string): ReplayEvent[] {
+  assertValidReplayId(replayId);
+  const raw = readTextFile(getReplayEventsPath(replayId));
+  if (!raw) {
+    return [];
+  }
+
+  const events: ReplayEvent[] = [];
+  for (const line of raw.split('\n')) {
+    if (line.trim().length === 0) {
+      continue;
+    }
+    try {
+      const parsed = parseEvent(JSON.parse(line));
+      if (parsed) {
+        events.push(parsed);
+      }
+    } catch {
+      // Skip malformed event lines.
+    }
+  }
+  return events;
+}
+
+export function writeReplayCheckpoint(replayId: string, checkpoint: ReplayCheckpoint, ansi: string): void {
+  assertValidReplayId(replayId);
+  assertValidCheckpointId(checkpoint.checkpointId);
+  ensureReplayCheckpointsDir(replayId);
+  writeFileSync(getReplayCheckpointAnsiPath(replayId, checkpoint.checkpointId), ansi, 'utf-8');
+  writeJsonFile(getReplayCheckpointMetaPath(replayId, checkpoint.checkpointId), checkpoint);
+}
+
+export function readReplayCheckpoint(replayId: string, checkpointId: string): ReplayCheckpointRecord | null {
+  assertValidReplayId(replayId);
+  assertValidCheckpointId(checkpointId);
+  const metaRaw = readTextFile(getReplayCheckpointMetaPath(replayId, checkpointId));
+  const ansi = readTextFile(getReplayCheckpointAnsiPath(replayId, checkpointId));
+  if (!metaRaw || ansi === null) {
+    return null;
+  }
+
+  try {
+    const checkpoint = parseCheckpoint(JSON.parse(metaRaw));
+    if (!checkpoint) {
+      return null;
+    }
+    return { checkpoint, ansi };
+  } catch {
+    return null;
+  }
+}
+
+export function listReplayCheckpoints(replayId: string): ReplayCheckpoint[] {
+  assertValidReplayId(replayId);
+  const dir = join(getReplayDir(replayId), 'checkpoints');
+  if (!existsSync(dir)) {
+    return [];
+  }
+
+  const checkpoints: ReplayCheckpoint[] = [];
+  const entries = readdirSync(dir)
+    .filter((entry) => entry.endsWith('.json'))
+    .sort((a, b) => a.localeCompare(b));
+
+  for (const entry of entries) {
+    const raw = readTextFile(join(dir, entry));
+    if (!raw) {
+      continue;
+    }
+    try {
+      const parsed = parseCheckpoint(JSON.parse(raw));
+      if (parsed) {
+        checkpoints.push(parsed);
+      }
+    } catch {
+      // Skip malformed checkpoints.
+    }
+  }
+
+  checkpoints.sort((a, b) => a.t - b.t || a.seq - b.seq);
+  return checkpoints;
+}
+
+export function listReplayInfos(filter: ReplayListFilter = {}): ReplayInfo[] {
+  const root = getReplayRootDir();
+  if (!existsSync(root)) {
+    return [];
+  }
+
+  const statuses = filter.status ? new Set(filter.status) : null;
+  const infos: ReplayInfo[] = [];
+  for (const entry of readdirSync(root)) {
+    let manifest: ReplayManifest | null;
+    try {
+      manifest = readReplayManifest(entry);
+    } catch {
+      continue;
+    }
+    if (!manifest) {
+      continue;
+    }
+    if (filter.workspaceId && manifest.workspaceId !== filter.workspaceId) {
+      continue;
+    }
+    if (filter.projectName && manifest.projectName !== filter.projectName) {
+      continue;
+    }
+    if (filter.workspaceName && manifest.workspaceName !== filter.workspaceName) {
+      continue;
+    }
+    if (filter.sessionId && manifest.sessionId !== filter.sessionId) {
+      continue;
+    }
+    if (statuses && !statuses.has(manifest.status)) {
+      continue;
+    }
+    if (!filter.includeDismissed && manifest.retention?.dismissedAt !== undefined) {
+      continue;
+    }
+    infos.push(toReplayInfo(manifest));
+  }
+
+  infos.sort((a, b) => {
+    if (a.startedAt !== b.startedAt) {
+      return b.startedAt - a.startedAt;
+    }
+    return a.replayId.localeCompare(b.replayId);
+  });
+  return infos;
+}
+
+export function ensureReplayStorage(): string {
+  const root = ensureReplayRootDir();
+  if (!existsSync(root)) {
+    mkdirSync(root, { recursive: true });
+  }
+  return root;
+}
+
+export function reconcileRunningReplaysAsCrashed(endedAt = Date.now()): ReplayReconciliationResult[] {
+  const runningReplays = listReplayInfos({ status: ['running'] });
+  const results: ReplayReconciliationResult[] = [];
+
+  for (const replay of runningReplays) {
+    const manifest = readReplayManifest(replay.replayId);
+    if (!manifest || manifest.status !== 'running') {
+      continue;
+    }
+
+    const durationMs = Math.max(manifest.stats.durationMs, endedAt - manifest.startedAt);
+    writeReplayManifest({
+      ...manifest,
+      endedAt,
+      status: 'crashed',
+      stats: {
+        ...manifest.stats,
+        durationMs,
+      },
+    });
+
+    results.push({
+      replayId: replay.replayId,
+      previousDurationMs: manifest.stats.durationMs,
+      endedAt,
+    });
+  }
+
+  return results;
+}
+
+export function dismissReplay(replayId: string, dismissedBy?: string, dismissedAt = Date.now()): void {
+  updateReplayManifest(replayId, (manifest) => ({
+    ...manifest,
+    retention: {
+      ...manifest.retention,
+      dismissedAt,
+      dismissedBy,
+    },
+  }));
+}
+
+export function undismissReplay(replayId: string): void {
+  updateReplayManifest(replayId, (manifest) => {
+    if (!manifest.retention) {
+      return manifest;
+    }
+    const { dismissedAt: _d, dismissedBy: _b, ...rest } = manifest.retention;
+    return {
+      ...manifest,
+      retention: Object.keys(rest).length > 0 ? rest : undefined,
+    };
+  });
+}
+
+export function deleteReplay(replayId: string): void {
+  assertValidReplayId(replayId);
+  const dir = getReplayDir(replayId);
+  if (existsSync(dir)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+export function deleteReplaysForWorkspace(
+  workspaceId: string,
+  options: { projectName?: string; workspaceName?: string } = {}
+): number {
+  const matches = listReplayInfos({
+    includeDismissed: true,
+    workspaceId,
+  });
+
+  const matchedIds = new Set(matches.map((replay) => replay.replayId));
+
+  if (options.projectName && options.workspaceName) {
+    const legacyMatches = listReplayInfos({
+      includeDismissed: true,
+      projectName: options.projectName,
+      workspaceName: options.workspaceName,
+    });
+    for (const replay of legacyMatches) {
+      matchedIds.add(replay.replayId);
+    }
+  }
+
+  for (const replayId of matchedIds) {
+    deleteReplay(replayId);
+  }
+
+  return matchedIds.size;
+}
+
+export function deleteReplaysForProject(projectName: string): number {
+  const matches = listReplayInfos({
+    includeDismissed: true,
+    projectName,
+  });
+
+  for (const replay of matches) {
+    deleteReplay(replay.replayId);
+  }
+
+  return matches.length;
+}

--- a/src/lib/tmux-lite/replay/store.ts
+++ b/src/lib/tmux-lite/replay/store.ts
@@ -6,9 +6,12 @@ import {
   readdirSync,
   renameSync,
   rmSync,
+  statSync,
   writeFileSync,
 } from 'fs';
 import { join } from 'path';
+import { gzipSync, gunzipSync } from 'zlib';
+import { SpacesError } from '../../../types/errors.js';
 import {
   assertValidCheckpointId,
   assertValidReplayId,
@@ -299,6 +302,7 @@ function toReplayInfo(manifest: ReplayManifest): ReplayInfo {
     exitCode: manifest.metadata.exitCode,
     dismissedAt: manifest.retention?.dismissedAt,
     dismissedBy: manifest.retention?.dismissedBy,
+    expiresAt: manifest.retention?.expiresAt,
   };
 }
 
@@ -400,19 +404,41 @@ export function readReplayEvents(replayId: string): ReplayEvent[] {
   return events;
 }
 
+function getReplayCheckpointAnsiGzPath(replayId: string, checkpointId: string): string {
+  return getReplayCheckpointAnsiPath(replayId, checkpointId) + '.gz';
+}
+
 export function writeReplayCheckpoint(replayId: string, checkpoint: ReplayCheckpoint, ansi: string): void {
   assertValidReplayId(replayId);
   assertValidCheckpointId(checkpoint.checkpointId);
   ensureReplayCheckpointsDir(replayId);
-  writeFileSync(getReplayCheckpointAnsiPath(replayId, checkpoint.checkpointId), ansi, 'utf-8');
+
+  // Write compressed checkpoint
+  const compressed = gzipSync(Buffer.from(ansi, 'utf-8'));
+  writeFileSync(getReplayCheckpointAnsiGzPath(replayId, checkpoint.checkpointId), compressed);
   writeJsonFile(getReplayCheckpointMetaPath(replayId, checkpoint.checkpointId), checkpoint);
+}
+
+function readCheckpointAnsi(replayId: string, checkpointId: string): string | null {
+  // Try compressed first, fall back to legacy uncompressed
+  const gzPath = getReplayCheckpointAnsiGzPath(replayId, checkpointId);
+  if (existsSync(gzPath)) {
+    try {
+      const compressed = readFileSync(gzPath);
+      return gunzipSync(compressed).toString('utf-8');
+    } catch {
+      return null;
+    }
+  }
+
+  return readTextFile(getReplayCheckpointAnsiPath(replayId, checkpointId));
 }
 
 export function readReplayCheckpoint(replayId: string, checkpointId: string): ReplayCheckpointRecord | null {
   assertValidReplayId(replayId);
   assertValidCheckpointId(checkpointId);
   const metaRaw = readTextFile(getReplayCheckpointMetaPath(replayId, checkpointId));
-  const ansi = readTextFile(getReplayCheckpointAnsiPath(replayId, checkpointId));
+  const ansi = readCheckpointAnsi(replayId, checkpointId);
   if (!metaRaw || ansi === null) {
     return null;
   }
@@ -459,7 +485,25 @@ export function listReplayCheckpoints(replayId: string): ReplayCheckpoint[] {
   return checkpoints;
 }
 
+let lastPruneSweepMs = 0;
+const PRUNE_SWEEP_INTERVAL_MS = 60_000;
+
+function maybePruneExpired(): void {
+  const now = Date.now();
+  if (now - lastPruneSweepMs < PRUNE_SWEEP_INTERVAL_MS) {
+    return;
+  }
+  lastPruneSweepMs = now;
+  try {
+    pruneExpiredReplays(now);
+  } catch {
+    // Best-effort cleanup; don't break listing.
+  }
+}
+
 export function listReplayInfos(filter: ReplayListFilter = {}): ReplayInfo[] {
+  maybePruneExpired();
+
   const root = getReplayRootDir();
   if (!existsSync(root)) {
     return [];
@@ -546,15 +590,25 @@ export function reconcileRunningReplaysAsCrashed(endedAt = Date.now()): ReplayRe
   return results;
 }
 
+/** Default deletion delay after dismiss: 7 days. */
+export const DISMISS_EXPIRY_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+
 export function dismissReplay(replayId: string, dismissedBy?: string, dismissedAt = Date.now()): void {
-  updateReplayManifest(replayId, (manifest) => ({
-    ...manifest,
-    retention: {
-      ...manifest.retention,
-      dismissedAt,
-      dismissedBy,
-    },
-  }));
+  updateReplayManifest(replayId, (manifest) => {
+    if (manifest.status === 'running') {
+      throw new SpacesError(`Cannot dismiss running replay: ${replayId}`, 'USER_ERROR', 1);
+    }
+
+    return {
+      ...manifest,
+      retention: {
+        ...manifest.retention,
+        dismissedAt,
+        dismissedBy,
+        expiresAt: dismissedAt + DISMISS_EXPIRY_TTL_MS,
+      },
+    };
+  });
 }
 
 export function undismissReplay(replayId: string): void {
@@ -562,7 +616,7 @@ export function undismissReplay(replayId: string): void {
     if (!manifest.retention) {
       return manifest;
     }
-    const { dismissedAt: _d, dismissedBy: _b, ...rest } = manifest.retention;
+    const { dismissedAt: _d, dismissedBy: _b, expiresAt: _e, ...rest } = manifest.retention;
     return {
       ...manifest,
       retention: Object.keys(rest).length > 0 ? rest : undefined,
@@ -617,4 +671,113 @@ export function deleteReplaysForProject(projectName: string): number {
   }
 
   return matches.length;
+}
+
+// ============================================================================
+// Retention sweep
+// ============================================================================
+
+/**
+ * Delete replays whose `expiresAt` has passed.
+ * Returns the number of replays permanently deleted.
+ */
+export function pruneExpiredReplays(now = Date.now()): number {
+  const root = getReplayRootDir();
+  if (!existsSync(root)) {
+    return 0;
+  }
+
+  let pruned = 0;
+  for (const entry of readdirSync(root)) {
+    let manifest: ReplayManifest | null;
+    try {
+      manifest = readReplayManifest(entry);
+    } catch {
+      continue;
+    }
+    if (!manifest) {
+      continue;
+    }
+
+    const expiresAt = manifest.retention?.expiresAt;
+    if (typeof expiresAt === 'number' && expiresAt <= now) {
+      deleteReplay(manifest.replayId);
+      pruned++;
+    }
+  }
+
+  return pruned;
+}
+
+// ============================================================================
+// Storage measurement
+// ============================================================================
+
+function safeStat(path: string): number {
+  try {
+    return statSync(path).size;
+  } catch {
+    return 0;
+  }
+}
+
+function dirSizeRecursive(dirPath: string): number {
+  if (!existsSync(dirPath)) {
+    return 0;
+  }
+
+  let total = 0;
+  for (const entry of readdirSync(dirPath, { withFileTypes: true })) {
+    const full = join(dirPath, entry.name);
+    if (entry.isDirectory()) {
+      total += dirSizeRecursive(full);
+    } else {
+      total += safeStat(full);
+    }
+  }
+  return total;
+}
+
+export function getReplayStorageInfo(replayId: string): import('./types.js').ReplayStorageInfo | null {
+  const manifest = readReplayManifest(replayId);
+  if (!manifest) {
+    return null;
+  }
+
+  const dir = getReplayDir(replayId);
+  const manifestBytes = safeStat(getReplayManifestPath(replayId));
+  const eventsBytes = safeStat(getReplayEventsPath(replayId));
+  const checkpointsDir = join(dir, 'checkpoints');
+  const checkpointsBytes = dirSizeRecursive(checkpointsDir);
+  const totalBytes = manifestBytes + eventsBytes + checkpointsBytes;
+
+  return {
+    replayId: manifest.replayId,
+    sessionName: manifest.sessionName,
+    status: manifest.status,
+    durationMs: manifest.stats.durationMs,
+    totalBytes,
+    eventsBytes,
+    checkpointsBytes,
+    manifestBytes,
+    dismissedAt: manifest.retention?.dismissedAt,
+    expiresAt: manifest.retention?.expiresAt,
+  };
+}
+
+export function getReplayStorageSummary(filter: ReplayListFilter = {}): import('./types.js').ReplayStorageSummary {
+  const infos = listReplayInfos({ ...filter, includeDismissed: true });
+  const replays: import('./types.js').ReplayStorageInfo[] = [];
+  let totalBytes = 0;
+
+  for (const info of infos) {
+    const storage = getReplayStorageInfo(info.replayId);
+    if (storage) {
+      replays.push(storage);
+      totalBytes += storage.totalBytes;
+    }
+  }
+
+  replays.sort((a, b) => b.totalBytes - a.totalBytes);
+  return { totalBytes, replayCount: replays.length, replays };
 }

--- a/src/lib/tmux-lite/replay/types.ts
+++ b/src/lib/tmux-lite/replay/types.ts
@@ -1,0 +1,166 @@
+export const REPLAY_FORMAT_VERSION = 1 as const;
+
+export type ReplayStatus = 'running' | 'closed' | 'crashed';
+
+export interface ReplayRetentionPolicy {
+  expiresAt?: number;
+  dismissedAt?: number;
+  dismissedBy?: string;
+}
+
+export interface ReplayManifestStats {
+  lastSeq: number;
+  eventCount: number;
+  checkpointCount: number;
+  durationMs: number;
+}
+
+export interface ReplayManifestMetadata {
+  title?: string;
+  processTitle?: string;
+  exitCode?: number;
+}
+
+export interface ReplayManifest {
+  version: typeof REPLAY_FORMAT_VERSION;
+  replayId: string;
+  sessionId: string;
+  sessionName: string;
+  cwd: string;
+  workspaceId?: string;
+  projectName?: string;
+  workspaceName?: string;
+  startedAt: number;
+  endedAt?: number;
+  status: ReplayStatus;
+  initialTerminal: {
+    cols: number;
+    rows: number;
+    termType?: string;
+  };
+  metadata: ReplayManifestMetadata;
+  retention?: ReplayRetentionPolicy;
+  stats: ReplayManifestStats;
+}
+
+interface ReplayEventBase {
+  v: typeof REPLAY_FORMAT_VERSION;
+  seq: number;
+  t: number;
+}
+
+export interface ReplayOutputEvent extends ReplayEventBase {
+  type: 'output';
+  encoding: 'base64';
+  data: string;
+}
+
+export interface ReplayInputEvent extends ReplayEventBase {
+  type: 'input';
+  encoding: 'base64';
+  data: string;
+}
+
+export interface ReplayResizeEvent extends ReplayEventBase {
+  type: 'resize';
+  cols: number;
+  rows: number;
+}
+
+export interface ReplayMarkerEvent extends ReplayEventBase {
+  type: 'marker';
+  label?: string;
+}
+
+export interface ReplayTitleEvent extends ReplayEventBase {
+  type: 'title';
+  title: string;
+}
+
+export interface ReplayProcessTitleEvent extends ReplayEventBase {
+  type: 'process-title';
+  processTitle: string;
+}
+
+export interface ReplayExitEvent extends ReplayEventBase {
+  type: 'exit';
+  code: number;
+}
+
+export type ReplayEvent =
+  | ReplayOutputEvent
+  | ReplayInputEvent
+  | ReplayResizeEvent
+  | ReplayMarkerEvent
+  | ReplayTitleEvent
+  | ReplayProcessTitleEvent
+  | ReplayExitEvent;
+
+export interface ReplayCheckpoint {
+  version: typeof REPLAY_FORMAT_VERSION;
+  checkpointId: string;
+  seq: number;
+  t: number;
+  terminal: {
+    cols: number;
+    rows: number;
+  };
+  metadata: ReplayManifestMetadata;
+  serializer: {
+    kind: 'xterm-serialize';
+    scrollbackLines: number;
+  };
+  ansiPath: string;
+}
+
+export interface ReplayInfo {
+  replayId: string;
+  sessionId: string;
+  sessionName: string;
+  cwd: string;
+  workspaceId?: string;
+  projectName?: string;
+  workspaceName?: string;
+  startedAt: number;
+  endedAt?: number;
+  status: ReplayStatus;
+  durationMs: number;
+  eventCount: number;
+  checkpointCount: number;
+  lastSeq: number;
+  title?: string;
+  processTitle?: string;
+  exitCode?: number;
+  dismissedAt?: number;
+  dismissedBy?: string;
+}
+
+export interface TerminalSnapshot {
+  version: typeof REPLAY_FORMAT_VERSION;
+  replayId: string;
+  sessionId: string;
+  workspaceId?: string;
+  source: 'live' | 'replay';
+  timeMs: number;
+  seq: number;
+  terminal: {
+    cols: number;
+    rows: number;
+    cursorX: number;
+    cursorY: number;
+    viewportY: number;
+    baseY: number;
+  };
+  metadata: {
+    title?: string;
+    processTitle?: string;
+    exitCode?: number;
+    attached?: boolean;
+    checkpointId?: string;
+  };
+  screen: {
+    visible: string[];
+    scrollbackTail: string[];
+    currentLine?: string;
+  };
+}

--- a/src/lib/tmux-lite/replay/types.ts
+++ b/src/lib/tmux-lite/replay/types.ts
@@ -133,6 +133,44 @@ export interface ReplayInfo {
   exitCode?: number;
   dismissedAt?: number;
   dismissedBy?: string;
+  expiresAt?: number;
+}
+
+export interface ReplayStorageInfo {
+  replayId: string;
+  sessionName: string;
+  status: ReplayStatus;
+  durationMs: number;
+  totalBytes: number;
+  eventsBytes: number;
+  checkpointsBytes: number;
+  manifestBytes: number;
+  dismissedAt?: number;
+  expiresAt?: number;
+}
+
+export interface ReplayStorageSummary {
+  totalBytes: number;
+  replayCount: number;
+  replays: ReplayStorageInfo[];
+}
+
+export interface ReplayFrameTarget {
+  atMs?: number;
+  atSeq?: number;
+}
+
+export interface ReplayTimelineStep {
+  timeMs: number;
+  seq: number;
+}
+
+export interface ReplayTimeline {
+  replayId: string;
+  durationMs: number;
+  latestTimeMs: number;
+  steps: ReplayTimelineStep[];
+  checkpointSteps: ReplayTimelineStep[];
 }
 
 export interface TerminalSnapshot {

--- a/src/lib/tmux-lite/server.ts
+++ b/src/lib/tmux-lite/server.ts
@@ -13,6 +13,7 @@ import { createBufferedSocketWriter } from "../../utils/bun-socket-writer";
 import { installDsrCprResponder } from "./terminal-queries";
 import { getNotificationConfig, type NotificationConfig } from "../../core/config.js";
 import { DEFAULT_NOTIFICATION_CONFIG } from "../../types/config.js";
+import { resolveWorkspaceRef } from "../events/paths.js";
 import {
   applyTmuxLiteSandboxEnvironment,
   getRouterSocket,
@@ -35,6 +36,16 @@ import {
   FrameType,
   MAX_FRAME_SIZE,
 } from "./protocol";
+import {
+  appendReplayEvent,
+  initializeReplay,
+  listReplayInfos,
+  reconcileRunningReplaysAsCrashed,
+  updateReplayManifest,
+  writeReplayCheckpoint,
+} from "./replay/store.js";
+import type { ReplayCheckpoint, ReplayEvent, ReplayManifest } from "./replay/types.js";
+import { getReplayMarkdown, getReplaySnapshot, getReplayText } from "./replay/snapshot.js";
 
 // Chunk size for large PTY data (leave room for frame header overhead)
 // Using 512KB to be well under the 1MB limit
@@ -52,6 +63,9 @@ if (rawArgs.includes("--test")) {
 const ROUTER_SOCKET = getRouterSocket();
 const PID_FILE = getPidFile();
 const SERVER_START_TIME = Date.now();
+const RECORD_REPLAY_INPUT = process.env.TMUX_LITE_REPLAY_RECORD_INPUT === "1";
+const REPLAY_CHECKPOINT_MIN_INTERVAL_MS = 2000;
+const REPLAY_CHECKPOINT_BYTE_INTERVAL = 128 * 1024;
 
 // Load notification config (with fallback to defaults)
 let notificationConfig: NotificationConfig;
@@ -90,6 +104,26 @@ try { unlinkSync(ROUTER_SOCKET); } catch {}
 // Write PID file
 writeFileSync(PID_FILE, String(process.pid));
 
+try {
+  const reconciled = reconcileRunningReplaysAsCrashed();
+  if (reconciled.length > 0) {
+    console.log(`[replay] marked ${reconciled.length} running replays as crashed`);
+  }
+} catch (error) {
+  const message = error instanceof Error ? error.message : String(error);
+  console.warn(`[replay] failed to reconcile running replays: ${message}`);
+}
+
+interface ReplayRuntime {
+  replayId: string;
+  startedAt: number;
+  nextSeq: number;
+  eventCount: number;
+  checkpointCount: number;
+  lastCheckpointAt: number;
+  bytesSinceCheckpoint: number;
+}
+
 interface SessionData {
   info: Session;
   listener: any;
@@ -110,6 +144,8 @@ interface SessionData {
   lastInteraction: number;  // Timestamp of last user input
   lastDetached: number;  // Timestamp of last detach (for grace period)
   lastAttached: number;  // Timestamp of last attach (for grace period)
+  replay: ReplayRuntime | null;
+  replayCheckpointPending: boolean;
 }
 
 const sessions = new Map<string, SessionData>();
@@ -202,13 +238,16 @@ function cleanupSessionResources(session: SessionData, options: { removeFromMap?
   }
 }
 
-function shutdownServer(): void {
+function shutdownServer(options: { markRunningSessionsCrashed?: boolean } = {}): void {
   if (shuttingDown) {
     return;
   }
   shuttingDown = true;
 
   for (const session of sessions.values()) {
+    if (options.markRunningSessionsCrashed !== false) {
+      markReplayCrashed(session);
+    }
     try { session.xterm.dispose(); } catch {}
     cleanupSessionResources(session, { removeFromMap: false });
     try { session.proc.kill(9); } catch {}
@@ -455,6 +494,253 @@ function genInboxId(): string {
   return String(inboxCounter++);
 }
 
+function buildCanonicalWorkspaceId(projectName: string, workspaceName: string): string {
+  return `${projectName}:${workspaceName}`;
+}
+
+function createReplayId(sessionId: string): string {
+  return `${Date.now()}-${sessionId}`;
+}
+
+function createReplayRuntime(
+  sessionId: string,
+  sessionName: string,
+  cwd: string,
+  cols: number,
+  rows: number
+): ReplayRuntime | null {
+  const startedAt = Date.now();
+  const replayId = createReplayId(sessionId);
+  const workspaceRef = resolveWorkspaceRef(cwd);
+  const workspaceId = workspaceRef
+    ? buildCanonicalWorkspaceId(workspaceRef.projectName, workspaceRef.workspaceId)
+    : undefined;
+
+  const manifest: ReplayManifest = {
+    version: 1,
+    replayId,
+    sessionId,
+    sessionName,
+    cwd,
+    workspaceId,
+    projectName: workspaceRef?.projectName,
+    workspaceName: workspaceRef?.workspaceId,
+    startedAt,
+    status: "running",
+    initialTerminal: {
+      cols,
+      rows,
+      termType: process.env.TERM,
+    },
+    metadata: {},
+    stats: {
+      lastSeq: 0,
+      eventCount: 0,
+      checkpointCount: 0,
+      durationMs: 0,
+    },
+  };
+
+  try {
+    initializeReplay(manifest);
+    return {
+      replayId,
+      startedAt,
+      nextSeq: 1,
+      eventCount: 0,
+      checkpointCount: 0,
+      lastCheckpointAt: startedAt,
+      bytesSinceCheckpoint: 0,
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.warn(`[replay] failed to initialize replay for ${sessionName}: ${message}`);
+    return null;
+  }
+}
+
+function disableReplay(session: SessionData, error: unknown): void {
+  const message = error instanceof Error ? error.message : String(error);
+  console.warn(`[replay] disabling replay for ${session.info.name}: ${message}`);
+  session.replay = null;
+}
+
+function syncReplayManifest(
+  session: SessionData,
+  options: {
+    status?: ReplayManifest["status"];
+    endedAt?: number;
+    title?: string;
+    processTitle?: string;
+    exitCode?: number;
+    durationMs?: number;
+  } = {}
+): void {
+  const replay = session.replay;
+  if (!replay) {
+    return;
+  }
+
+  const now = Date.now();
+  const durationMs = Math.max(options.durationMs ?? 0, now - replay.startedAt);
+
+  try {
+    updateReplayManifest(replay.replayId, (manifest) => ({
+      ...manifest,
+      status: options.status ?? manifest.status,
+      endedAt: options.endedAt ?? manifest.endedAt,
+      metadata: {
+        ...manifest.metadata,
+        ...(options.title !== undefined ? { title: options.title } : {}),
+        ...(options.processTitle !== undefined ? { processTitle: options.processTitle } : {}),
+        ...(options.exitCode !== undefined ? { exitCode: options.exitCode } : {}),
+      },
+      stats: {
+        ...manifest.stats,
+        lastSeq: Math.max(0, replay.nextSeq - 1),
+        eventCount: replay.eventCount,
+        checkpointCount: replay.checkpointCount,
+        durationMs,
+      },
+    }));
+  } catch (error) {
+    disableReplay(session, error);
+  }
+}
+
+function createReplayEvent(replay: ReplayRuntime, event: Omit<ReplayEvent, "v" | "seq" | "t">): ReplayEvent {
+  const base = {
+    v: 1 as const,
+    seq: replay.nextSeq,
+    t: Date.now() - replay.startedAt,
+  };
+
+  switch (event.type) {
+    case "output":
+      return { ...base, type: "output", encoding: event.encoding, data: event.data };
+    case "input":
+      return { ...base, type: "input", encoding: event.encoding, data: event.data };
+    case "resize":
+      return { ...base, type: "resize", cols: event.cols, rows: event.rows };
+    case "marker":
+      return { ...base, type: "marker", label: event.label };
+    case "title":
+      return { ...base, type: "title", title: event.title };
+    case "process-title":
+      return { ...base, type: "process-title", processTitle: event.processTitle };
+    case "exit":
+      return { ...base, type: "exit", code: event.code };
+  }
+}
+
+function recordReplayEvent(session: SessionData, event: Omit<ReplayEvent, "v" | "seq" | "t">): void {
+  const replay = session.replay;
+  if (!replay) {
+    return;
+  }
+
+  try {
+    appendReplayEvent(replay.replayId, createReplayEvent(replay, event));
+    replay.eventCount++;
+    replay.nextSeq++;
+  } catch (error) {
+    disableReplay(session, error);
+  }
+}
+
+function createReplayCheckpoint(replay: ReplayRuntime, session: SessionData): ReplayCheckpoint {
+  const checkpointId = String(replay.checkpointCount).padStart(6, "0");
+  return {
+    version: 1,
+    checkpointId,
+    seq: Math.max(0, replay.nextSeq - 1),
+    t: Date.now() - replay.startedAt,
+    terminal: {
+      cols: session.xterm.cols,
+      rows: session.xterm.rows,
+    },
+    metadata: {
+      title: session.processTitle || undefined,
+      processTitle: session.processTitle || undefined,
+      exitCode: session.info.exitCode,
+    },
+    serializer: {
+      kind: "xterm-serialize",
+      scrollbackLines: SERIALIZE_SCROLLBACK_LINES,
+    },
+    ansiPath: `checkpoints/${checkpointId}.ansi`,
+  };
+}
+
+function writeReplayCheckpointNow(session: SessionData): void {
+  const replay = session.replay;
+  if (!replay) {
+    return;
+  }
+
+  try {
+    const checkpoint = createReplayCheckpoint(replay, session);
+    const serialized = session.serialize.serialize({
+      scrollback: SERIALIZE_SCROLLBACK_LINES,
+    });
+    writeReplayCheckpoint(replay.replayId, checkpoint, serialized);
+    replay.checkpointCount++;
+    replay.lastCheckpointAt = Date.now();
+    replay.bytesSinceCheckpoint = 0;
+    syncReplayManifest(session);
+  } catch (error) {
+    disableReplay(session, error);
+  }
+}
+
+function scheduleReplayCheckpoint(session: SessionData, force = false): void {
+  const replay = session.replay;
+  if (!replay) {
+    return;
+  }
+
+  const now = Date.now();
+  if (!force) {
+    if (replay.bytesSinceCheckpoint < REPLAY_CHECKPOINT_BYTE_INTERVAL) {
+      return;
+    }
+    if (now - replay.lastCheckpointAt < REPLAY_CHECKPOINT_MIN_INTERVAL_MS) {
+      return;
+    }
+  }
+
+  if (session.replayCheckpointPending) {
+    return;
+  }
+
+  session.replayCheckpointPending = true;
+  const flush = () => {
+    if (!sessions.has(session.info.id)) {
+      return;
+    }
+    if (session.pendingWrites > 0) {
+      setTimeout(flush, 10);
+      return;
+    }
+    session.replayCheckpointPending = false;
+    writeReplayCheckpointNow(session);
+  };
+
+  setTimeout(flush, 0);
+}
+
+function markReplayCrashed(session: SessionData, endedAt = Date.now()): void {
+  if (!session.replay) {
+    return;
+  }
+  syncReplayManifest(session, {
+    status: "crashed",
+    endedAt,
+    processTitle: session.processTitle || undefined,
+    durationMs: endedAt - session.replay.startedAt,
+  });
+}
+
 function addInboxItem(item: Omit<InboxItem, 'id' | 'read'>): void {
   // Check if this notification type is enabled in config
   if (!isNotificationTypeEnabled(item.type)) {
@@ -645,6 +931,8 @@ function setupXtermEventHandlers(
     const session = sessions.get(id);
     if (session) {
       session.processTitle = title;
+      recordReplayEvent(session, { type: "process-title", processTitle: title });
+      syncReplayManifest(session, { processTitle: title, title });
       // Update client's terminal title if attached
       if (session.client) {
         sendTitle(session.client, sessionName, title);
@@ -707,6 +995,16 @@ function createPtyDataHandler(
 
     const session = sessions.get(id);
     if (!session) return;
+
+    recordReplayEvent(session, {
+      type: "output",
+      encoding: "base64",
+      data: data.toString("base64"),
+    });
+    if (session.replay) {
+      session.replay.bytesSinceCheckpoint += data.length;
+      scheduleReplayCheckpoint(session);
+    }
 
     const str = data.toString();
     const now = Date.now();
@@ -814,6 +1112,7 @@ function handleProcessExit(
     if (!session) {
       return;
     }
+    const endedAt = Date.now();
 
     // Clean up parser hooks
     try { disposeDsr(); } catch {}
@@ -835,6 +1134,14 @@ function handleProcessExit(
 
     // Update session info with exit code
     session.info.exitCode = code;
+    recordReplayEvent(session, { type: "exit", code });
+    syncReplayManifest(session, {
+      status: "closed",
+      endedAt,
+      exitCode: code,
+      processTitle: session.processTitle || getProcessTitle(),
+      durationMs: session.replay ? endedAt - session.replay.startedAt : undefined,
+    });
 
     if (session.client) {
       writeToClient(session, encodeControl({ type: "exited", code }));
@@ -1052,6 +1359,8 @@ function createSessionSocketHandlers(
         try {
           session.ptyTerminal.resize(cols, rows);
           session.xterm.resize(cols, rows);
+          recordReplayEvent(session, { type: "resize", cols, rows });
+          scheduleReplayCheckpoint(session, true);
           // Send SIGWINCH to process group so children (vim, etc.) get it
           try {
             process.kill(-proc.pid, "SIGWINCH");
@@ -1127,6 +1436,13 @@ function createSessionSocketHandlers(
           } else {
             // Raw PTY input - write to terminal
             session.ptyTerminal.write(frame.payload);
+          }
+          if (RECORD_REPLAY_INPUT) {
+            recordReplayEvent(session, {
+              type: "input",
+              encoding: "base64",
+              data: Buffer.from(frame.payload).toString("base64"),
+            });
           }
           // Track last interaction time
           session.lastInteraction = Date.now();
@@ -1255,6 +1571,7 @@ function createSession(
 
   const cols = process.stdout.columns || 80;
   const rows = process.stdout.rows || 24;
+  const replay = createReplayRuntime(id, sessionName, cwd, cols, rows);
 
   // Create xterm-headless for proper terminal state tracking
   const xterm = new XTerminal({
@@ -1391,7 +1708,14 @@ function createSession(
       lastInteraction: 0,  // No interaction yet
       lastDetached: 0,  // Never detached yet
       lastAttached: 0,  // Never attached yet (will be set on first attach)
+      replay,
+      replayCheckpointPending: false,
     });
+
+  const session = sessions.get(id);
+  if (session?.replay) {
+    writeReplayCheckpointNow(session);
+  }
 
   console.log(`[${sessionName}] created (pid ${proc.pid})`);
   return info;
@@ -1443,6 +1767,77 @@ routerListener = Bun.listen({
               sessions: Array.from(sessions.values()).map(getSessionInfo)
             };
             break;
+
+          case "list-replays":
+            res = {
+              type: "replays",
+              replays: listReplayInfos({
+                workspaceId: cmd.workspaceId,
+                sessionId: cmd.sessionId,
+                status: cmd.status,
+              }),
+            };
+            break;
+
+          case "replay-snapshot":
+            try {
+              res = {
+                type: "replay-snapshot",
+                snapshot: await getReplaySnapshot(cmd.replayId, {
+                  atMs: cmd.atMs,
+                  scrollbackLines: cmd.scrollbackLines,
+                }),
+              };
+            } catch (e) {
+              const errMsg = e instanceof Error ? e.message : String(e);
+              res = { type: "error", message: `Failed to load replay snapshot: ${errMsg}` };
+            }
+            break;
+
+          case "replay-text":
+            try {
+              res = {
+                type: "replay-text",
+                text: await getReplayText(cmd.replayId, {
+                  atMs: cmd.atMs,
+                  scrollbackLines: cmd.scrollbackLines,
+                  includeScrollback: cmd.includeScrollback,
+                  trimTrailingBlankRows: cmd.trimTrailingBlankRows,
+                }),
+              };
+            } catch (e) {
+              const errMsg = e instanceof Error ? e.message : String(e);
+              res = { type: "error", message: `Failed to load replay text: ${errMsg}` };
+            }
+            break;
+
+          case "replay-markdown":
+            try {
+              res = {
+                type: "replay-markdown",
+                markdown: await getReplayMarkdown(cmd.replayId, {
+                  atMs: cmd.atMs,
+                  scrollbackLines: cmd.scrollbackLines,
+                  includeScrollback: cmd.includeScrollback,
+                  trimTrailingBlankRows: cmd.trimTrailingBlankRows,
+                }),
+              };
+            } catch (e) {
+              const errMsg = e instanceof Error ? e.message : String(e);
+              res = { type: "error", message: `Failed to load replay markdown: ${errMsg}` };
+            }
+            break;
+
+          case "create-checkpoint": {
+            const s = sessions.get(cmd.id);
+            if (!s) {
+              res = { type: "error", message: `Session ${cmd.id} not found` };
+            } else {
+              writeReplayCheckpointNow(s);
+              res = { type: "ok" };
+            }
+            break;
+          }
 
           case "new":
             try {
@@ -1557,10 +1952,29 @@ routerListener = Bun.listen({
   }
 });
 
+// Handle unexpected termination - kill all session processes
+function cleanupAndExit(signal: string) {
+  console.log(`\nReceived ${signal}, cleaning up sessions...`);
+  for (const [id, s] of sessions) {
+    try {
+      markReplayCrashed(s);
+      s.xterm.dispose();
+      s.proc.kill(9);
+    } catch {}
+  }
+  // Clean up PID file
+  try { unlinkSync(PID_FILE); } catch {}
+  process.exit(0);
+}
+
+process.on('SIGTERM', () => cleanupAndExit('SIGTERM'));
+process.on('SIGINT', () => cleanupAndExit('SIGINT'));
+process.on('SIGHUP', () => cleanupAndExit('SIGHUP'));
+
 console.log("tmux-lite server running (xterm-headless)");
 console.log(`Socket: ${ROUTER_SOCKET}\n`);
 
-for (const signal of ["SIGINT", "SIGTERM", "SIGHUP"] as const) {
+for (const signal of ["SIGINT", "SIGTERM"] as const) {
   process.on(signal, () => {
     shutdownServer();
     process.exit(0);
@@ -1568,5 +1982,5 @@ for (const signal of ["SIGINT", "SIGTERM", "SIGHUP"] as const) {
 }
 
 process.on("exit", () => {
-  shutdownServer();
+  shutdownServer({ markRunningSessionsCrashed: false });
 });

--- a/src/session/__tests__/local-session-backend.test.ts
+++ b/src/session/__tests__/local-session-backend.test.ts
@@ -1143,4 +1143,114 @@ describe('LocalSessionBackend', () => {
       message: 'Workspace "ws-missing" does not exist',
     });
   });
+
+  it('emits replay lists and respects includeDismissed filters', async () => {
+    const events: BackendEvent[] = [];
+    const listReplaysCalls: Array<{ workspaceId?: string; includeDismissed?: boolean }> = [];
+
+    const deps: Partial<LocalSessionBackendDependencies> = {
+      listReplays: (filter = {}) => {
+        listReplaysCalls.push(filter);
+        return filter.includeDismissed
+          ? [
+              {
+                replayId: 'replay-visible',
+                sessionId: 'sess-1',
+                sessionName: 'visible',
+                cwd: '/tmp/ws-1',
+                workspaceId: 'ws-1',
+                projectName: 'alpha',
+                workspaceName: 'ws-1',
+                startedAt: 1,
+                endedAt: 2,
+                status: 'closed',
+                durationMs: 1,
+                eventCount: 1,
+                checkpointCount: 1,
+                lastSeq: 1,
+              },
+              {
+                replayId: 'replay-hidden',
+                sessionId: 'sess-2',
+                sessionName: 'hidden',
+                cwd: '/tmp/ws-1',
+                workspaceId: 'ws-1',
+                projectName: 'alpha',
+                workspaceName: 'ws-1',
+                startedAt: 3,
+                endedAt: 4,
+                status: 'closed',
+                durationMs: 1,
+                eventCount: 1,
+                checkpointCount: 1,
+                lastSeq: 1,
+                dismissedAt: 10,
+              },
+            ]
+          : [
+              {
+                replayId: 'replay-visible',
+                sessionId: 'sess-1',
+                sessionName: 'visible',
+                cwd: '/tmp/ws-1',
+                workspaceId: 'ws-1',
+                projectName: 'alpha',
+                workspaceName: 'ws-1',
+                startedAt: 1,
+                endedAt: 2,
+                status: 'closed',
+                durationMs: 1,
+                eventCount: 1,
+                checkpointCount: 1,
+                lastSeq: 1,
+              },
+            ];
+      },
+    };
+
+    const backend = new LocalSessionBackend({ deps });
+    backend.onEvent((event) => events.push(event));
+
+    await backend.listReplays('ws-1');
+    await backend.listReplays('ws-1', true);
+
+    expect(listReplaysCalls).toEqual([
+      { workspaceId: 'ws-1', includeDismissed: undefined },
+      { workspaceId: 'ws-1', includeDismissed: true },
+    ]);
+
+    const replayEvents = events.filter((event) => event.type === 'replays');
+    expect(replayEvents).toHaveLength(2);
+    expect(replayEvents[0]).toEqual({
+      type: 'replays',
+      replays: [expect.objectContaining({ replayId: 'replay-visible' })],
+    });
+    expect(replayEvents[1]).toEqual({
+      type: 'replays',
+      replays: [
+        expect.objectContaining({ replayId: 'replay-visible' }),
+        expect.objectContaining({ replayId: 'replay-hidden', dismissedAt: 10 }),
+      ],
+    });
+  });
+
+  it('returns replay ansi and delegates dismiss / undismiss', async () => {
+    const dismissCalls: string[] = [];
+    const undismissCalls: string[] = [];
+    const deps: Partial<LocalSessionBackendDependencies> = {
+      getReplayAnsi: async () => Buffer.from([0x1b, 0x5b, 0x33, 0x31, 0x6d]),
+      dismissReplay: (replayId) => { dismissCalls.push(replayId); },
+      undismissReplay: (replayId) => { undismissCalls.push(replayId); },
+    };
+
+    const backend = new LocalSessionBackend({ deps });
+    const ansi = await backend.getReplayAnsi('replay-1');
+    expect(Array.from(ansi)).toEqual([0x1b, 0x5b, 0x33, 0x31, 0x6d]);
+
+    await backend.dismissReplay('replay-1');
+    await backend.undismissReplay('replay-1');
+
+    expect(dismissCalls).toEqual(['replay-1']);
+    expect(undismissCalls).toEqual(['replay-1']);
+  });
 });

--- a/src/session/__tests__/remote-session-backend.test.ts
+++ b/src/session/__tests__/remote-session-backend.test.ts
@@ -422,12 +422,13 @@ describe('RemoteSessionBackend', () => {
 
     await connectAndHandshake(backend, socket);
 
-    const ansiPromise = backend.getReplayAnsi('replay-1', 50);
+    const ansiPromise = backend.getReplayAnsi('replay-1', { atMs: 50, atSeq: 2 });
     await Bun.sleep(0);
     expect(decodeRelayDataCommand(cryptoAdapter, socket.sent[socket.sent.length - 1])).toEqual({
       type: 'get_replay_ansi',
       replayId: 'replay-1',
       atMs: 50,
+      atSeq: 2,
     });
     socket.handlers?.onMessage(
       makeRelayDataPayload(cryptoAdapter, {
@@ -456,6 +457,31 @@ describe('RemoteSessionBackend', () => {
     });
     socket.handlers?.onMessage(makeRelayDataPayload(cryptoAdapter, { type: 'replay_undismissed', replayId: 'replay-1' }));
     await expect(undismissPromise).resolves.toBeUndefined();
+
+    const timelinePromise = backend.getReplayTimeline('replay-1');
+    await Bun.sleep(0);
+    expect(decodeRelayDataCommand(cryptoAdapter, socket.sent[socket.sent.length - 1])).toEqual({
+      type: 'get_replay_timeline',
+      replayId: 'replay-1',
+    });
+    socket.handlers?.onMessage(makeRelayDataPayload(cryptoAdapter, {
+      type: 'replay_timeline',
+      replayId: 'replay-1',
+      timeline: {
+        replayId: 'replay-1',
+        durationMs: 50,
+        latestTimeMs: 50,
+        steps: [{ timeMs: 0, seq: 0 }, { timeMs: 50, seq: 2 }],
+        checkpointSteps: [{ timeMs: 0, seq: 0 }],
+      },
+    }));
+    await expect(timelinePromise).resolves.toEqual({
+      replayId: 'replay-1',
+      durationMs: 50,
+      latestTimeMs: 50,
+      steps: [{ timeMs: 0, seq: 0 }, { timeMs: 50, seq: 2 }],
+      checkpointSteps: [{ timeMs: 0, seq: 0 }],
+    });
   });
 
   it('preserves script phase banner and output ordering during running scripts', async () => {

--- a/src/session/__tests__/remote-session-backend.test.ts
+++ b/src/session/__tests__/remote-session-backend.test.ts
@@ -339,6 +339,125 @@ describe('RemoteSessionBackend', () => {
     expect(output).toEqual(['snapshot-before-handler', 'live-after-handler']);
   });
 
+  it('lists replays and emits replay events', async () => {
+    const socket = createFakeSocket();
+    const events: BackendEvent[] = [];
+
+    const backend = new RemoteSessionBackend({
+      descriptor: {
+        key: buildRemoteBackendKey('wss://relay.test/ws', 'machine-1'),
+        kind: 'remote',
+        label: 'Machine 1',
+        relayUrl: 'wss://relay.test/ws',
+        machineId: 'machine-1',
+      },
+      socket,
+      socketAdapter,
+      identity,
+      machineId: 'machine-1',
+      deviceCertificate: 'test-device-cert',
+      signer: (message) => ({ ...message, signature: { sig: 'x' } }),
+      crypto: cryptoAdapter,
+      handshake: handshakeAdapter,
+    });
+
+    backend.onEvent((event) => events.push(event));
+    await connectAndHandshake(backend, socket);
+
+    await backend.listReplays('alpha:ws-1', true);
+    const command = decodeRelayDataCommand(cryptoAdapter, socket.sent[socket.sent.length - 1]);
+    expect(command).toEqual({ type: 'list_replays', workspaceId: 'alpha:ws-1', includeDismissed: true });
+
+    socket.handlers?.onMessage(
+      makeRelayDataPayload(cryptoAdapter, {
+        type: 'replay_list',
+        replays: [
+          {
+            replayId: 'replay-1',
+            sessionId: 'sess-1',
+            sessionName: 'ghost',
+            cwd: '/tmp/ws-1',
+            workspaceId: 'alpha:ws-1',
+            projectName: 'alpha',
+            workspaceName: 'ws-1',
+            startedAt: 1,
+            endedAt: 2,
+            status: 'closed',
+            durationMs: 1,
+            eventCount: 1,
+            checkpointCount: 1,
+            lastSeq: 1,
+          },
+        ],
+      })
+    );
+    await Bun.sleep(0);
+
+    expect(events).toContainEqual({
+      type: 'replays',
+      replays: [expect.objectContaining({ replayId: 'replay-1', workspaceId: 'alpha:ws-1' })],
+    });
+  });
+
+  it('round-trips replay ansi and replay dismissal commands', async () => {
+    const socket = createFakeSocket();
+
+    const backend = new RemoteSessionBackend({
+      descriptor: {
+        key: buildRemoteBackendKey('wss://relay.test/ws', 'machine-1'),
+        kind: 'remote',
+        label: 'Machine 1',
+        relayUrl: 'wss://relay.test/ws',
+        machineId: 'machine-1',
+      },
+      socket,
+      socketAdapter,
+      identity,
+      machineId: 'machine-1',
+      deviceCertificate: 'test-device-cert',
+      signer: (message) => ({ ...message, signature: { sig: 'x' } }),
+      crypto: cryptoAdapter,
+      handshake: handshakeAdapter,
+    });
+
+    await connectAndHandshake(backend, socket);
+
+    const ansiPromise = backend.getReplayAnsi('replay-1', 50);
+    await Bun.sleep(0);
+    expect(decodeRelayDataCommand(cryptoAdapter, socket.sent[socket.sent.length - 1])).toEqual({
+      type: 'get_replay_ansi',
+      replayId: 'replay-1',
+      atMs: 50,
+    });
+    socket.handlers?.onMessage(
+      makeRelayDataPayload(cryptoAdapter, {
+        type: 'replay_ansi',
+        replayId: 'replay-1',
+        data: cryptoAdapter.encodeBase64(new Uint8Array([1, 2, 3])),
+        encoding: 'base64',
+      })
+    );
+    await expect(ansiPromise).resolves.toEqual(new Uint8Array([1, 2, 3]));
+
+    const dismissPromise = backend.dismissReplay('replay-1');
+    await Bun.sleep(0);
+    expect(decodeRelayDataCommand(cryptoAdapter, socket.sent[socket.sent.length - 1])).toEqual({
+      type: 'dismiss_replay',
+      replayId: 'replay-1',
+    });
+    socket.handlers?.onMessage(makeRelayDataPayload(cryptoAdapter, { type: 'replay_dismissed', replayId: 'replay-1' }));
+    await expect(dismissPromise).resolves.toBeUndefined();
+
+    const undismissPromise = backend.undismissReplay('replay-1');
+    await Bun.sleep(0);
+    expect(decodeRelayDataCommand(cryptoAdapter, socket.sent[socket.sent.length - 1])).toEqual({
+      type: 'undismiss_replay',
+      replayId: 'replay-1',
+    });
+    socket.handlers?.onMessage(makeRelayDataPayload(cryptoAdapter, { type: 'replay_undismissed', replayId: 'replay-1' }));
+    await expect(undismissPromise).resolves.toBeUndefined();
+  });
+
   it('preserves script phase banner and output ordering during running scripts', async () => {
     const socket = createFakeSocket();
     const events: BackendEvent[] = [];

--- a/src/session/__tests__/useRemoteSessionClient.test.ts
+++ b/src/session/__tests__/useRemoteSessionClient.test.ts
@@ -44,6 +44,7 @@ class FakeRemoteBackend implements RemoteSessionPtyBackend {
   listProjectsCalls = 0
   listWorkspacesCalls = 0
   listSessionsCalls: Array<string | undefined> = []
+  listReplaysCalls: Array<{ workspaceId?: string; includeDismissed?: boolean }> = []
   attachCalls: AttachSessionParams[] = []
   detachCalls = 0
   killCalls: string[] = []
@@ -57,6 +58,9 @@ class FakeRemoteBackend implements RemoteSessionPtyBackend {
   bundleApplyCalls: Array<{ projectName: string; workspaceId: string; submission: BundleRefreshSubmission }> = []
   bundleConfigStateCalls: Array<{ projectName: string; workspaceId: string }> = []
   bundleConfigUpdateCalls: Array<{ projectName: string; workspaceId: string; submission: BundleConfigSubmission }> = []
+  replayAnsiCalls: Array<{ replayId: string; atMs?: number }> = []
+  dismissReplayCalls: string[] = []
+  undismissReplayCalls: string[] = []
   ptyWrites: Uint8Array[] = []
   ptyResizes: Array<{ cols: number; rows: number }> = []
 
@@ -123,6 +127,10 @@ class FakeRemoteBackend implements RemoteSessionPtyBackend {
 
   async listSessions(workspaceId?: string): Promise<void> {
     this.listSessionsCalls.push(workspaceId)
+  }
+
+  async listReplays(workspaceId?: string, includeDismissed?: boolean): Promise<void> {
+    this.listReplaysCalls.push({ workspaceId, includeDismissed })
   }
 
   async createProject(_params: CreateProjectParams): Promise<void> {}
@@ -217,6 +225,19 @@ class FakeRemoteBackend implements RemoteSessionPtyBackend {
 
   async sendReviewRequest(): Promise<never> {
     throw new Error('not implemented')
+  }
+
+  async getReplayAnsi(replayId: string, atMs?: number): Promise<Uint8Array> {
+    this.replayAnsiCalls.push({ replayId, atMs })
+    return new Uint8Array([1, 2, 3])
+  }
+
+  async dismissReplay(replayId: string): Promise<void> {
+    this.dismissReplayCalls.push(replayId)
+  }
+
+  async undismissReplay(replayId: string): Promise<void> {
+    this.undismissReplayCalls.push(replayId)
   }
 
   async writePtyData(data: Uint8Array): Promise<void> {
@@ -452,6 +473,7 @@ describe('useRemoteSessionClient', () => {
       result.current.requestProjects()
       result.current.selectProject('alpha')
       result.current.requestSessions('workspace-1')
+      result.current.requestReplays('workspace-1', true)
       result.current.attachSession({ workspaceId: 'workspace-1', sessionName: 'debug' })
       result.current.detachSession()
       result.current.killSession('session-1')
@@ -476,14 +498,17 @@ describe('useRemoteSessionClient', () => {
           holdWhenIdleMs: 12000,
         },
       })
+      await result.current.getReplayAnsi('replay-1', 50)
+      await result.current.dismissReplay('replay-1')
+      await result.current.undismissReplay('replay-1')
       await Bun.sleep(0)
     })
 
     const activeBackend = backends[1]
-    expect(result.current.selectedProjectName).toBe('alpha')
     expect(activeBackend.listProjectsCalls).toBe(1)
     expect(activeBackend.listWorkspacesCalls).toBe(1)
-    expect(activeBackend.listSessionsCalls).toEqual(['workspace-1'])
+    expect(activeBackend.listSessionsCalls).toEqual([undefined, 'workspace-1'])
+    expect(activeBackend.listReplaysCalls).toEqual([{ workspaceId: 'workspace-1', includeDismissed: true }])
     expect(activeBackend.attachCalls).toEqual([
       { workspaceId: 'workspace-1', sessionName: 'debug' },
     ])
@@ -495,6 +520,9 @@ describe('useRemoteSessionClient', () => {
     expect(activeBackend.markInboxReadCalls).toEqual(['item-2'])
     expect(activeBackend.getNotificationConfigCalls).toBe(1)
     expect(activeBackend.updateNotificationConfigCalls).toHaveLength(1)
+    expect(activeBackend.replayAnsiCalls).toEqual([{ replayId: 'replay-1', atMs: 50 }])
+    expect(activeBackend.dismissReplayCalls).toEqual(['replay-1'])
+    expect(activeBackend.undismissReplayCalls).toEqual(['replay-1'])
 
     await act(async () => {
       result.current.disconnect()

--- a/src/session/__tests__/useRemoteSessionClient.test.ts
+++ b/src/session/__tests__/useRemoteSessionClient.test.ts
@@ -9,6 +9,8 @@ import type {
   CreateWorkspaceParams,
   DeleteProjectParams,
   DeleteWorkspaceParams,
+  ReplayFrameTarget,
+  ReplayTimeline,
 } from '../backend.js'
 import type { BackendEvent } from '../events.js'
 import { buildRemoteBackendKey } from '../backend-key.js'
@@ -58,7 +60,8 @@ class FakeRemoteBackend implements RemoteSessionPtyBackend {
   bundleApplyCalls: Array<{ projectName: string; workspaceId: string; submission: BundleRefreshSubmission }> = []
   bundleConfigStateCalls: Array<{ projectName: string; workspaceId: string }> = []
   bundleConfigUpdateCalls: Array<{ projectName: string; workspaceId: string; submission: BundleConfigSubmission }> = []
-  replayAnsiCalls: Array<{ replayId: string; atMs?: number }> = []
+  replayAnsiCalls: Array<{ replayId: string; target?: ReplayFrameTarget }> = []
+  replayTimelineCalls: string[] = []
   dismissReplayCalls: string[] = []
   undismissReplayCalls: string[] = []
   ptyWrites: Uint8Array[] = []
@@ -227,9 +230,20 @@ class FakeRemoteBackend implements RemoteSessionPtyBackend {
     throw new Error('not implemented')
   }
 
-  async getReplayAnsi(replayId: string, atMs?: number): Promise<Uint8Array> {
-    this.replayAnsiCalls.push({ replayId, atMs })
+  async getReplayAnsi(replayId: string, target?: ReplayFrameTarget): Promise<Uint8Array> {
+    this.replayAnsiCalls.push({ replayId, target })
     return new Uint8Array([1, 2, 3])
+  }
+
+  async getReplayTimeline(replayId: string): Promise<ReplayTimeline> {
+    this.replayTimelineCalls.push(replayId)
+    return {
+      replayId,
+      durationMs: 50,
+      latestTimeMs: 50,
+      steps: [{ timeMs: 0, seq: 0 }, { timeMs: 50, seq: 1 }],
+      checkpointSteps: [{ timeMs: 0, seq: 0 }],
+    }
   }
 
   async dismissReplay(replayId: string): Promise<void> {
@@ -498,7 +512,8 @@ describe('useRemoteSessionClient', () => {
           holdWhenIdleMs: 12000,
         },
       })
-      await result.current.getReplayAnsi('replay-1', 50)
+      await result.current.getReplayAnsi('replay-1', { atMs: 50 })
+      await result.current.getReplayTimeline('replay-1')
       await result.current.dismissReplay('replay-1')
       await result.current.undismissReplay('replay-1')
       await Bun.sleep(0)
@@ -520,7 +535,8 @@ describe('useRemoteSessionClient', () => {
     expect(activeBackend.markInboxReadCalls).toEqual(['item-2'])
     expect(activeBackend.getNotificationConfigCalls).toBe(1)
     expect(activeBackend.updateNotificationConfigCalls).toHaveLength(1)
-    expect(activeBackend.replayAnsiCalls).toEqual([{ replayId: 'replay-1', atMs: 50 }])
+    expect(activeBackend.replayAnsiCalls).toEqual([{ replayId: 'replay-1', target: { atMs: 50 } }])
+    expect(activeBackend.replayTimelineCalls).toEqual(['replay-1'])
     expect(activeBackend.dismissReplayCalls).toEqual(['replay-1'])
     expect(activeBackend.undismissReplayCalls).toEqual(['replay-1'])
 

--- a/src/session/backend.ts
+++ b/src/session/backend.ts
@@ -1,5 +1,6 @@
 import type { NotificationConfig } from '../notifications/types.js';
 import type { BackendEvent } from './events.js';
+import type { ReplayInfo, TerminalSnapshot } from '../lib/tmux-lite/replay/index.js';
 import type {
   BundleRefreshPlan,
   BundleRefreshSubmission,
@@ -108,6 +109,7 @@ export interface SessionBackend {
   listLinearIssues(projectName: string): Promise<SessionLinearIssueSummary[]>;
   listWorkspaces(): Promise<void>;
   listSessions(workspaceId?: string): Promise<void>;
+  listReplays?(workspaceId?: string, includeDismissed?: boolean): Promise<void>;
 
   createProject(params: CreateProjectParams): Promise<void>;
   prepareProjectCreation?(params: CreateProjectParams): Promise<PreparedProjectResult>;
@@ -154,6 +156,27 @@ export interface SessionBackend {
 
   writePtyData?(data: Uint8Array): Promise<void>;
   resizePty?(cols: number, rows: number): Promise<void>;
+  createCheckpoint?(sessionId: string): Promise<void>;
+  getReplaySnapshot?(replayId: string, atMs?: number, scrollbackLines?: number): Promise<TerminalSnapshot>;
+  getReplayText?(
+    replayId: string,
+    atMs?: number,
+    scrollbackLines?: number,
+    includeScrollback?: boolean,
+    trimTrailingBlankRows?: boolean,
+  ): Promise<string>;
+  getReplayMarkdown?(
+    replayId: string,
+    atMs?: number,
+    scrollbackLines?: number,
+    includeScrollback?: boolean,
+    trimTrailingBlankRows?: boolean,
+  ): Promise<string>;
+  getReplayAnsi?(replayId: string, atMs?: number): Promise<Uint8Array>;
+  dismissReplay?(replayId: string): Promise<void>;
+  undismissReplay?(replayId: string): Promise<void>;
 
   onEvent(handler: (event: BackendEvent) => void): () => void;
 }
+
+export type { ReplayInfo, TerminalSnapshot };

--- a/src/session/backend.ts
+++ b/src/session/backend.ts
@@ -1,6 +1,11 @@
 import type { NotificationConfig } from '../notifications/types.js';
 import type { BackendEvent } from './events.js';
-import type { ReplayInfo, TerminalSnapshot } from '../lib/tmux-lite/replay/index.js';
+import type {
+  ReplayFrameTarget,
+  ReplayInfo,
+  ReplayTimeline,
+  TerminalSnapshot,
+} from '../lib/tmux-lite/replay/index.js';
 import type {
   BundleRefreshPlan,
   BundleRefreshSubmission,
@@ -172,11 +177,12 @@ export interface SessionBackend {
     includeScrollback?: boolean,
     trimTrailingBlankRows?: boolean,
   ): Promise<string>;
-  getReplayAnsi?(replayId: string, atMs?: number): Promise<Uint8Array>;
+  getReplayAnsi?(replayId: string, target?: ReplayFrameTarget): Promise<Uint8Array>;
+  getReplayTimeline?(replayId: string): Promise<ReplayTimeline>;
   dismissReplay?(replayId: string): Promise<void>;
   undismissReplay?(replayId: string): Promise<void>;
 
   onEvent(handler: (event: BackendEvent) => void): () => void;
 }
 
-export type { ReplayInfo, TerminalSnapshot };
+export type { ReplayFrameTarget, ReplayInfo, ReplayTimeline, TerminalSnapshot };

--- a/src/session/backends/local-session-backend.ts
+++ b/src/session/backends/local-session-backend.ts
@@ -22,6 +22,7 @@ import {
   getReplaySnapshotOffline,
   getReplayTextOffline,
   getReplayAnsiBufferOffline,
+  getReplayTimelineOffline,
   dismissReplayOffline,
   undismissReplayOffline,
 } from '../../lib/tmux-lite/replay/service.js';
@@ -123,6 +124,7 @@ export interface LocalSessionBackendDependencies {
   getReplayText: typeof getReplayTextOffline;
   getReplayMarkdown: typeof getReplayMarkdown;
   getReplayAnsi: typeof getReplayAnsiBufferOffline;
+  getReplayTimeline: typeof getReplayTimelineOffline;
   dismissReplay: typeof dismissReplayOffline;
   undismissReplay: typeof undismissReplayOffline;
   getNotificationConfig: typeof getNotificationConfig;
@@ -384,6 +386,7 @@ function buildDeps(
     getReplayText: getReplayTextOffline,
     getReplayMarkdown,
     getReplayAnsi: getReplayAnsiBufferOffline,
+    getReplayTimeline: getReplayTimelineOffline,
     dismissReplay: dismissReplayOffline,
     undismissReplay: undismissReplayOffline,
     getNotificationConfig,
@@ -608,8 +611,12 @@ export class LocalSessionBackend implements SessionBackend {
     });
   }
 
-  async getReplayAnsi(replayId: string, atMs?: number): Promise<Uint8Array> {
-    return this.deps.getReplayAnsi(replayId, atMs);
+  async getReplayAnsi(replayId: string, target?: import('../backend.js').ReplayFrameTarget): Promise<Uint8Array> {
+    return this.deps.getReplayAnsi(replayId, target);
+  }
+
+  async getReplayTimeline(replayId: string): Promise<import('../backend.js').ReplayTimeline> {
+    return this.deps.getReplayTimeline(replayId);
   }
 
   async dismissReplay(replayId: string): Promise<void> {

--- a/src/session/backends/local-session-backend.ts
+++ b/src/session/backends/local-session-backend.ts
@@ -9,10 +9,22 @@ import {
   ensureServer,
   createSession,
   killSession,
+  createCheckpoint,
   getInbox,
   clearInbox,
   markInboxRead,
+  getReplaySnapshot,
+  getReplayText,
+  getReplayMarkdown,
 } from '../../lib/tmux-lite/cli.js';
+import {
+  listReplaysOffline,
+  getReplaySnapshotOffline,
+  getReplayTextOffline,
+  getReplayAnsiBufferOffline,
+  dismissReplayOffline,
+  undismissReplayOffline,
+} from '../../lib/tmux-lite/replay/service.js';
 import {
   encodeControl,
   encodePTY,
@@ -95,15 +107,24 @@ import { resolveWorkspaceRef } from '../../lib/events/paths.js';
 import { loadSavedEventFilters } from '../../lib/events/filters.js';
 import { readProjectConfig } from '../../core/config.js';
 import { existsSync } from 'fs';
+import type { TerminalSnapshot } from '../backend.js';
 
 export interface LocalSessionBackendDependencies {
   listSessions: typeof listSessions;
+  listReplays: typeof listReplaysOffline;
   ensureServer: typeof ensureServer;
   createSession: typeof createSession;
   killSession: typeof killSession;
+  createCheckpoint: typeof createCheckpoint;
   getInbox: typeof getInbox;
   clearInbox: typeof clearInbox;
   markInboxRead: typeof markInboxRead;
+  getReplaySnapshot: typeof getReplaySnapshotOffline;
+  getReplayText: typeof getReplayTextOffline;
+  getReplayMarkdown: typeof getReplayMarkdown;
+  getReplayAnsi: typeof getReplayAnsiBufferOffline;
+  dismissReplay: typeof dismissReplayOffline;
+  undismissReplay: typeof undismissReplayOffline;
   getNotificationConfig: typeof getNotificationConfig;
   updateNotificationConfig: typeof updateNotificationConfig;
   listProjectSummaries: typeof listProjectSummaries;
@@ -351,12 +372,20 @@ function buildDeps(
 ): LocalSessionBackendDependencies {
   return {
     listSessions,
+    listReplays: listReplaysOffline,
     ensureServer,
     createSession,
     killSession,
+    createCheckpoint,
     getInbox,
     clearInbox,
     markInboxRead,
+    getReplaySnapshot: getReplaySnapshotOffline,
+    getReplayText: getReplayTextOffline,
+    getReplayMarkdown,
+    getReplayAnsi: getReplayAnsiBufferOffline,
+    dismissReplay: dismissReplayOffline,
+    undismissReplay: undismissReplayOffline,
     getNotificationConfig,
     updateNotificationConfig,
     listProjectSummaries,
@@ -534,6 +563,61 @@ export class LocalSessionBackend implements SessionBackend {
       });
 
     this.emit({ type: 'sessions', sessions: filtered });
+  }
+
+  async listReplays(workspaceId?: string, includeDismissed?: boolean): Promise<void> {
+    const replays = await this.deps.listReplays({ workspaceId, includeDismissed });
+    this.emit({ type: 'replays', replays });
+  }
+
+  async createCheckpoint(sessionId: string): Promise<void> {
+    await this.deps.createCheckpoint(sessionId);
+  }
+
+  async getReplaySnapshot(replayId: string, atMs?: number, scrollbackLines?: number): Promise<TerminalSnapshot> {
+    return this.deps.getReplaySnapshot(replayId, { atMs, scrollbackLines });
+  }
+
+  async getReplayText(
+    replayId: string,
+    atMs?: number,
+    scrollbackLines?: number,
+    includeScrollback?: boolean,
+    trimTrailingBlankRows?: boolean,
+  ): Promise<string> {
+    return this.deps.getReplayText(replayId, {
+      atMs,
+      scrollbackLines,
+      includeScrollback,
+      trimTrailingBlankRows,
+    });
+  }
+
+  async getReplayMarkdown(
+    replayId: string,
+    atMs?: number,
+    scrollbackLines?: number,
+    includeScrollback?: boolean,
+    trimTrailingBlankRows?: boolean,
+  ): Promise<string> {
+    return this.deps.getReplayMarkdown(replayId, {
+      atMs,
+      scrollbackLines,
+      includeScrollback,
+      trimTrailingBlankRows,
+    });
+  }
+
+  async getReplayAnsi(replayId: string, atMs?: number): Promise<Uint8Array> {
+    return this.deps.getReplayAnsi(replayId, atMs);
+  }
+
+  async dismissReplay(replayId: string): Promise<void> {
+    this.deps.dismissReplay(replayId);
+  }
+
+  async undismissReplay(replayId: string): Promise<void> {
+    this.deps.undismissReplay(replayId);
   }
 
   async createProject(params: CreateProjectParams): Promise<void> {

--- a/src/session/backends/remote-session-backend.ts
+++ b/src/session/backends/remote-session-backend.ts
@@ -23,6 +23,7 @@ import {
   type GetBundleRefreshPlanRequest,
   type GetBundleConfigStateRequest,
   type GetNotificationConfigRequest,
+  type GetReplayTimelineRequest,
   type KillSessionRequest,
   type ListLinearIssuesRequest,
   type ListProjectsRequest,
@@ -45,6 +46,7 @@ import {
   type RemoteBranchListResponse,
   type ScriptOutputResponse,
   type ReplayAnsiResponse,
+  type ReplayTimelineResponse,
   type ReplayDismissedResponse,
   type ReplayUndismissedResponse,
   type SessionCtrl,
@@ -75,6 +77,8 @@ import type {
   CreateProjectParams,
   FinalizeProjectParams,
   PreparedProjectResult,
+  ReplayFrameTarget,
+  ReplayTimeline,
   CreateWorkspaceParams,
   DeleteProjectParams,
   DeleteWorkspaceParams,
@@ -211,6 +215,7 @@ const MACHINE_TO_CLIENT_TYPES = new Set<string>([
   'session_list',
   'replay_list',
   'replay_ansi',
+  'replay_timeline',
   'replay_dismissed',
   'replay_undismissed',
   'attached',
@@ -489,6 +494,14 @@ export class RemoteSessionBackend<TSocket, THandshakeState, TServerHello, TServe
         timeout: ReturnType<typeof setTimeout>;
       }
     | null = null;
+  private pendingReplayTimeline:
+    | {
+        replayId: string;
+        resolve: (timeline: ReplayTimeline) => void;
+        reject: (error: Error) => void;
+        timeout: ReturnType<typeof setTimeout>;
+      }
+    | null = null;
   private pendingDismissReplay:
     | {
         replayId: string;
@@ -716,12 +729,17 @@ export class RemoteSessionBackend<TSocket, THandshakeState, TServerHello, TServe
     await this.sendCommand(command);
   }
 
-  async getReplayAnsi(replayId: string, atMs?: number): Promise<Uint8Array> {
+  async getReplayAnsi(replayId: string, target?: ReplayFrameTarget): Promise<Uint8Array> {
     if (this.pendingReplayAnsi) {
       throw new Error('Replay ANSI request already in progress');
     }
 
-    const command: GetReplayAnsiRequest = { type: 'get_replay_ansi', replayId, atMs };
+    const command: GetReplayAnsiRequest = {
+      type: 'get_replay_ansi',
+      replayId,
+      atMs: target?.atMs,
+      atSeq: target?.atSeq,
+    };
     return new Promise<Uint8Array>((resolve, reject) => {
       const timeout = setTimeout(() => {
         const pending = this.pendingReplayAnsi;
@@ -741,6 +759,36 @@ export class RemoteSessionBackend<TSocket, THandshakeState, TServerHello, TServe
         }
         clearTimeout(pending.timeout);
         this.pendingReplayAnsi = null;
+        pending.reject(error instanceof Error ? error : new Error(String(error)));
+      });
+    });
+  }
+
+  async getReplayTimeline(replayId: string): Promise<ReplayTimeline> {
+    if (this.pendingReplayTimeline) {
+      throw new Error('Replay timeline request already in progress');
+    }
+
+    const command: GetReplayTimelineRequest = { type: 'get_replay_timeline', replayId };
+    return new Promise<ReplayTimeline>((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        const pending = this.pendingReplayTimeline;
+        if (!pending || pending.replayId !== replayId) {
+          return;
+        }
+        this.pendingReplayTimeline = null;
+        pending.reject(new Error(`Timed out waiting for replay timeline (${replayId})`));
+      }, DEFAULT_LIFECYCLE_TIMEOUT_MS);
+
+      this.pendingReplayTimeline = { replayId, resolve, reject, timeout };
+
+      void this.sendCommand(command).catch((error) => {
+        const pending = this.pendingReplayTimeline;
+        if (!pending) {
+          return;
+        }
+        clearTimeout(pending.timeout);
+        this.pendingReplayTimeline = null;
         pending.reject(error instanceof Error ? error : new Error(String(error)));
       });
     });
@@ -1721,6 +1769,9 @@ export class RemoteSessionBackend<TSocket, THandshakeState, TServerHello, TServe
       case 'replay_ansi':
         this.resolveReplayAnsi(message);
         return;
+      case 'replay_timeline':
+        this.resolveReplayTimeline(message);
+        return;
       case 'replay_dismissed':
         this.resolveDismissReplay(message);
         return;
@@ -1830,6 +1881,7 @@ export class RemoteSessionBackend<TSocket, THandshakeState, TServerHello, TServe
         this.rejectPendingWorkspaceCreate(message.message, message.workspaceId, message.projectName);
         this.rejectPendingProjectDelete(message.message, message.projectName);
         this.rejectPendingReplayAnsi(message.message, undefined, true);
+        this.rejectPendingReplayTimeline(message.message, undefined, true);
         this.rejectPendingDismissReplay(message.message, undefined, true);
         this.rejectPendingUndismissReplay(message.message, undefined, true);
         if (message.workspaceId) {
@@ -2143,6 +2195,16 @@ export class RemoteSessionBackend<TSocket, THandshakeState, TServerHello, TServe
     pending.resolve(this.crypto.decodeBase64(message.data));
   }
 
+  private resolveReplayTimeline(message: ReplayTimelineResponse): void {
+    const pending = this.pendingReplayTimeline;
+    if (!pending || pending.replayId !== message.replayId) {
+      return;
+    }
+    clearTimeout(pending.timeout);
+    this.pendingReplayTimeline = null;
+    pending.resolve(message.timeline);
+  }
+
   private rejectPendingReplayAnsi(message: string, replayId?: string, force = false): void {
     const pending = this.pendingReplayAnsi;
     if (!pending) {
@@ -2153,6 +2215,19 @@ export class RemoteSessionBackend<TSocket, THandshakeState, TServerHello, TServe
     }
     clearTimeout(pending.timeout);
     this.pendingReplayAnsi = null;
+    pending.reject(new Error(message));
+  }
+
+  private rejectPendingReplayTimeline(message: string, replayId?: string, force = false): void {
+    const pending = this.pendingReplayTimeline;
+    if (!pending) {
+      return;
+    }
+    if (!force && replayId && pending.replayId !== replayId) {
+      return;
+    }
+    clearTimeout(pending.timeout);
+    this.pendingReplayTimeline = null;
     pending.reject(new Error(message));
   }
 
@@ -2532,6 +2607,7 @@ export class RemoteSessionBackend<TSocket, THandshakeState, TServerHello, TServe
     this.rejectPendingWorkspaceCreate('Remote session disconnected', undefined, undefined, true);
     this.rejectPendingProjectDelete('Remote session disconnected', undefined, true);
     this.rejectPendingReplayAnsi('Remote session disconnected', undefined, true);
+    this.rejectPendingReplayTimeline('Remote session disconnected', undefined, true);
     this.rejectPendingDismissReplay('Remote session disconnected', undefined, true);
     this.rejectPendingUndismissReplay('Remote session disconnected', undefined, true);
     this.rejectPendingWorkspaceDelete('DELETE_FAILED', 'Remote session disconnected', undefined, true);

--- a/src/session/backends/remote-session-backend.ts
+++ b/src/session/backends/remote-session-backend.ts
@@ -27,6 +27,7 @@ import {
   type ListLinearIssuesRequest,
   type ListProjectsRequest,
   type ListGithubReposRequest,
+  type ListReplaysRequest,
   type ListRemoteBranchesRequest,
   type ListSessionsRequest,
   type ListWorkspacesRequest,
@@ -43,11 +44,17 @@ import {
   type ProjectDeletedResponse,
   type RemoteBranchListResponse,
   type ScriptOutputResponse,
+  type ReplayAnsiResponse,
+  type ReplayDismissedResponse,
+  type ReplayUndismissedResponse,
   type SessionCtrl,
   type StartProcessRequest,
   type StopProcessRequest,
   type UpdateNotificationConfigRequest,
   type WorkspaceCreatedResponse,
+  type GetReplayAnsiRequest,
+  type DismissReplayRequest,
+  type UndismissReplayRequest,
 } from '../../lib/remote-session/protocol.js';
 import type { BundleRefreshPlan, BundleRefreshSubmission } from '../../types/bundle-refresh.js';
 import type { BundleConfigState, BundleConfigSubmission } from '../../types/bundle-config.js';
@@ -202,6 +209,10 @@ export interface RemoteSessionBackendOptions<TSocket, THandshakeState, TServerHe
 const MACHINE_TO_CLIENT_TYPES = new Set<string>([
   'workspace_list',
   'session_list',
+  'replay_list',
+  'replay_ansi',
+  'replay_dismissed',
+  'replay_undismissed',
   'attached',
   'detached',
   'session_exited',
@@ -470,6 +481,30 @@ export class RemoteSessionBackend<TSocket, THandshakeState, TServerHello, TServe
     reject: (error: Error) => void;
     timeout: ReturnType<typeof setTimeout>;
   }>();
+  private pendingReplayAnsi:
+    | {
+        replayId: string;
+        resolve: (data: Uint8Array) => void;
+        reject: (error: Error) => void;
+        timeout: ReturnType<typeof setTimeout>;
+      }
+    | null = null;
+  private pendingDismissReplay:
+    | {
+        replayId: string;
+        resolve: () => void;
+        reject: (error: Error) => void;
+        timeout: ReturnType<typeof setTimeout>;
+      }
+    | null = null;
+  private pendingUndismissReplay:
+    | {
+        replayId: string;
+        resolve: () => void;
+        reject: (error: Error) => void;
+        timeout: ReturnType<typeof setTimeout>;
+      }
+    | null = null;
   private ptyOutputHandler: ((data: Uint8Array) => void) | null = null;
   private pendingPtyChunks: Uint8Array[] = [];
   private pendingUtf8Bytes = new Uint8Array(0);
@@ -670,6 +705,101 @@ export class RemoteSessionBackend<TSocket, THandshakeState, TServerHello, TServe
   async listSessions(workspaceId?: string): Promise<void> {
     const command: ListSessionsRequest = { type: 'list_sessions', workspaceId };
     await this.sendCommand(command);
+  }
+
+  async listReplays(workspaceId?: string, includeDismissed?: boolean): Promise<void> {
+    const command: ListReplaysRequest = {
+      type: 'list_replays',
+      workspaceId,
+      includeDismissed,
+    };
+    await this.sendCommand(command);
+  }
+
+  async getReplayAnsi(replayId: string, atMs?: number): Promise<Uint8Array> {
+    if (this.pendingReplayAnsi) {
+      throw new Error('Replay ANSI request already in progress');
+    }
+
+    const command: GetReplayAnsiRequest = { type: 'get_replay_ansi', replayId, atMs };
+    return new Promise<Uint8Array>((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        const pending = this.pendingReplayAnsi;
+        if (!pending || pending.replayId !== replayId) {
+          return;
+        }
+        this.pendingReplayAnsi = null;
+        pending.reject(new Error(`Timed out waiting for replay ANSI (${replayId})`));
+      }, DEFAULT_LIFECYCLE_TIMEOUT_MS);
+
+      this.pendingReplayAnsi = { replayId, resolve, reject, timeout };
+
+      void this.sendCommand(command).catch((error) => {
+        const pending = this.pendingReplayAnsi;
+        if (!pending) {
+          return;
+        }
+        clearTimeout(pending.timeout);
+        this.pendingReplayAnsi = null;
+        pending.reject(error instanceof Error ? error : new Error(String(error)));
+      });
+    });
+  }
+
+  async dismissReplay(replayId: string): Promise<void> {
+    if (this.pendingDismissReplay) {
+      throw new Error('Replay dismiss request already in progress');
+    }
+    const command: DismissReplayRequest = { type: 'dismiss_replay', replayId };
+    return new Promise<void>((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        const pending = this.pendingDismissReplay;
+        if (!pending || pending.replayId !== replayId) {
+          return;
+        }
+        this.pendingDismissReplay = null;
+        pending.reject(new Error(`Timed out dismissing replay (${replayId})`));
+      }, DEFAULT_LIFECYCLE_TIMEOUT_MS);
+
+      this.pendingDismissReplay = { replayId, resolve, reject, timeout };
+      void this.sendCommand(command).catch((error) => {
+        const pending = this.pendingDismissReplay;
+        if (!pending) {
+          return;
+        }
+        clearTimeout(pending.timeout);
+        this.pendingDismissReplay = null;
+        pending.reject(error instanceof Error ? error : new Error(String(error)));
+      });
+    });
+  }
+
+  async undismissReplay(replayId: string): Promise<void> {
+    if (this.pendingUndismissReplay) {
+      throw new Error('Replay restore request already in progress');
+    }
+    const command: UndismissReplayRequest = { type: 'undismiss_replay', replayId };
+    return new Promise<void>((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        const pending = this.pendingUndismissReplay;
+        if (!pending || pending.replayId !== replayId) {
+          return;
+        }
+        this.pendingUndismissReplay = null;
+        pending.reject(new Error(`Timed out restoring replay (${replayId})`));
+      }, DEFAULT_LIFECYCLE_TIMEOUT_MS);
+
+      this.pendingUndismissReplay = { replayId, resolve, reject, timeout };
+      void this.sendCommand(command).catch((error) => {
+        const pending = this.pendingUndismissReplay;
+        if (!pending) {
+          return;
+        }
+        clearTimeout(pending.timeout);
+        this.pendingUndismissReplay = null;
+        pending.reject(error instanceof Error ? error : new Error(String(error)));
+      });
+    });
   }
 
   async createProject(params: CreateProjectParams): Promise<void> {
@@ -1585,6 +1715,18 @@ export class RemoteSessionBackend<TSocket, THandshakeState, TServerHello, TServe
       case 'session_list':
         this.emit({ type: 'sessions', sessions: message.sessions });
         return;
+      case 'replay_list':
+        this.emit({ type: 'replays', replays: message.replays });
+        return;
+      case 'replay_ansi':
+        this.resolveReplayAnsi(message);
+        return;
+      case 'replay_dismissed':
+        this.resolveDismissReplay(message);
+        return;
+      case 'replay_undismissed':
+        this.resolveUndismissReplay(message);
+        return;
       case 'attached':
         this.mode = 'attached';
         this.attachedSessionId = message.sessionId;
@@ -1687,6 +1829,9 @@ export class RemoteSessionBackend<TSocket, THandshakeState, TServerHello, TServe
         this.rejectPendingCancelProject(message.message, message.projectName);
         this.rejectPendingWorkspaceCreate(message.message, message.workspaceId, message.projectName);
         this.rejectPendingProjectDelete(message.message, message.projectName);
+        this.rejectPendingReplayAnsi(message.message, undefined, true);
+        this.rejectPendingDismissReplay(message.message, undefined, true);
+        this.rejectPendingUndismissReplay(message.message, undefined, true);
         if (message.workspaceId) {
           this.rejectPendingWorkspaceDelete(message.code, message.message, message.workspaceId);
         }
@@ -1985,6 +2130,75 @@ export class RemoteSessionBackend<TSocket, THandshakeState, TServerHello, TServe
 
     clearTimeout(pending.timeout);
     this.pendingDeleteProject = null;
+    pending.reject(new Error(message));
+  }
+
+  private resolveReplayAnsi(message: ReplayAnsiResponse): void {
+    const pending = this.pendingReplayAnsi;
+    if (!pending || pending.replayId !== message.replayId) {
+      return;
+    }
+    clearTimeout(pending.timeout);
+    this.pendingReplayAnsi = null;
+    pending.resolve(this.crypto.decodeBase64(message.data));
+  }
+
+  private rejectPendingReplayAnsi(message: string, replayId?: string, force = false): void {
+    const pending = this.pendingReplayAnsi;
+    if (!pending) {
+      return;
+    }
+    if (!force && replayId && pending.replayId !== replayId) {
+      return;
+    }
+    clearTimeout(pending.timeout);
+    this.pendingReplayAnsi = null;
+    pending.reject(new Error(message));
+  }
+
+  private resolveDismissReplay(message: ReplayDismissedResponse): void {
+    const pending = this.pendingDismissReplay;
+    if (!pending || pending.replayId !== message.replayId) {
+      return;
+    }
+    clearTimeout(pending.timeout);
+    this.pendingDismissReplay = null;
+    pending.resolve();
+  }
+
+  private rejectPendingDismissReplay(message: string, replayId?: string, force = false): void {
+    const pending = this.pendingDismissReplay;
+    if (!pending) {
+      return;
+    }
+    if (!force && replayId && pending.replayId !== replayId) {
+      return;
+    }
+    clearTimeout(pending.timeout);
+    this.pendingDismissReplay = null;
+    pending.reject(new Error(message));
+  }
+
+  private resolveUndismissReplay(message: ReplayUndismissedResponse): void {
+    const pending = this.pendingUndismissReplay;
+    if (!pending || pending.replayId !== message.replayId) {
+      return;
+    }
+    clearTimeout(pending.timeout);
+    this.pendingUndismissReplay = null;
+    pending.resolve();
+  }
+
+  private rejectPendingUndismissReplay(message: string, replayId?: string, force = false): void {
+    const pending = this.pendingUndismissReplay;
+    if (!pending) {
+      return;
+    }
+    if (!force && replayId && pending.replayId !== replayId) {
+      return;
+    }
+    clearTimeout(pending.timeout);
+    this.pendingUndismissReplay = null;
     pending.reject(new Error(message));
   }
 
@@ -2317,6 +2531,9 @@ export class RemoteSessionBackend<TSocket, THandshakeState, TServerHello, TServe
     this.rejectPendingCancelProject('Remote session disconnected', undefined, true);
     this.rejectPendingWorkspaceCreate('Remote session disconnected', undefined, undefined, true);
     this.rejectPendingProjectDelete('Remote session disconnected', undefined, true);
+    this.rejectPendingReplayAnsi('Remote session disconnected', undefined, true);
+    this.rejectPendingDismissReplay('Remote session disconnected', undefined, true);
+    this.rejectPendingUndismissReplay('Remote session disconnected', undefined, true);
     this.rejectPendingWorkspaceDelete('DELETE_FAILED', 'Remote session disconnected', undefined, true);
     this.rejectAllPendingReviewRequests('Remote session disconnected');
     this.connectPromise = null;

--- a/src/session/events.ts
+++ b/src/session/events.ts
@@ -8,12 +8,14 @@ import type {
 import type { NotificationConfig } from '../notifications/types.js';
 import type { ReviewOperation, ReviewResult } from '../types/review.js';
 import type { WideEvent, SavedEventFilter } from '../types/events.js';
+import type { ReplayInfo } from '../lib/tmux-lite/replay/index.js';
 
 export type BackendEvent =
   | { type: 'status'; status: 'disconnected' | 'connecting' | 'connected' | 'error'; error?: string }
   | { type: 'projects'; projects: ProjectInfo[] }
   | { type: 'workspaces'; workspaces: WorkspaceInfo[]; savedEventFilters?: SavedEventFilter[] }
   | { type: 'sessions'; sessions: SessionInfo[] }
+  | { type: 'replays'; replays: ReplayInfo[] }
   | { type: 'inbox'; items: InboxItem[]; unreadCount: number }
   | {
       type: 'script_output';

--- a/src/session/reducer.ts
+++ b/src/session/reducer.ts
@@ -6,16 +6,17 @@ import type {
 } from './types.js';
 
 function createBackendState(descriptor: BackendDescriptor): BackendSessionState {
-  return {
-    descriptor,
-    status: 'disconnected',
-    error: null,
-    commandError: null,
-    projects: [],
-    workspaces: [],
-    sessions: [],
-    inbox: [],
-    inboxUnreadCount: 0,
+    return {
+      descriptor,
+      status: 'disconnected',
+      error: null,
+      commandError: null,
+      projects: [],
+      workspaces: [],
+      sessions: [],
+      replays: [],
+      inbox: [],
+      inboxUnreadCount: 0,
     notificationConfig: null,
     mode: 'browsing',
     attachedSessionId: null,
@@ -165,6 +166,21 @@ export function sessionEngineReducer(
           [action.backendKey]: {
             ...backend,
             sessions: action.sessions,
+          },
+        },
+      };
+    }
+
+    case 'SET_REPLAYS': {
+      const backend = state.backends[action.backendKey];
+      if (!backend) return state;
+      return {
+        ...state,
+        backends: {
+          ...state.backends,
+          [action.backendKey]: {
+            ...backend,
+            replays: action.replays,
           },
         },
       };

--- a/src/session/types.ts
+++ b/src/session/types.ts
@@ -8,6 +8,7 @@ import type {
 import type { NotificationConfig } from '../notifications/types.js';
 import type { BackendDescriptor, BackendKey } from './backend.js';
 import type { WideEvent, SavedEventFilter } from '../types/events.js';
+import type { ReplayInfo } from '../lib/tmux-lite/replay/index.js';
 
 export interface ScriptRuntimeState {
   phase: ScriptOutputResponse['phase'];
@@ -25,6 +26,7 @@ export interface BackendSessionState {
   projects: ProjectInfo[];
   workspaces: WorkspaceInfo[];
   sessions: SessionInfo[];
+  replays: ReplayInfo[];
 
   inbox: InboxItem[];
   inboxUnreadCount: number;
@@ -61,6 +63,7 @@ export type SessionEngineAction =
   | { type: 'SET_PROJECTS'; backendKey: BackendKey; projects: ProjectInfo[] }
   | { type: 'SET_WORKSPACES'; backendKey: BackendKey; workspaces: WorkspaceInfo[] }
   | { type: 'SET_SESSIONS'; backendKey: BackendKey; sessions: SessionInfo[] }
+  | { type: 'SET_REPLAYS'; backendKey: BackendKey; replays: ReplayInfo[] }
   | {
       type: 'SET_INBOX';
       backendKey: BackendKey;

--- a/src/session/useRemoteSessionClient.ts
+++ b/src/session/useRemoteSessionClient.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type {
   InboxItem,
   ProjectInfo,
+  ReplayInfo,
   SessionInfo,
   WorkspaceInfo,
 } from '../lib/remote-session/protocol.js';
@@ -67,6 +68,7 @@ export interface UseRemoteSessionClientReturn<ConnectParams> {
   projects: ProjectInfo[];
   workspaces: WorkspaceInfo[];
   sessions: SessionInfo[];
+  replays: ReplayInfo[];
   attachedSessionId: string | null;
   attachedSessionName: string | null;
   selectedProjectName: string | null;
@@ -80,6 +82,7 @@ export interface UseRemoteSessionClientReturn<ConnectParams> {
   listLinearIssues: (projectName: string) => Promise<SessionLinearIssueSummary[]>;
   requestWorkspaces: () => void;
   requestSessions: (workspaceId?: string) => void;
+  requestReplays: (workspaceId?: string, includeDismissed?: boolean) => void;
   createProject: (params: CreateProjectParams) => Promise<void>;
   prepareProjectCreation: (params: CreateProjectParams) => Promise<PreparedProjectResult>;
   finalizeProjectCreation: (params: FinalizeProjectParams) => Promise<void>;
@@ -134,6 +137,9 @@ export interface UseRemoteSessionClientReturn<ConnectParams> {
   startProcess: (workspaceId: string, processName: string, instance?: number) => Promise<void>;
   stopProcess: (workspaceId: string, processName: string) => Promise<void>;
   requestEvents: (workspacePath: string, filter?: WideEventFilter, limit?: number, sinceMs?: number) => void;
+  getReplayAnsi: (replayId: string, atMs?: number) => Promise<Uint8Array>;
+  dismissReplay: (replayId: string) => Promise<void>;
+  undismissReplay: (replayId: string) => Promise<void>;
 }
 
 function defaultStatusMapper(
@@ -273,6 +279,10 @@ export function useRemoteSessionClient<ConnectParams>(
 
   const requestSessions = useCallback((workspaceId?: string) => {
     void withActiveBackend((backendKey) => engine.listSessions(backendKey, workspaceId));
+  }, [engine, withActiveBackend]);
+
+  const requestReplays = useCallback((workspaceId?: string, includeDismissed?: boolean) => {
+    void withActiveBackend((backendKey) => engine.listReplays(backendKey, workspaceId, includeDismissed));
   }, [engine, withActiveBackend]);
 
   const createProject = useCallback(async (params: CreateProjectParams): Promise<void> => {
@@ -525,6 +535,30 @@ export function useRemoteSessionClient<ConnectParams>(
     );
   }, [engine, withActiveBackend]);
 
+  const getReplayAnsi = useCallback(async (replayId: string, atMs?: number): Promise<Uint8Array> => {
+    const backendKey = activeBackendKeyRef.current;
+    if (!backendKey) {
+      throw createMissingBackendError(`getReplayAnsi(${replayId})`);
+    }
+    return engine.getReplayAnsi(backendKey, replayId, atMs);
+  }, [engine]);
+
+  const dismissReplay = useCallback(async (replayId: string): Promise<void> => {
+    const backendKey = activeBackendKeyRef.current;
+    if (!backendKey) {
+      throw createMissingBackendError(`dismissReplay(${replayId})`);
+    }
+    await engine.dismissReplay(backendKey, replayId);
+  }, [engine]);
+
+  const undismissReplay = useCallback(async (replayId: string): Promise<void> => {
+    const backendKey = activeBackendKeyRef.current;
+    if (!backendKey) {
+      throw createMissingBackendError(`undismissReplay(${replayId})`);
+    }
+    await engine.undismissReplay(backendKey, replayId);
+  }, [engine]);
+
   useEffect(() => {
     return () => {
       const backendKey = activeBackendKeyRef.current;
@@ -545,6 +579,7 @@ export function useRemoteSessionClient<ConnectParams>(
     projects: activeBackendState?.projects ?? [],
     workspaces: activeBackendState?.workspaces ?? [],
     sessions: activeBackendState?.sessions ?? [],
+    replays: activeBackendState?.replays ?? [],
     attachedSessionId: activeBackendState?.attachedSessionId ?? null,
     attachedSessionName: activeBackendState?.attachedSessionName ?? null,
     selectedProjectName,
@@ -558,6 +593,7 @@ export function useRemoteSessionClient<ConnectParams>(
     listLinearIssues,
     requestWorkspaces,
     requestSessions,
+    requestReplays,
     createProject,
     prepareProjectCreation,
     finalizeProjectCreation,
@@ -600,6 +636,9 @@ export function useRemoteSessionClient<ConnectParams>(
     startProcess,
     stopProcess,
     requestEvents,
+    getReplayAnsi,
+    dismissReplay,
+    undismissReplay,
   }), [
     status,
     activeBackendState,
@@ -612,6 +651,7 @@ export function useRemoteSessionClient<ConnectParams>(
     listLinearIssues,
     requestWorkspaces,
     requestSessions,
+    requestReplays,
     createProject,
     prepareProjectCreation,
     finalizeProjectCreation,
@@ -640,5 +680,8 @@ export function useRemoteSessionClient<ConnectParams>(
     startProcess,
     stopProcess,
     requestEvents,
+    getReplayAnsi,
+    dismissReplay,
+    undismissReplay,
   ]);
 }

--- a/src/session/useRemoteSessionClient.ts
+++ b/src/session/useRemoteSessionClient.ts
@@ -2,7 +2,9 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type {
   InboxItem,
   ProjectInfo,
+  ReplayFrameTarget,
   ReplayInfo,
+  ReplayTimeline,
   SessionInfo,
   WorkspaceInfo,
 } from '../lib/remote-session/protocol.js';
@@ -137,7 +139,8 @@ export interface UseRemoteSessionClientReturn<ConnectParams> {
   startProcess: (workspaceId: string, processName: string, instance?: number) => Promise<void>;
   stopProcess: (workspaceId: string, processName: string) => Promise<void>;
   requestEvents: (workspacePath: string, filter?: WideEventFilter, limit?: number, sinceMs?: number) => void;
-  getReplayAnsi: (replayId: string, atMs?: number) => Promise<Uint8Array>;
+  getReplayAnsi: (replayId: string, target?: ReplayFrameTarget) => Promise<Uint8Array>;
+  getReplayTimeline: (replayId: string) => Promise<ReplayTimeline>;
   dismissReplay: (replayId: string) => Promise<void>;
   undismissReplay: (replayId: string) => Promise<void>;
 }
@@ -535,12 +538,20 @@ export function useRemoteSessionClient<ConnectParams>(
     );
   }, [engine, withActiveBackend]);
 
-  const getReplayAnsi = useCallback(async (replayId: string, atMs?: number): Promise<Uint8Array> => {
+  const getReplayAnsi = useCallback(async (replayId: string, target?: ReplayFrameTarget): Promise<Uint8Array> => {
     const backendKey = activeBackendKeyRef.current;
     if (!backendKey) {
       throw createMissingBackendError(`getReplayAnsi(${replayId})`);
     }
-    return engine.getReplayAnsi(backendKey, replayId, atMs);
+    return engine.getReplayAnsi(backendKey, replayId, target);
+  }, [engine]);
+
+  const getReplayTimeline = useCallback(async (replayId: string): Promise<ReplayTimeline> => {
+    const backendKey = activeBackendKeyRef.current;
+    if (!backendKey) {
+      throw createMissingBackendError(`getReplayTimeline(${replayId})`);
+    }
+    return engine.getReplayTimeline(backendKey, replayId);
   }, [engine]);
 
   const dismissReplay = useCallback(async (replayId: string): Promise<void> => {
@@ -637,6 +648,7 @@ export function useRemoteSessionClient<ConnectParams>(
     stopProcess,
     requestEvents,
     getReplayAnsi,
+    getReplayTimeline,
     dismissReplay,
     undismissReplay,
   }), [
@@ -681,6 +693,7 @@ export function useRemoteSessionClient<ConnectParams>(
     stopProcess,
     requestEvents,
     getReplayAnsi,
+    getReplayTimeline,
     dismissReplay,
     undismissReplay,
   ]);

--- a/src/session/useSessionEngine.ts
+++ b/src/session/useSessionEngine.ts
@@ -623,19 +623,36 @@ export function useSessionEngine() {
   const getReplayAnsi = useCallback(async (
     backendKey: BackendKey,
     replayId: string,
-    atMs?: number,
+    target?: import('./backend.js').ReplayFrameTarget,
   ) => {
     let ansi: Uint8Array | null = null;
     await withBackend(backendKey, async (backend) => {
       if (!backend.getReplayAnsi) {
         throw new SpacesError('Replay ANSI rendering is not supported by this backend', 'SYSTEM_ERROR', 2);
       }
-      ansi = await backend.getReplayAnsi(replayId, atMs);
+      ansi = await backend.getReplayAnsi(replayId, target);
     });
     if (!ansi) {
       throw new SpacesError('Replay ANSI was not returned by backend', 'SYSTEM_ERROR', 2);
     }
     return ansi;
+  }, [withBackend]);
+
+  const getReplayTimeline = useCallback(async (
+    backendKey: BackendKey,
+    replayId: string,
+  ) => {
+    let timeline: import('./backend.js').ReplayTimeline | null = null;
+    await withBackend(backendKey, async (backend) => {
+      if (!backend.getReplayTimeline) {
+        throw new SpacesError('Replay timeline is not supported by this backend', 'SYSTEM_ERROR', 2);
+      }
+      timeline = await backend.getReplayTimeline(replayId);
+    });
+    if (!timeline) {
+      throw new SpacesError('Replay timeline was not returned by backend', 'SYSTEM_ERROR', 2);
+    }
+    return timeline;
   }, [withBackend]);
 
   const dismissReplay = useCallback(async (backendKey: BackendKey, replayId: string) => {
@@ -707,6 +724,7 @@ export function useSessionEngine() {
     getReplayText,
     getReplayMarkdown,
     getReplayAnsi,
+    getReplayTimeline,
     dismissReplay,
     undismissReplay,
   }), [
@@ -752,6 +770,7 @@ export function useSessionEngine() {
     getReplayText,
     getReplayMarkdown,
     getReplayAnsi,
+    getReplayTimeline,
     dismissReplay,
     undismissReplay,
   ]);

--- a/src/session/useSessionEngine.ts
+++ b/src/session/useSessionEngine.ts
@@ -78,6 +78,9 @@ export function useSessionEngine() {
         case 'sessions':
           dispatch({ type: 'SET_SESSIONS', backendKey, sessions: event.sessions });
           break;
+        case 'replays':
+          dispatch({ type: 'SET_REPLAYS', backendKey, replays: event.replays });
+          break;
         case 'inbox':
           dispatch({
             type: 'SET_INBOX',
@@ -272,6 +275,15 @@ export function useSessionEngine() {
 
   const listSessions = useCallback(async (backendKey: BackendKey, workspaceId?: string) => {
     await withBackend(backendKey, (backend) => backend.listSessions(workspaceId));
+  }, [withBackend]);
+
+  const listReplays = useCallback(async (backendKey: BackendKey, workspaceId?: string, includeDismissed?: boolean) => {
+    await withBackend(backendKey, async (backend) => {
+      if (!backend.listReplays) {
+        throw new SpacesError('Replay listing is not supported by this backend', 'SYSTEM_ERROR', 2);
+      }
+      await backend.listReplays(workspaceId, includeDismissed);
+    });
   }, [withBackend]);
 
   const createProject = useCallback(async (backendKey: BackendKey, params: CreateProjectParams) => {
@@ -538,6 +550,112 @@ export function useSessionEngine() {
     });
   }, [withBackend]);
 
+  const createCheckpoint = useCallback(async (backendKey: BackendKey, sessionId: string) => {
+    await withBackend(backendKey, async (backend) => {
+      if (!backend.createCheckpoint) {
+        throw new SpacesError('Checkpoint creation is not supported by this backend', 'SYSTEM_ERROR', 2);
+      }
+      await backend.createCheckpoint(sessionId);
+    });
+  }, [withBackend]);
+
+  const getReplaySnapshot = useCallback(async (
+    backendKey: BackendKey,
+    replayId: string,
+    atMs?: number,
+    scrollbackLines?: number,
+  ) => {
+    let snapshot = null;
+    await withBackend(backendKey, async (backend) => {
+      if (!backend.getReplaySnapshot) {
+        throw new SpacesError('Replay snapshots are not supported by this backend', 'SYSTEM_ERROR', 2);
+      }
+      snapshot = await backend.getReplaySnapshot(replayId, atMs, scrollbackLines);
+    });
+    if (!snapshot) {
+      throw new SpacesError('Replay snapshot was not returned by backend', 'SYSTEM_ERROR', 2);
+    }
+    return snapshot;
+  }, [withBackend]);
+
+  const getReplayText = useCallback(async (
+    backendKey: BackendKey,
+    replayId: string,
+    atMs?: number,
+    scrollbackLines?: number,
+    includeScrollback?: boolean,
+    trimTrailingBlankRows?: boolean,
+  ) => {
+    let text: string | null = null;
+    await withBackend(backendKey, async (backend) => {
+      if (!backend.getReplayText) {
+        throw new SpacesError('Replay text rendering is not supported by this backend', 'SYSTEM_ERROR', 2);
+      }
+      text = await backend.getReplayText(replayId, atMs, scrollbackLines, includeScrollback, trimTrailingBlankRows);
+    });
+    if (text === null) {
+      throw new SpacesError('Replay text was not returned by backend', 'SYSTEM_ERROR', 2);
+    }
+    return text;
+  }, [withBackend]);
+
+  const getReplayMarkdown = useCallback(async (
+    backendKey: BackendKey,
+    replayId: string,
+    atMs?: number,
+    scrollbackLines?: number,
+    includeScrollback?: boolean,
+    trimTrailingBlankRows?: boolean,
+  ) => {
+    let markdown: string | null = null;
+    await withBackend(backendKey, async (backend) => {
+      if (!backend.getReplayMarkdown) {
+        throw new SpacesError('Replay markdown rendering is not supported by this backend', 'SYSTEM_ERROR', 2);
+      }
+      markdown = await backend.getReplayMarkdown(replayId, atMs, scrollbackLines, includeScrollback, trimTrailingBlankRows);
+    });
+    if (markdown === null) {
+      throw new SpacesError('Replay markdown was not returned by backend', 'SYSTEM_ERROR', 2);
+    }
+    return markdown;
+  }, [withBackend]);
+
+  const getReplayAnsi = useCallback(async (
+    backendKey: BackendKey,
+    replayId: string,
+    atMs?: number,
+  ) => {
+    let ansi: Uint8Array | null = null;
+    await withBackend(backendKey, async (backend) => {
+      if (!backend.getReplayAnsi) {
+        throw new SpacesError('Replay ANSI rendering is not supported by this backend', 'SYSTEM_ERROR', 2);
+      }
+      ansi = await backend.getReplayAnsi(replayId, atMs);
+    });
+    if (!ansi) {
+      throw new SpacesError('Replay ANSI was not returned by backend', 'SYSTEM_ERROR', 2);
+    }
+    return ansi;
+  }, [withBackend]);
+
+  const dismissReplay = useCallback(async (backendKey: BackendKey, replayId: string) => {
+    await withBackend(backendKey, async (backend) => {
+      if (!backend.dismissReplay) {
+        throw new SpacesError('Replay dismissal is not supported by this backend', 'SYSTEM_ERROR', 2);
+      }
+      await backend.dismissReplay(replayId);
+    });
+  }, [withBackend]);
+
+  const undismissReplay = useCallback(async (backendKey: BackendKey, replayId: string) => {
+    await withBackend(backendKey, async (backend) => {
+      if (!backend.undismissReplay) {
+        throw new SpacesError('Replay restore is not supported by this backend', 'SYSTEM_ERROR', 2);
+      }
+      await backend.undismissReplay(replayId);
+    });
+  }, [withBackend]);
+
   return useMemo(() => ({
     state,
     activeBackendKey: getActiveBackendKey(state),
@@ -557,6 +675,7 @@ export function useSessionEngine() {
     listLinearIssues,
     listWorkspaces,
     listSessions,
+    listReplays,
     createProject,
     prepareProjectCreation,
     finalizeProjectCreation,
@@ -583,6 +702,13 @@ export function useSessionEngine() {
     startProcess,
     stopProcess,
     requestEvents,
+    createCheckpoint,
+    getReplaySnapshot,
+    getReplayText,
+    getReplayMarkdown,
+    getReplayAnsi,
+    dismissReplay,
+    undismissReplay,
   }), [
     state,
     registerBackend,
@@ -596,6 +722,7 @@ export function useSessionEngine() {
     listLinearIssues,
     listWorkspaces,
     listSessions,
+    listReplays,
     createProject,
     prepareProjectCreation,
     finalizeProjectCreation,
@@ -620,5 +747,12 @@ export function useSessionEngine() {
     startProcess,
     stopProcess,
     requestEvents,
+    createCheckpoint,
+    getReplaySnapshot,
+    getReplayText,
+    getReplayMarkdown,
+    getReplayAnsi,
+    dismissReplay,
+    undismissReplay,
   ]);
 }

--- a/src/tui/local-terminal-sync.ts
+++ b/src/tui/local-terminal-sync.ts
@@ -1,4 +1,4 @@
-export type AppView = 'machines' | 'projects' | 'terminal' | 'inbox' | 'scripts' | 'events'
+export type AppView = 'machines' | 'projects' | 'terminal' | 'replay' | 'inbox' | 'scripts' | 'events'
 
 export type LocalSessionStatus = 'disconnected' | 'connecting' | 'connected' | 'error'
 export type LocalSessionMode = 'browsing' | 'attached'

--- a/src/types/errors.ts
+++ b/src/types/errors.ts
@@ -290,3 +290,10 @@ export class SessionNameExistsError extends Error {
     }
   }
 }
+
+export class ReplayScreenshotError extends SpacesError {
+  constructor(message: string) {
+    super(message, 'SYSTEM_ERROR', 2);
+    this.name = 'ReplayScreenshotError';
+  }
+}

--- a/web/ghostty-shot.html
+++ b/web/ghostty-shot.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Ghostty Screenshot Lab</title>
+    <script type="module" src="/src/ghostty-shot.ts"></script>
+  </head>
+  <body>
+    <div id="app"></div>
+  </body>
+</html>

--- a/web/src/ghostty-shot.ts
+++ b/web/src/ghostty-shot.ts
@@ -1,0 +1,320 @@
+import { init, Terminal as GhosttyTerminal } from 'ghostty-web';
+
+type Example = {
+  id: string;
+  title: string;
+  subtitle: string;
+  cols: number;
+  rows: number;
+  ansi: string;
+};
+
+const CSI = '\x1b[';
+const OSC = '\x1b]';
+const RESET = `${CSI}0m`;
+const CLEAR = `${CSI}2J${CSI}H`;
+
+function sgr(...codes: Array<number | string>): string {
+  return `${CSI}${codes.join(';')}m`;
+}
+
+function oscTitle(value: string): string {
+  return `${OSC}0;${value}\x07`;
+}
+
+function line(value = ''): string {
+  return `${value}\r\n`;
+}
+
+const examples: Example[] = [
+  {
+    id: 'palette',
+    title: 'ANSI Palette + Attributes',
+    subtitle: 'bold, underline, inverse, dim, bright colors',
+    cols: 84,
+    rows: 22,
+    ansi: [
+      oscTitle('Ghostty Screenshot Lab'),
+      CLEAR,
+      line(`${sgr(1, 38, 5, 81)}GitSpace replay screenshot lab${RESET}`),
+      line(`${sgr(2, 37)}Testing Ghostty-web fidelity for color-rich terminal captures.${RESET}`),
+      line(),
+      line(`${sgr(1)}Base palette${RESET}`),
+      line(`  ${sgr(30)}black${RESET}  ${sgr(31)}red${RESET}  ${sgr(32)}green${RESET}  ${sgr(33)}yellow${RESET}  ${sgr(34)}blue${RESET}  ${sgr(35)}magenta${RESET}  ${sgr(36)}cyan${RESET}  ${sgr(37)}white${RESET}`),
+      line(`  ${sgr(90)}bright black${RESET}  ${sgr(91)}bright red${RESET}  ${sgr(92)}bright green${RESET}  ${sgr(93)}bright yellow${RESET}`),
+      line(`  ${sgr(94)}bright blue${RESET}  ${sgr(95)}bright magenta${RESET}  ${sgr(96)}bright cyan${RESET}  ${sgr(97)}bright white${RESET}`),
+      line(),
+      line(`${sgr(1)}Attributes${RESET}`),
+      line(`  ${sgr(1, 38, 5, 120)}bold${RESET}  ${sgr(2, 38, 5, 246)}dim${RESET}  ${sgr(3, 38, 5, 215)}italic${RESET}  ${sgr(4, 38, 5, 75)}underline${RESET}  ${sgr(9, 38, 5, 203)}strike${RESET}`),
+      line(`  ${sgr(7, 38, 5, 232, 48, 5, 159)}inverse video${RESET}  ${sgr(38, 2, 255, 121, 198)}truecolor pink${RESET}  ${sgr(48, 2, 17, 85, 204, 38, 2, 255, 255, 255)}rgb bg${RESET}`),
+      line(),
+      line(`${sgr(1)}Borders + selection-like blocks${RESET}`),
+      line(`  ${sgr(48, 5, 238)}        ${RESET}${sgr(48, 5, 31)}        ${RESET}${sgr(48, 5, 64)}        ${RESET}${sgr(48, 5, 130)}        ${RESET}${sgr(48, 5, 196)}        ${RESET}`),
+      line(`  ${sgr(38, 5, 244)}╭──────────────────────────────────────────────────────────────╮${RESET}`),
+      line(`  ${sgr(38, 5, 244)}│${RESET} ${sgr(38, 5, 195)}Need feedback on spacing, palette, and text weight.${RESET} ${sgr(38, 5, 244)}│${RESET}`),
+      line(`  ${sgr(38, 5, 244)}╰──────────────────────────────────────────────────────────────╯${RESET}`),
+      line(),
+      line(`${sgr(2, 37)}example=palette theme=gitspace-dark renderer=ghostty-web${RESET}`),
+      `${CSI}?25l`,
+    ].join(''),
+  },
+  {
+    id: 'git-diff',
+    title: 'Git Diff',
+    subtitle: 'mixed insertions, deletions, headers, comments, search hits',
+    cols: 100,
+    rows: 24,
+    ansi: [
+      oscTitle('git diff --color'),
+      CLEAR,
+      line(`${sgr(38, 5, 39)}diff --git a/src/lib/tmux-lite/replay/screenshot.ts b/src/lib/tmux-lite/replay/screenshot.ts${RESET}`),
+      line(`${sgr(38, 5, 244)}index 8f01ca1..f4a3d77 100644${RESET}`),
+      line(`${sgr(31)}--- a/src/lib/tmux-lite/replay/screenshot.ts${RESET}`),
+      line(`${sgr(32)}+++ b/src/lib/tmux-lite/replay/screenshot.ts${RESET}`),
+      line(`${sgr(38, 5, 81)}@@ -84,12 +84,28 @@ export function renderTerminalSnapshotSvg(...)${RESET}`),
+      line(` ${sgr(38, 5, 244)}const includeScrollback = options.includeScrollback ?? false;${RESET}`),
+      line(`${sgr(31)}-const textElements = lineText.map((line, index) => {${RESET}`),
+      line(`${sgr(31)}-  return \`<text x="${'${paddingX}'}" y="${'${y}'}">${'${content}'}</text>\`;${RESET}`),
+      line(`${sgr(31)}-}).join('');${RESET}`),
+      line(`${sgr(32)}+const styledRows = snapshot.screen.styledVisible.map((row, rowIndex) => {${RESET}`),
+      line(`${sgr(32)}+  return renderStyledRowSvg({${RESET}`),
+      line(`${sgr(32)}+    row,${RESET}`),
+      line(`${sgr(32)}+    y: headerHeight + paddingY + fontSize + rowIndex * cellHeight,${RESET}`),
+      line(`${sgr(32)}+    cellWidth,${RESET}`),
+      line(`${sgr(32)}+    cellHeight,${RESET}`),
+      line(`${sgr(32)}+  });${RESET}`),
+      line(`${sgr(32)}+}).join('');${RESET}`),
+      line(),
+      line(`${sgr(90)}// TODO(brad): compare this to actual Ghostty screenshots side-by-side${RESET}`),
+      line(`${sgr(33)}@@ reviewer${RESET} ${sgr(38, 5, 111)}This is the kind of screenshot fidelity pass we should ship next.${RESET}`),
+      line(),
+      line(`${sgr(2, 37)}Search: ${RESET}${sgr(30, 43)}renderStyledRowSvg${RESET} ${sgr(2, 37)}  7 matches  [1/7]${RESET}`),
+      `${CSI}?25l`,
+    ].join(''),
+  },
+  {
+    id: 'dashboard',
+    title: 'Build Dashboard',
+    subtitle: 'box drawing, progress bars, wrapped log chunks, warnings',
+    cols: 104,
+    rows: 26,
+    ansi: [
+      oscTitle('build dashboard'),
+      CLEAR,
+      line(`${sgr(1, 38, 5, 81)}GitSpace Build Dashboard${RESET} ${sgr(2, 37)}recorded-resumable-sessions${RESET}`),
+      line(`${sgr(38, 5, 244)}┌───────────────────────┬────────────┬──────────┬──────────────────────────────┐${RESET}`),
+      line(`${sgr(38, 5, 244)}│${RESET} ${sgr(1)}Stage${RESET}                 ${sgr(38, 5, 244)}│${RESET} ${sgr(1)}Status${RESET}     ${sgr(38, 5, 244)}│${RESET} ${sgr(1)}Duration${RESET} ${sgr(38, 5, 244)}│${RESET} ${sgr(1)}Notes${RESET}                        ${sgr(38, 5, 244)}│${RESET}`),
+      line(`${sgr(38, 5, 244)}├───────────────────────┼────────────┼──────────┼──────────────────────────────┤${RESET}`),
+      line(`${sgr(38, 5, 244)}│${RESET} typecheck             ${sgr(38, 5, 244)}│${RESET} ${sgr(32)}passed${RESET}     ${sgr(38, 5, 244)}│${RESET} 12.4s    ${sgr(38, 5, 244)}│${RESET} strict TS, zero errors          ${sgr(38, 5, 244)}│${RESET}`),
+      line(`${sgr(38, 5, 244)}│${RESET} replay screenshots     ${sgr(38, 5, 244)}│${RESET} ${sgr(33)}running${RESET}    ${sgr(38, 5, 244)}│${RESET} 04.1s    ${sgr(38, 5, 244)}│${RESET} capturing Ghostty review frames ${sgr(38, 5, 244)}│${RESET}`),
+      line(`${sgr(38, 5, 244)}│${RESET} remote parity          ${sgr(38, 5, 244)}│${RESET} ${sgr(90)}pending${RESET}    ${sgr(38, 5, 244)}│${RESET} --       ${sgr(38, 5, 244)}│${RESET} out of scope for this pass      ${sgr(38, 5, 244)}│${RESET}`),
+      line(`${sgr(38, 5, 244)}└───────────────────────┴────────────┴──────────┴──────────────────────────────┘${RESET}`),
+      line(),
+      line(` ${sgr(38, 5, 244)}replay render:${RESET} ${sgr(48, 5, 237, 38, 5, 255)} ##############      ${RESET} ${sgr(38, 5, 81)}68%${RESET}`),
+      line(` ${sgr(38, 5, 244)}png encode:   ${RESET} ${sgr(48, 5, 22, 38, 5, 255)} ##########          ${RESET} ${sgr(38, 5, 120)}49%${RESET}`),
+      line(),
+      line(`${sgr(1, 38, 5, 220)}WARN${RESET} ${sgr(38, 5, 252)}wrapped log output should still look good inside the screenshot frame even when the terminal width forces long explanatory sentences to continue across multiple visual rows.${RESET}`),
+      line(`${sgr(38, 5, 244)}[15:42:08]${RESET} ${sgr(38, 5, 110)}renderer${RESET} loaded font ${sgr(1)}JetBrains Mono${RESET} in 112ms`),
+      line(`${sgr(38, 5, 244)}[15:42:09]${RESET} ${sgr(38, 5, 110)}renderer${RESET} wrote ${sgr(38, 5, 81)}24${RESET} styled rows and ${sgr(38, 5, 81)}196${RESET} text spans`),
+      line(`${sgr(38, 5, 244)}[15:42:10]${RESET} ${sgr(38, 5, 110)}review${RESET} waiting on human feedback for contrast, padding, and cursor visibility`),
+      `${CSI}?25l`,
+    ].join(''),
+  },
+];
+
+function getExample(exampleId: string | null): Example {
+  return examples.find((example) => example.id === exampleId) ?? examples[0];
+}
+
+function injectBaseStyles(): void {
+  const style = document.createElement('style');
+  style.textContent = `
+    :root {
+      color-scheme: dark;
+      font-family: Inter, system-ui, sans-serif;
+      background: radial-gradient(circle at top, #1c2430 0%, #0b0f14 55%, #06080c 100%);
+      color: #e6edf3;
+    }
+
+    * { box-sizing: border-box; }
+
+    body {
+      margin: 0;
+      min-height: 100vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 24px;
+    }
+
+    #app {
+      width: max-content;
+      max-width: 100%;
+    }
+
+    .shot-shell {
+      display: flex;
+      flex-direction: column;
+      gap: 14px;
+      padding: 18px;
+      border: 1px solid rgba(255, 255, 255, 0.08);
+      border-radius: 24px;
+      background: linear-gradient(180deg, rgba(14, 20, 28, 0.92), rgba(9, 13, 18, 0.96));
+      box-shadow: 0 30px 90px rgba(0, 0, 0, 0.4);
+    }
+
+    .shot-label {
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+      padding: 0 4px;
+    }
+
+    .shot-title {
+      font-size: 16px;
+      font-weight: 650;
+      letter-spacing: 0.01em;
+    }
+
+    .shot-subtitle {
+      font-size: 12px;
+      color: #8b949e;
+    }
+
+    .terminal-frame {
+      width: max-content;
+      border-radius: 18px;
+      overflow: hidden;
+      border: 1px solid rgba(255, 255, 255, 0.08);
+      background: #0d1117;
+      box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
+    }
+
+    .terminal-chrome {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 12px 14px;
+      background: linear-gradient(180deg, #171d26, #121820);
+      border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+    }
+
+    .terminal-dots {
+      display: flex;
+      gap: 8px;
+    }
+
+    .terminal-dot {
+      width: 10px;
+      height: 10px;
+      border-radius: 999px;
+    }
+
+    .terminal-name {
+      font-size: 12px;
+      font-weight: 600;
+      color: #c9d1d9;
+    }
+
+    .terminal-meta {
+      font-size: 11px;
+      color: #7d8590;
+    }
+
+    .terminal-body {
+      padding: 12px;
+      background: #0d1117;
+    }
+
+    .terminal-host {
+      width: max-content;
+    }
+
+    .terminal-host canvas {
+      display: block;
+      border-radius: 10px;
+      background: #0d1117;
+    }
+  `;
+  document.head.appendChild(style);
+}
+
+async function main(): Promise<void> {
+  injectBaseStyles();
+  const params = new URLSearchParams(window.location.search);
+  const example = getExample(params.get('example'));
+
+  const app = document.getElementById('app');
+  if (!app) {
+    throw new Error('Missing app root');
+  }
+
+  app.innerHTML = `
+    <div class="shot-shell">
+      <div class="shot-label">
+        <div class="shot-title">${example.title}</div>
+        <div class="shot-subtitle">${example.subtitle}</div>
+      </div>
+      <div class="terminal-frame">
+        <div class="terminal-chrome">
+          <div class="terminal-dots">
+            <span class="terminal-dot" style="background:#ff5f57"></span>
+            <span class="terminal-dot" style="background:#febc2e"></span>
+            <span class="terminal-dot" style="background:#28c840"></span>
+          </div>
+          <div class="terminal-name">${example.id}</div>
+          <div class="terminal-meta">${example.cols}x${example.rows}</div>
+        </div>
+        <div class="terminal-body">
+          <div class="terminal-host" id="terminal-host"></div>
+        </div>
+      </div>
+    </div>
+  `;
+
+  await init();
+
+  const host = document.getElementById('terminal-host');
+  if (!host) {
+    throw new Error('Missing terminal host');
+  }
+
+  const terminal = new GhosttyTerminal({
+    fontSize: 14,
+    fontFamily: "'JetBrains Mono', 'SF Mono', Monaco, monospace",
+    cursorStyle: 'block',
+    cursorBlink: false,
+    theme: {
+      background: '#0d1117',
+      foreground: '#e6edf3',
+      cursor: '#58a6ff',
+      cursorAccent: '#0d1117',
+      selectionBackground: '#264f78',
+      selectionForeground: '#f0f6fc',
+      black: '#484f58',
+      red: '#ff7b72',
+      green: '#3fb950',
+      yellow: '#d29922',
+      blue: '#58a6ff',
+      magenta: '#bc8cff',
+      cyan: '#39c5cf',
+      white: '#b1bac4',
+      brightBlack: '#6e7681',
+      brightRed: '#ffa198',
+      brightGreen: '#56d364',
+      brightYellow: '#e3b341',
+      brightBlue: '#79c0ff',
+      brightMagenta: '#d2a8ff',
+      brightCyan: '#56d4dd',
+      brightWhite: '#f0f6fc',
+    },
+  });
+
+  terminal.open(host);
+  terminal.resize(example.cols, example.rows);
+  terminal.write(example.ansi, () => {
+    document.body.setAttribute('data-shot-ready', example.id);
+  });
+}
+
+void main();


### PR DESCRIPTION
## Summary
- add durable tmux-lite replay capture, checkpoints, reconstruction, screenshot export, and offline replay store/service APIs that survive daemon crashes
- surface replay history across CLI, TUI, and web with workspace history sections, orphaned replay grouping, dismiss/restore flows, and Ghostty-based replay rendering in TUI/web
- extend local and remote session backends/protocols for replay browsing and add integration coverage for replay lifecycle, offline access, backend routing, and UI grouping

## Validation
- bun run typecheck
- bun test "src/lib/tmux-lite/replay.store.test.ts" "src/lib/tmux-lite/replay.screenshot.test.ts" "src/lib/tmux-lite/replay.integration.test.ts" "src/components/__tests__/SpacesBrowser.test.ts" "src/components/__tests__/SpacesBrowser.tui.test.tsx"
- bun test "src/lib/tmux-lite/replay.integration.test.ts" "src/session/__tests__/local-session-backend.test.ts" "src/session/__tests__/remote-session-backend.test.ts" "src/session/__tests__/useRemoteSessionClient.test.ts" "src/components/__tests__/SpacesBrowser.test.ts"
- bun run build

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Broad feature addition spanning UI, CLI, tmux-lite protocol, remote session messaging, and filesystem-backed replay storage; regressions could impact session browsing and remote permission enforcement for replay access/dismissal.
> 
> **Overview**
> Adds **durable tmux-lite replay artifacts** (timeline/snapshot/text/markdown/ANSI, screenshots, dismiss/restore/delete, prune/usage) backed by an on-disk replay store that remains usable *offline* after daemon shutdown/crash.
> 
> Surfaces replay history in both **TUI and web** by extending `SpacesBrowser` with replay sections (including orphaned history), a new replay viewer (`ReplayTerminal`/`ReplayTerminalWeb`) with playback controls, and a `h` toggle to show/hide dismissed replays.
> 
> Extends **CLI + remote/local backends**: new `gssh machine tmux replay ...` subcommands, new tmux-lite protocol commands for listing/reading replays and creating checkpoints, remote-session protocol/handler support with access filtering, and workspace/project deletion now also cleans up associated replay artifacts.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8ba0da905bd570bd684e6da1839d4a897882ab75. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full replay system: record, store, browse, view, checkpoint, export text/markdown, and capture screenshots (PNG).
* **Workspace / UI**
  * History sections in workspace browser (including orphaned history), toggle-hidden for dismissed replays, navigation and contextual actions, and in-app replay viewer with keyboard shortcuts.
* **CLI**
  * Commands to list, show text, screenshot, dismiss/undismiss, and delete replays.
* **Tests**
  * Extensive unit & integration tests covering replay lifecycle and tooling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->