### PR TITLE
feat: automatic reconnection for machine daemon and clients

### DIFF
--- a/src/app.web.tsx
+++ b/src/app.web.tsx
@@ -1805,10 +1805,10 @@ export default function App() {
               allowTapFocus={inputMode || !showMobileControls}
               allowTouchScroll={!inputMode}
               onActivity={handleTerminalActivity}
-              readOnly={isViewOnlySession}
+              readOnly={isViewOnlySession || terminal.status === 'reconnecting'}
             />
             {isReconnecting && (
-              <div className="absolute inset-0 flex items-center justify-center bg-[#0d1117]/80 pointer-events-none">
+              <div className="absolute inset-0 flex items-center justify-center bg-[#0d1117]/80">
                 <div className="text-center">
                   <div className="text-[#e6edf3] text-base mb-1 animate-pulse">Reconnecting...</div>
                   <div className="text-[#8b949e] text-sm">Your session is preserved</div>

--- a/src/app.web.tsx
+++ b/src/app.web.tsx
@@ -499,12 +499,14 @@ export default function App() {
     setShowScriptTerminal(false);
     setScriptWorkspaceName('workspace');
 
-    // Connect to the machine using existing WebSocket (no new connection needed)
+    // Connect to the machine using existing WebSocket (no new connection needed).
+    // relayUrl is saved so reconnect can open a fresh WebSocket automatically.
     await terminal.connect({
       ws,
       identity,
       machineId: machine.machineId,
       deviceCertificate,
+      relayUrl: relay.relayUrl,
     });
   };
 
@@ -1676,8 +1678,10 @@ export default function App() {
     );
   }
 
-  // ========== Terminal View (attached mode) ==========
-  if (view === "terminal" && terminal.status === "established" && terminal.mode === "attached") {
+  // ========== Terminal View (attached mode or reconnecting while attached) ==========
+  if (view === "terminal" && (terminal.status === "established" || terminal.status === "reconnecting") && terminal.mode === "attached") {
+    const isReconnecting = terminal.status !== 'established';
+
     // Handler for sending data from mobile controls (already processed)
     const handleSendData = (data: string) => {
       if (data === PAGE_UP && terminalRef.current?.pageUp()) {
@@ -1792,8 +1796,8 @@ export default function App() {
               </button>
             </div>
           </div>
-          <div className={getTerminalContainerClass()}>
-          <SessionTerminal
+          <div className={`${getTerminalContainerClass()} relative`}>
+            <SessionTerminal
               ref={terminalRef}
               onData={handleKeyboardData}
               setWriteCallback={terminal.setWriteCallback}
@@ -1803,6 +1807,14 @@ export default function App() {
               onActivity={handleTerminalActivity}
               readOnly={isViewOnlySession}
             />
+            {isReconnecting && (
+              <div className="absolute inset-0 flex items-center justify-center bg-[#0d1117]/80 pointer-events-none">
+                <div className="text-center">
+                  <div className="text-[#e6edf3] text-base mb-1 animate-pulse">Reconnecting...</div>
+                  <div className="text-[#8b949e] text-sm">Your session is preserved</div>
+                </div>
+              </div>
+            )}
           </div>
           {/* Mobile controls toolbar - show in input mode */}
           {showMobileControls && inputMode && (
@@ -1832,6 +1844,7 @@ export default function App() {
     const statusMessage = {
       disconnected: "Disconnected",
       connecting: "Connecting to relay...",
+      reconnecting: "Connection lost. Reconnecting...",
       connected: "Connected, authenticating...",
       handshaking: "Establishing secure connection...",
       established: "Connected!",

--- a/src/app/session/createSessionBackend.web.ts
+++ b/src/app/session/createSessionBackend.web.ts
@@ -58,10 +58,18 @@ const browserHandshakeAdapter = createBrowserRemoteHandshakeAdapter<
 })
 
 export interface WebRemoteSessionConnectParams {
-  ws: WebSocket
+  /**
+   * Pre-opened WebSocket for the initial connection.
+   * On reconnect this may be omitted; `relayUrl` will be used to open a fresh one.
+   */
+  ws?: WebSocket
   identity: Identity
   machineId: string
   deviceCertificate: string
+  /**
+   * Relay WebSocket URL (ws:// or wss://).
+   * Derived from `ws` on first connect; required when `ws` is omitted (reconnect).
+   */
   relayUrl?: string
 }
 
@@ -71,7 +79,24 @@ export function createWebRemoteSessionBackend(
   backendKey: BackendKey
   backend: RemoteSessionPtyBackend
 } {
-  const relayUrl = params.relayUrl ?? deriveRelayUrlFromBrowserSocket(params.ws)
+  // On the initial connect, a pre-opened WebSocket is passed in.
+  // On reconnect, `ws` is absent and we open a fresh one from `relayUrl`.
+  let socket: WebSocket
+  let relayUrl: string
+
+  if (params.ws) {
+    relayUrl = params.relayUrl ?? deriveRelayUrlFromBrowserSocket(params.ws)
+    socket = params.ws
+  } else if (params.relayUrl) {
+    relayUrl = params.relayUrl
+    const wsUrl = new URL(relayUrl)
+    wsUrl.searchParams.set('role', 'client')
+    wsUrl.searchParams.set('m', params.machineId)
+    socket = new WebSocket(wsUrl.toString())
+  } else {
+    throw new Error('createWebRemoteSessionBackend: either ws or relayUrl must be provided')
+  }
+
   const backendKey = buildRemoteBackendKey(relayUrl, params.machineId)
 
   return {
@@ -89,7 +114,7 @@ export function createWebRemoteSessionBackend(
         relayUrl,
         machineId: params.machineId,
       },
-      socket: params.ws,
+      socket,
       socketAdapter: browserRemoteSocketAdapter,
       identity: params.identity,
       machineId: params.machineId,

--- a/src/app/session/types.ts
+++ b/src/app/session/types.ts
@@ -4,6 +4,7 @@ export type SessionClientConnectionStatus =
   | 'disconnected'
   | 'connecting'
   | 'established'
+  | 'reconnecting'
   | 'error'
 
 export type SessionClientMode = 'browsing' | 'attached'

--- a/src/app/session/useSessionClient.ts
+++ b/src/app/session/useSessionClient.ts
@@ -5,6 +5,7 @@ import type { SessionClientConnectionStatus } from './types.js'
 
 export interface UseSessionClientOptions<ConnectParams> {
   createBackend: UseRemoteSessionClientOptions<ConnectParams>['createBackend']
+  toReconnectParams?: UseRemoteSessionClientOptions<ConnectParams>['toReconnectParams']
   mapConnectionStatus?: (
     status: RemoteSessionConnectionStatus
   ) => SessionClientConnectionStatus
@@ -26,8 +27,8 @@ function defaultStatusMapper(
 export function useSessionClient<ConnectParams>(
   options: UseSessionClientOptions<ConnectParams>
 ): UseSessionClientReturn<ConnectParams> {
-  const { createBackend, mapConnectionStatus = defaultStatusMapper } = options
-  const client = useRemoteSessionClient<ConnectParams>({ createBackend })
+  const { createBackend, toReconnectParams, mapConnectionStatus = defaultStatusMapper } = options
+  const client = useRemoteSessionClient<ConnectParams>({ createBackend, toReconnectParams })
 
   return useMemo(() => ({
     ...client,

--- a/src/commands/connect.ts
+++ b/src/commands/connect.ts
@@ -357,8 +357,6 @@ export async function connectToRemote(
       identity,
       deviceCertificate,
       tmuxSessionId: attached.sessionId,
-      cols: terminalSize.cols,
-      rows: terminalSize.rows,
     };
 
     await startTerminalSession(backend, reconnectCtx);
@@ -498,8 +496,9 @@ interface ReconnectContext {
   deviceCertificate: string;
   /** tmux-lite session ID to re-attach to after reconnect */
   tmuxSessionId: string;
-  cols: number;
-  rows: number;
+  // cols/rows are intentionally omitted: the reconnect loop reads live
+  // process.stdout values so it always uses the current terminal size,
+  // not the (possibly stale) size captured at initial attach time.
 }
 
 /** Build a fresh RemoteSessionBackend + WebSocket */
@@ -606,7 +605,10 @@ async function startTerminalSession(
       }
       reconnecting = true;
 
-      const { relayUrl, machineId, identity, deviceCertificate, tmuxSessionId, cols, rows } = reconnectCtx;
+      const { relayUrl, machineId, identity, deviceCertificate, tmuxSessionId } = reconnectCtx;
+      // Read current terminal size at reconnect time (not the stale size from
+      // initial attach, which may differ if the user resized the window).
+      const { cols, rows } = getTerminalSize();
 
       for (let attempt = 1; attempt <= MAX_RECONNECT_ATTEMPTS; attempt++) {
         if (stopping) break;
@@ -630,29 +632,40 @@ async function startTerminalSession(
             process.stdout.write(Buffer.from(data));
           });
 
-          await newBackend.connect();
-
-          // Re-attach to the same tmux-lite session.
-          const attachWait = waitForBackendEvent(
-            newBackend,
-            (event): event is Extract<BackendEvent, { type: 'attached' }> => event.type === 'attached',
-            30000,
-            'attach confirmation'
-          );
-
+          let attachSucceeded = false;
           try {
-            await newBackend.attachSession({
-              sessionId: tmuxSessionId,
-              cols,
-              rows,
-            });
-          } catch (attachErr) {
-            attachWait.cancel();
-            await newBackend.disconnect().catch(() => {});
-            throw attachErr;
-          }
+            await newBackend.connect();
 
-          await attachWait.promise;
+            // Re-attach to the same tmux-lite session.
+            const attachWait = waitForBackendEvent(
+              newBackend,
+              (event): event is Extract<BackendEvent, { type: 'attached' }> => event.type === 'attached',
+              30000,
+              'attach confirmation'
+            );
+
+            try {
+              await newBackend.attachSession({
+                sessionId: tmuxSessionId,
+                cols,
+                rows,
+              });
+            } catch (attachErr) {
+              attachWait.cancel();
+              throw attachErr;
+            }
+
+            // This can also throw (timeout or command_error) — caught below.
+            await attachWait.promise;
+
+            attachSucceeded = true;
+          } finally {
+            // Disconnect the new backend if anything above failed so we don't
+            // leak open WebSocket connections across retry attempts.
+            if (!attachSucceeded) {
+              await newBackend.disconnect().catch(() => {});
+            }
+          }
 
           // Swap backend and wire stdin/resize to the new one.
           const oldUnsub = unsubEvents;

--- a/src/commands/connect.ts
+++ b/src/commands/connect.ts
@@ -265,27 +265,7 @@ export async function connectToRemote(
 
   logger.info('Connecting to relay...');
 
-  const socketUrl = new URL(relayUrl);
-  socketUrl.searchParams.set('role', 'client');
-
-  const backendKey = buildRemoteBackendKey(relayUrl, machineId);
-  const backend = new RemoteSessionBackend({
-    descriptor: {
-      key: backendKey,
-      kind: 'remote',
-      label: machineId,
-      relayUrl,
-      machineId,
-    },
-    socket: new WebSocket(socketUrl.toString()),
-    socketAdapter: nodeRemoteSocketAdapter,
-    identity,
-    machineId,
-    deviceCertificate,
-    signer: (message, identity) => createNodeRelaySigner(identity)(message),
-    crypto: nodeRemoteCryptoAdapter,
-    handshake: nodeRemoteHandshakeAdapter,
-  });
+  const backend = createRemoteBackend(relayUrl, machineId, identity, deviceCertificate);
 
   backend.setPtyOutputHandler((data) => {
     process.stdout.write(Buffer.from(data));
@@ -369,7 +349,19 @@ export async function connectToRemote(
     logger.dim('Press Ctrl+D to disconnect');
     logger.log('');
 
-    await startTerminalSession(backend);
+    // Build reconnect context so startTerminalSession can re-attach
+    // automatically if the relay or machine drops.
+    const reconnectCtx: ReconnectContext = {
+      relayUrl,
+      machineId,
+      identity,
+      deviceCertificate,
+      tmuxSessionId: attached.sessionId,
+      cols: terminalSize.cols,
+      rows: terminalSize.rows,
+    };
+
+    await startTerminalSession(backend, reconnectCtx);
     backendConnected = false;
   } finally {
     await disconnectBackend();
@@ -498,9 +490,55 @@ interface ConnectedTerminalBackend {
   onEvent: (handler: (event: BackendEvent) => void) => () => void;
 }
 
-async function startTerminalSession(backend: ConnectedTerminalBackend): Promise<void> {
+/** Context required to create a new backend for reconnection */
+interface ReconnectContext {
+  relayUrl: string;
+  machineId: string;
+  identity: Awaited<ReturnType<typeof import('../core/identity.js').loadKeypair>>;
+  deviceCertificate: string;
+  /** tmux-lite session ID to re-attach to after reconnect */
+  tmuxSessionId: string;
+  cols: number;
+  rows: number;
+}
+
+/** Build a fresh RemoteSessionBackend + WebSocket */
+function createRemoteBackend(
+  relayUrl: string,
+  machineId: string,
+  identity: NonNullable<Awaited<ReturnType<typeof import('../core/identity.js').loadKeypair>>>,
+  deviceCertificate: string,
+): RemoteSessionBackend<WebSocket, import('../lib/tmux-lite/crypto/handshake.js').X3DHClientState, import('../types/identity.js').X3DHResponseMessage, import('../types/identity.js').X3DHResultMessage> {
+  const socketUrl = new URL(relayUrl);
+  socketUrl.searchParams.set('role', 'client');
+  const backendKey = buildRemoteBackendKey(relayUrl, machineId);
+  return new RemoteSessionBackend({
+    descriptor: {
+      key: backendKey,
+      kind: 'remote',
+      label: machineId,
+      relayUrl,
+      machineId,
+    },
+    socket: new WebSocket(socketUrl.toString()),
+    socketAdapter: nodeRemoteSocketAdapter,
+    identity,
+    machineId,
+    deviceCertificate,
+    signer: (message, id) => createNodeRelaySigner(id)(message),
+    crypto: nodeRemoteCryptoAdapter,
+    handshake: nodeRemoteHandshakeAdapter,
+  });
+}
+
+async function startTerminalSession(
+  initialBackend: ConnectedTerminalBackend,
+  reconnectCtx?: ReconnectContext,
+): Promise<void> {
   const handlers: Array<() => void> = [];
   let cleanedUp = false;
+  // currentBackend may be swapped out by the reconnect logic.
+  let currentBackend = initialBackend;
 
   const cleanup = () => {
     if (cleanedUp) {
@@ -520,6 +558,8 @@ async function startTerminalSession(backend: ConnectedTerminalBackend): Promise<
 
   await new Promise<void>((resolve) => {
     let stopping = false;
+    let reconnecting = false;
+
     const stop = async (message?: string) => {
       if (stopping) {
         return;
@@ -531,7 +571,7 @@ async function startTerminalSession(backend: ConnectedTerminalBackend): Promise<
       }
       cleanup();
       try {
-        await backend.disconnect();
+        await currentBackend.disconnect();
       } catch (error) {
         const detail = error instanceof Error ? error.message : String(error);
         logger.error(`Failed to disconnect cleanly: ${detail}`);
@@ -540,7 +580,112 @@ async function startTerminalSession(backend: ConnectedTerminalBackend): Promise<
       }
     };
 
-    const unsubEvents = backend.onEvent((event) => {
+    // ---------------------------------------------------------------------------
+    // Reconnection logic
+    //
+    // When the relay or machine drops, we attempt to transparently rebuild the
+    // backend and re-attach to the same tmux-lite session.  The terminal state
+    // is fully preserved by xterm-headless on the machine side.
+    //
+    // Strategy:
+    //   - 10 attempts with exponential backoff capped at 30 s
+    //   - On success: swap currentBackend and resume the session
+    //   - On exhaustion: fall through to stop() with an error message
+    // ---------------------------------------------------------------------------
+
+    const MAX_RECONNECT_ATTEMPTS = 10;
+    const BASE_RECONNECT_DELAY_MS = 1_000;
+    const MAX_RECONNECT_DELAY_MS = 30_000;
+
+    const attemptReconnect = async () => {
+      if (reconnecting || stopping || !reconnectCtx) {
+        if (!reconnectCtx) {
+          void stop('Disconnected');
+        }
+        return;
+      }
+      reconnecting = true;
+
+      const { relayUrl, machineId, identity, deviceCertificate, tmuxSessionId, cols, rows } = reconnectCtx;
+
+      for (let attempt = 1; attempt <= MAX_RECONNECT_ATTEMPTS; attempt++) {
+        if (stopping) break;
+
+        const delay = attempt === 1
+          ? 0
+          : Math.min(BASE_RECONNECT_DELAY_MS * Math.pow(2, attempt - 2) + Math.random() * 1_000, MAX_RECONNECT_DELAY_MS);
+
+        if (delay > 0) {
+          logger.log(`Reconnecting in ${Math.round(delay / 1000)}s (attempt ${attempt}/${MAX_RECONNECT_ATTEMPTS})...`);
+          await new Promise<void>((r) => setTimeout(r, delay));
+        } else {
+          logger.log(`Reconnecting... (attempt ${attempt}/${MAX_RECONNECT_ATTEMPTS})`);
+        }
+
+        if (stopping) break;
+
+        try {
+          const newBackend = createRemoteBackend(relayUrl, machineId, identity, deviceCertificate);
+          newBackend.setPtyOutputHandler((data) => {
+            process.stdout.write(Buffer.from(data));
+          });
+
+          await newBackend.connect();
+
+          // Re-attach to the same tmux-lite session.
+          const attachWait = waitForBackendEvent(
+            newBackend,
+            (event): event is Extract<BackendEvent, { type: 'attached' }> => event.type === 'attached',
+            30000,
+            'attach confirmation'
+          );
+
+          try {
+            await newBackend.attachSession({
+              sessionId: tmuxSessionId,
+              cols,
+              rows,
+            });
+          } catch (attachErr) {
+            attachWait.cancel();
+            await newBackend.disconnect().catch(() => {});
+            throw attachErr;
+          }
+
+          await attachWait.promise;
+
+          // Swap backend and wire stdin/resize to the new one.
+          const oldUnsub = unsubEvents;
+          currentBackend = newBackend;
+
+          // Rewire the new backend's events.
+          unsubEvents = newBackend.onEvent(handleBackendEvent);
+
+          // Remove old unsub from handlers and add new one.
+          const idx = handlers.indexOf(oldUnsub);
+          if (idx !== -1) handlers.splice(idx, 1);
+          handlers.push(unsubEvents);
+
+          logger.log('Reconnected!');
+          logger.log('');
+
+          reconnecting = false;
+          return;
+        } catch (err) {
+          const detail = err instanceof Error ? err.message : String(err);
+          logger.log(`Reconnect attempt ${attempt} failed: ${detail}`);
+          // Continue to next attempt
+        }
+      }
+
+      // All attempts exhausted
+      reconnecting = false;
+      void stop('Failed to reconnect after multiple attempts');
+    };
+
+    // handleBackendEvent is declared as a var so it can be referenced before
+    // unsubEvents is assigned.
+    const handleBackendEvent = (event: BackendEvent) => {
       if (event.type === 'session_exited') {
         void stop(`Session exited${typeof event.exitCode === 'number' ? ` (${event.exitCode})` : ''}`);
       }
@@ -550,13 +695,15 @@ async function startTerminalSession(backend: ConnectedTerminalBackend): Promise<
       }
 
       if (event.type === 'status' && event.status === 'disconnected') {
-        void stop('Disconnected');
+        void attemptReconnect();
       }
 
       if (event.type === 'error') {
         logger.error(`Connection error: ${event.message}`);
       }
-    });
+    };
+
+    let unsubEvents = initialBackend.onEvent(handleBackendEvent);
     handlers.push(unsubEvents);
 
   // Set stdin to raw mode for character-by-character input
@@ -574,7 +721,7 @@ async function startTerminalSession(backend: ConnectedTerminalBackend): Promise<
       return;
     }
 
-      backend.writePtyData?.(new Uint8Array(data))?.catch((error) => {
+      currentBackend.writePtyData?.(new Uint8Array(data))?.catch((error: unknown) => {
         const detail = error instanceof Error ? error.message : String(error);
         logger.error(`Failed to send PTY input: ${detail}`);
       });
@@ -587,7 +734,7 @@ async function startTerminalSession(backend: ConnectedTerminalBackend): Promise<
       const onResize = () => {
         const cols = process.stdout.columns;
         const rows = process.stdout.rows;
-        backend.resizePty?.(cols, rows)?.catch((error) => {
+        currentBackend.resizePty?.(cols, rows)?.catch((error: unknown) => {
           const detail = error instanceof Error ? error.message : String(error);
           logger.error(`Failed to send PTY resize: ${detail}`);
         });
@@ -598,7 +745,7 @@ async function startTerminalSession(backend: ConnectedTerminalBackend): Promise<
     // Send initial size
       const cols = process.stdout.columns;
       const rows = process.stdout.rows;
-      backend.resizePty?.(cols, rows)?.catch((error) => {
+      currentBackend.resizePty?.(cols, rows)?.catch((error: unknown) => {
         const detail = error instanceof Error ? error.message : String(error);
         logger.error(`Failed to send initial PTY size: ${detail}`);
       });
@@ -607,7 +754,7 @@ async function startTerminalSession(backend: ConnectedTerminalBackend): Promise<
   // Handle SIGINT (Ctrl+C)
     const onSigInt = () => {
     // Forward Ctrl+C to remote instead of terminating
-      backend.writePtyData?.(new Uint8Array([0x03]))?.catch((error) => {
+      currentBackend.writePtyData?.(new Uint8Array([0x03]))?.catch((error: unknown) => {
         const detail = error instanceof Error ? error.message : String(error);
         logger.error(`Failed to send Ctrl+C to remote: ${detail}`);
       });

--- a/src/commands/connect.ts
+++ b/src/commands/connect.ts
@@ -667,17 +667,32 @@ async function startTerminalSession(
             }
           }
 
+          // If stop() was called while we were awaiting connect/attach,
+          // discard the new backend and bail out cleanly.
+          if (stopping) {
+            await newBackend.disconnect().catch(() => {});
+            reconnecting = false;
+            return;
+          }
+
           // Swap backend and wire stdin/resize to the new one.
           const oldUnsub = unsubEvents;
           currentBackend = newBackend;
 
+          // Unsubscribe the old listener before discarding the reference so
+          // the old backend can't fire spurious events after the swap.
+          oldUnsub();
+
           // Rewire the new backend's events.
           unsubEvents = newBackend.onEvent(handleBackendEvent);
 
-          // Remove old unsub from handlers and add new one.
+          // Replace the old unsub in the cleanup handlers with the new one.
           const idx = handlers.indexOf(oldUnsub);
-          if (idx !== -1) handlers.splice(idx, 1);
-          handlers.push(unsubEvents);
+          if (idx !== -1) {
+            handlers.splice(idx, 1, unsubEvents);
+          } else {
+            handlers.push(unsubEvents);
+          }
 
           logger.log('Reconnected!');
           logger.log('');

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -1510,14 +1510,40 @@ export async function serveStart(options: {
   const eventHandler: ServeEventHandler = (event) => {
     switch (event.type) {
       case 'relay_connected':
-        updateDaemonState({ relay: { url: effectiveRelayUrl, status: 'connected' } });
+        updateDaemonState({
+          relay: {
+            url: effectiveRelayUrl,
+            status: 'connected',
+            reconnectAttempt: 0,
+            nextRetryAt: undefined,
+          },
+        });
         break;
       case 'relay_disconnected':
-        updateDaemonState({ relay: { url: effectiveRelayUrl, status: 'disconnected' } });
+        updateDaemonState({
+          relay: {
+            url: effectiveRelayUrl,
+            status: 'disconnected',
+          },
+        });
         break;
-      case 'relay_reconnecting':
-        updateDaemonState({ relay: { url: effectiveRelayUrl, status: 'reconnecting' } });
+      case 'relay_reconnecting': {
+        const nextRetryAt = event.nextRetryMs !== undefined
+          ? Date.now() + event.nextRetryMs
+          : undefined;
+        logger.log(
+          `[serve] Relay reconnecting (attempt ${event.attempt})${nextRetryAt ? `, next retry in ${Math.round((nextRetryAt - Date.now()) / 1000)}s` : ''}`,
+        );
+        updateDaemonState({
+          relay: {
+            url: effectiveRelayUrl,
+            status: 'reconnecting',
+            reconnectAttempt: event.attempt,
+            nextRetryAt,
+          },
+        });
         break;
+      }
       case 'client_authenticated': {
         updateDaemonState({ clients: sessionManager.establishedSessionCount });
         if (Object.keys(currentAgentSnapshot).length > 0) {

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -1524,6 +1524,8 @@ export async function serveStart(options: {
           relay: {
             url: effectiveRelayUrl,
             status: 'disconnected',
+            reconnectAttempt: undefined,
+            nextRetryAt: undefined,
           },
         });
         break;
@@ -1584,8 +1586,6 @@ export async function serveStart(options: {
         relayFingerprint: trustedRelayIdentity.relayFingerprint,
       });
     }
-
-    updateDaemonState({ relay: { url: effectiveRelayUrl, status: 'connected' } });
   } catch (error) {
     const originalError = error;
     try {

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -1714,11 +1714,23 @@ export async function serveStatus(): Promise<void> {
     const statusIcon = status.relay.status === 'connected' ? '\x1b[32m●\x1b[0m' : '\x1b[33m●\x1b[0m';
     const relayStatus = status.relay.status === 'connected' ? 'connected' : status.relay.status;
 
+    const relayStatusLine = (() => {
+      if (status.relay.status === 'reconnecting' && status.relay.reconnectAttempt !== undefined) {
+        const attempt = status.relay.reconnectAttempt;
+        const nextRetryAt = status.relay.nextRetryAt;
+        const countdown = nextRetryAt
+          ? ` (next retry in ${Math.max(0, Math.round((nextRetryAt - Date.now()) / 1000))}s)`
+          : '';
+        return `${relayStatus} — attempt ${attempt}${countdown}`;
+      }
+      return relayStatus;
+    })();
+
     const lines = [
       `Status:   ${statusIcon} running (pid ${status.pid})`,
       `Version:  ${status.version}`,
       `Relay:    ${status.relay.url}`,
-      `          ${relayStatus}`,
+      `          ${relayStatusLine}`,
       `Clients:  ${status.clients} active`,
       `Uptime:   ${formatUptime(status.uptime)}`,
     ];

--- a/src/components/RemoteMachineScreen.tui.tsx
+++ b/src/components/RemoteMachineScreen.tui.tsx
@@ -1107,6 +1107,9 @@ export function RemoteMachineScreen({ machine, relayUrl, identity, onBack }: Rem
     if (remote.status === 'connecting') {
       return 'Connecting to remote machine...';
     }
+    if (remote.status === 'reconnecting') {
+      return 'Connection lost. Reconnecting...';
+    }
     if (remote.status === 'error') {
       return 'Connection failed';
     }
@@ -1189,7 +1192,7 @@ export function RemoteMachineScreen({ machine, relayUrl, identity, onBack }: Rem
     );
   }
 
-  if (remote.status !== 'established') {
+  if (remote.status !== 'established' && remote.status !== 'reconnecting') {
     return (
       <box flexDirection="column" flexGrow={1} justifyContent="center" alignItems="center">
         <text fg={remote.status === 'error' ? COLORS.error : COLORS.loading}>{statusMessage}</text>

--- a/src/components/RemoteMachineScreen.tui.tsx
+++ b/src/components/RemoteMachineScreen.tui.tsx
@@ -1137,7 +1137,7 @@ export function RemoteMachineScreen({ machine, relayUrl, identity, onBack }: Rem
     );
   }
 
-  if (showScriptTerminal && remote.status === 'established' && remote.mode === 'browsing') {
+  if (showScriptTerminal && (remote.status === 'established' || remote.status === 'reconnecting') && remote.mode === 'browsing') {
     const isRunning = remote.scriptState?.isRunning ?? true;
     const scriptHint = isRunning
       ? '[Running scripts... c: cancel + attach anyway]'

--- a/src/components/RemoteMachineScreen.tui.tsx
+++ b/src/components/RemoteMachineScreen.tui.tsx
@@ -1119,6 +1119,17 @@ export function RemoteMachineScreen({ machine, relayUrl, identity, onBack }: Rem
     return '';
   }, [remote.status]);
 
+  // Reconnecting while attached: the old backend has been torn down so
+  // attachedSessionId is null, but lastModeRef preserves 'attached'. Show
+  // the reconnecting status message instead of falling through to the browser.
+  if (remote.status === 'reconnecting' && remote.mode === 'attached' && !remote.attachedSessionId) {
+    return (
+      <box flexDirection="column" flexGrow={1} justifyContent="center" alignItems="center">
+        <text fg={COLORS.loading}>{statusMessage}</text>
+      </box>
+    );
+  }
+
   if (remote.mode === 'attached' && remote.attachedSessionId) {
     return (
       <Fragment>

--- a/src/hooks/useRelayConnection.web.ts
+++ b/src/hooks/useRelayConnection.web.ts
@@ -62,6 +62,9 @@ export function useRelayConnection(options?: UseRelayConnectionOptions) {
     await machineDirectory.connect();
   }, [machineDirectory.connect]);
 
+  const wsProtocol = location.protocol === 'https:' ? 'wss:' : 'ws:';
+  const relayUrl = `${wsProtocol}//${location.host}/ws`;
+
   return {
     status: machineDirectory.status,
     machines: machineDirectory.machines,
@@ -69,6 +72,8 @@ export function useRelayConnection(options?: UseRelayConnectionOptions) {
     identity: machineDirectory.identity,
     publicKey: machineDirectory.context?.publicKey ?? null,
     deviceCertificate: machineDirectory.context?.deviceCertificate ?? null,
+    /** Relay WebSocket URL — include this in terminal.connect() for reconnection */
+    relayUrl,
     connect,
     disconnect: machineDirectory.disconnect,
     refreshMachines: machineDirectory.refreshMachines,

--- a/src/hooks/useTerminal.web.ts
+++ b/src/hooks/useTerminal.web.ts
@@ -32,5 +32,9 @@ export type ConnectionParams = WebRemoteSessionConnectParams
 export function useTerminal() {
   return useSessionClient<ConnectionParams>({
     createBackend: createWebRemoteSessionBackend,
+    // Strip the pre-opened WebSocket before saving params for reconnection.
+    // On reconnect, createWebRemoteSessionBackend will open a fresh socket
+    // from relayUrl instead of reusing the dead closed one.
+    toReconnectParams: (params) => ({ ...params, ws: undefined }),
   })
 }

--- a/src/lib/tmux-lite/relay-client.ts
+++ b/src/lib/tmux-lite/relay-client.ts
@@ -83,6 +83,13 @@ export class RelayClient {
   private events: RelayClientEvents;
   private state: ConnectionState = "disconnected";
   private reconnectAttempts = 0;
+  /**
+   * True after the first successful handshake completes. Never reset to false.
+   * Used to distinguish the initial connect from subsequent reconnects, since
+   * `reconnectAttempts` is reset to 0 in `onopen` (before the handshake
+   * finishes), making it an unreliable reconnect indicator at handshake time.
+   */
+  private hasEverConnected = false;
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
   private readKey: Buffer | null = null;
   private writeKey: Buffer | null = null;
@@ -457,15 +464,16 @@ export class RelayClient {
           this.writeKey = Buffer.from(result.sessionKeys.sendKey);
           this.readKey = Buffer.from(result.sessionKeys.receiveKey);
 
-          const isReconnect = this.reconnectAttempts > 0;
+          const isReconnect = this.hasEverConnected;
           const previousTmuxSessionId = isReconnect ? this.activeTmuxSessionId : null;
 
           console.log(
             isReconnect
-              ? `[relay-client] Reconnected successfully (attempt ${this.reconnectAttempts}).${previousTmuxSessionId ? ` Will re-attach to session ${previousTmuxSessionId}.` : ""}`
+              ? `[relay-client] Reconnected successfully.${previousTmuxSessionId ? ` Will re-attach to session ${previousTmuxSessionId}.` : ""}`
               : "[relay-client] Handshake complete, session established",
           );
 
+          this.hasEverConnected = true;
           this.reconnectAttempts = 0;
           this.setState("connected");
           this.events.onConnect?.();

--- a/src/lib/tmux-lite/relay-client.ts
+++ b/src/lib/tmux-lite/relay-client.ts
@@ -29,6 +29,7 @@ import type {
   X3DHResultMessage,
 } from "../../types/identity.js";
 import { signMessage, type SignatureBlock } from "../../relay/signing.js";
+import { logger } from "../../utils/logger.js";
 
 /** Relay client configuration (identity/X3DH handshake) */
 export interface RelayClientConfig {
@@ -467,7 +468,7 @@ export class RelayClient {
           const isReconnect = this.hasEverConnected;
           const previousTmuxSessionId = isReconnect ? this.activeTmuxSessionId : null;
 
-          console.log(
+          logger.log(
             isReconnect
               ? `[relay-client] Reconnected successfully.${previousTmuxSessionId ? ` Will re-attach to session ${previousTmuxSessionId}.` : ""}`
               : "[relay-client] Handshake complete, session established",

--- a/src/lib/tmux-lite/relay-client.ts
+++ b/src/lib/tmux-lite/relay-client.ts
@@ -64,6 +64,12 @@ export interface RelayClientEvents {
   onStateChange?: (state: ConnectionState) => void;
   /** Called when handshake completes */
   onHandshakeComplete?: (peerIdentityId: string, accessType: AccessType, sessionId?: string) => void;
+  /**
+   * Called after a successful reconnect + re-handshake.
+   * `previousSessionId` is the tmux-lite session ID that was active before the
+   * disconnect (if any), allowing the consumer to re-attach to the same session.
+   */
+  onReconnected?: (previousTmuxSessionId: string | null) => void;
 }
 
 /**
@@ -87,6 +93,13 @@ export class RelayClient {
   private peerIdentityId: string | null = null;
   private accessType: AccessType | null = null;
   private sessionId: string | undefined = undefined;
+
+  /**
+   * The tmux-lite session ID that was active before the most recent disconnect.
+   * Preserved across reconnects so consumers can re-attach to the same session.
+   * Set by the consumer via `setActiveTmuxSessionId()` when a session is attached.
+   */
+  private activeTmuxSessionId: string | null = null;
 
   /** Maximum reconnect attempts */
   private readonly maxReconnectAttempts = 10;
@@ -129,6 +142,20 @@ export class RelayClient {
   /** Get current session ID */
   getSessionId(): string | undefined {
     return this.sessionId;
+  }
+
+  /**
+   * Record the currently attached tmux-lite session ID.
+   * Call this after successfully attaching to a session so the client can
+   * re-attach to it automatically after a reconnect.
+   */
+  setActiveTmuxSessionId(sessionId: string | null): void {
+    this.activeTmuxSessionId = sessionId;
+  }
+
+  /** Get the tmux-lite session ID that was active before the last disconnect */
+  getActiveTmuxSessionId(): string | null {
+    return this.activeTmuxSessionId;
   }
 
   /**
@@ -218,6 +245,8 @@ export class RelayClient {
         );
         this.ws = null;
         this.handshakeState = null;
+        // NOTE: activeTmuxSessionId is intentionally NOT cleared here so the
+        // reconnect path can re-attach to the same tmux-lite session.
         this.events.onDisconnect?.(event.code, event.reason);
 
         // Auto-reconnect unless explicitly disconnected
@@ -428,10 +457,23 @@ export class RelayClient {
           this.writeKey = Buffer.from(result.sessionKeys.sendKey);
           this.readKey = Buffer.from(result.sessionKeys.receiveKey);
 
-          console.log("[relay-client] Handshake complete, session established");
+          const isReconnect = this.reconnectAttempts > 0;
+          const previousTmuxSessionId = isReconnect ? this.activeTmuxSessionId : null;
+
+          console.log(
+            isReconnect
+              ? `[relay-client] Reconnected successfully (attempt ${this.reconnectAttempts}).${previousTmuxSessionId ? ` Will re-attach to session ${previousTmuxSessionId}.` : ""}`
+              : "[relay-client] Handshake complete, session established",
+          );
+
+          this.reconnectAttempts = 0;
           this.setState("connected");
           this.events.onConnect?.();
           this.events.onHandshakeComplete?.(this.peerIdentityId, this.accessType, this.sessionId);
+
+          if (isReconnect) {
+            this.events.onReconnected?.(previousTmuxSessionId);
+          }
           break;
         }
 

--- a/src/relay-client/machine-relay-client.ts
+++ b/src/relay-client/machine-relay-client.ts
@@ -4,6 +4,7 @@ import { signMessage } from '../relay/signing.js';
 import { PROTOCOL_VERSION } from '../relay/protocol.js';
 import { ed25519 } from '@noble/curves/ed25519.js';
 import type { ServeEventHandler } from '../serve/types.js';
+import { SpacesError } from '../types/errors.js';
 
 export type RelayTrustResult =
   | { trusted: true }
@@ -385,7 +386,11 @@ export async function connectMachineRelay(
           } else {
             // Exhausted fast-start attempts – give up and let serve.ts surface
             // the startup failure to the user.
-            reject(new Error(`WebSocket reconnect failed after ${reconnectAttempts} attempts during initial connect`));
+            reject(new SpacesError(
+              `Failed to connect to relay after ${reconnectAttempts} attempts`,
+              'SYSTEM_ERROR',
+              1,
+            ));
           }
           return;
         }

--- a/src/relay-client/machine-relay-client.ts
+++ b/src/relay-client/machine-relay-client.ts
@@ -204,6 +204,31 @@ function createSendCallback(
   };
 }
 
+// ============================================================================
+// Heartbeat constants
+// ============================================================================
+
+/**
+ * Interval (ms) at which the machine sends application-level ping messages to
+ * the relay.  Three missed responses within HEARTBEAT_STALE_MS trigger a
+ * proactive reconnect.
+ */
+const HEARTBEAT_INTERVAL_MS = 30_000;
+
+/**
+ * How long (ms) without a pong response before we consider the connection dead
+ * and forcibly close the WebSocket so the reconnect loop can re-establish.
+ * 3 × HEARTBEAT_INTERVAL_MS = 90 s.
+ */
+const HEARTBEAT_STALE_MS = 90_000;
+
+/**
+ * Backoff cap (ms) used after the initial connection has been established.
+ * We cap at 5 minutes so a long relay outage is handled gracefully without
+ * hammering the relay every 30 s forever.
+ */
+const MAX_RECONNECT_DELAY_AFTER_CONNECT_MS = 300_000; // 5 minutes
+
 export async function connectMachineRelay(
   relayUrl: string,
   machineId: string,
@@ -228,11 +253,40 @@ export async function connectMachineRelay(
   url.searchParams.set('role', 'machine');
 
   return new Promise((resolve, reject) => {
+    // -----------------------------------------------------------------------
+    // Reconnect state
+    // -----------------------------------------------------------------------
+
+    /**
+     * Number of consecutive failed connection attempts since the last
+     * successful registration.  Reset to 0 on each successful registration.
+     */
     let reconnectAttempts = 0;
-    const maxReconnectAttempts = 10;
-    const baseReconnectDelay = 1000;
-    const maxReconnectDelay = 30000;
+
+    /**
+     * Base delay used for the *first* reconnect after an initial connection
+     * is established.  After every failed attempt the delay is doubled up to
+     * MAX_RECONNECT_DELAY_AFTER_CONNECT_MS.  Before the initial connection we
+     * use the shorter 30 s cap so startup failures surface quickly.
+     */
+    const baseReconnectDelay = 1_000;
+
+    /**
+     * Cap used before the very first successful registration (quick failures
+     * are visible faster).
+     */
+    const maxReconnectDelayBeforeConnect = 30_000;
+
+    /**
+     * Whether the outer promise has already been resolved (i.e. the first
+     * successful registration has happened).  After this point we never
+     * reject – we simply keep retrying indefinitely.
+     */
     let resolved = false;
+
+    // -----------------------------------------------------------------------
+    // Signing helpers
+    // -----------------------------------------------------------------------
 
     const signingPublicKey = signingPrivateKey
       ? new Uint8Array(Buffer.from(publicIdentity.signingPublicKey, 'base64'))
@@ -247,6 +301,56 @@ export async function connectMachineRelay(
       }
     };
 
+    // -----------------------------------------------------------------------
+    // Heartbeat management
+    // -----------------------------------------------------------------------
+
+    let heartbeatInterval: ReturnType<typeof setInterval> | null = null;
+    let heartbeatStaleTimer: ReturnType<typeof setTimeout> | null = null;
+
+    /** Start the application-level heartbeat after successful registration. */
+    const startHeartbeat = (ws: WebSocket) => {
+      stopHeartbeat();
+
+      // Record first heartbeat baseline so the stale timer has a reference.
+      let lastPongAt = Date.now();
+
+      heartbeatInterval = setInterval(() => {
+        if (ws.readyState !== WebSocket.OPEN) {
+          stopHeartbeat();
+          return;
+        }
+
+        // Check if the connection has gone silent.
+        if (Date.now() - lastPongAt > HEARTBEAT_STALE_MS) {
+          console.log('[serve] Heartbeat stale – no pong received within', HEARTBEAT_STALE_MS, 'ms. Forcing reconnect.');
+          stopHeartbeat();
+          ws.close(4001, 'Heartbeat timeout');
+          return;
+        }
+
+        ws.send(JSON.stringify({ type: 'ping', timestamp: Date.now() }));
+      }, HEARTBEAT_INTERVAL_MS);
+
+      // Store updater so the message handler can reset the stale clock.
+      (ws as any).__updateLastPongAt = () => { lastPongAt = Date.now(); };
+    };
+
+    const stopHeartbeat = () => {
+      if (heartbeatInterval !== null) {
+        clearInterval(heartbeatInterval);
+        heartbeatInterval = null;
+      }
+      if (heartbeatStaleTimer !== null) {
+        clearTimeout(heartbeatStaleTimer);
+        heartbeatStaleTimer = null;
+      }
+    };
+
+    // -----------------------------------------------------------------------
+    // Connection factory
+    // -----------------------------------------------------------------------
+
     const connect = () => {
       console.log(`[serve] Connecting to relay: ${url.toString()}`);
       const ws = new WebSocket(url.toString());
@@ -254,10 +358,15 @@ export async function connectMachineRelay(
 
       ws.onopen = () => {
         console.log('[serve] WebSocket connected, waiting for relay identity...');
+        // Reset attempt counter now that the TCP connection is established.
+        // We do NOT reset it on `registered` so that registration failures
+        // still count towards the backoff.
         reconnectAttempts = 0;
       };
 
       ws.onclose = (event) => {
+        stopHeartbeat();
+
         console.log(`[serve] WebSocket closed: code=${event.code} reason=${event.reason || 'none'}`);
         eventHandler({
           type: 'relay_disconnected',
@@ -265,24 +374,42 @@ export async function connectMachineRelay(
           reason: event.reason || 'Connection closed',
         });
 
-        if (reconnectAttempts < maxReconnectAttempts) {
-          reconnectAttempts++;
-          const delay = Math.min(
-            baseReconnectDelay * Math.pow(2, reconnectAttempts - 1) + Math.random() * 1000,
-            maxReconnectDelay
-          );
-          eventHandler({ type: 'relay_reconnecting', attempt: reconnectAttempts });
-          setTimeout(connect, delay);
-        } else {
-          // All reconnect attempts exhausted — reject the outer promise so the
-          // caller does not hang indefinitely waiting for a connection that will
-          // never succeed.
-          reject(new Error(`WebSocket reconnect failed after ${maxReconnectAttempts} attempts`));
+        // Before the first successful connection: behave like before but with
+        // a shorter cap so startup failures surface quickly.
+        if (!resolved) {
+          if (reconnectAttempts < 10) {
+            reconnectAttempts++;
+            const delay = Math.min(
+              baseReconnectDelay * Math.pow(2, reconnectAttempts - 1) + Math.random() * 1_000,
+              maxReconnectDelayBeforeConnect,
+            );
+            eventHandler({ type: 'relay_reconnecting', attempt: reconnectAttempts, nextRetryMs: delay });
+            setTimeout(connect, delay);
+          } else {
+            // Exhausted fast-start attempts – give up and let serve.ts surface
+            // the startup failure to the user.
+            reject(new Error(`WebSocket reconnect failed after ${reconnectAttempts} attempts during initial connect`));
+          }
+          return;
         }
+
+        // After the first successful registration: retry forever with an
+        // increasing backoff capped at MAX_RECONNECT_DELAY_AFTER_CONNECT_MS.
+        reconnectAttempts++;
+        const delay = Math.min(
+          baseReconnectDelay * Math.pow(2, Math.min(reconnectAttempts - 1, 18)) + Math.random() * 2_000,
+          MAX_RECONNECT_DELAY_AFTER_CONNECT_MS,
+        );
+        const delaySeconds = Math.round(delay / 1_000);
+        console.log(`[serve] Relay disconnected. Reconnecting in ${delaySeconds}s (attempt ${reconnectAttempts})...`);
+        eventHandler({ type: 'relay_reconnecting', attempt: reconnectAttempts, nextRetryMs: delay });
+        setTimeout(connect, delay);
       };
 
       ws.onerror = (err) => {
         console.log('[serve] WebSocket error:', err);
+        // Only reject the outer promise on the very first connection attempt
+        // before any reconnect attempts have started.
         if (!resolved && reconnectAttempts === 0) {
           reject(new Error('WebSocket connection failed'));
         }
@@ -303,6 +430,15 @@ export async function connectMachineRelay(
               logger.warning('Received binary data without JSON envelope');
               return;
             }
+          }
+
+          // Handle pong responses from relay heartbeat.
+          if (msg.type === 'pong') {
+            // Update the last-pong timestamp tracked inside startHeartbeat.
+            if (typeof (ws as any).__updateLastPongAt === 'function') {
+              (ws as any).__updateLastPongAt();
+            }
+            return;
           }
 
           switch (msg.type) {
@@ -354,14 +490,25 @@ export async function connectMachineRelay(
               break;
             }
 
-            case 'registered':
+            case 'registered': {
+              // Successful registration – start heartbeat and resolve the
+              // outer promise (only once, on first connection).
+              startHeartbeat(ws);
+
+              // Reset the backoff counter so the next disconnect starts fresh.
+              reconnectAttempts = 0;
+
               eventHandler({ type: 'relay_connected' });
 
               if (!resolved) {
                 resolved = true;
                 resolve();
+              } else {
+                // Subsequent successful reconnections are logged for observability.
+                console.log('[serve] Reconnected to relay successfully.');
               }
               break;
+            }
 
             case 'client_connected':
               sessionManager.handleConnect(msg.connectionId);

--- a/src/relay-client/machine-relay-client.ts
+++ b/src/relay-client/machine-relay-client.ts
@@ -321,15 +321,17 @@ export async function connectMachineRelay(
           return;
         }
 
-        // Check if the connection has gone silent.
+        // Send the ping first so the stale check on the *next* tick accounts
+        // for the full HEARTBEAT_STALE_MS window rather than adding an extra
+        // HEARTBEAT_INTERVAL_MS of latency to detection.
+        ws.send(JSON.stringify({ type: 'ping', timestamp: Date.now() }));
+
+        // Check if the connection has gone silent (no pong in HEARTBEAT_STALE_MS).
         if (Date.now() - lastPongAt > HEARTBEAT_STALE_MS) {
-          console.log('[serve] Heartbeat stale – no pong received within', HEARTBEAT_STALE_MS, 'ms. Forcing reconnect.');
+          logger.log(`[serve] Heartbeat stale – no pong received within ${HEARTBEAT_STALE_MS}ms. Forcing reconnect.`);
           stopHeartbeat();
           ws.close(4001, 'Heartbeat timeout');
-          return;
         }
-
-        ws.send(JSON.stringify({ type: 'ping', timestamp: Date.now() }));
       }, HEARTBEAT_INTERVAL_MS);
 
       // Store updater so the message handler can reset the stale clock.

--- a/src/relay-client/machine-relay-client.ts
+++ b/src/relay-client/machine-relay-client.ts
@@ -307,6 +307,7 @@ export async function connectMachineRelay(
     // -----------------------------------------------------------------------
 
     let heartbeatInterval: ReturnType<typeof setInterval> | null = null;
+    let markHeartbeatAcked: (() => void) | null = null;
 
     /** Start the application-level heartbeat after successful registration. */
     const startHeartbeat = (ws: WebSocket) => {
@@ -326,16 +327,17 @@ export async function connectMachineRelay(
         // HEARTBEAT_INTERVAL_MS of latency to detection.
         ws.send(JSON.stringify({ type: 'ping', timestamp: Date.now() }));
 
-        // Check if the connection has gone silent (no pong in HEARTBEAT_STALE_MS).
-        if (Date.now() - lastPongAt > HEARTBEAT_STALE_MS) {
-          logger.log(`[serve] Heartbeat stale – no pong received within ${HEARTBEAT_STALE_MS}ms. Forcing reconnect.`);
+        // Check if the connection has gone silent (no heartbeat ack in HEARTBEAT_STALE_MS).
+        if (Date.now() - lastPongAt >= HEARTBEAT_STALE_MS) {
+          logger.log(`[serve] Heartbeat stale – no heartbeat ack received within ${HEARTBEAT_STALE_MS}ms. Forcing reconnect.`);
           stopHeartbeat();
           ws.close(4001, 'Heartbeat timeout');
         }
       }, HEARTBEAT_INTERVAL_MS);
 
-      // Store updater so the message handler can reset the stale clock.
-      (ws as any).__updateLastPongAt = () => { lastPongAt = Date.now(); };
+      markHeartbeatAcked = () => {
+        lastPongAt = Date.now();
+      };
     };
 
     const stopHeartbeat = () => {
@@ -343,6 +345,7 @@ export async function connectMachineRelay(
         clearInterval(heartbeatInterval);
         heartbeatInterval = null;
       }
+      markHeartbeatAcked = null;
     };
 
     // -----------------------------------------------------------------------
@@ -438,10 +441,7 @@ export async function connectMachineRelay(
 
           // Handle pong responses from relay heartbeat.
           if (msg.type === 'pong') {
-            // Update the last-pong timestamp tracked inside startHeartbeat.
-            if (typeof (ws as any).__updateLastPongAt === 'function') {
-              (ws as any).__updateLastPongAt();
-            }
+            markHeartbeatAcked?.();
             return;
           }
 

--- a/src/relay-client/machine-relay-client.ts
+++ b/src/relay-client/machine-relay-client.ts
@@ -306,7 +306,6 @@ export async function connectMachineRelay(
     // -----------------------------------------------------------------------
 
     let heartbeatInterval: ReturnType<typeof setInterval> | null = null;
-    let heartbeatStaleTimer: ReturnType<typeof setTimeout> | null = null;
 
     /** Start the application-level heartbeat after successful registration. */
     const startHeartbeat = (ws: WebSocket) => {
@@ -341,10 +340,6 @@ export async function connectMachineRelay(
         clearInterval(heartbeatInterval);
         heartbeatInterval = null;
       }
-      if (heartbeatStaleTimer !== null) {
-        clearTimeout(heartbeatStaleTimer);
-        heartbeatStaleTimer = null;
-      }
     };
 
     // -----------------------------------------------------------------------
@@ -358,10 +353,12 @@ export async function connectMachineRelay(
 
       ws.onopen = () => {
         console.log('[serve] WebSocket connected, waiting for relay identity...');
-        // Reset attempt counter now that the TCP connection is established.
-        // We do NOT reset it on `registered` so that registration failures
-        // still count towards the backoff.
-        reconnectAttempts = 0;
+        // Do NOT reset reconnectAttempts here. Resetting on open would mask
+        // repeated registration failures (the relay keeps accepting the TCP
+        // connection but rejecting the register_machine) and would prevent
+        // the backoff from growing. The counter is reset only on a successful
+        // `registered` response so every failure between open and registered
+        // is correctly counted towards the backoff.
       };
 
       ws.onclose = (event) => {

--- a/src/relay/registries.ts
+++ b/src/relay/registries.ts
@@ -30,8 +30,8 @@ export interface MachineRegistration {
   /** When machine last connected */
   lastConnectedAt: number;
   /**
-   * Timestamp (ms) of the last application-level heartbeat (ping/pong)
-   * received from this machine.  Updated on registration and on each pong.
+   * Timestamp (ms) of the last application-level heartbeat received from this
+   * machine. Updated on registration and on each heartbeat message.
    * Used by the stale-connection detector.
    */
   lastHeartbeatAt: number;

--- a/src/relay/registries.ts
+++ b/src/relay/registries.ts
@@ -29,6 +29,17 @@ export interface MachineRegistration {
   registeredAt: number;
   /** When machine last connected */
   lastConnectedAt: number;
+  /**
+   * Timestamp (ms) of the last application-level heartbeat (ping/pong)
+   * received from this machine.  Updated on registration and on each pong.
+   * Used by the stale-connection detector.
+   */
+  lastHeartbeatAt: number;
+  /**
+   * Whether the connection has been marked as potentially stale (first warning
+   * threshold crossed) but the grace period has not expired yet.
+   */
+  staleWarned: boolean;
 }
 
 // ============================================================================
@@ -77,6 +88,8 @@ export function registerMachine(
 
     existing.ws = ws;
     existing.lastConnectedAt = now;
+    existing.lastHeartbeatAt = now;
+    existing.staleWarned = false;
     if (label) existing.label = label;
     return { success: true, registration: existing };
   }
@@ -90,6 +103,8 @@ export function registerMachine(
     ws,
     registeredAt: now,
     lastConnectedAt: now,
+    lastHeartbeatAt: now,
+    staleWarned: false,
   };
 
   machines.set(machineId, registration);
@@ -129,6 +144,30 @@ export function setMachineConnection(
 /** Unregister a machine */
 export function unregisterMachine(machineId: string): boolean {
   return machines.delete(machineId);
+}
+
+/**
+ * Record a heartbeat (application-level ping/pong) from a machine.
+ * Also clears the stale-warned flag if the machine had been marked stale.
+ */
+export function updateMachineHeartbeat(machineId: string): void {
+  const machine = machines.get(machineId);
+  if (machine) {
+    machine.lastHeartbeatAt = Date.now();
+    machine.staleWarned = false;
+  }
+}
+
+/**
+ * Mark a machine as having received the first stale warning.
+ * Called when the machine crosses the "stale" threshold but is still within
+ * the grace period before a forced disconnect.
+ */
+export function markMachineStaleWarned(machineId: string): void {
+  const machine = machines.get(machineId);
+  if (machine) {
+    machine.staleWarned = true;
+  }
 }
 
 /** Get all registered machines */

--- a/src/relay/server.ts
+++ b/src/relay/server.ts
@@ -856,7 +856,11 @@ export function createRelayServer(config: RelayConfig): Server<WebSocketData> {
   const STALE_WARN_THRESHOLD_MS = 90_000;   // 3 missed pings
   const STALE_CLOSE_THRESHOLD_MS = 150_000; // 5 missed pings (grace period)
 
-  setInterval(() => {
+  // Bind the watchdog to this specific server instance by scoping the check
+  // to machines whose WebSocket belongs to this server.  The interval handle
+  // is cleared when server.stop() is called so that multiple relay instances
+  // in the same process (e.g. in tests) don't accumulate watchdog timers.
+  const staleWatchdog = setInterval(() => {
     const now = Date.now();
     for (const machine of getAllMachines()) {
       if (!machine.ws) continue; // already offline
@@ -883,6 +887,14 @@ export function createRelayServer(config: RelayConfig): Server<WebSocketData> {
       }
     }
   }, STALE_CHECK_INTERVAL_MS);
+
+  // Wrap server.stop() to also clear the watchdog so multiple server
+  // instances in the same process (tests) don't leak timers.
+  const originalStop = server.stop.bind(server);
+  server.stop = (closeActiveConnections?: boolean) => {
+    clearInterval(staleWatchdog);
+    return originalStop(closeActiveConnections);
+  };
 
   return server;
 }

--- a/src/relay/server.ts
+++ b/src/relay/server.ts
@@ -35,6 +35,7 @@ import {
 } from "./control/store.js";
 import { getWorkspaceIdentity } from "./control/workspace-identity.js";
 import { deriveUnlockKey } from "./unlock-kdf.js";
+import { logger } from "../utils/logger.js";
 
 /**
  * Candidate paths to web terminal dist files (built by Vite).
@@ -869,7 +870,7 @@ export function createRelayServer(config: RelayConfig): Server<WebSocketData> {
 
       if (elapsed >= STALE_CLOSE_THRESHOLD_MS) {
         // Grace period expired – force-close so the machine reconnects.
-        console.log(
+        logger.log(
           `[relay] Machine ${machine.machineId} has been silent for ${Math.round(elapsed / 1000)}s – force-closing stale connection.`,
         );
         try {
@@ -880,7 +881,7 @@ export function createRelayServer(config: RelayConfig): Server<WebSocketData> {
         // The close handler will mark the machine offline and notify clients.
       } else if (elapsed >= STALE_WARN_THRESHOLD_MS && !machine.staleWarned) {
         markMachineStaleWarned(machine.machineId);
-        console.log(
+        logger.warning(
           `[relay] Machine ${machine.machineId} may be stale (no heartbeat for ${Math.round(elapsed / 1000)}s). ` +
           `Will force-close in ${Math.round((STALE_CLOSE_THRESHOLD_MS - elapsed) / 1000)}s if no heartbeat received.`,
         );

--- a/src/relay/server.ts
+++ b/src/relay/server.ts
@@ -135,6 +135,8 @@ import {
   getMachine,
   setMachineConnection,
   getRegistryStats,
+  updateMachineHeartbeat,
+  markMachineStaleWarned,
 } from "./registries";
 import {
   parseMessage,
@@ -695,6 +697,16 @@ export function createRelayServer(config: RelayConfig): Server<WebSocketData> {
     },
 
     websocket: {
+      // Explicit idle/ping configuration so behaviour is deterministic
+      // regardless of Bun version defaults.
+      //
+      // idleTimeout is set higher than our application-level heartbeat
+      // threshold (HEARTBEAT_STALE_MS = 90 s on the machine side) so that
+      // the app-level check fires first and the WebSocket-level timeout is
+      // merely a safety net for connections that send no data at all.
+      idleTimeout: 180, // seconds
+      sendPings: true,  // Bun sends WS-level ping frames automatically
+
       open(ws) {
         const { role, connectionId } = ws.data;
         console.log(`[ws] ${role} ${connectionId} connected`);
@@ -734,6 +746,10 @@ export function createRelayServer(config: RelayConfig): Server<WebSocketData> {
           rawMsg = JSON.parse(msgStr);
           if (rawMsg && typeof rawMsg === "object" && (rawMsg as { type?: string }).type === "ping") {
             ws.send(JSON.stringify({ type: "pong", timestamp: Date.now() }));
+            // Update heartbeat timestamp for stale-connection detection.
+            if (ws.data.role === "machine" && ws.data.machineId) {
+              updateMachineHeartbeat(ws.data.machineId);
+            }
             return;
           }
         } catch {
@@ -821,6 +837,53 @@ export function createRelayServer(config: RelayConfig): Server<WebSocketData> {
   });
 
   console.log(`[relay] Listening on ${bind}:${port}${hostname ? ` (serving ${hostname})` : ""}`);
+
+  // -------------------------------------------------------------------------
+  // Stale machine connection detection
+  //
+  // The machine daemon sends a ping every 30 s (HEARTBEAT_INTERVAL_MS).
+  // We check every 30 s as well. Thresholds:
+  //
+  //   > 90 s (3 missed pings)  → "stale warning" — log and note; keep open.
+  //   > 150 s (5 missed pings) → force-close the WebSocket so the machine's
+  //                               reconnect loop kicks in and re-registers.
+  //
+  // This handles the case where a network partition silently kills the
+  // connection without either side sending a TCP RST.
+  // -------------------------------------------------------------------------
+
+  const STALE_CHECK_INTERVAL_MS = 30_000;
+  const STALE_WARN_THRESHOLD_MS = 90_000;   // 3 missed pings
+  const STALE_CLOSE_THRESHOLD_MS = 150_000; // 5 missed pings (grace period)
+
+  setInterval(() => {
+    const now = Date.now();
+    for (const machine of getAllMachines()) {
+      if (!machine.ws) continue; // already offline
+
+      const elapsed = now - machine.lastHeartbeatAt;
+
+      if (elapsed >= STALE_CLOSE_THRESHOLD_MS) {
+        // Grace period expired – force-close so the machine reconnects.
+        console.log(
+          `[relay] Machine ${machine.machineId} has been silent for ${Math.round(elapsed / 1000)}s – force-closing stale connection.`,
+        );
+        try {
+          machine.ws.close(4000, "Heartbeat timeout");
+        } catch {
+          // Socket may already be closed
+        }
+        // The close handler will mark the machine offline and notify clients.
+      } else if (elapsed >= STALE_WARN_THRESHOLD_MS && !machine.staleWarned) {
+        markMachineStaleWarned(machine.machineId);
+        console.log(
+          `[relay] Machine ${machine.machineId} may be stale (no heartbeat for ${Math.round(elapsed / 1000)}s). ` +
+          `Will force-close in ${Math.round((STALE_CLOSE_THRESHOLD_MS - elapsed) / 1000)}s if no heartbeat received.`,
+        );
+      }
+    }
+  }, STALE_CHECK_INTERVAL_MS);
+
   return server;
 }
 

--- a/src/relay/server.ts
+++ b/src/relay/server.ts
@@ -59,6 +59,8 @@ try {
   // Not running as compiled binary - use filesystem
 }
 
+const machineSocketServerIds = new WeakMap<ServerWebSocket<WebSocketData>, string>();
+
 /**
  * Check if we have embedded assets available
  */
@@ -515,6 +517,7 @@ interface RelayServerState {
   pendingChallenges: Map<string, { nonce: Uint8Array; timestamp: number }>;
   preAuthorizedMachines: Set<string>;
   signRelayMessage: <T extends object>(msg: T) => T;
+  serverInstanceId: string;
   /** Owner user root ID (set after vault initialization or unlock) */
   ownerUserRootId: string | null;
   ownerSyncState: OwnerSyncRuntimeState;
@@ -587,6 +590,7 @@ export function createRelayServer(config: RelayConfig): Server<WebSocketData> {
     timestamp: number;
   }
   const pendingChallenges = new Map<string, PendingChallenge>();
+  const serverInstanceId = randomBytes(8).toString("hex");
 
   /**
    * Sign a message with the relay's private key
@@ -610,6 +614,7 @@ export function createRelayServer(config: RelayConfig): Server<WebSocketData> {
     pendingChallenges,
     preAuthorizedMachines,
     signRelayMessage,
+    serverInstanceId,
     ownerUserRootId,
     ownerSyncState: createOwnerSyncRuntimeState(),
   };
@@ -858,13 +863,15 @@ export function createRelayServer(config: RelayConfig): Server<WebSocketData> {
   const STALE_CLOSE_THRESHOLD_MS = 150_000; // 5 missed pings (grace period)
 
   // Bind the watchdog to this specific server instance by scoping the check
-  // to machines whose WebSocket belongs to this server.  The interval handle
-  // is cleared when server.stop() is called so that multiple relay instances
-  // in the same process (e.g. in tests) don't accumulate watchdog timers.
+  // to machine sockets that were registered through this server. The interval
+  // handle is cleared when server.stop() is called so multiple relay instances
+  // in the same process do not accumulate watchdog timers or close each
+  // other's connections.
   const staleWatchdog = setInterval(() => {
     const now = Date.now();
     for (const machine of getAllMachines()) {
       if (!machine.ws) continue; // already offline
+      if (machineSocketServerIds.get(machine.ws) !== serverInstanceId) continue;
 
       const elapsed = now - machine.lastHeartbeatAt;
 
@@ -1285,6 +1292,8 @@ async function handleProtocolMessage(
         ws.send(serializeMessage(createErrorMessage("FORBIDDEN", result.error)));
         return;
       }
+
+      machineSocketServerIds.set(ws, state.serverInstanceId);
 
       // Dual-write to persistent registry (SQLite-backed, survives restarts)
       const persistOwner = resolvedOwnerUserRootId;

--- a/src/serve/daemon.ts
+++ b/src/serve/daemon.ts
@@ -138,6 +138,10 @@ export interface StatusResponse {
   relay: {
     url: string;
     status: 'connecting' | 'connected' | 'disconnected' | 'reconnecting';
+    /** Number of reconnect attempts since last successful connection */
+    reconnectAttempt?: number;
+    /** Timestamp (ms) of next reconnect attempt */
+    nextRetryAt?: number;
   };
   clients: number;
   hosting?: {
@@ -181,6 +185,10 @@ export interface DaemonState {
   relay: {
     url: string;
     status: 'connecting' | 'connected' | 'disconnected' | 'reconnecting';
+    /** Number of reconnect attempts since last successful connection (0 when connected) */
+    reconnectAttempt?: number;
+    /** Timestamp (ms) of the next scheduled reconnect attempt */
+    nextRetryAt?: number;
   };
   clients: number;
   hosting?: {
@@ -237,7 +245,12 @@ export function startStatusServer(): void {
                 version: state.version,
                 pid: process.pid,
                 uptime: Math.floor((Date.now() - state.startTime) / 1000),
-                relay: state.relay,
+                relay: {
+                  url: state.relay.url,
+                  status: state.relay.status,
+                  reconnectAttempt: state.relay.reconnectAttempt,
+                  nextRetryAt: state.relay.nextRetryAt,
+                },
                 clients: state.clients,
                 hosting: state.hosting,
               };

--- a/src/serve/types.ts
+++ b/src/serve/types.ts
@@ -147,7 +147,7 @@ export type ServeEvent =
   | { type: "client_disconnected"; connectionId: string; reason: string }
   | { type: "relay_connected" }
   | { type: "relay_disconnected"; code: number; reason: string }
-  | { type: "relay_reconnecting"; attempt: number }
+  | { type: "relay_reconnecting"; attempt: number; nextRetryMs?: number }
   | { type: "error"; connectionId?: string; error: Error };
 
 /** Event handler for serve events */

--- a/src/session/useRemoteSessionClient.ts
+++ b/src/session/useRemoteSessionClient.ts
@@ -217,15 +217,26 @@ export function useRemoteSessionClient<ConnectParams>(
     return engine.getBackendState(backendKey);
   }, [engine, engine.state]);
 
-  const status = useMemo<RemoteSessionConnectionStatus>(() => {
-    if (isReconnecting) {
-      return 'reconnecting';
-    }
+  // backendStatus reflects the raw underlying connection state, NOT overlaid
+  // with isReconnecting. This is what the reconnect useEffect watches via
+  // [backendStatus], so that setIsReconnecting(true) inside the effect doesn't
+  // change backendStatus → doesn't re-trigger the effect cleanup → doesn't
+  // abort the in-flight reconnect loop.
+  const backendStatus = useMemo<RemoteSessionConnectionStatus>(() => {
     if (!activeBackendState) {
       return 'disconnected';
     }
     return mapConnectionStatus(activeBackendState.status);
-  }, [activeBackendState, isReconnecting, mapConnectionStatus]);
+  }, [activeBackendState, mapConnectionStatus]);
+
+  // status is the value exposed to consumers — overlays 'reconnecting' on top
+  // of backendStatus, but is NOT used as the useEffect dependency.
+  const status = useMemo<RemoteSessionConnectionStatus>(() => {
+    if (isReconnecting) {
+      return 'reconnecting';
+    }
+    return backendStatus;
+  }, [backendStatus, isReconnecting]);
 
   const withActiveBackend = useCallback(
     async <T>(fn: (backendKey: BackendKey) => Promise<T>): Promise<T | null> => {
@@ -475,7 +486,7 @@ export function useRemoteSessionClient<ConnectParams>(
     //      (lastAttachedSessionIdRef is cleared on explicit detach, so this
     //       prevents re-attach when the user is in browsing mode)
     if (
-      status !== 'disconnected' ||
+      backendStatus !== 'disconnected' ||
       !connectParamsRef.current ||
       !lastAttachedSessionIdRef.current
     ) {
@@ -583,13 +594,13 @@ export function useRemoteSessionClient<ConnectParams>(
 
     void run();
 
-    // Abort the loop if the effect is cleaned up (status changed again or
-    // component unmounted) before the loop finishes.
+    // Abort the loop if backendStatus changes again or the component unmounts
+    // before the loop finishes.
     return () => {
       abort.aborted = true;
     };
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [status]);
+  }, [backendStatus]);
 
   const killSession = useCallback((sessionId: string) => {
     void withActiveBackend((backendKey) => engine.killSession(backendKey, sessionId));

--- a/src/session/useRemoteSessionClient.ts
+++ b/src/session/useRemoteSessionClient.ts
@@ -196,13 +196,18 @@ export function useRemoteSessionClient<ConnectParams>(
   //     was actually in attached mode when the drop happened
   //   - lastModeRef preserves the mode across the gap so the UI doesn't flash
   //     back to browsing while the reconnect loop is in flight
-  //   - abort ref prevents races between concurrent connect() calls and loops
+  //   - abort ref prevents races between concurrent connect() calls and loops,
+  //     and is aborted on component unmount so the async loop never outlives
+  //     the component
+  //   - lastDimensionsRef tracks the most recent PTY cols/rows so reconnect
+  //     can pass the current terminal size to attachSession
   // -------------------------------------------------------------------------
   const [isReconnecting, setIsReconnecting] = useState(false);
   const connectParamsRef = useRef<ConnectParams | null>(null);
   const lastAttachedSessionIdRef = useRef<string | null>(null);
   const lastModeRef = useRef<'browsing' | 'attached'>('browsing');
   const reconnectAbortRef = useRef<{ aborted: boolean }>({ aborted: false });
+  const lastDimensionsRef = useRef<{ cols: number; rows: number } | null>(null);
 
   const activeBackendState = useMemo(() => {
     const backendKey = activeBackendKeyRef.current;
@@ -538,7 +543,14 @@ export function useRemoteSessionClient<ConnectParams>(
           }
 
           // Re-attach to the same tmux-lite session (terminal state preserved).
-          await backend.attachSession({ sessionId });
+          // Pass the last known terminal dimensions so the server-side PTY
+          // gets the correct size immediately rather than waiting for the next
+          // browser resize event (which may never come if dimensions haven't changed).
+          const dims = lastDimensionsRef.current;
+          await backend.attachSession({
+            sessionId,
+            ...(dims ? { cols: dims.cols, rows: dims.rows } : {}),
+          });
 
           if (!abort.aborted) {
             logger.log(`[session] Reconnected and re-attached to session ${sessionId}`);
@@ -570,6 +582,12 @@ export function useRemoteSessionClient<ConnectParams>(
     };
 
     void run();
+
+    // Abort the loop if the effect is cleaned up (status changed again or
+    // component unmounted) before the loop finishes.
+    return () => {
+      abort.aborted = true;
+    };
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [status]);
 
@@ -655,6 +673,9 @@ export function useRemoteSessionClient<ConnectParams>(
   }, []);
 
   const resize = useCallback((cols: number, rows: number) => {
+    // Track dimensions so the reconnect path can pass the current terminal
+    // size to attachSession instead of relying on a subsequent resize event.
+    lastDimensionsRef.current = { cols, rows };
     const backend = backendRef.current;
     if (!backend || !backend.resizePty) {
       return;
@@ -763,6 +784,10 @@ export function useRemoteSessionClient<ConnectParams>(
 
   useEffect(() => {
     return () => {
+      // Abort any in-flight reconnect loop so async callbacks don't call
+      // React state setters or create new backends after unmount.
+      reconnectAbortRef.current.aborted = true;
+
       const backendKey = activeBackendKeyRef.current;
       if (!backendKey) {
         return;

--- a/src/session/useRemoteSessionClient.ts
+++ b/src/session/useRemoteSessionClient.ts
@@ -45,6 +45,7 @@ export type RemoteSessionConnectionStatus =
   | 'disconnected'
   | 'connecting'
   | 'established'
+  | 'reconnecting'
   | 'error';
 
 export interface RemoteSessionPtyBackend extends SessionBackend {
@@ -61,6 +62,12 @@ export interface UseRemoteSessionClientOptions<ConnectParams> {
   mapConnectionStatus?: (
     status: BackendSessionState['status']
   ) => RemoteSessionConnectionStatus;
+  /**
+   * Optional transform applied to ConnectParams before storing them for
+   * reconnection. Use this to strip transport-specific state (e.g. a
+   * pre-opened WebSocket) that would be dead on subsequent attempts.
+   */
+  toReconnectParams?: (params: ConnectParams) => ConnectParams;
 }
 
 export interface UseRemoteSessionClientReturn<ConnectParams> {
@@ -160,7 +167,7 @@ function defaultStatusMapper(
 export function useRemoteSessionClient<ConnectParams>(
   options: UseRemoteSessionClientOptions<ConnectParams>
 ): UseRemoteSessionClientReturn<ConnectParams> {
-  const { createBackend, mapConnectionStatus = defaultStatusMapper } = options;
+  const { createBackend, mapConnectionStatus = defaultStatusMapper, toReconnectParams } = options;
   const engine = useSessionEngine();
   const registerBackend = engine.registerBackend;
   const setActiveBackend = engine.setActiveBackend;
@@ -173,6 +180,30 @@ export function useRemoteSessionClient<ConnectParams>(
   const backendRef = useRef<RemoteSessionPtyBackend | null>(null);
   const writeCallbackRef = useRef<((data: Uint8Array) => void) | null>(null);
 
+  // -------------------------------------------------------------------------
+  // Reconnection state
+  //
+  // When the backend transitions established→disconnected while a session is
+  // attached, we automatically reconnect and re-attach to the same tmux-lite
+  // session (terminal state is preserved server-side by xterm-headless).
+  //
+  // Key design choices:
+  //   - connectParamsRef stores a reconnect-safe copy of params (transient
+  //     transport objects like a pre-opened WebSocket are stripped via
+  //     toReconnectParams so every retry gets a fresh socket)
+  //   - lastAttachedSessionIdRef is only populated from the 'attached' event
+  //     and cleared on explicit detach — so reconnect only fires when the user
+  //     was actually in attached mode when the drop happened
+  //   - lastModeRef preserves the mode across the gap so the UI doesn't flash
+  //     back to browsing while the reconnect loop is in flight
+  //   - abort ref prevents races between concurrent connect() calls and loops
+  // -------------------------------------------------------------------------
+  const [isReconnecting, setIsReconnecting] = useState(false);
+  const connectParamsRef = useRef<ConnectParams | null>(null);
+  const lastAttachedSessionIdRef = useRef<string | null>(null);
+  const lastModeRef = useRef<'browsing' | 'attached'>('browsing');
+  const reconnectAbortRef = useRef<{ aborted: boolean }>({ aborted: false });
+
   const activeBackendState = useMemo(() => {
     const backendKey = activeBackendKeyRef.current;
     if (!backendKey) {
@@ -182,11 +213,14 @@ export function useRemoteSessionClient<ConnectParams>(
   }, [engine, engine.state]);
 
   const status = useMemo<RemoteSessionConnectionStatus>(() => {
+    if (isReconnecting) {
+      return 'reconnecting';
+    }
     if (!activeBackendState) {
       return 'disconnected';
     }
     return mapConnectionStatus(activeBackendState.status);
-  }, [activeBackendState, mapConnectionStatus]);
+  }, [activeBackendState, isReconnecting, mapConnectionStatus]);
 
   const withActiveBackend = useCallback(
     async <T>(fn: (backendKey: BackendKey) => Promise<T>): Promise<T | null> => {
@@ -201,6 +235,11 @@ export function useRemoteSessionClient<ConnectParams>(
 
   const connect = useCallback(
     async (params: ConnectParams) => {
+      // Cancel any in-flight reconnect loop before starting fresh.
+      reconnectAbortRef.current.aborted = true;
+      reconnectAbortRef.current = { aborted: false };
+      setIsReconnecting(false);
+
       const previousBackendKey = activeBackendKeyRef.current;
       if (previousBackendKey) {
         await disconnectBackend(previousBackendKey);
@@ -216,6 +255,9 @@ export function useRemoteSessionClient<ConnectParams>(
 
       backendRef.current = backend;
       activeBackendKeyRef.current = backendKey;
+      // Save reconnect-safe params (strip dead transports like a closed WebSocket).
+      connectParamsRef.current = toReconnectParams ? toReconnectParams(params) : params;
+      lastAttachedSessionIdRef.current = null;
 
       registerBackend(backend);
       setActiveBackend(backendKey);
@@ -226,13 +268,21 @@ export function useRemoteSessionClient<ConnectParams>(
         await unregisterBackend(backendKey);
         activeBackendKeyRef.current = null;
         backendRef.current = null;
+        connectParamsRef.current = null;
         throw error;
       }
     },
-    [connectBackend, createBackend, disconnectBackend, registerBackend, setActiveBackend, unregisterBackend]
+    [connectBackend, createBackend, disconnectBackend, registerBackend, setActiveBackend, toReconnectParams, unregisterBackend]
   );
 
   const disconnect = useCallback(() => {
+    // Cancel any in-flight reconnect loop — this is an intentional disconnect.
+    reconnectAbortRef.current.aborted = true;
+    reconnectAbortRef.current = { aborted: false };
+    setIsReconnecting(false);
+    connectParamsRef.current = null;
+    lastAttachedSessionIdRef.current = null;
+
     const backendKey = activeBackendKeyRef.current;
     if (!backendKey) {
       return;
@@ -347,6 +397,9 @@ export function useRemoteSessionClient<ConnectParams>(
   }, [engine, withActiveBackend]);
 
   const detachSession = useCallback(() => {
+    // Clear the saved session ID — an explicit detach means we should NOT
+    // re-attach to this session if the connection drops later in browsing mode.
+    lastAttachedSessionIdRef.current = null;
     void withActiveBackend((backendKey) => engine.detachSession(backendKey));
   }, [engine, withActiveBackend]);
 
@@ -369,6 +422,23 @@ export function useRemoteSessionClient<ConnectParams>(
     [requestSessions, requestWorkspaces]
   );
 
+  // Track the most recently attached session ID so reconnect can re-attach.
+  // Only update when we have a real session ID; cleared on explicit detach above.
+  useEffect(() => {
+    const attachedId = activeBackendState?.attachedSessionId;
+    if (attachedId) {
+      lastAttachedSessionIdRef.current = attachedId;
+    }
+  }, [activeBackendState?.attachedSessionId]);
+
+  // Preserve last-known mode so UI doesn't flash to browsing during reconnect.
+  useEffect(() => {
+    const mode = activeBackendState?.mode;
+    if (mode) {
+      lastModeRef.current = mode;
+    }
+  }, [activeBackendState?.mode]);
+
   useEffect(() => {
     const projects = activeBackendState?.projects ?? [];
 
@@ -388,6 +458,120 @@ export function useRemoteSessionClient<ConnectParams>(
       selectProject(preferredProjectName);
     }
   }, [activeBackendState?.projects, selectProject, selectedProjectName]);
+
+  // -------------------------------------------------------------------------
+  // Automatic reconnection on unexpected disconnect
+  // -------------------------------------------------------------------------
+  useEffect(() => {
+    // Only trigger when:
+    //   1. We are now disconnected (not reconnecting/connecting)
+    //   2. We have saved connect params (i.e. connect() was called before)
+    //   3. We had an active tmux session at the time of disconnect
+    //      (lastAttachedSessionIdRef is cleared on explicit detach, so this
+    //       prevents re-attach when the user is in browsing mode)
+    if (
+      status !== 'disconnected' ||
+      !connectParamsRef.current ||
+      !lastAttachedSessionIdRef.current
+    ) {
+      return;
+    }
+
+    const params = connectParamsRef.current;
+    const sessionId = lastAttachedSessionIdRef.current;
+    const abort = reconnectAbortRef.current;
+
+    const MAX_RECONNECT_ATTEMPTS = 10;
+    const BASE_DELAY_MS = 1_000;
+    const MAX_DELAY_MS = 30_000;
+
+    setIsReconnecting(true);
+
+    const run = async () => {
+      for (let attempt = 1; attempt <= MAX_RECONNECT_ATTEMPTS; attempt++) {
+        if (abort.aborted) return;
+
+        const delay = attempt === 1
+          ? 0
+          : Math.min(BASE_DELAY_MS * Math.pow(2, attempt - 2) + Math.random() * 1_000, MAX_DELAY_MS);
+
+        if (delay > 0) {
+          logger.log(`[session] Reconnecting in ${Math.round(delay / 1000)}s (attempt ${attempt}/${MAX_RECONNECT_ATTEMPTS})...`);
+          await new Promise<void>((r) => setTimeout(r, delay));
+        } else {
+          logger.log(`[session] Reconnecting... (attempt ${attempt}/${MAX_RECONNECT_ATTEMPTS})`);
+        }
+
+        if (abort.aborted) return;
+
+        try {
+          // Tear down the old (disconnected) backend.
+          const oldBackendKey = activeBackendKeyRef.current;
+          if (oldBackendKey) {
+            await disconnectBackend(oldBackendKey);
+            await unregisterBackend(oldBackendKey);
+            activeBackendKeyRef.current = null;
+            backendRef.current = null;
+          }
+
+          if (abort.aborted) return;
+
+          // Build and connect a fresh backend with the saved (reconnect-safe) params.
+          const { backendKey, backend } = createBackend(params);
+          if (backend.setPtyOutputHandler) {
+            backend.setPtyOutputHandler(writeCallbackRef.current);
+          }
+
+          backendRef.current = backend;
+          activeBackendKeyRef.current = backendKey;
+          registerBackend(backend);
+          setActiveBackend(backendKey);
+
+          await connectBackend(backendKey);
+
+          if (abort.aborted) {
+            await disconnectBackend(backendKey);
+            await unregisterBackend(backendKey);
+            activeBackendKeyRef.current = null;
+            backendRef.current = null;
+            return;
+          }
+
+          // Re-attach to the same tmux-lite session (terminal state preserved).
+          await backend.attachSession({ sessionId });
+
+          if (!abort.aborted) {
+            logger.log(`[session] Reconnected and re-attached to session ${sessionId}`);
+            setIsReconnecting(false);
+          }
+          return;
+        } catch (err) {
+          const detail = err instanceof Error ? err.message : String(err);
+          logger.log(`[session] Reconnect attempt ${attempt} failed: ${detail}`);
+
+          // Clean up failed backend before next attempt.
+          const failedKey = activeBackendKeyRef.current;
+          if (failedKey) {
+            await disconnectBackend(failedKey).catch(() => {});
+            await unregisterBackend(failedKey).catch(() => {});
+            activeBackendKeyRef.current = null;
+            backendRef.current = null;
+          }
+        }
+      }
+
+      // All attempts exhausted.
+      if (!abort.aborted) {
+        logger.log('[session] Reconnect failed after all attempts.');
+        setIsReconnecting(false);
+        connectParamsRef.current = null;
+        lastAttachedSessionIdRef.current = null;
+      }
+    };
+
+    void run();
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [status]);
 
   const killSession = useCallback((sessionId: string) => {
     void withActiveBackend((backendKey) => engine.killSession(backendKey, sessionId));
@@ -592,7 +776,9 @@ export function useRemoteSessionClient<ConnectParams>(
 
   return useMemo(() => ({
     status,
-    mode: activeBackendState?.mode ?? 'browsing',
+    // During reconnect, preserve the last known mode so the UI doesn't flash
+    // back to the browsing state while the reconnect loop is in flight.
+    mode: isReconnecting ? lastModeRef.current : (activeBackendState?.mode ?? 'browsing'),
 
     projects: activeBackendState?.projects ?? [],
     workspaces: activeBackendState?.workspaces ?? [],
@@ -663,6 +849,7 @@ export function useRemoteSessionClient<ConnectParams>(
     sessionBackend: backendRef.current as SessionBackend | null,
   }), [
     status,
+    isReconnecting,
     activeBackendState,
     selectedProjectName,
     connect,

--- a/src/session/useRemoteSessionClient.ts
+++ b/src/session/useRemoteSessionClient.ts
@@ -218,10 +218,8 @@ export function useRemoteSessionClient<ConnectParams>(
   }, [engine, engine.state]);
 
   // backendStatus reflects the raw underlying connection state, NOT overlaid
-  // with isReconnecting. This is what the reconnect useEffect watches via
-  // [backendStatus], so that setIsReconnecting(true) inside the effect doesn't
-  // change backendStatus → doesn't re-trigger the effect cleanup → doesn't
-  // abort the in-flight reconnect loop.
+  // with isReconnecting. Used only for detecting the established→disconnected
+  // transition that should fire the reconnect loop.
   const backendStatus = useMemo<RemoteSessionConnectionStatus>(() => {
     if (!activeBackendState) {
       return 'disconnected';
@@ -230,13 +228,21 @@ export function useRemoteSessionClient<ConnectParams>(
   }, [activeBackendState, mapConnectionStatus]);
 
   // status is the value exposed to consumers — overlays 'reconnecting' on top
-  // of backendStatus, but is NOT used as the useEffect dependency.
+  // of backendStatus.
   const status = useMemo<RemoteSessionConnectionStatus>(() => {
     if (isReconnecting) {
       return 'reconnecting';
     }
     return backendStatus;
   }, [backendStatus, isReconnecting]);
+
+  // reconnectTrigger is a monotonically increasing counter that increments
+  // exactly when we detect a genuine established→disconnected transition with
+  // a session to restore. The reconnect loop effect watches ONLY this counter
+  // so it is never re-triggered by status changes that happen DURING the loop
+  // (e.g. backendStatus flipping to 'connecting' when connectBackend fires).
+  const [reconnectTrigger, setReconnectTrigger] = useState(0);
+  const prevBackendStatusRef = useRef<RemoteSessionConnectionStatus>('disconnected');
 
   const withActiveBackend = useCallback(
     async <T>(fn: (backendKey: BackendKey) => Promise<T>): Promise<T | null> => {
@@ -476,17 +482,37 @@ export function useRemoteSessionClient<ConnectParams>(
   }, [activeBackendState?.projects, selectProject, selectedProjectName]);
 
   // -------------------------------------------------------------------------
+  // Detect established → disconnected transition and fire reconnect trigger.
+  //
+  // This effect watches backendStatus for the specific transition that should
+  // start a reconnect. It increments reconnectTrigger (a counter), which is
+  // what the reconnect loop effect depends on — NOT backendStatus directly.
+  // This breaks the dependency cycle: the loop can change backendStatus (e.g.
+  // to 'connecting') without re-triggering its own cleanup.
+  // -------------------------------------------------------------------------
+  useEffect(() => {
+    const prev = prevBackendStatusRef.current;
+    prevBackendStatusRef.current = backendStatus;
+
+    // Only fire on the established → disconnected transition with a live session.
+    if (
+      prev === 'established' &&
+      backendStatus === 'disconnected' &&
+      connectParamsRef.current &&
+      lastAttachedSessionIdRef.current
+    ) {
+      setReconnectTrigger((t) => t + 1);
+    }
+  }, [backendStatus]);
+
+  // -------------------------------------------------------------------------
   // Automatic reconnection on unexpected disconnect
   // -------------------------------------------------------------------------
   useEffect(() => {
-    // Only trigger when:
-    //   1. We are now disconnected (not reconnecting/connecting)
-    //   2. We have saved connect params (i.e. connect() was called before)
-    //   3. We had an active tmux session at the time of disconnect
-    //      (lastAttachedSessionIdRef is cleared on explicit detach, so this
-    //       prevents re-attach when the user is in browsing mode)
+    // Guard: only run when the trigger is non-zero and we still have the
+    // required context (params/session may have been cleared by disconnect()).
     if (
-      backendStatus !== 'disconnected' ||
+      reconnectTrigger === 0 ||
       !connectParamsRef.current ||
       !lastAttachedSessionIdRef.current
     ) {
@@ -594,13 +620,12 @@ export function useRemoteSessionClient<ConnectParams>(
 
     void run();
 
-    // Abort the loop if backendStatus changes again or the component unmounts
-    // before the loop finishes.
+    // Abort the loop if the component unmounts or a new trigger fires.
     return () => {
       abort.aborted = true;
     };
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [backendStatus]);
+  }, [reconnectTrigger]);
 
   const killSession = useCallback((sessionId: string) => {
     void withActiveBackend((backendKey) => engine.killSession(backendKey, sessionId));

--- a/src/session/useRemoteSessionClient.ts
+++ b/src/session/useRemoteSessionClient.ts
@@ -426,6 +426,11 @@ export function useRemoteSessionClient<ConnectParams>(
   }, [engine, withActiveBackend]);
 
   const detachSession = useCallback(() => {
+    reconnectAbortRef.current.aborted = true;
+    reconnectAbortRef.current = { aborted: false };
+    isReconnectingRef.current = false;
+    setIsReconnecting(false);
+
     // Clear the saved session ID — an explicit detach means we should NOT
     // re-attach to this session if the connection drops later in browsing mode.
     lastAttachedSessionIdRef.current = null;
@@ -628,6 +633,7 @@ export function useRemoteSessionClient<ConnectParams>(
               resolveAttach(true);
             } else if (
               event.type === 'error' ||
+              event.type === 'command_error' ||
               (event.type === 'status' && event.status === 'disconnected')
             ) {
               clearTimeout(attachTimeoutId);
@@ -635,6 +641,10 @@ export function useRemoteSessionClient<ConnectParams>(
               resolveAttach(false);
             }
           });
+
+          if (abort.aborted || lastAttachedSessionIdRef.current !== sessionId) {
+            throw new Error('Reconnect cancelled before re-attach');
+          }
 
           await backend.attachSession({
             sessionId,

--- a/src/session/useRemoteSessionClient.ts
+++ b/src/session/useRemoteSessionClient.ts
@@ -521,7 +521,13 @@ export function useRemoteSessionClient<ConnectParams>(
 
     const params = connectParamsRef.current;
     const sessionId = lastAttachedSessionIdRef.current;
-    const abort = reconnectAbortRef.current;
+
+    // Create a fresh abort sentinel for this invocation. The cleanup from the
+    // previous run may have set the old object to aborted; assigning a new one
+    // here ensures each reconnect cycle starts clean even when reconnectTrigger
+    // increments multiple times in succession.
+    const abort = { aborted: false };
+    reconnectAbortRef.current = abort;
 
     const MAX_RECONNECT_ATTEMPTS = 10;
     const BASE_DELAY_MS = 1_000;

--- a/src/session/useRemoteSessionClient.ts
+++ b/src/session/useRemoteSessionClient.ts
@@ -203,6 +203,11 @@ export function useRemoteSessionClient<ConnectParams>(
   //     can pass the current terminal size to attachSession
   // -------------------------------------------------------------------------
   const [isReconnecting, setIsReconnecting] = useState(false);
+  // Mirror of isReconnecting as a ref so the transition detector can check it
+  // without adding isReconnecting to its dependency array (which would cause
+  // the detector to run on every isReconnecting toggle rather than only on
+  // backendStatus changes).
+  const isReconnectingRef = useRef(false);
   const connectParamsRef = useRef<ConnectParams | null>(null);
   const lastAttachedSessionIdRef = useRef<string | null>(null);
   const lastModeRef = useRef<'browsing' | 'attached'>('browsing');
@@ -260,6 +265,7 @@ export function useRemoteSessionClient<ConnectParams>(
       // Cancel any in-flight reconnect loop before starting fresh.
       reconnectAbortRef.current.aborted = true;
       reconnectAbortRef.current = { aborted: false };
+      isReconnectingRef.current = false;
       setIsReconnecting(false);
 
       const previousBackendKey = activeBackendKeyRef.current;
@@ -301,6 +307,7 @@ export function useRemoteSessionClient<ConnectParams>(
     // Cancel any in-flight reconnect loop — this is an intentional disconnect.
     reconnectAbortRef.current.aborted = true;
     reconnectAbortRef.current = { aborted: false };
+    isReconnectingRef.current = false;
     setIsReconnecting(false);
     connectParamsRef.current = null;
     lastAttachedSessionIdRef.current = null;
@@ -494,15 +501,18 @@ export function useRemoteSessionClient<ConnectParams>(
     const prev = prevBackendStatusRef.current;
     prevBackendStatusRef.current = backendStatus;
 
-    // Fire on any "was connected" → disconnected transition with a live session.
-    // 'error' is included because a WebSocket onerror fires before onclose,
-    // so the engine may briefly enter 'error' before settling on 'disconnected'.
-    // 'connecting' is excluded — a failure before establishing means there was
-    // no session to restore.
+    // Fire on any "was connected" → disconnected transition with a live session,
+    // but NOT while a reconnect loop is already running. Without this guard,
+    // a failed attach inside the loop (connectBackend succeeds → attachSession
+    // fails → disconnectBackend) would look like a fresh established→disconnected
+    // transition and re-trigger the counter, resetting the attempt limit.
+    // 'error' is included because onerror fires before onclose.
+    // 'connecting' is excluded — pre-connect failures have no session to restore.
     const wasConnected = prev === 'established' || prev === 'error';
     if (
       wasConnected &&
       backendStatus === 'disconnected' &&
+      !isReconnectingRef.current &&
       connectParamsRef.current &&
       lastAttachedSessionIdRef.current
     ) {
@@ -538,6 +548,7 @@ export function useRemoteSessionClient<ConnectParams>(
     const BASE_DELAY_MS = 1_000;
     const MAX_DELAY_MS = 30_000;
 
+    isReconnectingRef.current = true;
     setIsReconnecting(true);
 
     const run = async () => {
@@ -602,6 +613,7 @@ export function useRemoteSessionClient<ConnectParams>(
 
           if (!abort.aborted) {
             logger.log(`[session] Reconnected and re-attached to session ${sessionId}`);
+            isReconnectingRef.current = false;
             setIsReconnecting(false);
           }
           return;
@@ -623,6 +635,7 @@ export function useRemoteSessionClient<ConnectParams>(
       // All attempts exhausted.
       if (!abort.aborted) {
         logger.log('[session] Reconnect failed after all attempts.');
+        isReconnectingRef.current = false;
         setIsReconnecting(false);
         connectParamsRef.current = null;
         lastAttachedSessionIdRef.current = null;
@@ -834,6 +847,7 @@ export function useRemoteSessionClient<ConnectParams>(
       // Abort any in-flight reconnect loop so async callbacks don't call
       // React state setters or create new backends after unmount.
       reconnectAbortRef.current.aborted = true;
+      isReconnectingRef.current = false;
 
       const backendKey = activeBackendKeyRef.current;
       if (!backendKey) {

--- a/src/session/useRemoteSessionClient.ts
+++ b/src/session/useRemoteSessionClient.ts
@@ -606,10 +606,42 @@ export function useRemoteSessionClient<ConnectParams>(
           // gets the correct size immediately rather than waiting for the next
           // browser resize event (which may never come if dimensions haven't changed).
           const dims = lastDimensionsRef.current;
+
+          // Wait for the 'attached' confirmation event before declaring success,
+          // mirroring what connect.ts does with waitForBackendEvent. Without this,
+          // the reconnect declares success immediately even if the session no longer
+          // exists on the machine (e.g. after a machine restart), leaving the UI
+          // stuck in a connected-but-unattached state with no further recovery.
+          const attachConfirmed = await new Promise<boolean>((resolve) => {
+            const timeoutId = setTimeout(() => {
+              unsub();
+              resolve(false);
+            }, 30_000);
+
+            const unsub = backend.onEvent((event) => {
+              if (event.type === 'attached') {
+                clearTimeout(timeoutId);
+                unsub();
+                resolve(true);
+              } else if (
+                event.type === 'error' ||
+                (event.type === 'status' && event.status === 'disconnected')
+              ) {
+                clearTimeout(timeoutId);
+                unsub();
+                resolve(false);
+              }
+            });
+          });
+
           await backend.attachSession({
             sessionId,
             ...(dims ? { cols: dims.cols, rows: dims.rows } : {}),
           });
+
+          if (!attachConfirmed) {
+            throw new Error('Session attachment timed out or was rejected — session may no longer exist');
+          }
 
           if (!abort.aborted) {
             logger.log(`[session] Reconnected and re-attached to session ${sessionId}`);

--- a/src/session/useRemoteSessionClient.ts
+++ b/src/session/useRemoteSessionClient.ts
@@ -607,31 +607,33 @@ export function useRemoteSessionClient<ConnectParams>(
           // browser resize event (which may never come if dimensions haven't changed).
           const dims = lastDimensionsRef.current;
 
-          // Wait for the 'attached' confirmation event before declaring success,
-          // mirroring what connect.ts does with waitForBackendEvent. Without this,
-          // the reconnect declares success immediately even if the session no longer
-          // exists on the machine (e.g. after a machine restart), leaving the UI
-          // stuck in a connected-but-unattached state with no further recovery.
-          const attachConfirmed = await new Promise<boolean>((resolve) => {
-            const timeoutId = setTimeout(() => {
-              unsub();
-              resolve(false);
-            }, 30_000);
+          // Subscribe to the attached confirmation BEFORE sending the command
+          // so we can't miss the event. This mirrors connect.ts: subscribe → send
+          // → await. Awaiting before calling attachSession would deadlock because
+          // the 'attached' event can only fire after the command is sent.
+          let resolveAttach!: (ok: boolean) => void;
+          const attachConfirmed = new Promise<boolean>((resolve) => {
+            resolveAttach = resolve;
+          });
 
-            const unsub = backend.onEvent((event) => {
-              if (event.type === 'attached') {
-                clearTimeout(timeoutId);
-                unsub();
-                resolve(true);
-              } else if (
-                event.type === 'error' ||
-                (event.type === 'status' && event.status === 'disconnected')
-              ) {
-                clearTimeout(timeoutId);
-                unsub();
-                resolve(false);
-              }
-            });
+          const attachTimeoutId = setTimeout(() => {
+            unsubAttach();
+            resolveAttach(false);
+          }, 30_000);
+
+          const unsubAttach = backend.onEvent((event) => {
+            if (event.type === 'attached') {
+              clearTimeout(attachTimeoutId);
+              unsubAttach();
+              resolveAttach(true);
+            } else if (
+              event.type === 'error' ||
+              (event.type === 'status' && event.status === 'disconnected')
+            ) {
+              clearTimeout(attachTimeoutId);
+              unsubAttach();
+              resolveAttach(false);
+            }
           });
 
           await backend.attachSession({
@@ -639,7 +641,7 @@ export function useRemoteSessionClient<ConnectParams>(
             ...(dims ? { cols: dims.cols, rows: dims.rows } : {}),
           });
 
-          if (!attachConfirmed) {
+          if (!await attachConfirmed) {
             throw new Error('Session attachment timed out or was rejected — session may no longer exist');
           }
 

--- a/src/session/useRemoteSessionClient.ts
+++ b/src/session/useRemoteSessionClient.ts
@@ -494,9 +494,14 @@ export function useRemoteSessionClient<ConnectParams>(
     const prev = prevBackendStatusRef.current;
     prevBackendStatusRef.current = backendStatus;
 
-    // Only fire on the established → disconnected transition with a live session.
+    // Fire on any "was connected" → disconnected transition with a live session.
+    // 'error' is included because a WebSocket onerror fires before onclose,
+    // so the engine may briefly enter 'error' before settling on 'disconnected'.
+    // 'connecting' is excluded — a failure before establishing means there was
+    // no session to restore.
+    const wasConnected = prev === 'established' || prev === 'error';
     if (
-      prev === 'established' &&
+      wasConnected &&
       backendStatus === 'disconnected' &&
       connectParamsRef.current &&
       lastAttachedSessionIdRef.current


### PR DESCRIPTION
## Summary

- **Machine daemon never becomes a zombie**: after the first successful relay connection, retry is infinite with exponential backoff capped at 5 minutes — the daemon keeps trying forever when the relay goes down
- **Application-level heartbeat** (30s interval, 90s stale threshold): machine pings relay after registration; if no pong is received for 90s the socket is force-closed so the OS-silent network partition case is caught and the reconnect loop fires
- **Relay stale detection**: relay tracks `lastHeartbeatAt` per machine, logs a warning at 90s, force-closes at 150s (60s grace period) — triggers machine reconnect and client `connection_failed` notification; explicit Bun WS config (`idleTimeout: 180`, `sendPings: true`)
- **Daemon status improvements**: `gssh status` now shows reconnect attempt count and time until next retry
- **RelayClient** (TUI/web): preserves `activeTmuxSessionId` across reconnects; emits `onReconnected(previousTmuxSessionId)` after successful re-handshake for consumers to re-attach to the same session
- **CLI client** (`gssh client connect`): on disconnect, automatically retries up to 10 times with exponential backoff — creates a fresh backend + X3DH handshake and re-attaches to the same tmux-lite session ID (terminal state is preserved server-side by xterm-headless)

## Files changed

| File | Change |
|------|--------|
| `src/relay-client/machine-relay-client.ts` | Infinite retry, 30s heartbeat, pong handler |
| `src/relay/registries.ts` | `lastHeartbeatAt`, `staleWarned` fields + helpers |
| `src/relay/server.ts` | Stale detection timer, heartbeat tracking on ping, explicit Bun WS config |
| `src/serve/daemon.ts` | `reconnectAttempt` + `nextRetryAt` in `DaemonState`/`StatusResponse` |
| `src/serve/types.ts` | `nextRetryMs` on `relay_reconnecting` event |
| `src/commands/serve.ts` | Updated event handler to populate new daemon state fields with logging |
| `src/lib/tmux-lite/relay-client.ts` | `activeTmuxSessionId` preserved across reconnects, `onReconnected` event |
| `src/commands/connect.ts` | `createRemoteBackend` factory, reconnect loop in `startTerminalSession` |

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> High risk because it changes core relay connectivity, WebSocket lifecycle, and session attach/reattach behavior across web, TUI, CLI, and relay server/daemon codepaths; regressions could cause stuck reconnect loops or dropped sessions.
> 
> **Overview**
> Implements **automatic reconnect + session re-attach** for remote terminal clients: `useRemoteSessionClient` now tracks last attached session/dimensions, overlays a new `reconnecting` status, and retries connection/`attachSession` with exponential backoff; web UI/TUI render reconnecting states and prevent input while reconnecting.
> 
> Updates the web backend connect params to persist a `relayUrl` and reopen a fresh WebSocket on reconnect (instead of reusing a dead socket), and extends session client APIs (`toReconnectParams`, new `reconnecting` status) to support this flow.
> 
> Hardens relay/machine connectivity: machine daemon adds application-level heartbeat ping/pong and **infinite** reconnect after first successful registration (with longer backoff cap), relay tracks per-machine heartbeat timestamps and force-closes stale machine sockets, and `serve`/daemon status reporting now includes reconnect attempt + next retry time for `gssh status`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b90364ea99fc760ed265c64bc79c6fe0f37def93. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic reconnection with exponential backoff, transparent session reattachment, and preserved terminal session state.
  * UI shows a “Reconnecting…” overlay and treats reconnecting as a readable state.
  * Relay client emits reconnected events; client hooks expose relay URL for reconnect flows.
  * Server heartbeat/watchdog to detect and recover stale machine connections.

* **Bug Fixes**
  * Improved disconnect handling to avoid resource leaks and reliably resume I/O and resize after reconnect.
  * Stale-connection warnings and forced reconnects to reduce silent failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->