### PR TITLE
feat: opencode agent sessions with notification system and session persistence

### DIFF
--- a/docs/AGENT-INTEGRATIONS-V1.md
+++ b/docs/AGENT-INTEGRATIONS-V1.md
@@ -1,0 +1,119 @@
+# Agent And Integrations V1
+
+## Goals
+
+- Use native OpenCode server as the default agent runtime.
+- Mount a GitSpace shell around an OpenCode core in both TUI and web.
+- Design the runtime layer so later we can add `sandbox-agent` or other OpenCode-compatible backends.
+- Add a typed integrations/plugins system for installing tools and capturing portable config or credentials.
+- Use real user paths for materialization in V1.
+
+## Non-goals
+
+- Universal OAuth portability across machines.
+- Fake `HOME` overlays as the default execution model.
+- Relay-owned execution of third-party integrations.
+
+## Runtime Model
+
+- A workspace exposes two runtime types:
+  - `terminal`
+  - `agent`
+- `agent` runtime is backed by an `AgentBackend`.
+- V1 ships `OpenCodeBackend` only.
+- GitSpace owns workspace selection, access control, relay transport, and session lifecycle.
+- OpenCode owns the agent runtime and session protocol.
+- Remote clients reach workspace OpenCode runtimes through a GitSpace-managed HTTP and SSE bridge over the encrypted relay channel.
+
+## Agent Backend Contract
+
+- `detect()` reports install and server status for a workspace target.
+- `ensureInstalled()` makes sure the backend runtime exists.
+- `ensureServer()` starts or reuses the backend server.
+- `listSessions()`, `createSession()`, `resumeSession()`, and `destroySession()` manage agent sessions.
+- GitSpace normalizes backend-specific events into a shared internal event model.
+
+## V1 Agent Backend
+
+- `OpenCodeBackend`
+  - starts and connects to `opencode serve`
+  - uses OpenCode HTTP and SSE APIs
+  - supports multiple concurrent sessions in a workspace
+  - is the single backend surfaced by the UI in V1
+  - is run once per workspace, not once per machine
+
+## UI Model
+
+- Workspace UI offers:
+  - `Terminal`
+  - `Agent`
+- `Agent` uses a GitSpace session picker for OpenCode sessions per workspace.
+- V1 launches native `opencode attach` inside GitSpace terminal surfaces for both TUI and web clients.
+- GitSpace wraps backend selection, connection state, and workspace context around the OpenCode core.
+
+## Integrations
+
+- `Integration` is the runtime-facing unit.
+- Integrations are scoped to `user` or `project`.
+- Integrations declare:
+  - install methods
+  - health checks
+  - capture rules
+  - materialization rules
+  - optional local-auth requirements
+
+Supported V1 capture modes:
+
+- `capture-file`
+- `capture-section`
+- `env-secret`
+- `manual-local`
+
+## Plugins
+
+- `Plugin` is the packaging and distribution unit.
+- Plugins contribute one or more integrations.
+- Plugins are distributed through relay artifact storage.
+- Machines download and execute plugins locally.
+- The relay does not run plugin code.
+
+## Credential Policy
+
+- Use native user paths in V1 when the tool expects them.
+- Sync only portable config and credentials.
+- Treat OAuth-heavy auth for agent runtimes as local to each machine or persistent workspace in V1.
+
+Examples of portable V1 integrations:
+
+- `git` selected `~/.gitconfig` sections
+- `npm` `~/.npmrc`
+- `aws` `~/.aws/config`, `~/.aws/credentials`
+- `kubectl` `~/.kube/config`
+- `terraform` `~/.terraformrc`
+- `pulumi` `~/.pulumi/credentials.json`
+- `wrangler` config or API token
+- `vercel` auth/config where portable
+
+Examples of V1 local auth only:
+
+- `opencode` OAuth
+- `claude` OAuth
+- `codex` OAuth
+
+## Extensibility
+
+- Future agent backends:
+  - `sandbox-agent`
+  - other OpenCode-compatible runtimes
+- Future credential strategies:
+  - helper or proxy delivery
+  - sandbox adapter for isolated execution
+  - brokered OAuth flows
+
+## Suggested Implementation Order
+
+1. Add `AgentBackend` types and `OpenCodeClient`.
+2. Add `OpenCodeBackend` foundation.
+3. Add integration and plugin manifest types.
+4. Add built-in integration registry.
+5. Wire backend and integration foundations into UI and workspace lifecycle.

--- a/src/agents/__tests__/opencode-client.test.ts
+++ b/src/agents/__tests__/opencode-client.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'bun:test';
+import { OpenCodeClient } from '../opencode-client';
+
+describe('OpenCodeClient', () => {
+  it('trims trailing slashes from baseUrl', () => {
+    const client = new OpenCodeClient({
+      baseUrl: 'http://localhost:4096/',
+      fetch: async () => new Response(JSON.stringify([]), { status: 200 }),
+    });
+
+    expect(client.baseUrl).toBe('http://localhost:4096');
+  });
+
+  it('requests the expected session endpoint', async () => {
+    const seen: string[] = [];
+    const client = new OpenCodeClient({
+      baseUrl: 'http://localhost:4096/',
+      fetch: async (input) => {
+        seen.push(String(input));
+        return new Response(JSON.stringify([]), { status: 200 });
+      },
+    });
+
+    await client.listSessions();
+
+    expect(seen).toEqual(['http://localhost:4096/session']);
+  });
+});

--- a/src/agents/__tests__/opencode-relay-client.test.ts
+++ b/src/agents/__tests__/opencode-relay-client.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'bun:test';
+import { OpenCodeRelayClient } from '../opencode-relay-client';
+
+describe('OpenCodeRelayClient', () => {
+  it('lists sessions through the bridge backend', async () => {
+    const client = new OpenCodeRelayClient({
+      workspaceId: 'project:workspace',
+      backend: {
+        async requestOpenCode() {
+          return {
+            requestId: 'req-1',
+            status: 200,
+            bodyBase64: Buffer.from(JSON.stringify([{ id: 'sess-1' }])).toString('base64'),
+          };
+        },
+        async subscribeOpenCode() {
+          return async () => {};
+        },
+      },
+    });
+
+    const sessions = await client.listSessions() as Array<{ id: string }>;
+    expect(sessions).toEqual([{ id: 'sess-1' }]);
+  });
+});

--- a/src/agents/__tests__/opencode-web.test.ts
+++ b/src/agents/__tests__/opencode-web.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'bun:test';
+import { buildOpenCodeWebUrl } from '../opencode-web';
+
+describe('buildOpenCodeWebUrl', () => {
+  it('builds a workspace session route for OpenCode web', () => {
+    const url = buildOpenCodeWebUrl({
+      workspaceId: 'demo:ws',
+      workspacePath: '/tmp/demo/workspaces/ws',
+      hostname: '127.0.0.1',
+      port: 42001,
+      baseUrl: 'http://127.0.0.1:42001',
+      username: 'gitspace',
+      password: 'secret',
+      startedAt: '2026-03-14T00:00:00.000Z',
+    }, 'sess-123');
+
+    expect(url).toContain('/session/sess-123');
+    expect(url).toContain('gitspace:secret@127.0.0.1:42001');
+  });
+});

--- a/src/agents/agentNotificationToInboxItem.ts
+++ b/src/agents/agentNotificationToInboxItem.ts
@@ -1,0 +1,75 @@
+import type { InboxItem } from '../lib/tmux-lite/protocol.js';
+import type { AgentNotification } from './useWorkspaceAgentEvents.js';
+
+let _idCounter = 0;
+function nextId(): string {
+  return `agent-${Date.now()}-${++_idCounter}`;
+}
+
+/**
+ * Convert an AgentNotification to an InboxItem for the existing inbox pipeline.
+ *
+ * sessionName format: "<project>:<workspace>:agent:<sessionTitle>"
+ * This slots naturally into the inbox hierarchical grouping.
+ */
+export function agentNotificationToInboxItem(
+  notification: AgentNotification,
+  projectName: string,
+  workspaceName: string,
+): InboxItem {
+  const safeTitle = notification.sessionTitle.replace(/:/g, '-');
+  const sessionName = `${projectName}:${workspaceName}:agent:${safeTitle}`;
+
+  switch (notification.type) {
+    case 'permission_needed':
+      return {
+        id: nextId(),
+        sessionId: notification.sessionId,
+        sessionName,
+        type: 'agent_permission',
+        context: notification.permissionTitle ?? 'Permission requested',
+        timestamp: notification.timestamp,
+        read: false,
+        processTitle: 'opencode',
+        agentAction: {
+          workspaceId: notification.workspaceId,
+          agentSessionId: notification.sessionId,
+          permissionId: notification.permissionId,
+          permissionTitle: notification.permissionTitle,
+        },
+      };
+
+    case 'agent_idle':
+      return {
+        id: nextId(),
+        sessionId: notification.sessionId,
+        sessionName,
+        type: 'agent_idle',
+        context: notification.messagePreview ?? 'Agent finished and is waiting',
+        timestamp: notification.timestamp,
+        read: false,
+        processTitle: 'opencode',
+        agentAction: {
+          workspaceId: notification.workspaceId,
+          agentSessionId: notification.sessionId,
+          messagePreview: notification.messagePreview,
+        },
+      };
+
+    case 'agent_error':
+      return {
+        id: nextId(),
+        sessionId: notification.sessionId,
+        sessionName,
+        type: 'agent_error',
+        context: notification.errorMessage ?? 'Agent error',
+        timestamp: notification.timestamp,
+        read: false,
+        processTitle: 'opencode',
+        agentAction: {
+          workspaceId: notification.workspaceId,
+          agentSessionId: notification.sessionId,
+        },
+      };
+  }
+}

--- a/src/agents/backend.ts
+++ b/src/agents/backend.ts
@@ -1,0 +1,94 @@
+export type AgentBackendId = string;
+
+export interface AgentWorkspaceTarget {
+  workspaceId: string;
+  workspacePath?: string;
+  projectName?: string;
+  machineId?: string;
+  backendKey?: string;
+}
+
+export interface AgentServerHandle {
+  backendId: AgentBackendId;
+  baseUrl: string;
+  startedAt: string;
+}
+
+export interface AgentBackendStatus {
+  backendId: AgentBackendId;
+  installed: boolean;
+  serverRunning: boolean;
+  credentialsAvailable?: boolean;
+  baseUrl?: string;
+}
+
+export interface CreateAgentSessionInput {
+  title?: string;
+  prompt?: string;
+  providerId?: string;
+  model?: string;
+  cwd?: string;
+}
+
+export interface AgentSessionSummary {
+  id: string;
+  workspaceId: string;
+  backendId: AgentBackendId;
+  title?: string;
+  status: 'running' | 'idle' | 'error' | 'closed';
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+export interface AgentMessagePart {
+  type: 'text';
+  text: string;
+}
+
+export interface AgentMessageInput {
+  parts: AgentMessagePart[];
+}
+
+export type AgentEvent =
+  | {
+      type: 'message';
+      sessionId: string;
+      payload: unknown;
+    }
+  | {
+      type: 'permission_request';
+      sessionId: string;
+      payload: unknown;
+    }
+  | {
+      type: 'question';
+      sessionId: string;
+      payload: unknown;
+    }
+  | {
+      type: 'status';
+      sessionId: string;
+      payload: unknown;
+    }
+  | {
+      type: 'error';
+      sessionId: string;
+      error: string;
+    };
+
+export interface AgentSessionHandle {
+  readonly summary: AgentSessionSummary;
+  sendMessage(input: AgentMessageInput): Promise<void>;
+  onEvent(handler: (event: AgentEvent) => void): () => void;
+}
+
+export interface AgentBackend {
+  readonly id: AgentBackendId;
+  detect(target: AgentWorkspaceTarget): Promise<AgentBackendStatus>;
+  ensureInstalled(target: AgentWorkspaceTarget): Promise<void>;
+  ensureServer(target: AgentWorkspaceTarget): Promise<AgentServerHandle>;
+  listSessions(target: AgentWorkspaceTarget): Promise<AgentSessionSummary[]>;
+  createSession(target: AgentWorkspaceTarget, input: CreateAgentSessionInput): Promise<AgentSessionHandle>;
+  resumeSession(target: AgentWorkspaceTarget, sessionId: string): Promise<AgentSessionHandle>;
+  destroySession(target: AgentWorkspaceTarget, sessionId: string): Promise<void>;
+}

--- a/src/agents/backends/opencode-backend.ts
+++ b/src/agents/backends/opencode-backend.ts
@@ -1,0 +1,117 @@
+import { OpenCodeClient, type OpenCodeFetch } from '../opencode-client.js';
+import type {
+  AgentBackend,
+  AgentBackendStatus,
+  AgentEvent,
+  AgentServerHandle,
+  AgentSessionHandle,
+  AgentSessionSummary,
+  AgentWorkspaceTarget,
+  CreateAgentSessionInput,
+} from '../backend.js';
+
+export interface OpenCodeBackendDependencies {
+  ensureInstalledForTarget: (target: AgentWorkspaceTarget) => Promise<void>;
+  ensureServerForTarget: (target: AgentWorkspaceTarget) => Promise<{ baseUrl: string }>;
+  detectTarget: (target: AgentWorkspaceTarget) => Promise<{
+    installed: boolean;
+    serverRunning: boolean;
+    credentialsAvailable?: boolean;
+    baseUrl?: string;
+  }>;
+  fetch?: OpenCodeFetch;
+}
+
+class OpenCodeSessionHandle implements AgentSessionHandle {
+  readonly summary: AgentSessionSummary;
+  private readonly client: OpenCodeClient;
+
+  constructor(summary: AgentSessionSummary, client: OpenCodeClient) {
+    this.summary = summary;
+    this.client = client;
+  }
+
+  async sendMessage(input: { parts: Array<{ type: 'text'; text: string }> }): Promise<void> {
+    await this.client.sendMessage(this.summary.id, input);
+  }
+
+  onEvent(_handler: (event: AgentEvent) => void): () => void {
+    return () => {};
+  }
+}
+
+function toSummary(target: AgentWorkspaceTarget, record: { id: string; title?: string; createdAt?: string; updatedAt?: string }): AgentSessionSummary {
+  return {
+    id: record.id,
+    workspaceId: target.workspaceId,
+    backendId: 'opencode',
+    title: record.title,
+    status: 'idle',
+    createdAt: record.createdAt,
+    updatedAt: record.updatedAt,
+  };
+}
+
+export class OpenCodeBackend implements AgentBackend {
+  readonly id = 'opencode';
+  private readonly deps: OpenCodeBackendDependencies;
+
+  constructor(deps: OpenCodeBackendDependencies) {
+    this.deps = deps;
+  }
+
+  async detect(target: AgentWorkspaceTarget): Promise<AgentBackendStatus> {
+    const result = await this.deps.detectTarget(target);
+    return {
+      backendId: this.id,
+      installed: result.installed,
+      serverRunning: result.serverRunning,
+      credentialsAvailable: result.credentialsAvailable,
+      baseUrl: result.baseUrl,
+    };
+  }
+
+  async ensureInstalled(target: AgentWorkspaceTarget): Promise<void> {
+    await this.deps.ensureInstalledForTarget(target);
+  }
+
+  async ensureServer(target: AgentWorkspaceTarget): Promise<AgentServerHandle> {
+    const ensured = await this.deps.ensureServerForTarget(target);
+    return {
+      backendId: this.id,
+      baseUrl: ensured.baseUrl,
+      startedAt: new Date().toISOString(),
+    };
+  }
+
+  async listSessions(target: AgentWorkspaceTarget): Promise<AgentSessionSummary[]> {
+    const client = await this.getClient(target);
+    const sessions = await client.listSessions();
+    return sessions.map((session) => toSummary(target, session));
+  }
+
+  async createSession(target: AgentWorkspaceTarget, input: CreateAgentSessionInput): Promise<AgentSessionHandle> {
+    const client = await this.getClient(target);
+    const session = await client.createSession({ title: input.title });
+    return new OpenCodeSessionHandle(toSummary(target, session), client);
+  }
+
+  async resumeSession(target: AgentWorkspaceTarget, sessionId: string): Promise<AgentSessionHandle> {
+    const client = await this.getClient(target);
+    const session = await client.getSession(sessionId);
+    return new OpenCodeSessionHandle(toSummary(target, session), client);
+  }
+
+  async destroySession(target: AgentWorkspaceTarget, sessionId: string): Promise<void> {
+    const client = await this.getClient(target);
+    await client.destroySession(sessionId);
+  }
+
+  private async getClient(target: AgentWorkspaceTarget): Promise<OpenCodeClient> {
+    const { baseUrl } = await this.deps.ensureServerForTarget(target);
+    return new OpenCodeClient({
+      baseUrl,
+      fetch: this.deps.fetch,
+    });
+  }
+}

--- a/src/agents/opencode-attach.ts
+++ b/src/agents/opencode-attach.ts
@@ -1,0 +1,22 @@
+import { buildAuthenticatedOpenCodeUrl, type OpenCodeRuntimeInfo } from './opencode-runtime.js';
+
+export function buildOpenCodeAttachUrlCommand(url: string, sessionId?: string): {
+  command: string;
+  args: string[];
+} {
+  const args = ['attach', url];
+  if (sessionId) {
+    args.push('--session', sessionId);
+  }
+  return {
+    command: 'opencode',
+    args,
+  };
+}
+
+export function buildOpenCodeAttachCommand(runtime: OpenCodeRuntimeInfo, sessionId?: string): {
+  command: string;
+  args: string[];
+} {
+  return buildOpenCodeAttachUrlCommand(buildAuthenticatedOpenCodeUrl(runtime), sessionId);
+}

--- a/src/agents/opencode-bridge.ts
+++ b/src/agents/opencode-bridge.ts
@@ -1,0 +1,87 @@
+export type OpenCodeHttpMethod = 'GET' | 'POST' | 'PATCH' | 'PUT' | 'DELETE';
+
+export interface OpenCodeBridgeRequest {
+  requestId: string;
+  workspaceId: string;
+  method: OpenCodeHttpMethod;
+  path: string;
+  query?: Record<string, string | number | boolean>;
+  headers?: Record<string, string>;
+  bodyBase64?: string;
+}
+
+export interface OpenCodeBridgeResponse {
+  requestId: string;
+  status: number;
+  headers?: Record<string, string>;
+  bodyBase64?: string;
+}
+
+export interface OpenCodeBridgeStreamOpen {
+  requestId: string;
+  workspaceId: string;
+  path: string;
+  query?: Record<string, string | number | boolean>;
+  headers?: Record<string, string>;
+}
+
+export interface OpenCodeBridgeStreamOpened {
+  requestId: string;
+}
+
+export interface OpenCodeBridgeStreamEvent {
+  requestId: string;
+  event?: string;
+  data: string;
+  id?: string;
+}
+
+export interface OpenCodeBridgeStreamClosed {
+  requestId: string;
+}
+
+export interface OpenCodeBridgeStreamError {
+  requestId: string;
+  message: string;
+}
+
+export interface OpenCodeBridgeStreamClose {
+  requestId: string;
+}
+
+export interface OpenCodeBridgeBackend {
+  requestOpenCode(request: Omit<OpenCodeBridgeRequest, 'requestId'>): Promise<OpenCodeBridgeResponse>;
+  subscribeOpenCode(
+    request: Omit<OpenCodeBridgeStreamOpen, 'requestId'>,
+    handler: (event: OpenCodeBridgeStreamEvent) => void
+  ): Promise<() => Promise<void>>;
+}
+
+export function encodeBridgeBody(body: Uint8Array | ArrayBuffer | string | undefined): string | undefined {
+  if (body === undefined) {
+    return undefined;
+  }
+  if (typeof body === 'string') {
+    return Buffer.from(body).toString('base64');
+  }
+  return Buffer.from(body instanceof Uint8Array ? body : new Uint8Array(body)).toString('base64');
+}
+
+export function decodeBridgeBody(bodyBase64: string | undefined): Uint8Array {
+  if (!bodyBase64) {
+    return new Uint8Array(0);
+  }
+  return new Uint8Array(Buffer.from(bodyBase64, 'base64'));
+}
+
+export function buildOpenCodeUrl(
+  baseUrl: string,
+  path: string,
+  query?: Record<string, string | number | boolean>
+): string {
+  const url = new URL(path, `${baseUrl.endsWith('/') ? baseUrl : `${baseUrl}/`}`);
+  for (const [key, value] of Object.entries(query ?? {})) {
+    url.searchParams.set(key, String(value));
+  }
+  return url.toString();
+}

--- a/src/agents/opencode-bridge.ts
+++ b/src/agents/opencode-bridge.ts
@@ -49,14 +49,6 @@ export interface OpenCodeBridgeStreamClose {
   requestId: string;
 }
 
-export interface OpenCodeBridgeBackend {
-  requestOpenCode(request: Omit<OpenCodeBridgeRequest, 'requestId'>): Promise<OpenCodeBridgeResponse>;
-  subscribeOpenCode(
-    request: Omit<OpenCodeBridgeStreamOpen, 'requestId'>,
-    handler: (event: OpenCodeBridgeStreamEvent) => void
-  ): Promise<() => Promise<void>>;
-}
-
 export function encodeBridgeBody(body: Uint8Array | ArrayBuffer | string | undefined): string | undefined {
   if (body === undefined) {
     return undefined;

--- a/src/agents/opencode-client.ts
+++ b/src/agents/opencode-client.ts
@@ -1,0 +1,115 @@
+import type { SessionStatus } from './opencode-event-types.js';
+
+export interface OpenCodeSessionRecord {
+  id: string;
+  title?: string;
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+export interface OpenCodeProviderRecord {
+  id: string;
+  name?: string;
+}
+
+export type OpenCodeFetch = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
+
+export interface OpenCodeClientOptions {
+  baseUrl: string;
+  fetch?: OpenCodeFetch;
+}
+
+function trimTrailingSlash(value: string): string {
+  return value.endsWith('/') ? value.slice(0, -1) : value;
+}
+
+export class OpenCodeClient {
+  readonly baseUrl: string;
+  private readonly fetchImpl: OpenCodeFetch;
+
+  constructor(options: OpenCodeClientOptions) {
+    this.baseUrl = trimTrailingSlash(options.baseUrl);
+    this.fetchImpl = options.fetch ?? fetch;
+  }
+
+  async listSessions(): Promise<OpenCodeSessionRecord[]> {
+    return this.request<OpenCodeSessionRecord[]>('/session');
+  }
+
+  async createSession(input: { title?: string }): Promise<OpenCodeSessionRecord> {
+    return this.request<OpenCodeSessionRecord>('/session', {
+      method: 'POST',
+      body: JSON.stringify(input),
+    });
+  }
+
+  async getSession(sessionId: string): Promise<OpenCodeSessionRecord> {
+    return this.request<OpenCodeSessionRecord>(`/session/${encodeURIComponent(sessionId)}`);
+  }
+
+  async destroySession(sessionId: string): Promise<void> {
+    await this.request(`/session/${encodeURIComponent(sessionId)}`, {
+      method: 'DELETE',
+    });
+  }
+
+  async sendMessage(sessionId: string, input: { parts: Array<{ type: 'text'; text: string }> }): Promise<void> {
+    await this.request(`/session/${encodeURIComponent(sessionId)}/message`, {
+      method: 'POST',
+      body: JSON.stringify(input),
+    });
+  }
+
+  async listProviders(): Promise<OpenCodeProviderRecord[]> {
+    return this.request<OpenCodeProviderRecord[]>('/provider');
+  }
+
+  /** GET /session/status — returns per-session status map */
+  async getSessionStatuses(): Promise<Record<string, SessionStatus>> {
+    return this.request<Record<string, SessionStatus>>('/session/status');
+  }
+
+  /** POST /session/:id/abort — stops a running session */
+  async abortSession(sessionId: string): Promise<boolean> {
+    return this.request<boolean>(`/session/${encodeURIComponent(sessionId)}/abort`, {
+      method: 'POST',
+    });
+  }
+
+  /** POST /session/:id/permissions/:permissionId — respond to a permission request */
+  async respondToPermission(
+    sessionId: string,
+    permissionId: string,
+    response: 'allow' | 'deny',
+    remember?: boolean,
+  ): Promise<boolean> {
+    return this.request<boolean>(
+      `/session/${encodeURIComponent(sessionId)}/permissions/${encodeURIComponent(permissionId)}`,
+      {
+        method: 'POST',
+        body: JSON.stringify({ response, remember }),
+      },
+    );
+  }
+
+  async request<T = unknown>(path: string, init?: RequestInit): Promise<T> {
+    const response = await this.fetchImpl(`${this.baseUrl}${path}`, {
+      ...init,
+      headers: {
+        'content-type': 'application/json',
+        ...(init?.headers ?? {}),
+      },
+    });
+
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(`OpenCode request failed (${response.status}): ${text || response.statusText}`);
+    }
+
+    if (response.status === 204) {
+      return undefined as T;
+    }
+
+    return await response.json() as T;
+  }
+}

--- a/src/agents/opencode-event-types.ts
+++ b/src/agents/opencode-event-types.ts
@@ -1,0 +1,109 @@
+/**
+ * OpenCode server-sent event types.
+ * Ported from @opencode-ai/sdk types.gen.ts
+ * Only the subset relevant to GitSpace agent tracking.
+ */
+
+export type SessionStatus =
+  | { type: 'idle' }
+  | { type: 'busy' }
+  | { type: 'retry'; attempt: number; message: string; next: number };
+
+export interface Permission {
+  id: string;
+  type: string;
+  pattern?: string | string[];
+  sessionID: string;
+  messageID: string;
+  callID?: string;
+  title: string;
+  metadata: Record<string, unknown>;
+  time: { created: number };
+}
+
+export interface EventSessionStatus {
+  type: 'session.status';
+  properties: { sessionID: string; status: SessionStatus };
+}
+
+export interface EventSessionIdle {
+  type: 'session.idle';
+  properties: { sessionID: string };
+}
+
+export interface EventSessionError {
+  type: 'session.error';
+  properties: {
+    sessionID?: string;
+    error?: { name: string; data?: { message?: string } };
+  };
+}
+
+export interface EventSessionCreated {
+  type: 'session.created';
+  properties: { info: { id: string; title: string; directory: string } };
+}
+
+export interface EventSessionUpdated {
+  type: 'session.updated';
+  properties: { info: { id: string; title: string; directory: string } };
+}
+
+export interface EventSessionDeleted {
+  type: 'session.deleted';
+  properties: { info: { id: string } };
+}
+
+export interface EventPermissionUpdated {
+  type: 'permission.updated';
+  properties: Permission;
+}
+
+export interface EventPermissionReplied {
+  type: 'permission.replied';
+  properties: { sessionID: string; permissionID: string; response: string };
+}
+
+export interface EventMessagePartUpdated {
+  type: 'message.part.updated';
+  properties: {
+    part: {
+      id: string;
+      sessionID: string;
+      messageID: string;
+      type: string;
+      text?: string;
+    };
+    delta?: string;
+  };
+}
+
+export interface EventServerConnected {
+  type: 'server.connected';
+  properties: Record<string, unknown>;
+}
+
+export type OpenCodeEvent =
+  | EventSessionStatus
+  | EventSessionIdle
+  | EventSessionError
+  | EventSessionCreated
+  | EventSessionUpdated
+  | EventSessionDeleted
+  | EventPermissionUpdated
+  | EventPermissionReplied
+  | EventMessagePartUpdated
+  | EventServerConnected
+  | { type: string; properties?: unknown };
+
+export function parseOpenCodeEvent(data: string): OpenCodeEvent | null {
+  try {
+    const parsed = JSON.parse(data);
+    if (!parsed || typeof parsed.type !== 'string') {
+      return null;
+    }
+    return parsed as OpenCodeEvent;
+  } catch {
+    return null;
+  }
+}

--- a/src/agents/opencode-local-bridge.ts
+++ b/src/agents/opencode-local-bridge.ts
@@ -11,6 +11,7 @@ export interface OpenCodeLocalBridgeHandle {
 interface BridgeEntry {
   handle: OpenCodeLocalBridgeHandle;
   server: ReturnType<typeof Bun.serve>;
+  backend: OpenCodeBridgeBackend;
 }
 
 const bridgeEntries = new Map<string, BridgeEntry>();
@@ -45,7 +46,12 @@ export async function ensureOpenCodeLocalBridge(options: {
 }): Promise<OpenCodeLocalBridgeHandle> {
   const existing = bridgeEntries.get(options.workspaceId);
   if (existing) {
-    return existing.handle;
+    // Invalidate if the backend instance changed (e.g., reconnect to different machine)
+    if (existing.backend === options.backend) {
+      return existing.handle;
+    }
+    // Stop the stale bridge so a new one can be created with the fresh backend
+    await existing.handle.stop();
   }
 
   let lastError: unknown = null;
@@ -126,7 +132,7 @@ export async function ensureOpenCodeLocalBridge(options: {
           bridgeEntries.delete(options.workspaceId);
         },
       };
-      bridgeEntries.set(options.workspaceId, { handle, server });
+      bridgeEntries.set(options.workspaceId, { handle, server, backend: options.backend });
       return handle;
     } catch (error) {
       lastError = error;

--- a/src/agents/opencode-local-bridge.ts
+++ b/src/agents/opencode-local-bridge.ts
@@ -1,0 +1,137 @@
+import { createHash } from 'node:crypto';
+import type { OpenCodeBridgeBackend } from '../session/backend.js';
+import { decodeBridgeBody, encodeBridgeBody } from './opencode-bridge.js';
+
+export interface OpenCodeLocalBridgeHandle {
+  workspaceId: string;
+  baseUrl: string;
+  stop: () => Promise<void>;
+}
+
+interface BridgeEntry {
+  handle: OpenCodeLocalBridgeHandle;
+  server: ReturnType<typeof Bun.serve>;
+}
+
+const bridgeEntries = new Map<string, BridgeEntry>();
+
+function hashToPort(key: string): number {
+  const hash = createHash('sha256').update(key).digest();
+  return 44000 + (hash.readUInt16BE(0) % 10000);
+}
+
+function getContentType(headers?: Record<string, string>): string {
+  return headers?.['content-type'] ?? headers?.['Content-Type'] ?? 'application/octet-stream';
+}
+
+function buildSseChunk(event?: string, data?: string, id?: string): string {
+  const lines: string[] = [];
+  if (id) {
+    lines.push(`id: ${id}`);
+  }
+  if (event) {
+    lines.push(`event: ${event}`);
+  }
+  for (const line of (data ?? '').split('\n')) {
+    lines.push(`data: ${line}`);
+  }
+  lines.push('');
+  return `${lines.join('\n')}\n`;
+}
+
+export async function ensureOpenCodeLocalBridge(options: {
+  backend: OpenCodeBridgeBackend;
+  workspaceId: string;
+}): Promise<OpenCodeLocalBridgeHandle> {
+  const existing = bridgeEntries.get(options.workspaceId);
+  if (existing) {
+    return existing.handle;
+  }
+
+  let lastError: unknown = null;
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    const port = hashToPort(`${options.workspaceId}:${attempt}`);
+    try {
+      const server = Bun.serve({
+        hostname: '127.0.0.1',
+        port,
+        fetch: async (request) => {
+          const url = new URL(request.url);
+          const path = url.pathname;
+          const query = Object.fromEntries(url.searchParams.entries());
+
+          if (path === '/event') {
+            let unsubscribe: (() => Promise<void>) | undefined;
+            const stream = new ReadableStream<Uint8Array>({
+              async start(controller) {
+                const encoder = new TextEncoder();
+                controller.enqueue(encoder.encode(buildSseChunk('server.connected', JSON.stringify({ workspaceId: options.workspaceId }))));
+                unsubscribe = await options.backend.subscribeOpenCode(
+                  { workspaceId: options.workspaceId, path, query },
+                  (event) => {
+                    controller.enqueue(encoder.encode(buildSseChunk(event.event, event.data, event.id)));
+                  },
+                );
+              },
+              async cancel() {
+                await unsubscribe?.();
+              },
+            });
+
+            return new Response(stream, {
+              headers: {
+                'content-type': 'text/event-stream; charset=utf-8',
+                'cache-control': 'no-cache',
+                connection: 'keep-alive',
+                'access-control-allow-origin': '*',
+              },
+            });
+          }
+
+          const bodyBytes = request.method === 'GET' || request.method === 'HEAD'
+            ? undefined
+            : new Uint8Array(await request.arrayBuffer());
+
+          const response = await options.backend.requestOpenCode({
+            workspaceId: options.workspaceId,
+            method: request.method as 'GET' | 'POST' | 'PATCH' | 'PUT' | 'DELETE',
+            path,
+            query,
+            headers: (() => {
+              const headers: Record<string, string> = {};
+              request.headers.forEach((value, key) => {
+                headers[key] = value;
+              });
+              return headers;
+            })(),
+            bodyBase64: encodeBridgeBody(bodyBytes),
+          });
+
+          return new Response(Buffer.from(decodeBridgeBody(response.bodyBase64)), {
+            status: response.status,
+            headers: {
+              ...response.headers,
+              'content-type': getContentType(response.headers),
+              'access-control-allow-origin': '*',
+            },
+          });
+        },
+      });
+
+      const handle: OpenCodeLocalBridgeHandle = {
+        workspaceId: options.workspaceId,
+        baseUrl: `http://127.0.0.1:${server.port}`,
+        stop: async () => {
+          server.stop(true);
+          bridgeEntries.delete(options.workspaceId);
+        },
+      };
+      bridgeEntries.set(options.workspaceId, { handle, server });
+      return handle;
+    } catch (error) {
+      lastError = error;
+    }
+  }
+
+  throw lastError instanceof Error ? lastError : new Error('Failed to start OpenCode local bridge');
+}

--- a/src/agents/opencode-relay-client.ts
+++ b/src/agents/opencode-relay-client.ts
@@ -1,0 +1,100 @@
+import type { OpenCodeBridgeBackend } from '../session/backend.js';
+import {
+  decodeBridgeBody,
+  encodeBridgeBody,
+  type OpenCodeBridgeStreamEvent,
+} from './opencode-bridge.js';
+import type { SessionStatus } from './opencode-event-types.js';
+
+export interface OpenCodeRelayClientOptions {
+  backend: OpenCodeBridgeBackend;
+  workspaceId: string;
+}
+
+export class OpenCodeRelayClient {
+  private readonly backend: OpenCodeBridgeBackend;
+  private readonly workspaceId: string;
+
+  constructor(options: OpenCodeRelayClientOptions) {
+    this.backend = options.backend;
+    this.workspaceId = options.workspaceId;
+  }
+
+  async listSessions(): Promise<unknown> {
+    const response = await this.backend.requestOpenCode({
+      workspaceId: this.workspaceId,
+      method: 'GET',
+      path: '/session',
+    });
+
+    return JSON.parse(Buffer.from(decodeBridgeBody(response.bodyBase64)).toString('utf8'));
+  }
+
+  async createSession(title?: string): Promise<unknown> {
+    const response = await this.backend.requestOpenCode({
+      workspaceId: this.workspaceId,
+      method: 'POST',
+      path: '/session',
+      headers: {
+        'content-type': 'application/json',
+      },
+      bodyBase64: encodeBridgeBody(JSON.stringify({ title })),
+    });
+
+    return JSON.parse(Buffer.from(decodeBridgeBody(response.bodyBase64)).toString('utf8'));
+  }
+
+  async getSessionMessages(sessionId: string): Promise<unknown> {
+    const response = await this.backend.requestOpenCode({
+      workspaceId: this.workspaceId,
+      method: 'GET',
+      path: `/session/${encodeURIComponent(sessionId)}/message`,
+    });
+
+    return JSON.parse(Buffer.from(decodeBridgeBody(response.bodyBase64)).toString('utf8'));
+  }
+
+  async subscribe(handler: (event: OpenCodeBridgeStreamEvent) => void): Promise<() => Promise<void>> {
+    return this.backend.subscribeOpenCode(
+      {
+        workspaceId: this.workspaceId,
+        path: '/event',
+      },
+      handler,
+    );
+  }
+
+  async getSessionStatuses(): Promise<Record<string, SessionStatus>> {
+    const response = await this.backend.requestOpenCode({
+      workspaceId: this.workspaceId,
+      method: 'GET',
+      path: '/session/status',
+    });
+    return JSON.parse(Buffer.from(decodeBridgeBody(response.bodyBase64)).toString('utf8'));
+  }
+
+  async abortSession(sessionId: string): Promise<boolean> {
+    const response = await this.backend.requestOpenCode({
+      workspaceId: this.workspaceId,
+      method: 'POST',
+      path: `/session/${encodeURIComponent(sessionId)}/abort`,
+    });
+    return JSON.parse(Buffer.from(decodeBridgeBody(response.bodyBase64)).toString('utf8'));
+  }
+
+  async respondToPermission(
+    sessionId: string,
+    permissionId: string,
+    response: 'allow' | 'deny',
+    remember?: boolean,
+  ): Promise<boolean> {
+    const resp = await this.backend.requestOpenCode({
+      workspaceId: this.workspaceId,
+      method: 'POST',
+      path: `/session/${encodeURIComponent(sessionId)}/permissions/${encodeURIComponent(permissionId)}`,
+      headers: { 'content-type': 'application/json' },
+      bodyBase64: encodeBridgeBody(JSON.stringify({ response, remember })),
+    });
+    return JSON.parse(Buffer.from(decodeBridgeBody(resp.bodyBase64)).toString('utf8'));
+  }
+}

--- a/src/agents/opencode-runtime.ts
+++ b/src/agents/opencode-runtime.ts
@@ -1,0 +1,199 @@
+import { createHash, randomBytes } from 'node:crypto';
+import { setTimeout as delay } from 'node:timers/promises';
+import { prepareWorkspaceIntegrations } from '../integrations/apply.js';
+
+export interface OpenCodeRuntimeTarget {
+  workspaceId: string;
+  workspacePath: string;
+  projectName?: string;
+}
+
+export interface OpenCodeRuntimeInfo {
+  workspaceId: string;
+  workspacePath: string;
+  hostname: string;
+  port: number;
+  baseUrl: string;
+  username: string;
+  password: string;
+  startedAt: string;
+}
+
+export function buildAuthenticatedOpenCodeUrl(info: Pick<OpenCodeRuntimeInfo, 'hostname' | 'port' | 'username' | 'password'>): string {
+  const url = new URL(`http://${info.hostname}:${info.port}`);
+  url.username = info.username;
+  url.password = info.password;
+  return url.toString();
+}
+
+interface RuntimeEntry {
+  info: OpenCodeRuntimeInfo;
+  process: ReturnType<typeof Bun.spawn>;
+}
+
+function hashToPort(workspaceId: string): number {
+  const hash = createHash('sha256').update(workspaceId).digest();
+  return 41000 + (hash.readUInt16BE(0) % 10000);
+}
+
+function createPassword(): string {
+  return randomBytes(24).toString('base64url');
+}
+
+function buildBasicAuth(username: string, password: string): string {
+  return `Basic ${Buffer.from(`${username}:${password}`).toString('base64')}`;
+}
+
+async function checkHealth(info: OpenCodeRuntimeInfo): Promise<boolean> {
+  try {
+    const response = await fetch(`${info.baseUrl}/global/health`, {
+      headers: {
+        authorization: buildBasicAuth(info.username, info.password),
+      },
+    });
+    return response.ok;
+  } catch {
+    return false;
+  }
+}
+
+async function waitForHealthy(info: OpenCodeRuntimeInfo, timeoutMs = 10000): Promise<void> {
+  const started = Date.now();
+  while (Date.now() - started < timeoutMs) {
+    if (await checkHealth(info)) {
+      return;
+    }
+    await delay(200);
+  }
+  throw new Error(`Timed out waiting for OpenCode runtime for ${info.workspaceId}`);
+}
+
+export class OpenCodeRuntimeManager {
+  private readonly entries = new Map<string, RuntimeEntry>();
+  private readonly runtimeStartedHandlers = new Set<(info: OpenCodeRuntimeInfo) => void>();
+  private readonly runtimeStoppedHandlers = new Set<(workspaceId: string) => void>();
+
+  /** Register a callback for when a runtime is successfully started. Returns unsubscribe. */
+  onRuntimeStarted(handler: (info: OpenCodeRuntimeInfo) => void): () => void {
+    this.runtimeStartedHandlers.add(handler);
+    return () => { this.runtimeStartedHandlers.delete(handler); };
+  }
+
+  /** Register a callback for when a runtime is removed. Returns unsubscribe. */
+  onRuntimeStopped(handler: (workspaceId: string) => void): () => void {
+    this.runtimeStoppedHandlers.add(handler);
+    return () => { this.runtimeStoppedHandlers.delete(handler); };
+  }
+
+  private emitRuntimeStarted(info: OpenCodeRuntimeInfo): void {
+    for (const handler of this.runtimeStartedHandlers) {
+      try { handler(info); } catch { /* non-fatal */ }
+    }
+  }
+
+  private emitRuntimeStopped(workspaceId: string): void {
+    for (const handler of this.runtimeStoppedHandlers) {
+      try { handler(workspaceId); } catch { /* non-fatal */ }
+    }
+  }
+
+  /** Returns all currently tracked runtime infos (may include crashed/stale ones) */
+  listRuntimes(): OpenCodeRuntimeInfo[] {
+    return Array.from(this.entries.values()).map((e) => e.info);
+  }
+
+  async ensureWorkspaceRuntime(target: OpenCodeRuntimeTarget): Promise<OpenCodeRuntimeInfo> {
+    const existing = this.entries.get(target.workspaceId);
+    if (existing) {
+      if (existing.process.exitCode === null && (await checkHealth(existing.info))) {
+        return existing.info;
+      }
+
+      try {
+        existing.process.kill();
+      } catch {
+        // no-op
+      }
+      this.entries.delete(target.workspaceId);
+      this.emitRuntimeStopped(target.workspaceId);
+    }
+
+    const username = 'gitspace';
+    const password = createPassword();
+
+    for (let attempt = 0; attempt < 20; attempt += 1) {
+      const port = hashToPort(`${target.workspaceId}:${attempt}`);
+      const info: OpenCodeRuntimeInfo = {
+        workspaceId: target.workspaceId,
+        workspacePath: target.workspacePath,
+        hostname: '127.0.0.1',
+        port,
+        baseUrl: `http://127.0.0.1:${port}`,
+        username,
+        password,
+        startedAt: new Date().toISOString(),
+      };
+
+      if (await checkHealth(info)) {
+        continue;
+      }
+
+      const child = Bun.spawn({
+        cmd: ['opencode', 'web', '--hostname', '127.0.0.1', '--port', String(port)],
+        cwd: target.workspacePath,
+        env: {
+          ...process.env,
+          ...(target.projectName ? (await prepareWorkspaceIntegrations(target.projectName, target.workspacePath)).env : {}),
+          OPENCODE_SERVER_USERNAME: username,
+          OPENCODE_SERVER_PASSWORD: password,
+        },
+        stdout: 'ignore',
+        stderr: 'ignore',
+      });
+
+      try {
+        await waitForHealthy(info);
+        this.entries.set(target.workspaceId, { info, process: child });
+        this.emitRuntimeStarted(info);
+        return info;
+      } catch (error) {
+        try {
+          child.kill();
+        } catch {
+          // no-op
+        }
+
+        if (attempt === 19) {
+          throw error;
+        }
+      }
+    }
+
+    throw new Error(`Failed to start OpenCode runtime for ${target.workspaceId}`);
+  }
+
+  async getWorkspaceRuntime(workspaceId: string): Promise<OpenCodeRuntimeInfo | null> {
+    const entry = this.entries.get(workspaceId);
+    if (!entry) {
+      return null;
+    }
+
+    if (entry.process.exitCode !== null) {
+      this.entries.delete(workspaceId);
+      this.emitRuntimeStopped(workspaceId);
+      return null;
+    }
+
+    if (!(await checkHealth(entry.info))) {
+      return null;
+    }
+
+    return entry.info;
+  }
+}
+
+export const defaultOpenCodeRuntimeManager = new OpenCodeRuntimeManager();
+
+export function createOpenCodeBasicAuthHeader(info: Pick<OpenCodeRuntimeInfo, 'username' | 'password'>): string {
+  return buildBasicAuth(info.username, info.password);
+}

--- a/src/agents/opencode-sse.ts
+++ b/src/agents/opencode-sse.ts
@@ -1,0 +1,71 @@
+export interface ParsedSseEvent {
+  event?: string;
+  data: string;
+  id?: string;
+}
+
+export function parseSseEvent(rawEvent: string): ParsedSseEvent | null {
+  const lines = rawEvent.split(/\r?\n/);
+  let event: string | undefined;
+  let id: string | undefined;
+  const dataLines: string[] = [];
+
+  for (const line of lines) {
+    if (!line || line.startsWith(':')) {
+      continue;
+    }
+    if (line.startsWith('event:')) {
+      event = line.slice(6).trim();
+      continue;
+    }
+    if (line.startsWith('id:')) {
+      id = line.slice(3).trim();
+      continue;
+    }
+    if (line.startsWith('data:')) {
+      dataLines.push(line.slice(5).trimStart());
+    }
+  }
+
+  if (dataLines.length === 0) {
+    return null;
+  }
+
+  return {
+    event,
+    id,
+    data: dataLines.join('\n'),
+  };
+}
+
+export async function consumeSseStream(
+  stream: ReadableStream<Uint8Array>,
+  onEvent: (event: ParsedSseEvent) => Promise<void> | void,
+): Promise<void> {
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  let buffer = '';
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) {
+      break;
+    }
+
+    buffer += decoder.decode(value, { stream: true });
+
+    while (true) {
+      const boundary = buffer.indexOf('\n\n');
+      if (boundary === -1) {
+        break;
+      }
+      const rawEvent = buffer.slice(0, boundary);
+      buffer = buffer.slice(boundary + 2);
+      const parsed = parseSseEvent(rawEvent);
+      if (!parsed) {
+        continue;
+      }
+      await onEvent(parsed);
+    }
+  }
+}

--- a/src/agents/opencode-sse.ts
+++ b/src/agents/opencode-sse.ts
@@ -53,6 +53,8 @@ export async function consumeSseStream(
     }
 
     buffer += decoder.decode(value, { stream: true });
+    // Normalize \r\n to \n (SSE spec allows both line endings)
+    buffer = buffer.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
 
     while (true) {
       const boundary = buffer.indexOf('\n\n');

--- a/src/agents/opencode-sse.ts
+++ b/src/agents/opencode-sse.ts
@@ -23,7 +23,9 @@ export function parseSseEvent(rawEvent: string): ParsedSseEvent | null {
       continue;
     }
     if (line.startsWith('data:')) {
-      dataLines.push(line.slice(5).trimStart());
+      // SSE spec: strip exactly one leading space after the colon, not all whitespace
+      const value = line.slice(5);
+      dataLines.push(value.startsWith(' ') ? value.slice(1) : value);
     }
   }
 

--- a/src/agents/opencode-web.ts
+++ b/src/agents/opencode-web.ts
@@ -1,0 +1,30 @@
+import { buildAuthenticatedOpenCodeUrl, type OpenCodeRuntimeInfo } from './opencode-runtime.js';
+
+export function encodeWorkspacePathForRoute(workspacePath: string): string {
+  return Buffer.from(workspacePath, 'utf8').toString('base64url');
+}
+
+export function buildOpenCodeWebUrl(runtime: OpenCodeRuntimeInfo, sessionId?: string): string {
+  const base = new URL(buildAuthenticatedOpenCodeUrl(runtime));
+  const encodedDir = encodeWorkspacePathForRoute(runtime.workspacePath);
+  if (sessionId) {
+    base.pathname = `/${encodedDir}/session/${encodeURIComponent(sessionId)}`;
+  } else {
+    base.pathname = `/${encodedDir}/session`;
+  }
+  return base.toString();
+}
+
+export function buildOpenCodeWebProxyUrl(params: {
+  machineId: string;
+  workspaceId: string;
+  workspacePath: string;
+  sessionId?: string;
+}): string {
+  const encodedDir = encodeWorkspacePathForRoute(params.workspacePath);
+  const base = `/agent-ui/${encodeURIComponent(params.machineId)}/${encodeURIComponent(params.workspaceId)}`;
+  if (params.sessionId) {
+    return `${base}/${encodedDir}/session/${encodeURIComponent(params.sessionId)}`;
+  }
+  return `${base}/${encodedDir}/session`;
+}

--- a/src/agents/opencode-web.ts
+++ b/src/agents/opencode-web.ts
@@ -1,7 +1,13 @@
 import { buildAuthenticatedOpenCodeUrl, type OpenCodeRuntimeInfo } from './opencode-runtime.js';
 
 export function encodeWorkspacePathForRoute(workspacePath: string): string {
-  return Buffer.from(workspacePath, 'utf8').toString('base64url');
+  // Isomorphic: Buffer for Bun/Node, TextEncoder+btoa for browser
+  if (typeof Buffer !== 'undefined') {
+    return Buffer.from(workspacePath, 'utf8').toString('base64url');
+  }
+  const bytes = new TextEncoder().encode(workspacePath);
+  const binary = String.fromCharCode(...bytes);
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '');
 }
 
 export function buildOpenCodeWebUrl(runtime: OpenCodeRuntimeInfo, sessionId?: string): string {

--- a/src/agents/useAgentSessionPicker.ts
+++ b/src/agents/useAgentSessionPicker.ts
@@ -88,6 +88,8 @@ export function useAgentSessionPicker(options: UseAgentSessionPickerOptions) {
       });
 
       for (const session of resolvedSessions) {
+        // Skip the resume session — it's already shown as a special entry at the top
+        if (resumeSession && session.id === resumeSession.id) continue;
         const badge = statusBadge(session);
         options2.push({
           label: session.title,

--- a/src/agents/useAgentSessionPicker.ts
+++ b/src/agents/useAgentSessionPicker.ts
@@ -1,0 +1,171 @@
+import { useCallback } from 'react';
+import type { UseFlowReturn } from '../components/Flow.js';
+import type { AgentSessionInfo } from './useWorkspaceAgentSessions.js';
+
+function statusBadge(session: AgentSessionInfo): string {
+  if (!session.status) return '';
+  switch (session.status.type) {
+    case 'busy': return ' ● Running';
+    case 'retry': return ` ↺ Retrying (attempt ${session.status.attempt})`;
+    case 'idle': return ' ○ Idle';
+    default: return '';
+  }
+}
+
+export interface OpenPickerOptions {
+  /** If set, immediately open this session (skip the picker UI) */
+  preselectSessionId?: string;
+}
+
+export interface UseAgentSessionPickerOptions {
+  flow: UseFlowReturn;
+  loadWorkspaceSessions: (workspaceId: string) => Promise<AgentSessionInfo[]>;
+  createSession: (workspaceId: string, title?: string) => Promise<AgentSessionInfo[]>;
+  abortSession: (workspaceId: string, sessionId: string) => Promise<AgentSessionInfo[]>;
+  onOpenSession?: (session: AgentSessionInfo) => Promise<void> | void;
+  /** Persisted last-selected session ID for the workspace */
+  persistedSessionId?: string | null;
+  /** Called when a session is selected to persist the choice */
+  onPersistSession?: (sessionId: string) => void;
+}
+
+type PickerValue =
+  | { type: 'new' }
+  | { type: 'session'; session: AgentSessionInfo }
+  | { type: 'abort'; session: AgentSessionInfo };
+
+export function useAgentSessionPicker(options: UseAgentSessionPickerOptions) {
+  const {
+    flow,
+    loadWorkspaceSessions,
+    createSession,
+    abortSession,
+    onOpenSession,
+    persistedSessionId,
+    onPersistSession,
+  } = options;
+
+  const openPicker = useCallback(async (
+    workspaceId: string,
+    workspaceLabel: string,
+    pickerOptions?: OpenPickerOptions,
+  ) => {
+    const openSelector = async (sessions?: AgentSessionInfo[]) => {
+      const resolvedSessions = sessions ?? await loadWorkspaceSessions(workspaceId);
+
+      // Check if the persisted session still exists in the current list
+      const resumeSession = persistedSessionId
+        ? resolvedSessions.find((s) => s.id === persistedSessionId)
+        : null;
+
+      // If preselectSessionId is given, immediately open that session
+      if (pickerOptions?.preselectSessionId) {
+        const preselected = resolvedSessions.find((s) => s.id === pickerOptions.preselectSessionId);
+        if (preselected) {
+          onPersistSession?.(preselected.id);
+          if (onOpenSession) {
+            await onOpenSession(preselected);
+            return;
+          }
+        }
+      }
+
+      const options2: Array<{ label: string; value: PickerValue; description?: string }> = [];
+
+      // Resume option at top if available
+      if (resumeSession) {
+        options2.push({
+          label: `↩ Resume: ${resumeSession.title}`,
+          value: { type: 'session', session: resumeSession },
+          description: `Last used${statusBadge(resumeSession)}`,
+        });
+      }
+
+      options2.push({
+        label: '+ New agent session',
+        value: { type: 'new' },
+        description: 'Create a new OpenCode session in this workspace.',
+      });
+
+      for (const session of resolvedSessions) {
+        const badge = statusBadge(session);
+        options2.push({
+          label: session.title,
+          value: { type: 'session', session },
+          description: session.updatedAt
+            ? `Updated ${new Date(session.updatedAt).toLocaleString()}${badge}`
+            : `${session.id}${badge}`,
+        });
+        // Add Abort option for busy/retrying sessions
+        if (session.status?.type === 'busy' || session.status?.type === 'retry') {
+          options2.push({
+            label: `  ✗ Abort: ${session.title}`,
+            value: { type: 'abort', session },
+            description: 'Stop this running session',
+          });
+        }
+      }
+
+      flow.showSelect<PickerValue>({
+        title: `Agent Sessions: ${workspaceLabel}`,
+        searchable: true,
+        options: options2,
+        onSelect: async (selection) => {
+          if (selection.type === 'new') {
+            flow.showInput({
+              title: `New Agent Session: ${workspaceLabel}`,
+              label: 'Session title',
+              placeholder: 'Investigate auth regression',
+              defaultValue: '',
+              onSubmit: async (value) => {
+                const updated = await createSession(workspaceId, value.trim() || undefined);
+                await openSelector(updated);
+              },
+            });
+            return;
+          }
+
+          if (selection.type === 'abort') {
+            flow.showConfirm({
+              title: 'Abort Session',
+              message: `Stop running session "${selection.session.title}"?`,
+              confirmLabel: 'Abort',
+              cancelLabel: 'Cancel',
+              variant: 'warning',
+              onConfirm: async () => {
+                const updated = await abortSession(workspaceId, selection.session.id);
+                await openSelector(updated);
+              },
+            });
+            return;
+          }
+
+          // type === 'session'
+          onPersistSession?.(selection.session.id);
+          if (onOpenSession) {
+            await onOpenSession(selection.session);
+          }
+        },
+      });
+    };
+
+    try {
+      flow.showLoading({
+        title: 'Loading Agent Sessions',
+        message: `Fetching OpenCode sessions for ${workspaceLabel}...`,
+      });
+      const sessions = await loadWorkspaceSessions(workspaceId);
+      await openSelector(sessions);
+    } catch (error) {
+      flow.showMessage({
+        title: 'Agent Sessions Unavailable',
+        message: error instanceof Error ? error.message : String(error),
+        variant: 'error',
+      });
+    }
+  }, [createSession, abortSession, flow, loadWorkspaceSessions, onOpenSession, persistedSessionId, onPersistSession]);
+
+  return {
+    openPicker,
+  };
+}

--- a/src/agents/usePersistedAgentSession.ts
+++ b/src/agents/usePersistedAgentSession.ts
@@ -1,0 +1,93 @@
+import { useState, useCallback, useEffect } from 'react';
+import type { SessionBackend } from '../session/backend.js';
+
+/**
+ * Persists the last-selected agent session ID per workspace.
+ *
+ * - Web: localStorage (synchronous init)
+ * - TUI: SessionBackend.getAgentSessionPreference (async init via useEffect)
+ *
+ * Both write paths are used on persist so the value is available to either context.
+ * Preferences are best-effort — failures are silently swallowed.
+ */
+
+export interface UsePersistedAgentSessionResult {
+  /** The persisted session ID for this workspace, or null if none */
+  lastSessionId: string | null;
+  /** Persist a new session selection */
+  persist: (sessionId: string) => void;
+  /** Clear the persisted selection */
+  clear: () => void;
+}
+
+function readFromLocalStorage(workspaceId: string): string | null {
+  try {
+    if (typeof localStorage !== 'undefined') {
+      return localStorage.getItem(`gssh:agent-session:${workspaceId}`);
+    }
+  } catch { /* non-fatal */ }
+  return null;
+}
+
+function writeToLocalStorage(workspaceId: string, sessionId: string): void {
+  try {
+    if (typeof localStorage !== 'undefined') {
+      localStorage.setItem(`gssh:agent-session:${workspaceId}`, sessionId);
+    }
+  } catch { /* non-fatal */ }
+}
+
+function removeFromLocalStorage(workspaceId: string): void {
+  try {
+    if (typeof localStorage !== 'undefined') {
+      localStorage.removeItem(`gssh:agent-session:${workspaceId}`);
+    }
+  } catch { /* non-fatal */ }
+}
+
+export function usePersistedAgentSession(
+  workspaceId: string,
+  backend: SessionBackend | null,
+): UsePersistedAgentSessionResult {
+  // Initialize from localStorage synchronously (web context).
+  // In TUI (Bun), localStorage is unavailable — this returns null.
+  const [lastSessionId, setLastSessionId] = useState<string | null>(() => {
+    if (!workspaceId) return null;
+    return readFromLocalStorage(workspaceId);
+  });
+
+  // Async init from backend for TUI disk persistence.
+  // If localStorage already had a value (web), this is a no-op.
+  useEffect(() => {
+    if (!workspaceId || !backend) return;
+    // Skip async load if localStorage already provided a value
+    const fromLs = readFromLocalStorage(workspaceId);
+    if (fromLs !== null) return;
+
+    let cancelled = false;
+    void backend.getAgentSessionPreference(workspaceId).then((pref) => {
+      if (!cancelled && pref) {
+        setLastSessionId(pref);
+      }
+    });
+    return () => { cancelled = true; };
+  }, [workspaceId, backend]);
+
+  const persist = useCallback(
+    (sessionId: string) => {
+      if (!workspaceId) return;
+      setLastSessionId(sessionId);
+      writeToLocalStorage(workspaceId, sessionId);
+      void backend?.setAgentSessionPreference(workspaceId, sessionId);
+    },
+    [workspaceId, backend],
+  );
+
+  const clear = useCallback(() => {
+    if (!workspaceId) return;
+    setLastSessionId(null);
+    removeFromLocalStorage(workspaceId);
+  }, [workspaceId]);
+
+  return { lastSessionId, persist, clear };
+}

--- a/src/agents/usePersistedAgentSession.ts
+++ b/src/agents/usePersistedAgentSession.ts
@@ -56,18 +56,30 @@ export function usePersistedAgentSession(
     return readFromLocalStorage(workspaceId);
   });
 
-  // Async init from backend for TUI disk persistence.
-  // If localStorage already had a value (web), this is a no-op.
+  // Reset state when workspaceId changes — the useState initializer only runs once,
+  // so subsequent workspace switches need an explicit sync.
   useEffect(() => {
-    if (!workspaceId || !backend) return;
-    // Skip async load if localStorage already provided a value
+    if (!workspaceId) {
+      setLastSessionId(null);
+      return;
+    }
+    // Re-read from localStorage for the new workspace
     const fromLs = readFromLocalStorage(workspaceId);
-    if (fromLs !== null) return;
+    if (fromLs !== null) {
+      setLastSessionId(fromLs);
+      return;
+    }
+
+    // Async init from backend for TUI disk persistence.
+    if (!backend) {
+      setLastSessionId(null);
+      return;
+    }
 
     let cancelled = false;
     void backend.getAgentSessionPreference(workspaceId).then((pref) => {
-      if (!cancelled && pref) {
-        setLastSessionId(pref);
+      if (!cancelled) {
+        setLastSessionId(pref ?? null);
       }
     });
     return () => { cancelled = true; };

--- a/src/agents/useWorkspaceAgentEvents.ts
+++ b/src/agents/useWorkspaceAgentEvents.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useRef } from 'react';
+import { useState, useEffect, useCallback, useRef, useMemo } from 'react';
 import type { SessionBackend } from '../session/backend.js';
 import type { AgentStateUpdateDelta, WorkspaceAgentState } from '../serve/agent-event-manager.js';
 import type { Permission, SessionStatus } from './opencode-event-types.js';
@@ -323,7 +323,10 @@ export function useWorkspaceAgentEvents({
     await backend.respondToAgentPermission(workspaceId, agentSessionId, permissionId, response);
   }, [backend]);
 
-  const { total, byWorkspace } = countPendingPermissions(workspaceStates);
+  const { total, byWorkspace } = useMemo(
+    () => countPendingPermissions(workspaceStates),
+    [workspaceStates],
+  );
 
   return {
     workspaceStates,

--- a/src/agents/useWorkspaceAgentEvents.ts
+++ b/src/agents/useWorkspaceAgentEvents.ts
@@ -1,0 +1,334 @@
+import { useState, useEffect, useCallback, useRef } from 'react';
+import type { SessionBackend } from '../session/backend.js';
+import type { AgentStateUpdateDelta, WorkspaceAgentState } from '../serve/agent-event-manager.js';
+import type { Permission, SessionStatus } from './opencode-event-types.js';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface AgentSessionLiveState {
+  status: SessionStatus;
+  pendingPermissions: Record<string, Permission>;  // permissionId → Permission
+  lastMessagePreview: string;
+  lastActivityAt: number;
+  errorMessage?: string;
+}
+
+export type AgentNotificationType = 'permission_needed' | 'agent_idle' | 'agent_error';
+
+export interface AgentNotification {
+  type: AgentNotificationType;
+  workspaceId: string;
+  sessionId: string;
+  sessionTitle: string;
+  /** For permission_needed */
+  permissionId?: string;
+  permissionTitle?: string;
+  /** For agent_idle */
+  messagePreview?: string;
+  /** For agent_error */
+  errorMessage?: string;
+  timestamp: number;
+}
+
+/** workspaceId → sessionId → live state */
+export type WorkspaceAgentStateMap = Record<string, Record<string, AgentSessionLiveState>>;
+
+export interface UseWorkspaceAgentEventsOptions {
+  backend: SessionBackend | null;
+  onNotification?: (notification: AgentNotification) => void;
+}
+
+export interface UseWorkspaceAgentEventsResult {
+  /** All live agent session state, keyed by workspaceId then sessionId */
+  workspaceStates: WorkspaceAgentStateMap;
+  /** Total pending permission count across all workspaces */
+  totalPendingPermissions: number;
+  /** Pending permission count per workspace */
+  pendingPermissionsByWorkspace: Record<string, number>;
+  /** Respond to a permission request */
+  respondToPermission(
+    workspaceId: string,
+    agentSessionId: string,
+    permissionId: string,
+    response: 'allow' | 'deny',
+  ): Promise<void>;
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function buildLiveStateFromWorkspace(workspace: WorkspaceAgentState): Record<string, AgentSessionLiveState> {
+  const result: Record<string, AgentSessionLiveState> = {};
+  for (const session of workspace.sessions) {
+    const status: SessionStatus = workspace.statuses[session.id] ?? { type: 'idle' };
+    const permissions = workspace.pendingPermissions[session.id] ?? [];
+    const pendingMap: Record<string, Permission> = {};
+    for (const p of permissions) {
+      pendingMap[p.id] = p;
+    }
+    result[session.id] = {
+      status,
+      pendingPermissions: pendingMap,
+      lastMessagePreview: workspace.lastMessages[session.id] ?? '',
+      lastActivityAt: Date.now(),
+    };
+  }
+  return result;
+}
+
+function snapshotToWorkspaceStates(snapshot: Record<string, WorkspaceAgentState>): WorkspaceAgentStateMap {
+  const result: WorkspaceAgentStateMap = {};
+  for (const [workspaceId, workspace] of Object.entries(snapshot)) {
+    result[workspaceId] = buildLiveStateFromWorkspace(workspace);
+  }
+  return result;
+}
+
+function countPendingPermissions(states: WorkspaceAgentStateMap): {
+  total: number;
+  byWorkspace: Record<string, number>;
+} {
+  let total = 0;
+  const byWorkspace: Record<string, number> = {};
+  for (const [workspaceId, sessions] of Object.entries(states)) {
+    let count = 0;
+    for (const session of Object.values(sessions)) {
+      count += Object.keys(session.pendingPermissions).length;
+    }
+    byWorkspace[workspaceId] = count;
+    total += count;
+  }
+  return { total, byWorkspace };
+}
+
+// ============================================================================
+// Hook
+// ============================================================================
+
+export function useWorkspaceAgentEvents({
+  backend,
+  onNotification,
+}: UseWorkspaceAgentEventsOptions): UseWorkspaceAgentEventsResult {
+  const [workspaceStates, setWorkspaceStates] = useState<WorkspaceAgentStateMap>(() => {
+    if (!backend) return {};
+    return snapshotToWorkspaceStates(backend.getAgentStateSnapshot());
+  });
+
+  // Mutable refs for cross-delta tracking (not React state — never triggers re-renders)
+  const prevStatusesRef = useRef<Record<string, SessionStatus>>({});
+  const sessionTitlesRef = useRef<Record<string, string>>({});
+
+  // Populate from snapshot on first render (refs are stable across renders)
+  if (backend && Object.keys(prevStatusesRef.current).length === 0) {
+    const snapshot = backend.getAgentStateSnapshot();
+    for (const [wid, ws] of Object.entries(snapshot)) {
+      for (const [sid, status] of Object.entries(ws.statuses)) {
+        prevStatusesRef.current[`${wid}:${sid}`] = status;
+      }
+      for (const s of ws.sessions) {
+        sessionTitlesRef.current[`${ws.workspaceId}:${s.id}`] = s.title;
+      }
+    }
+  }
+
+  // Keep onNotification in a ref so the effect always uses the latest callback
+  const onNotificationRef = useRef(onNotification);
+  onNotificationRef.current = onNotification;
+
+  useEffect(() => {
+    if (!backend) return;
+
+    const snapshot = backend.getAgentStateSnapshot();
+    setWorkspaceStates(snapshotToWorkspaceStates(snapshot));
+
+    const unsubscribe = backend.subscribeAgentState((delta: AgentStateUpdateDelta) => {
+      setWorkspaceStates((prev) => {
+        const next = { ...prev };
+
+        if (delta.type === 'agent_state_snapshot') {
+          return snapshotToWorkspaceStates(delta.workspaces);
+        }
+
+        if (!('workspaceId' in delta)) return next;
+        const { workspaceId } = delta;
+
+        switch (delta.type) {
+          case 'agent_session_status': {
+            const { sessionId, status } = delta;
+            const prevKey = `${workspaceId}:${sessionId}`;
+            const prevStatus = prevStatusesRef.current[prevKey];
+            prevStatusesRef.current[prevKey] = status;
+
+            next[workspaceId] = {
+              ...next[workspaceId],
+              [sessionId]: {
+                ...(next[workspaceId]?.[sessionId] ?? {
+                  pendingPermissions: {},
+                  lastMessagePreview: '',
+                  lastActivityAt: Date.now(),
+                }),
+                status,
+                lastActivityAt: Date.now(),
+              },
+            };
+
+            if (prevStatus?.type === 'busy' && status.type === 'idle' && onNotificationRef.current) {
+              const preview = next[workspaceId]?.[sessionId]?.lastMessagePreview ?? '';
+              onNotificationRef.current({
+                type: 'agent_idle',
+                workspaceId,
+                sessionId,
+                sessionTitle: sessionTitlesRef.current[`${workspaceId}:${sessionId}`] ?? sessionId,
+                messagePreview: preview,
+                timestamp: Date.now(),
+              });
+            }
+            break;
+          }
+
+          case 'agent_permission_added': {
+            const { sessionId, permission } = delta;
+            const existing = next[workspaceId]?.[sessionId];
+            next[workspaceId] = {
+              ...next[workspaceId],
+              [sessionId]: {
+                ...(existing ?? {
+                  status: { type: 'idle' },
+                  lastMessagePreview: '',
+                  lastActivityAt: Date.now(),
+                }),
+                pendingPermissions: {
+                  ...(existing?.pendingPermissions ?? {}),
+                  [permission.id]: permission,
+                },
+                lastActivityAt: Date.now(),
+              },
+            };
+            onNotificationRef.current?.({
+              type: 'permission_needed',
+              workspaceId,
+              sessionId,
+              sessionTitle: sessionTitlesRef.current[`${workspaceId}:${sessionId}`] ?? sessionId,
+              permissionId: permission.id,
+              permissionTitle: permission.title,
+              timestamp: Date.now(),
+            });
+            break;
+          }
+
+          case 'agent_permission_removed': {
+            const { sessionId, permissionId } = delta;
+            const existing = next[workspaceId]?.[sessionId];
+            if (existing?.pendingPermissions[permissionId]) {
+              const { [permissionId]: _removed, ...rest } = existing.pendingPermissions;
+              next[workspaceId] = {
+                ...next[workspaceId],
+                [sessionId]: { ...existing, pendingPermissions: rest },
+              };
+            }
+            break;
+          }
+
+          case 'agent_session_error': {
+            const { sessionId, errorMessage } = delta;
+            const existing = next[workspaceId]?.[sessionId];
+            next[workspaceId] = {
+              ...next[workspaceId],
+              [sessionId]: {
+                ...(existing ?? {
+                  status: { type: 'idle' },
+                  pendingPermissions: {},
+                  lastMessagePreview: '',
+                  lastActivityAt: Date.now(),
+                }),
+                errorMessage,
+                lastActivityAt: Date.now(),
+              },
+            };
+            onNotificationRef.current?.({
+              type: 'agent_error',
+              workspaceId,
+              sessionId,
+              sessionTitle: sessionTitlesRef.current[`${workspaceId}:${sessionId}`] ?? sessionId,
+              errorMessage,
+              timestamp: Date.now(),
+            });
+            break;
+          }
+
+          case 'agent_last_message': {
+            const { sessionId, preview } = delta;
+            const existing = next[workspaceId]?.[sessionId];
+            if (existing) {
+              next[workspaceId] = {
+                ...next[workspaceId],
+                [sessionId]: { ...existing, lastMessagePreview: preview },
+              };
+            }
+            break;
+          }
+
+          case 'agent_session_created': {
+            const { sessionId, title } = delta;
+            sessionTitlesRef.current[`${workspaceId}:${sessionId}`] = title;
+            if (!next[workspaceId]?.[sessionId]) {
+              next[workspaceId] = {
+                ...next[workspaceId],
+                [sessionId]: {
+                  status: { type: 'idle' },
+                  pendingPermissions: {},
+                  lastMessagePreview: '',
+                  lastActivityAt: Date.now(),
+                },
+              };
+            }
+            break;
+          }
+
+          case 'agent_session_updated': {
+            const { sessionId, title } = delta;
+            sessionTitlesRef.current[`${workspaceId}:${sessionId}`] = title;
+            break;
+          }
+
+          case 'agent_session_deleted': {
+            const { sessionId } = delta;
+            if (next[workspaceId]) {
+              const { [sessionId]: _removed, ...rest } = next[workspaceId];
+              next[workspaceId] = rest;
+              delete prevStatusesRef.current[`${workspaceId}:${sessionId}`];
+              delete sessionTitlesRef.current[`${workspaceId}:${sessionId}`];
+            }
+            break;
+          }
+        }
+
+        return next;
+      });
+    });
+
+    return unsubscribe;
+  }, [backend]);
+
+  const respondToPermission = useCallback(async (
+    workspaceId: string,
+    agentSessionId: string,
+    permissionId: string,
+    response: 'allow' | 'deny',
+  ) => {
+    if (!backend) return;
+    await backend.respondToAgentPermission(workspaceId, agentSessionId, permissionId, response);
+  }, [backend]);
+
+  const { total, byWorkspace } = countPendingPermissions(workspaceStates);
+
+  return {
+    workspaceStates,
+    totalPendingPermissions: total,
+    pendingPermissionsByWorkspace: byWorkspace,
+    respondToPermission,
+  };
+}

--- a/src/agents/useWorkspaceAgentSessions.ts
+++ b/src/agents/useWorkspaceAgentSessions.ts
@@ -1,0 +1,107 @@
+import { useCallback, useMemo, useState } from 'react';
+import { OpenCodeRelayClient } from './opencode-relay-client.js';
+import type { OpenCodeBridgeBackend, SessionBackend } from '../session/backend.js';
+import type { SessionStatus } from './opencode-event-types.js';
+
+export interface AgentSessionInfo {
+  id: string;
+  workspaceId: string;
+  title: string;
+  updatedAt?: string;
+  /** Current status from AgentEventManager snapshot, if available */
+  status?: SessionStatus;
+}
+
+export interface UseWorkspaceAgentSessionsOptions {
+  bridge: Pick<OpenCodeBridgeBackend, 'requestOpenCode' | 'subscribeOpenCode'> | null;
+  /** Full backend for status merging and abort */
+  backend?: SessionBackend | null;
+}
+
+function normalizeTitle(value: unknown, fallback: string): string {
+  return typeof value === 'string' && value.trim().length > 0 ? value : fallback;
+}
+
+export function useWorkspaceAgentSessions(options: UseWorkspaceAgentSessionsOptions) {
+  const [sessionsByWorkspace, setSessionsByWorkspace] = useState<Record<string, AgentSessionInfo[]>>({});
+  const [loadingWorkspaceId, setLoadingWorkspaceId] = useState<string | null>(null);
+  const [activeWorkspaceId, setActiveWorkspaceId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const createClient = useCallback((workspaceId: string) => {
+    if (!options.bridge) {
+      throw new Error('OpenCode bridge unavailable');
+    }
+    return new OpenCodeRelayClient({
+      workspaceId,
+      backend: options.bridge,
+    });
+  }, [options.bridge]);
+
+  const loadWorkspaceSessions = useCallback(async (workspaceId: string) => {
+    setLoadingWorkspaceId(workspaceId);
+    setActiveWorkspaceId(workspaceId);
+    setError(null);
+    try {
+      const client = createClient(workspaceId);
+      const raw = await client.listSessions() as Array<Record<string, unknown>>;
+
+      // Merge status from AgentEventManager snapshot if available
+      const agentSnapshot = options.backend?.getAgentStateSnapshot() ?? {};
+      const workspaceAgentState = agentSnapshot[workspaceId];
+      const statusMap = workspaceAgentState?.statuses ?? {};
+
+      const mapped: AgentSessionInfo[] = raw.map((session) => ({
+        id: String(session.id),
+        workspaceId,
+        title: normalizeTitle(session.title, String(session.id)),
+        updatedAt: typeof session.updatedAt === 'string' ? session.updatedAt : undefined,
+        status: statusMap[String(session.id)],
+      }));
+
+      setSessionsByWorkspace((current) => ({
+        ...current,
+        [workspaceId]: mapped,
+      }));
+      return mapped;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      setError(message);
+      throw err;
+    } finally {
+      setLoadingWorkspaceId((current) => (current === workspaceId ? null : current));
+    }
+  }, [createClient, options.backend]);
+
+  const createSession = useCallback(async (workspaceId: string, title?: string) => {
+    const client = createClient(workspaceId);
+    await client.createSession(title);
+    return loadWorkspaceSessions(workspaceId);
+  }, [createClient, loadWorkspaceSessions]);
+
+  const abortSession = useCallback(async (workspaceId: string, sessionId: string) => {
+    const client = createClient(workspaceId);
+    await client.abortSession(sessionId);
+    // Refresh list after abort
+    return loadWorkspaceSessions(workspaceId);
+  }, [createClient, loadWorkspaceSessions]);
+
+  const sessions = useMemo(() => {
+    if (!activeWorkspaceId) {
+      return [];
+    }
+    return sessionsByWorkspace[activeWorkspaceId] ?? [];
+  }, [activeWorkspaceId, sessionsByWorkspace]);
+
+  return {
+    activeWorkspaceId,
+    sessionsByWorkspace,
+    sessions,
+    loadingWorkspaceId,
+    error,
+    setActiveWorkspaceId,
+    loadWorkspaceSessions,
+    createSession,
+    abortSession,
+  };
+}

--- a/src/app.tui.tsx
+++ b/src/app.tui.tsx
@@ -11,7 +11,7 @@
 import { createCliRenderer } from '@opentui/core';
 import type { PasteEvent } from '@opentui/core';
 import { createRoot, useKeyboard, useRenderer } from '@opentui/react';
-import { useState, useEffect, useCallback, useReducer, Fragment, useRef } from 'react';
+import { useState, useEffect, useCallback, useReducer, Fragment, useRef, useMemo } from 'react';
 import { Toaster } from '@opentui-ui/toast/react';
 
 // Terminal components
@@ -118,6 +118,12 @@ import {
   VT_KITTY_KEYBOARD_CONFIG,
   forceDisableKittyKeyboard,
 } from './tui/kitty-keyboard.js';
+import { useWorkspaceAgentSessions } from './agents/useWorkspaceAgentSessions.js';
+import { useAgentSessionPicker } from './agents/useAgentSessionPicker.js';
+import { useWorkspaceAgentEvents } from './agents/useWorkspaceAgentEvents.js';
+import { usePersistedAgentSession } from './agents/usePersistedAgentSession.js';
+import { agentNotificationToInboxItem } from './agents/agentNotificationToInboxItem.js';
+import { buildOpenCodeAttachCommand } from './agents/opencode-attach.js';
 
 // Types
 import type { InboxItem } from './lib/tmux-lite/cli.js';
@@ -155,6 +161,13 @@ type SettingsFlowState =
   | { type: 'types-menu'; selectedIndex: number; config: NotificationConfig }
   | { type: 'edit-duration'; value: string; config: NotificationConfig }
   | { type: 'edit-hold-duration'; value: string; config: NotificationConfig };
+
+function getInitialInputValueForStep(step: OnboardingStep): string {
+  if (step.type === 'input') {
+    return step.defaultValue || '';
+  }
+  return '';
+}
 
 // ============================================================================
 // Constants
@@ -816,10 +829,48 @@ function App({ relayConfig, remoteIdentity, onQuit, keyboardMode }: AppProps) {
     const newValues = { ...projectFlow.collectedValues };
     const newSecrets = { ...projectFlow.collectedSecrets };
 
+    const currentValue = projectFlow.inputValue.trim();
+
+    const validateValue = (
+      required: boolean | undefined,
+      validationPattern: string | undefined,
+      validationMessage: string | undefined,
+      value: string,
+    ): string | null => {
+      if (required !== false && value.length === 0) {
+        return 'This field is required.';
+      }
+      if (validationPattern && value.length > 0) {
+        try {
+          const regex = new RegExp(validationPattern);
+          if (!regex.test(value)) {
+            return validationMessage || `Value must match pattern: ${validationPattern}`;
+          }
+        } catch {
+          return 'Invalid validation pattern in bundle.';
+        }
+      }
+      return null;
+    };
+
     // Save current step's value if applicable
     if (currentStep && (currentStep.type === 'input' || currentStep.type === 'secret')) {
       const stepWithKey = currentStep as { configKey: string; defaultValue?: string };
-      const value = projectFlow.inputValue.trim() || stepWithKey.defaultValue || '';
+      const value = currentValue || stepWithKey.defaultValue || '';
+      const validationError = validateValue(
+        currentStep.required,
+        'validationPattern' in currentStep ? currentStep.validationPattern : undefined,
+        'validationMessage' in currentStep ? currentStep.validationMessage : undefined,
+        value,
+      );
+      if (validationError) {
+        flow.showMessage({
+          title: 'Invalid Value',
+          message: validationError,
+          variant: 'error',
+        });
+        return;
+      }
 
       if (currentStep.type === 'secret') {
         newSecrets[stepWithKey.configKey] = value;
@@ -859,18 +910,19 @@ function App({ relayConfig, remoteIdentity, onQuit, keyboardMode }: AppProps) {
       }
     } else {
       // Move to next step
-      const nextStep = projectFlow.steps[nextStepIndex];
+        const nextStep = projectFlow.steps[nextStepIndex];
+        const defaultValue = (nextStep as { defaultValue?: string }).defaultValue || '';
 
-      // If it's a confirm step with checkCommand, start checking
-      if (nextStep.type === 'confirm' && (nextStep as { checkCommand?: string }).checkCommand) {
-        setProjectFlow({
-          ...projectFlow,
-          currentStep: nextStepIndex,
-          collectedValues: newValues,
-          collectedSecrets: newSecrets,
-          inputValue: '',
-          confirmStatus: 'checking',
-        });
+        // If it's a confirm step with checkCommand, start checking
+        if (nextStep.type === 'confirm' && (nextStep as { checkCommand?: string }).checkCommand) {
+          setProjectFlow({
+            ...projectFlow,
+            currentStep: nextStepIndex,
+            collectedValues: newValues,
+            collectedSecrets: newSecrets,
+            inputValue: '',
+            confirmStatus: 'checking',
+          });
 
         const found = await checkCommand((nextStep as { checkCommand: string }).checkCommand);
         setProjectFlow(prev =>
@@ -878,17 +930,16 @@ function App({ relayConfig, remoteIdentity, onQuit, keyboardMode }: AppProps) {
             ? { ...prev, confirmStatus: found ? 'found' : 'missing' }
             : prev
         );
-      } else {
-        const defaultValue = (nextStep as { defaultValue?: string }).defaultValue || '';
-        setProjectFlow({
-          ...projectFlow,
-          currentStep: nextStepIndex,
-          collectedValues: newValues,
-          collectedSecrets: newSecrets,
-          inputValue: defaultValue,
-          confirmStatus: null,
-        });
-      }
+        } else {
+          setProjectFlow({
+            ...projectFlow,
+            currentStep: nextStepIndex,
+            collectedValues: newValues,
+            collectedSecrets: newSecrets,
+            inputValue: defaultValue,
+            confirmStatus: null,
+          });
+        }
     }
   }, [projectFlow, checkCommand, finalizeProject, flow]);
 
@@ -922,7 +973,7 @@ function App({ relayConfig, remoteIdentity, onQuit, keyboardMode }: AppProps) {
         if (loadedBundle.bundle.onboarding && loadedBundle.bundle.onboarding.length > 0) {
           // Start onboarding flow
           const firstStep = loadedBundle.bundle.onboarding[0];
-          const initialInputValue = (firstStep as { defaultValue?: string }).defaultValue || '';
+          const initialInputValue = getInitialInputValueForStep(firstStep);
 
           // If first step is a confirm with checkCommand, start checking
           if (firstStep.type === 'confirm' && (firstStep as { checkCommand?: string }).checkCommand) {
@@ -1053,8 +1104,14 @@ function App({ relayConfig, remoteIdentity, onQuit, keyboardMode }: AppProps) {
     ? localReplays.filter((replay) => replay.projectName === currentProject)
     : [];
 
-  const inboxItems = localInbox as InboxItem[];
-  const inboxUnreadCount = localInboxUnreadCount;
+  // Agent inbox items — generated from useWorkspaceAgentEvents notifications
+  const [agentInboxItems, setAgentInboxItems] = useState<InboxItem[]>([]);
+
+  const inboxItems = useMemo(
+    () => [...(localInbox as InboxItem[]), ...agentInboxItems],
+    [localInbox, agentInboxItems],
+  );
+  const inboxUnreadCount = localInboxUnreadCount + agentInboxItems.filter((i) => !i.read).length;
 
   // Project list hook
   const projectListProps = useProjectList({
@@ -1197,6 +1254,54 @@ function App({ relayConfig, remoteIdentity, onQuit, keyboardMode }: AppProps) {
     return Promise.resolve(getReplayTimelineOffline(replayId));
   }, []);
 
+  const localBackend = localSession as unknown as import('./session/backend.js').SessionBackend | null;
+
+  const workspaceAgentSessions = useWorkspaceAgentSessions({
+    bridge: localSession.hasOpenCodeBridge
+      ? {
+          requestOpenCode: localSession.requestOpenCode,
+          subscribeOpenCode: localSession.subscribeOpenCode,
+        }
+      : null,
+    backend: localBackend,
+  });
+
+  // Agent event subscription — machine-side push, no per-client SSE
+  const agentEvents = useWorkspaceAgentEvents({
+    backend: localBackend,
+    onNotification: (notification) => {
+      const workspace = localWorkspaces.find((w) => w.id === notification.workspaceId);
+      const projectName = workspace?.projectName ?? 'unknown';
+      const workspaceName = workspace?.name ?? notification.workspaceId;
+      const item = agentNotificationToInboxItem(notification, projectName, workspaceName);
+      setAgentInboxItems((prev) => [item, ...prev.slice(0, 49)]);
+    },
+  });
+
+  // Per-workspace agent session persistence — use spacesBrowser's selected workspace if available
+  // Fallback to empty string when no workspace is focused (hook is always called, ID may be empty)
+  const [agentPickerWorkspaceId, setAgentPickerWorkspaceId] = useState('');
+  const agentSessionPref = usePersistedAgentSession(agentPickerWorkspaceId, localBackend);
+
+  const agentSessionPicker = useAgentSessionPicker({
+    flow,
+    loadWorkspaceSessions: workspaceAgentSessions.loadWorkspaceSessions,
+    createSession: workspaceAgentSessions.createSession,
+    abortSession: workspaceAgentSessions.abortSession,
+    persistedSessionId: agentSessionPref.lastSessionId,
+    onPersistSession: agentSessionPref.persist,
+    onOpenSession: async (session) => {
+      agentSessionPref.persist(session.id);
+      const runtime = await localSession.getOpenCodeRuntimeInfo(session.workspaceId);
+      const commandSpec = buildOpenCodeAttachCommand(runtime, session.id);
+      await attachLocal({
+        workspaceId: session.workspaceId,
+        command: commandSpec.command,
+        args: commandSpec.args,
+      });
+    },
+  });
+
   // Spaces browser hook
   const spacesBrowserProps = useSpacesBrowser({
     workspaces: workspaceInfos,
@@ -1215,6 +1320,23 @@ function App({ relayConfig, remoteIdentity, onQuit, keyboardMode }: AppProps) {
     onStopProcess: handleStopProcess,
     onProcessDisabled: handleProcessDisabled,
     onOpenEvents: handleOpenEvents,
+    onOpenAgents: async (workspaceId) => {
+      setAgentPickerWorkspaceId(workspaceId);
+      const workspace = workspaceInfos.find((item) => item.id === workspaceId);
+      await agentSessionPicker.openPicker(workspaceId, workspace?.name ?? workspaceId);
+    },
+    agentSessionCounts: (() => {
+      // Start with explicit session load counts, then overlay live counts from agent events
+      const counts: Record<string, number> = {};
+      for (const [wid, sessions] of Object.entries(workspaceAgentSessions.sessionsByWorkspace)) {
+        counts[wid] = sessions.length;
+      }
+      for (const [wid, sessions] of Object.entries(agentEvents.workspaceStates)) {
+        counts[wid] = Object.keys(sessions).length;
+      }
+      return counts;
+    })(),
+    pendingPermissionsByWorkspace: agentEvents.pendingPermissionsByWorkspace,
     onRefresh: refreshWorkspaces,
     onRefreshSessions: async () => {
       await Promise.all([
@@ -1271,6 +1393,36 @@ function App({ relayConfig, remoteIdentity, onQuit, keyboardMode }: AppProps) {
       await refreshInbox();
     },
     onAttachSession: async (sessionId) => {
+      // Check if this is an agent notification item
+      const agentItem = agentInboxItems.find((i) => i.sessionId === sessionId && i.agentAction);
+      if (agentItem?.agentAction) {
+        const { workspaceId, agentSessionId, permissionId, permissionTitle } = agentItem.agentAction;
+        dispatch({ type: 'SET_VIEW', view: 'projects' });
+        if (permissionId) {
+          flow.showSelect<'allow' | 'deny' | 'dismiss'>({
+            title: `Permission: ${permissionTitle ?? 'Action requested'}`,
+            options: [
+              { label: 'Allow', value: 'allow' as const, description: 'Grant the agent permission to proceed' },
+              { label: 'Deny', value: 'deny' as const, description: 'Deny the agent and stop this action' },
+              { label: 'Dismiss', value: 'dismiss' as const, description: 'Close without responding (agent keeps waiting)' },
+            ],
+            onSelect: async (choice) => {
+              if (choice === 'allow' || choice === 'deny') {
+                await agentEvents.respondToPermission(workspaceId, agentSessionId, permissionId, choice);
+              }
+              setAgentInboxItems((prev) => prev.map((i) => i.sessionId === sessionId ? { ...i, read: true } : i));
+            },
+          });
+        } else {
+          // Open agent session picker pre-selected on this session
+          const workspace = workspaceInfos.find((w) => w.id === workspaceId);
+          setAgentPickerWorkspaceId(workspaceId);
+          await agentSessionPicker.openPicker(workspaceId, workspace?.name ?? workspaceId, {
+            preselectSessionId: agentSessionId,
+          });
+        }
+        return;
+      }
       dispatch({ type: 'SET_VIEW', view: 'projects' });
       await handleAttachSession({ sessionId });
     },
@@ -2610,6 +2762,9 @@ function getWorkspacesPanelHint(selectedItem: TreeItem | null | undefined): stri
   }
   if (selectedItem?.type === 'bundle-config') {
     return '[Tab] Switch  [Enter] Edit Bundle Config  [b] Bundle  [,] Settings  [?] Help  [q] Quit';
+  }
+  if (selectedItem?.type === 'agents') {
+    return '[Tab] Switch  [Enter] Agent Sessions  [,] Settings  [?] Help  [q] Quit';
   }
   if (selectedItem?.type === 'events') {
     return '[Tab] Switch  [Enter] Open Events  [b] Bundle  [,] Settings  [?] Help  [q] Quit';

--- a/src/app.tui.tsx
+++ b/src/app.tui.tsx
@@ -166,6 +166,7 @@ function getInitialInputValueForStep(step: OnboardingStep): string {
   if (step.type === 'input') {
     return step.defaultValue || '';
   }
+  // SecretStep intentionally has no defaultValue — secrets shouldn't be pre-filled
   return '';
 }
 

--- a/src/app.tui.tsx
+++ b/src/app.tui.tsx
@@ -1302,6 +1302,19 @@ function App({ relayConfig, remoteIdentity, onQuit, keyboardMode }: AppProps) {
     },
   });
 
+  // Memoize agent session counts to preserve referential stability for useSpacesBrowser
+  const agentSessionCounts = useMemo(() => {
+    // Start with explicit session load counts, then overlay live counts from agent events
+    const counts: Record<string, number> = {};
+    for (const [wid, sessions] of Object.entries(workspaceAgentSessions.sessionsByWorkspace)) {
+      counts[wid] = sessions.length;
+    }
+    for (const [wid, sessions] of Object.entries(agentEvents.workspaceStates)) {
+      counts[wid] = Object.keys(sessions).length;
+    }
+    return counts;
+  }, [workspaceAgentSessions.sessionsByWorkspace, agentEvents.workspaceStates]);
+
   // Spaces browser hook
   const spacesBrowserProps = useSpacesBrowser({
     workspaces: workspaceInfos,
@@ -1325,17 +1338,7 @@ function App({ relayConfig, remoteIdentity, onQuit, keyboardMode }: AppProps) {
       const workspace = workspaceInfos.find((item) => item.id === workspaceId);
       await agentSessionPicker.openPicker(workspaceId, workspace?.name ?? workspaceId);
     },
-    agentSessionCounts: (() => {
-      // Start with explicit session load counts, then overlay live counts from agent events
-      const counts: Record<string, number> = {};
-      for (const [wid, sessions] of Object.entries(workspaceAgentSessions.sessionsByWorkspace)) {
-        counts[wid] = sessions.length;
-      }
-      for (const [wid, sessions] of Object.entries(agentEvents.workspaceStates)) {
-        counts[wid] = Object.keys(sessions).length;
-      }
-      return counts;
-    })(),
+    agentSessionCounts: agentSessionCounts,
     pendingPermissionsByWorkspace: agentEvents.pendingPermissionsByWorkspace,
     onRefresh: refreshWorkspaces,
     onRefreshSessions: async () => {

--- a/src/app.tui.tsx
+++ b/src/app.tui.tsx
@@ -1255,7 +1255,7 @@ function App({ relayConfig, remoteIdentity, onQuit, keyboardMode }: AppProps) {
     return Promise.resolve(getReplayTimelineOffline(replayId));
   }, []);
 
-  const localBackend = localSession as unknown as import('./session/backend.js').SessionBackend | null;
+  const localBackend = localSession.sessionBackend;
 
   const workspaceAgentSessions = useWorkspaceAgentSessions({
     bridge: localSession.hasOpenCodeBridge
@@ -1305,13 +1305,15 @@ function App({ relayConfig, remoteIdentity, onQuit, keyboardMode }: AppProps) {
 
   // Memoize agent session counts to preserve referential stability for useSpacesBrowser
   const agentSessionCounts = useMemo(() => {
-    // Start with explicit session load counts, then overlay live counts from agent events
+    // Merge explicit session load counts with live event counts, taking the higher value
+    // (event state may be incomplete if it only received updates for a subset of sessions)
     const counts: Record<string, number> = {};
     for (const [wid, sessions] of Object.entries(workspaceAgentSessions.sessionsByWorkspace)) {
       counts[wid] = sessions.length;
     }
     for (const [wid, sessions] of Object.entries(agentEvents.workspaceStates)) {
-      counts[wid] = Object.keys(sessions).length;
+      const eventCount = Object.keys(sessions).length;
+      counts[wid] = Math.max(counts[wid] ?? 0, eventCount);
     }
     return counts;
   }, [workspaceAgentSessions.sessionsByWorkspace, agentEvents.workspaceStates]);

--- a/src/app.web.tsx
+++ b/src/app.web.tsx
@@ -913,7 +913,8 @@ export default function App() {
       counts[wid] = sessions.length;
     }
     for (const [wid, sessions] of Object.entries(agentEvents.workspaceStates)) {
-      counts[wid] = Object.keys(sessions).length;
+      const eventCount = Object.keys(sessions).length;
+      counts[wid] = Math.max(counts[wid] ?? 0, eventCount);
     }
     return counts;
   }, [workspaceAgentSessions.sessionsByWorkspace, agentEvents.workspaceStates]);

--- a/src/app.web.tsx
+++ b/src/app.web.tsx
@@ -26,6 +26,10 @@ import { useWorkspaceDeleteFlow } from './app/session/useWorkspaceDeleteFlow.js'
 import { useLifecycleController } from './app/session/useLifecycleController.js';
 import { ReviewPage } from './pages/ReviewPage.web.js';
 import { buildEditProcessesCommand } from './lib/processes/editor.js';
+import { useWorkspaceAgentSessions } from './agents/useWorkspaceAgentSessions.js';
+import { useAgentSessionPicker } from './agents/useAgentSessionPicker.js';
+import { buildOpenCodeAttachCommand } from './agents/opencode-attach.js';
+import { buildOpenCodeWebProxyUrl } from './agents/opencode-web.js';
 
 // Import shared components and hooks
 import {
@@ -44,6 +48,9 @@ import { SpacesBrowserWeb } from "./components/SpacesBrowser.web.js";
 import { FlowWeb } from "./components/Flow.web.js";
 import { useInbox } from "./components/Inbox.js";
 import { InboxWeb } from "./components/Inbox.web.js";
+import { useWorkspaceAgentEvents } from './agents/useWorkspaceAgentEvents.js';
+import { usePersistedAgentSession } from './agents/usePersistedAgentSession.js';
+import { agentNotificationToInboxItem } from './agents/agentNotificationToInboxItem.js';
 import { useEvents, toWideEventItem, type WideEventItem } from "./components/Events.js";
 import { EventsWeb } from "./components/Events.web.js";
 import type { WideEventFilter } from "./types/events.js";
@@ -60,7 +67,7 @@ import {
   resolveSessionBrowserCommand,
 } from './app/input/sessionCommands.js';
 
-type View = "machines" | "terminal" | "review" | 'replay';
+type View = "machines" | "terminal" | "review" | "replay" | "agent";
 
 const PAGE_UP = '\x1b[5~';
 const PAGE_DOWN = '\x1b[6~';
@@ -124,6 +131,14 @@ export default function App() {
     workspaceId: string;
     workspaceLabel?: string;
   } | null>(null);
+  const [activeAgentView, setActiveAgentView] = useState<{
+    machineId: string;
+    workspaceId: string;
+    title: string;
+    url: string;
+  } | null>(null);
+  const activeAgentViewRef = useRef<typeof activeAgentView>(null);
+  const selectedMachineRef = useRef<MachineInfo | null>(null);
 
   // Identity state (resolved by IdentityGate before relay connection)
   const [resolvedIdentity, setResolvedIdentity] = useState<Identity | null>(null);
@@ -135,6 +150,117 @@ export default function App() {
   const terminal = useTerminal();
   const activeNotificationConfig =
     terminal.notificationConfig ?? localNotificationConfig ?? DEFAULT_NOTIFICATION_CONFIG;
+
+  useEffect(() => {
+    activeAgentViewRef.current = activeAgentView;
+  }, [activeAgentView]);
+
+  useEffect(() => {
+    selectedMachineRef.current = selectedMachine;
+  }, [selectedMachine]);
+
+  useEffect(() => {
+    if (!('serviceWorker' in navigator)) {
+      return;
+    }
+
+    const handleServiceWorkerMessage = (event: MessageEvent) => {
+      const data = event.data as {
+        type?: string;
+        mode?: 'request' | 'stream';
+        machineId?: string;
+        workspaceId?: string;
+        method?: 'GET' | 'POST' | 'PATCH' | 'PUT' | 'DELETE';
+        path?: string;
+        query?: Record<string, string>;
+        headers?: Record<string, string>;
+        bodyBase64?: string;
+      } | null;
+      const port = event.ports?.[0];
+      if (!data || data.type !== 'gitspace-agent-proxy-request' || !port) {
+        return;
+      }
+
+      const agentView = activeAgentViewRef.current;
+      const machine = selectedMachineRef.current;
+
+      if (
+        !agentView ||
+        !machine ||
+        data.machineId !== agentView.machineId ||
+        data.machineId !== machine.machineId ||
+        data.workspaceId !== agentView.workspaceId
+      ) {
+        port.postMessage({ ok: false, status: 409, error: 'Active agent session is unavailable' });
+        return;
+      }
+
+      if (data.mode === 'stream') {
+        let closed = false;
+        const unsubscribePromise = terminal.subscribeOpenCode(
+          {
+            workspaceId: data.workspaceId!,
+            path: data.path!,
+            query: data.query,
+            headers: data.headers,
+          },
+          (streamEvent) => {
+            if (closed) {
+              return;
+            }
+            port.postMessage({
+              type: 'stream-event',
+              event: streamEvent.event,
+              data: streamEvent.data,
+              id: streamEvent.id,
+            });
+          },
+        );
+
+        unsubscribePromise
+          .then(() => {
+            if (!closed) {
+              port.postMessage({ type: 'stream-open' });
+            }
+          })
+          .catch((error) => {
+            port.postMessage({ type: 'stream-error', message: error instanceof Error ? error.message : String(error) });
+          });
+
+        port.onmessage = async (messageEvent) => {
+          if (messageEvent.data?.type !== 'stream-close' || closed) {
+            return;
+          }
+          closed = true;
+          try {
+            const unsubscribe = await unsubscribePromise;
+            await unsubscribe();
+          } finally {
+            port.postMessage({ type: 'stream-close' });
+          }
+        };
+        return;
+      }
+
+      void terminal.requestOpenCode({
+        workspaceId: data.workspaceId!,
+        method: data.method!,
+        path: data.path!,
+        query: data.query,
+        headers: data.headers,
+        bodyBase64: data.bodyBase64,
+      }).then((response) => {
+        port.postMessage({ ok: true, ...response });
+      }).catch((error) => {
+        port.postMessage({ ok: false, status: 502, error: error instanceof Error ? error.message : String(error) });
+      });
+    };
+
+    navigator.serviceWorker.addEventListener('message', handleServiceWorkerMessage);
+    return () => {
+      navigator.serviceWorker.removeEventListener('message', handleServiceWorkerMessage);
+    };
+  }, [terminal]);
 
   // Visual viewport hook for keyboard detection
   const keyboardVisible = useVisualViewport();
@@ -716,6 +842,70 @@ export default function App() {
     return terminal.getReplayTimeline(replayId);
   }, [terminal]);
 
+  const webBackend = terminal as unknown as import('./session/backend.js').SessionBackend | null;
+
+  const workspaceAgentSessions = useWorkspaceAgentSessions({
+    bridge: terminal.hasOpenCodeBridge
+      ? {
+          requestOpenCode: terminal.requestOpenCode,
+          subscribeOpenCode: terminal.subscribeOpenCode,
+        }
+      : null,
+    backend: webBackend,
+  });
+
+  // Agent event subscription — machine-side push state
+  const [agentInboxItems, setAgentInboxItems] = useState<import('./lib/tmux-lite/protocol.js').InboxItem[]>([]);
+
+  const agentEvents = useWorkspaceAgentEvents({
+    backend: webBackend,
+    onNotification: (notification) => {
+      const workspace = terminal.workspaces.find((w) => w.id === notification.workspaceId);
+      const projectName = workspace?.projectName ?? 'unknown';
+      const workspaceName = workspace?.name ?? notification.workspaceId;
+      const item = agentNotificationToInboxItem(notification, projectName, workspaceName);
+      setAgentInboxItems((prev) => [item, ...prev.slice(0, 49)]);
+    },
+  });
+
+  const [agentPickerWorkspaceId, setAgentPickerWorkspaceId] = useState('');
+  const agentSessionPref = usePersistedAgentSession(agentPickerWorkspaceId, webBackend);
+
+  const agentSessionPicker = useAgentSessionPicker({
+    flow,
+    loadWorkspaceSessions: workspaceAgentSessions.loadWorkspaceSessions,
+    createSession: workspaceAgentSessions.createSession,
+    abortSession: workspaceAgentSessions.abortSession,
+    persistedSessionId: agentSessionPref.lastSessionId,
+    onPersistSession: agentSessionPref.persist,
+    onOpenSession: async (session) => {
+      agentSessionPref.persist(session.id);
+      const runtime = await terminal.getOpenCodeRuntimeInfo(session.workspaceId);
+      if ('serviceWorker' in navigator && selectedMachine?.machineId) {
+        setActiveAgentView({
+          machineId: selectedMachine.machineId,
+          workspaceId: session.workspaceId,
+          title: session.title,
+          url: buildOpenCodeWebProxyUrl({
+            machineId: selectedMachine.machineId,
+            workspaceId: session.workspaceId,
+            workspacePath: runtime.workspacePath,
+            sessionId: session.id,
+          }),
+        });
+        setView('agent');
+        return;
+      }
+
+      const commandSpec = buildOpenCodeAttachCommand(runtime, session.id);
+      await attachController.attach({
+        workspaceId: session.workspaceId,
+        command: commandSpec.command,
+        args: commandSpec.args,
+      });
+    },
+  });
+
   // Spaces browser hook
   const spacesBrowserProps = useSpacesBrowser({
     workspaces: filteredWorkspaces,
@@ -739,6 +929,22 @@ export default function App() {
         terminal.requestEvents(workspace.path, undefined, undefined, undefined);
       }
     },
+    onOpenAgents: async (workspaceId) => {
+      setAgentPickerWorkspaceId(workspaceId);
+      const workspace = terminal.workspaces.find((item) => item.id === workspaceId);
+      await agentSessionPicker.openPicker(workspaceId, workspace?.name ?? workspaceId);
+    },
+    agentSessionCounts: (() => {
+      const counts: Record<string, number> = {};
+      for (const [wid, sessions] of Object.entries(workspaceAgentSessions.sessionsByWorkspace)) {
+        counts[wid] = sessions.length;
+      }
+      for (const [wid, sessions] of Object.entries(agentEvents.workspaceStates)) {
+        counts[wid] = Object.keys(sessions).length;
+      }
+      return counts;
+    })(),
+    pendingPermissionsByWorkspace: agentEvents.pendingPermissionsByWorkspace,
     onRefresh: () => { terminal.requestWorkspaces(); refreshReplayList(); },
     onRefreshSessions: () => { terminal.requestSessions(); refreshReplayList(); },
     onBack: handleBackToMachines,
@@ -806,15 +1012,62 @@ export default function App() {
     onRefresh: () => terminal.requestProjects(),
   });
 
-  // Inbox hook
+  // Inbox hook — merges PTY inbox with agent notifications
+  const allWebInboxItems = useMemo(
+    () => [...terminal.inbox, ...agentInboxItems],
+    [terminal.inbox, agentInboxItems],
+  );
+
   const inboxProps = useInbox({
-    items: terminal.inbox,
-    unreadCount: terminal.inboxUnreadCount,
-    onClearItem: async (id) => terminal.clearInboxItem(id),
-    onClearAll: async () => terminal.clearInboxItem(),
-    onMarkRead: async (id) => terminal.markInboxItemRead(id),
+    items: allWebInboxItems,
+    unreadCount: terminal.inboxUnreadCount + agentInboxItems.filter((i) => !i.read).length,
+    onClearItem: async (id) => {
+      if (agentInboxItems.some((i) => i.id === id)) {
+        setAgentInboxItems((prev) => prev.filter((i) => i.id !== id));
+      } else {
+        terminal.clearInboxItem(id);
+      }
+    },
+    onClearAll: async () => {
+      setAgentInboxItems([]);
+      terminal.clearInboxItem();
+    },
+    onMarkRead: async (id) => {
+      if (agentInboxItems.some((i) => i.id === id)) {
+        setAgentInboxItems((prev) => prev.map((i) => i.id === id ? { ...i, read: true } : i));
+      } else {
+        terminal.markInboxItemRead(id);
+      }
+    },
     onAttachSession: async (sessionId) => {
       setShowInbox(false);
+      const agentItem = agentInboxItems.find((i) => i.sessionId === sessionId && i.agentAction);
+      if (agentItem?.agentAction) {
+        const { workspaceId, agentSessionId, permissionId, permissionTitle } = agentItem.agentAction;
+        if (permissionId) {
+          flow.showSelect<'allow' | 'deny' | 'dismiss'>({
+            title: `Permission: ${permissionTitle ?? 'Action requested'}`,
+            options: [
+              { label: 'Allow', value: 'allow' as const, description: 'Grant the agent permission to proceed' },
+              { label: 'Deny', value: 'deny' as const, description: 'Deny the agent and stop this action' },
+              { label: 'Dismiss', value: 'dismiss' as const, description: 'Close without responding (agent keeps waiting)' },
+            ],
+            onSelect: async (choice) => {
+              if (choice === 'allow' || choice === 'deny') {
+                await agentEvents.respondToPermission(workspaceId, agentSessionId, permissionId, choice);
+              }
+              setAgentInboxItems((prev) => prev.map((i) => i.sessionId === sessionId ? { ...i, read: true } : i));
+            },
+          });
+        } else {
+          const workspace = terminal.workspaces.find((w) => w.id === workspaceId);
+          setAgentPickerWorkspaceId(workspaceId);
+          await agentSessionPicker.openPicker(workspaceId, workspace?.name ?? workspaceId, {
+            preselectSessionId: agentSessionId,
+          });
+        }
+        return;
+      }
       await attachController.attach({ sessionId });
     },
     onClose: () => setShowInbox(false),
@@ -1465,6 +1718,55 @@ export default function App() {
           </div>
         </div>
         <FlowWeb flow={flow} />
+        <Toaster theme="dark" position="top-right" richColors />
+      </>
+    );
+  }
+
+  if (view === 'agent' && activeAgentView) {
+    return (
+      <>
+        <div className="h-screen w-screen flex flex-col bg-[#0d1117]">
+          <div className="bg-[#161b22] px-4 py-2 flex items-center justify-between border-b border-[#30363d] min-h-[52px] gap-2">
+            <div className="flex items-center gap-2 sm:gap-4 min-w-0 flex-1">
+              <button
+                onClick={() => {
+                  setView('terminal');
+                  setActiveAgentView(null);
+                }}
+                className="text-sm text-[#8b949e] hover:text-[#e6edf3] active:text-[#22c55e] py-2 pr-2 -ml-2 min-h-[44px] flex items-center flex-shrink-0"
+              >
+                ← <span className="hidden sm:inline ml-1">Sessions</span>
+              </button>
+              <div className="text-sm text-[#8b949e] truncate">
+                <span className="text-[#c678dd]">✦</span>{' '}
+                <span className="text-[#e6edf3]">{activeAgentView.title}</span>
+              </div>
+            </div>
+            <div className="flex items-center gap-2 flex-shrink-0">
+              <button
+                onClick={() => window.open(activeAgentView.url, '_blank', 'noopener,noreferrer')}
+                className="px-3 py-2 text-sm bg-[#21262d] hover:bg-[#30363d] active:bg-[#161b22] rounded text-[#e6edf3] min-h-[44px] border border-[#30363d]"
+              >
+                Open in Tab
+              </button>
+              <button
+                onClick={handleDisconnect}
+                className="px-3 py-2 text-sm bg-[#f85149] hover:bg-[#ff7b72] active:bg-[#da3633] rounded text-white min-h-[44px] border border-[#f85149]"
+              >
+                Disconnect
+              </button>
+            </div>
+          </div>
+          <div className="flex-1 bg-[#0d1117]">
+            <iframe
+              src={activeAgentView.url}
+              title={activeAgentView.title}
+              className="w-full h-full border-0"
+              sandbox="allow-same-origin allow-scripts allow-forms allow-popups allow-downloads"
+            />
+          </div>
+        </div>
         <Toaster theme="dark" position="top-right" richColors />
       </>
     );

--- a/src/app.web.tsx
+++ b/src/app.web.tsx
@@ -906,6 +906,18 @@ export default function App() {
     },
   });
 
+  // Memoize agent session counts to preserve referential stability for useSpacesBrowser
+  const agentSessionCounts = useMemo(() => {
+    const counts: Record<string, number> = {};
+    for (const [wid, sessions] of Object.entries(workspaceAgentSessions.sessionsByWorkspace)) {
+      counts[wid] = sessions.length;
+    }
+    for (const [wid, sessions] of Object.entries(agentEvents.workspaceStates)) {
+      counts[wid] = Object.keys(sessions).length;
+    }
+    return counts;
+  }, [workspaceAgentSessions.sessionsByWorkspace, agentEvents.workspaceStates]);
+
   // Spaces browser hook
   const spacesBrowserProps = useSpacesBrowser({
     workspaces: filteredWorkspaces,
@@ -934,16 +946,7 @@ export default function App() {
       const workspace = terminal.workspaces.find((item) => item.id === workspaceId);
       await agentSessionPicker.openPicker(workspaceId, workspace?.name ?? workspaceId);
     },
-    agentSessionCounts: (() => {
-      const counts: Record<string, number> = {};
-      for (const [wid, sessions] of Object.entries(workspaceAgentSessions.sessionsByWorkspace)) {
-        counts[wid] = sessions.length;
-      }
-      for (const [wid, sessions] of Object.entries(agentEvents.workspaceStates)) {
-        counts[wid] = Object.keys(sessions).length;
-      }
-      return counts;
-    })(),
+    agentSessionCounts,
     pendingPermissionsByWorkspace: agentEvents.pendingPermissionsByWorkspace,
     onRefresh: () => { terminal.requestWorkspaces(); refreshReplayList(); },
     onRefreshSessions: () => { terminal.requestSessions(); refreshReplayList(); },

--- a/src/app.web.tsx
+++ b/src/app.web.tsx
@@ -842,7 +842,7 @@ export default function App() {
     return terminal.getReplayTimeline(replayId);
   }, [terminal]);
 
-  const webBackend = terminal as unknown as import('./session/backend.js').SessionBackend | null;
+  const webBackend = terminal.sessionBackend;
 
   const workspaceAgentSessions = useWorkspaceAgentSessions({
     bridge: terminal.hasOpenCodeBridge

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -34,6 +34,7 @@ import {
 } from '../core/identity.js';
 import { loadUserRootIdentity, createLocalDeviceCertificate } from '../core/user-identity.js';
 import { ClientSessionManager } from '../serve/client-session-manager.js';
+import { defaultAgentEventManager } from '../serve/agent-event-manager.js';
 import type { ServeEventHandler } from '../serve/types.js';
 import type { Identity, StoredIdentity } from '../types/identity.js';
 import {
@@ -1323,6 +1324,14 @@ export async function serveStart(options: {
     throw error;
   }
 
+  // Initialize AgentEventManager — subscribes to already-running OpenCode runtimes
+  void defaultAgentEventManager.initialize();
+
+  // Broadcast agent state changes to all connected authenticated clients
+  defaultAgentEventManager.subscribe((delta) => {
+    void sessionManager.broadcastAgentStateUpdate(delta);
+  });
+
   // Event handler - update daemon state
   const eventHandler: ServeEventHandler = (event) => {
     switch (event.type) {
@@ -1335,7 +1344,15 @@ export async function serveStart(options: {
       case 'relay_reconnecting':
         updateDaemonState({ relay: { url: effectiveRelayUrl, status: 'reconnecting' } });
         break;
-      case 'client_authenticated':
+      case 'client_authenticated': {
+        updateDaemonState({ clients: sessionManager.establishedSessionCount });
+        // Push full agent state snapshot to newly authenticated client
+        const snapshot = defaultAgentEventManager.getSnapshot();
+        if (Object.keys(snapshot).length > 0) {
+          void sessionManager.sendAgentStateSnapshot(event.connectionId, snapshot);
+        }
+        break;
+      }
       case 'client_disconnected':
         updateDaemonState({ clients: sessionManager.establishedSessionCount });
         break;

--- a/src/components/Inbox.tsx
+++ b/src/components/Inbox.tsx
@@ -12,9 +12,11 @@ import { useState, useCallback, useMemo, useEffect } from 'react';
 // ============================================================================
 
 /** Inbox item type */
-export type InboxItemType = 'exit' | 'title' | 'idle' | 'bell' | 'osc';
+export type InboxItemType =
+  | 'exit' | 'title' | 'idle' | 'bell' | 'osc'
+  | 'agent_permission' | 'agent_idle' | 'agent_error';
 
-/** Inbox item from tmux-lite */
+/** Inbox item from tmux-lite or agent notification system */
 export interface InboxItem {
   id: string;
   sessionId: string;
@@ -25,6 +27,14 @@ export interface InboxItem {
   read: boolean;
   processTitle?: string;
   exitCode?: number;
+  /** Present only for agent_* item types — carries routing metadata for the app layer */
+  agentAction?: {
+    workspaceId: string;
+    agentSessionId: string;
+    permissionId?: string;
+    permissionTitle?: string;
+    messagePreview?: string;
+  };
 }
 
 /** Parsed session name components */
@@ -110,10 +120,13 @@ export function parseSessionName(sessionName: string): ParsedSessionName {
     return { project: 'unknown', workspace: 'unknown', session: 'unknown' };
   }
   const parts = sessionName.split(':');
+  // Handle agent:<title> session segment — parts may be: project:workspace:agent:<title>
+  // where the title itself may contain colons. Join everything from index 2 onward.
+  const sessionPart = parts.slice(2).join(':') || 'unknown';
   return {
     project: parts[0] || 'unknown',
     workspace: parts[1] || 'unknown',
-    session: parts[2] || 'unknown',
+    session: sessionPart,
   };
 }
 
@@ -123,7 +136,16 @@ export function getInboxIcon(item: InboxItem): string {
   if (item.type === 'title') return '📝';
   if (item.type === 'idle') return '⏸️';
   if (item.type === 'osc') return '📟';
+  if (item.type === 'agent_permission') return '⚡';
+  if (item.type === 'agent_idle') return '💬';
+  if (item.type === 'agent_error') return '🤖';
   return '🔔';
+}
+
+/** Returns true if the item is an agent notification type */
+export function isAgentInboxItem(item: InboxItem): item is InboxItem & { agentAction: NonNullable<InboxItem['agentAction']> } {
+  return (item.type === 'agent_permission' || item.type === 'agent_idle' || item.type === 'agent_error')
+    && item.agentAction != null;
 }
 
 /** Get label for inbox item type */
@@ -132,6 +154,9 @@ export function getInboxTypeLabel(item: InboxItem): string {
   if (item.type === 'title') return 'Title Change';
   if (item.type === 'idle') return 'Activity Complete';
   if (item.type === 'osc') return 'OSC Notification';
+  if (item.type === 'agent_permission') return 'Permission Request';
+  if (item.type === 'agent_idle') return 'Agent Done';
+  if (item.type === 'agent_error') return 'Agent Error';
   return 'Bell';
 }
 

--- a/src/components/RemoteMachineScreen.tui.tsx
+++ b/src/components/RemoteMachineScreen.tui.tsx
@@ -610,7 +610,6 @@ export function RemoteMachineScreen({ machine, relayUrl, identity, onBack }: Rem
     onPersistSession: agentSessionPref.persist,
     onOpenSession: async (session) => {
       agentSessionPref.persist(session.id);
-      const runtime = await remote.getOpenCodeRuntimeInfo(session.workspaceId);
       const bridge = await ensureOpenCodeLocalBridge({
         workspaceId: session.workspaceId,
         backend: {
@@ -626,6 +625,18 @@ export function RemoteMachineScreen({ machine, relayUrl, identity, onBack }: Rem
       });
     },
   });
+
+  // Memoize agent session counts to preserve referential stability for useSpacesBrowser
+  const agentSessionCounts = useMemo(() => {
+    const counts: Record<string, number> = {};
+    for (const [wid, sessions] of Object.entries(workspaceAgentSessions.sessionsByWorkspace)) {
+      counts[wid] = sessions.length;
+    }
+    for (const [wid, sessions] of Object.entries(agentEvents.workspaceStates)) {
+      counts[wid] = Object.keys(sessions).length;
+    }
+    return counts;
+  }, [workspaceAgentSessions.sessionsByWorkspace, agentEvents.workspaceStates]);
 
   const spacesBrowserProps = useSpacesBrowser({
     workspaces: remote.workspaces,
@@ -645,16 +656,7 @@ export function RemoteMachineScreen({ machine, relayUrl, identity, onBack }: Rem
       const workspace = remote.workspaces.find((item) => item.id === workspaceId);
       await agentSessionPicker.openPicker(workspaceId, workspace?.name ?? workspaceId);
     },
-    agentSessionCounts: (() => {
-      const counts: Record<string, number> = {};
-      for (const [wid, sessions] of Object.entries(workspaceAgentSessions.sessionsByWorkspace)) {
-        counts[wid] = sessions.length;
-      }
-      for (const [wid, sessions] of Object.entries(agentEvents.workspaceStates)) {
-        counts[wid] = Object.keys(sessions).length;
-      }
-      return counts;
-    })(),
+    agentSessionCounts,
     pendingPermissionsByWorkspace: agentEvents.pendingPermissionsByWorkspace,
     onOpenEvents: handleOpenEvents,
     onRefresh: remote.requestWorkspaces,

--- a/src/components/RemoteMachineScreen.tui.tsx
+++ b/src/components/RemoteMachineScreen.tui.tsx
@@ -572,7 +572,7 @@ export function RemoteMachineScreen({ machine, relayUrl, identity, onBack }: Rem
     await bundleConfigFlow.openBundleConfig({ workspaceId, projectName });
   }, [bundleConfigFlow, remote.selectedProjectName, remote.workspaces]);
 
-  const remoteBackend = remote as unknown as import('../session/backend.js').SessionBackend | null;
+  const remoteBackend = remote.sessionBackend;
 
   const workspaceAgentSessions = useWorkspaceAgentSessions({
     bridge: remote.hasOpenCodeBridge

--- a/src/components/RemoteMachineScreen.tui.tsx
+++ b/src/components/RemoteMachineScreen.tui.tsx
@@ -633,7 +633,8 @@ export function RemoteMachineScreen({ machine, relayUrl, identity, onBack }: Rem
       counts[wid] = sessions.length;
     }
     for (const [wid, sessions] of Object.entries(agentEvents.workspaceStates)) {
-      counts[wid] = Object.keys(sessions).length;
+      const eventCount = Object.keys(sessions).length;
+      counts[wid] = Math.max(counts[wid] ?? 0, eventCount);
     }
     return counts;
   }, [workspaceAgentSessions.sessionsByWorkspace, agentEvents.workspaceStates]);

--- a/src/components/RemoteMachineScreen.tui.tsx
+++ b/src/components/RemoteMachineScreen.tui.tsx
@@ -39,6 +39,13 @@ import { createLocalDeviceCertificate } from '../core/user-identity.js';
 import { writeCrashLog } from '../utils/crash-log.js';
 import { logger } from '../utils/logger.js';
 import type { ReplayInfo } from '../lib/tmux-lite/replay/index.js';
+import { useWorkspaceAgentSessions } from '../agents/useWorkspaceAgentSessions.js';
+import { useAgentSessionPicker } from '../agents/useAgentSessionPicker.js';
+import { useWorkspaceAgentEvents } from '../agents/useWorkspaceAgentEvents.js';
+import { usePersistedAgentSession } from '../agents/usePersistedAgentSession.js';
+import { agentNotificationToInboxItem } from '../agents/agentNotificationToInboxItem.js';
+import { buildOpenCodeAttachUrlCommand } from '../agents/opencode-attach.js';
+import { ensureOpenCodeLocalBridge } from '../agents/opencode-local-bridge.js';
 
 const COLORS = {
   statusBar: '#333333',
@@ -565,6 +572,61 @@ export function RemoteMachineScreen({ machine, relayUrl, identity, onBack }: Rem
     await bundleConfigFlow.openBundleConfig({ workspaceId, projectName });
   }, [bundleConfigFlow, remote.selectedProjectName, remote.workspaces]);
 
+  const remoteBackend = remote as unknown as import('../session/backend.js').SessionBackend | null;
+
+  const workspaceAgentSessions = useWorkspaceAgentSessions({
+    bridge: remote.hasOpenCodeBridge
+      ? {
+          requestOpenCode: remote.requestOpenCode,
+          subscribeOpenCode: remote.subscribeOpenCode,
+        }
+      : null,
+    backend: remoteBackend,
+  });
+
+  // Agent event subscription — machine-side push state
+  const [agentInboxItems, setAgentInboxItems] = useState<import('../lib/tmux-lite/protocol.js').InboxItem[]>([]);
+
+  const agentEvents = useWorkspaceAgentEvents({
+    backend: remoteBackend,
+    onNotification: (notification) => {
+      const workspace = remote.workspaces.find((w) => w.id === notification.workspaceId);
+      const projectName = workspace?.projectName ?? 'unknown';
+      const workspaceName = workspace?.name ?? notification.workspaceId;
+      const item = agentNotificationToInboxItem(notification, projectName, workspaceName);
+      setAgentInboxItems((prev) => [item, ...prev.slice(0, 49)]);
+    },
+  });
+
+  const [agentPickerWorkspaceId, setAgentPickerWorkspaceId] = useState('');
+  const agentSessionPref = usePersistedAgentSession(agentPickerWorkspaceId, remoteBackend);
+
+  const agentSessionPicker = useAgentSessionPicker({
+    flow,
+    loadWorkspaceSessions: workspaceAgentSessions.loadWorkspaceSessions,
+    createSession: workspaceAgentSessions.createSession,
+    abortSession: workspaceAgentSessions.abortSession,
+    persistedSessionId: agentSessionPref.lastSessionId,
+    onPersistSession: agentSessionPref.persist,
+    onOpenSession: async (session) => {
+      agentSessionPref.persist(session.id);
+      const runtime = await remote.getOpenCodeRuntimeInfo(session.workspaceId);
+      const bridge = await ensureOpenCodeLocalBridge({
+        workspaceId: session.workspaceId,
+        backend: {
+          requestOpenCode: remote.requestOpenCode,
+          subscribeOpenCode: remote.subscribeOpenCode,
+        },
+      });
+      const commandSpec = buildOpenCodeAttachUrlCommand(bridge.baseUrl, session.id);
+      await attachController.attach({
+        workspaceId: session.workspaceId,
+        command: commandSpec.command,
+        args: commandSpec.args,
+      });
+    },
+  });
+
   const spacesBrowserProps = useSpacesBrowser({
     workspaces: remote.workspaces,
     sessions: remote.sessions,
@@ -578,6 +640,22 @@ export function RemoteMachineScreen({ machine, relayUrl, identity, onBack }: Rem
     onStartProcessAttach: handleStartProcessAttach,
     onStopProcess: handleStopProcess,
     onProcessDisabled: handleProcessDisabled,
+    onOpenAgents: async (workspaceId) => {
+      setAgentPickerWorkspaceId(workspaceId);
+      const workspace = remote.workspaces.find((item) => item.id === workspaceId);
+      await agentSessionPicker.openPicker(workspaceId, workspace?.name ?? workspaceId);
+    },
+    agentSessionCounts: (() => {
+      const counts: Record<string, number> = {};
+      for (const [wid, sessions] of Object.entries(workspaceAgentSessions.sessionsByWorkspace)) {
+        counts[wid] = sessions.length;
+      }
+      for (const [wid, sessions] of Object.entries(agentEvents.workspaceStates)) {
+        counts[wid] = Object.keys(sessions).length;
+      }
+      return counts;
+    })(),
+    pendingPermissionsByWorkspace: agentEvents.pendingPermissionsByWorkspace,
     onOpenEvents: handleOpenEvents,
     onRefresh: remote.requestWorkspaces,
     onRefreshSessions: () => {
@@ -606,20 +684,63 @@ export function RemoteMachineScreen({ machine, relayUrl, identity, onBack }: Rem
     return null;
   }, [spacesBrowserProps.selectedItem]);
 
+  const allInboxItems = useMemo(
+    () => [...remote.inbox, ...agentInboxItems],
+    [remote.inbox, agentInboxItems],
+  );
+
   const inboxProps = useInbox({
-    items: remote.inbox,
-    unreadCount: remote.inboxUnreadCount,
+    items: allInboxItems,
+    unreadCount: remote.inboxUnreadCount + agentInboxItems.filter((i) => !i.read).length,
     onClearItem: async (id) => {
-      remote.clearInboxItem(id);
+      const isAgent = agentInboxItems.some((i) => i.id === id);
+      if (isAgent) {
+        setAgentInboxItems((prev) => prev.filter((i) => i.id !== id));
+      } else {
+        remote.clearInboxItem(id);
+      }
     },
     onClearAll: async () => {
+      setAgentInboxItems([]);
       remote.clearInboxItem();
     },
     onMarkRead: async (id) => {
-      remote.markInboxItemRead(id);
+      const isAgent = agentInboxItems.some((i) => i.id === id);
+      if (isAgent) {
+        setAgentInboxItems((prev) => prev.map((i) => i.id === id ? { ...i, read: true } : i));
+      } else {
+        remote.markInboxItemRead(id);
+      }
     },
     onAttachSession: async (sessionId) => {
       setShowInbox(false);
+      const agentItem = agentInboxItems.find((i) => i.sessionId === sessionId && i.agentAction);
+      if (agentItem?.agentAction) {
+        const { workspaceId, agentSessionId, permissionId, permissionTitle } = agentItem.agentAction;
+        if (permissionId) {
+          flow.showSelect<'allow' | 'deny' | 'dismiss'>({
+            title: `Permission: ${permissionTitle ?? 'Action requested'}`,
+            options: [
+              { label: 'Allow', value: 'allow' as const, description: 'Grant the agent permission to proceed' },
+              { label: 'Deny', value: 'deny' as const, description: 'Deny the agent and stop this action' },
+              { label: 'Dismiss', value: 'dismiss' as const, description: 'Close without responding (agent keeps waiting)' },
+            ],
+            onSelect: async (choice) => {
+              if (choice === 'allow' || choice === 'deny') {
+                await agentEvents.respondToPermission(workspaceId, agentSessionId, permissionId, choice);
+              }
+              setAgentInboxItems((prev) => prev.map((i) => i.sessionId === sessionId ? { ...i, read: true } : i));
+            },
+          });
+        } else {
+          const workspace = remote.workspaces.find((w) => w.id === workspaceId);
+          setAgentPickerWorkspaceId(workspaceId);
+          await agentSessionPicker.openPicker(workspaceId, workspace?.name ?? workspaceId, {
+            preselectSessionId: agentSessionId,
+          });
+        }
+        return;
+      }
       await handleAttachSession({ sessionId });
     },
     onClose: () => {

--- a/src/components/SpacesBrowser.tsx
+++ b/src/components/SpacesBrowser.tsx
@@ -59,6 +59,7 @@ export interface SessionInfo {
 export type TreeItem =
   | { type: 'project'; name: string; workspaceCount: number }
   | { type: 'workspace'; workspace: WorkspaceInfo; expanded: boolean }
+  | { type: 'agents'; workspaceId: string; count?: number; pendingPermissions?: number }
   | { type: 'session'; session: SessionInfo; workspaceId: string }
   | { type: 'replay-section'; workspaceId: string; count: number; expanded: boolean }
   | { type: 'orphaned-replay-section'; projectName: string; count: number; expanded: boolean }
@@ -90,6 +91,10 @@ export interface UseSpacesBrowserProps {
   onStopProcess?: (params: { workspaceId: string; processName: string }) => void;
   onProcessDisabled?: (params: { workspaceId: string; processName: string }) => void;
   onOpenEvents: (workspaceId: string) => void;
+  onOpenAgents?: (workspaceId: string) => void | Promise<void>;
+  agentSessionCounts?: Record<string, number>;
+  /** Pending permission count per workspace, from useWorkspaceAgentEvents */
+  pendingPermissionsByWorkspace?: Record<string, number>;
   onEditProcesses?: (params: { workspaceId: string }) => void;
   onManageBundleConfig?: (params: { workspaceId: string }) => void;
   onRefresh: () => void | Promise<void>;
@@ -176,7 +181,9 @@ function buildTree(
   replays: ReplayInfo[],
   expandedWorkspaces: Set<string>,
   expandedReplaySections: Set<string>,
-  showProjectHeaders: boolean = true
+  agentSessionCounts: Record<string, number>,
+  showProjectHeaders: boolean = true,
+  pendingPermissionsByWorkspace: Record<string, number> = {},
 ): TreeItem[] {
   const items: TreeItem[] = [];
   const projectGroups = groupByProject(workspaces, replays);
@@ -339,6 +346,13 @@ function buildTree(
           workspaceId: ws.id,
         });
 
+        items.push({
+          type: 'agents',
+          workspaceId: ws.id,
+          count: agentSessionCounts[ws.id] ?? 0,
+          pendingPermissions: pendingPermissionsByWorkspace[ws.id] ?? 0,
+        });
+
         // Events action
         items.push({
           type: 'events',
@@ -403,6 +417,9 @@ export function useSpacesBrowser(props: UseSpacesBrowserProps): UseSpacesBrowser
     onStopProcess,
     onProcessDisabled,
     onOpenEvents,
+    onOpenAgents,
+    agentSessionCounts = {},
+    pendingPermissionsByWorkspace = {},
     onEditProcesses,
     onManageBundleConfig,
     onRefresh,
@@ -420,8 +437,8 @@ export function useSpacesBrowser(props: UseSpacesBrowserProps): UseSpacesBrowser
 
   // Build tree
   const tree = useMemo(
-    () => buildTree(workspaces, sessions, replays, expandedWorkspaces, expandedReplaySections, showProjectHeaders),
-    [workspaces, sessions, replays, expandedWorkspaces, expandedReplaySections, showProjectHeaders]
+    () => buildTree(workspaces, sessions, replays, expandedWorkspaces, expandedReplaySections, agentSessionCounts, showProjectHeaders, pendingPermissionsByWorkspace),
+    [workspaces, sessions, replays, expandedWorkspaces, expandedReplaySections, agentSessionCounts, showProjectHeaders, pendingPermissionsByWorkspace]
   );
 
   // Add selection state
@@ -546,12 +563,14 @@ export function useSpacesBrowser(props: UseSpacesBrowserProps): UseSpacesBrowser
       onEditProcesses?.({ workspaceId: item.workspaceId });
     } else if (item.type === 'bundle-config') {
       onManageBundleConfig?.({ workspaceId: item.workspaceId });
+    } else if (item.type === 'agents') {
+      await onOpenAgents?.(item.workspaceId);
     } else if (item.type === 'events') {
       onOpenEvents(item.workspaceId);
     } else if (item.type === 'new-session') {
       await onAttachSession({ workspaceId: item.workspaceId });
     }
-  }, [toggleWorkspace, toggleReplaySection, onAttachSession, onOpenReplay, onStartProcessAttach, findSessionForProcess, onProcessDisabled, onEditProcesses, onManageBundleConfig, onOpenEvents]);
+  }, [toggleWorkspace, toggleReplaySection, onAttachSession, onOpenReplay, onStartProcessAttach, findSessionForProcess, onProcessDisabled, onEditProcesses, onManageBundleConfig, onOpenAgents, onOpenEvents]);
 
   const activateSelected = useCallback(async () => {
     await activateItem(selectedItem);

--- a/src/components/SpacesBrowser.tui.tsx
+++ b/src/components/SpacesBrowser.tui.tsx
@@ -78,6 +78,9 @@ function getSpacesBrowserHint(selectedItem: TreeItem | null | undefined): string
   if (selectedItem?.type === 'bundle-config') {
     return '[↑↓] Navigate  [Enter] Edit Bundle Config  [b] Bundle  [r] Refresh  [q] Back';
   }
+  if (selectedItem?.type === 'agents') {
+    return '[↑↓] Navigate  [Enter] Agent Sessions  [r] Refresh  [q] Back';
+  }
   if (selectedItem?.type === 'events') {
     return '[↑↓] Navigate  [Enter] Open Events  [r] Refresh  [q] Back';
   }
@@ -280,6 +283,18 @@ export function SpacesBrowserTUI(props: SpacesBrowserTUIProps) {
             return (
               <text key={`bundle-config-${item.workspaceId}`} fg={textColor} height={1}>
                 {prefix}   ◇ Edit Bundle Config
+              </text>
+            );
+          }
+
+          if (item.type === 'agents') {
+            const textColor = isSelected ? COLORS.selected : '#C678DD';
+            const prefix = isSelected ? '>' : ' ';
+            const count = (item.count ?? 0) > 0 ? ` (${item.count})` : '';
+            const permBadge = (item.pendingPermissions ?? 0) > 0 ? ` ⚡${item.pendingPermissions}` : '';
+            return (
+              <text key={`agents-${item.workspaceId}`} fg={textColor} height={1}>
+                {prefix}   ✦ Agent Sessions{count}{permBadge}
               </text>
             );
           }

--- a/src/components/SpacesBrowser.web.tsx
+++ b/src/components/SpacesBrowser.web.tsx
@@ -476,6 +476,34 @@ export function SpacesBrowserWeb(props: SpacesBrowserWebProps) {
             );
           }
 
+          if (item.type === 'agents') {
+            return (
+              <div
+                key={`agents-${item.workspaceId}`}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  void activateIndex(index);
+                }}
+                className={`
+                  pl-10 sm:pl-12 pr-4 py-3 cursor-pointer border-b border-[#30363d] min-h-[48px] flex items-center justify-between
+                  ${isSelected ? 'bg-[#21262d] border-l-4 border-l-[#58a6ff]' : 'hover:bg-[#161b22] active:bg-[#21262d]'}
+                `}
+              >
+                <span className="text-[#c678dd]">✦ Agent Sessions</span>
+                <div className="flex items-center gap-1">
+                  {(item.pendingPermissions ?? 0) > 0 && (
+                    <span className="text-xs px-2 py-0.5 rounded bg-[#d29922] text-[#0d1117] font-medium">
+                      ⚡{item.pendingPermissions}
+                    </span>
+                  )}
+                  {(item.count ?? 0) > 0 && (
+                    <span className="text-xs px-2 py-1 rounded bg-[#30363d] text-[#e6edf3]">{item.count}</span>
+                  )}
+                </div>
+              </div>
+            );
+          }
+
           if (item.type === 'events') {
             return (
               <SimpleTreeRow

--- a/src/core/__tests__/bundle.test.ts
+++ b/src/core/__tests__/bundle.test.ts
@@ -206,4 +206,5 @@ describe('validateBundle', () => {
       })
     ).toThrow(/Bundle configKey alias collision/);
   });
+
 });

--- a/src/core/bundle-refresh.ts
+++ b/src/core/bundle-refresh.ts
@@ -9,6 +9,7 @@ import { createHash } from 'crypto';
 import { existsSync, readFileSync } from 'fs';
 import { basename, join, resolve, sep } from 'path';
 import { logger } from '../utils/logger.js';
+
 import {
   getProjectBaseDir,
   getProjectWorkspacesDir,

--- a/src/hooks/__tests__/useLocalSession.tui.test.ts
+++ b/src/hooks/__tests__/useLocalSession.tui.test.ts
@@ -13,6 +13,7 @@ import type {
 import type { NotificationConfig } from '../../notifications/types.js'
 import type { BundleRefreshPlan, BundleRefreshSubmission } from '../../types/bundle-refresh.js'
 import type { BundleConfigState, BundleConfigSubmission } from '../../types/bundle-config.js'
+import type { AgentStateUpdateDelta } from '../../serve/agent-event-manager.js'
 import { SpacesError } from '../../types/errors.js'
 import {
   useLocalSession,
@@ -173,6 +174,12 @@ class FakeLocalBackend implements SessionBackend {
   async sendReviewRequest(): Promise<never> {
     throw new Error('not implemented')
   }
+
+  subscribeAgentState(_handler: (delta: AgentStateUpdateDelta) => void): () => void { return () => {}; }
+  getAgentStateSnapshot(): Record<string, never> { return {}; }
+  async respondToAgentPermission(): Promise<boolean> { return false; }
+  async getAgentSessionPreference(_workspaceId: string): Promise<null> { return null; }
+  async setAgentSessionPreference(_workspaceId: string, _sessionId: string): Promise<void> {}
 
   async writePtyData(data: Uint8Array): Promise<void> {
     this.writeCalls.push(new Uint8Array(data))

--- a/src/hooks/useLocalSession.tui.ts
+++ b/src/hooks/useLocalSession.tui.ts
@@ -14,6 +14,8 @@ import {
   type SessionBackend,
 } from '../session/index.js';
 import type { NotificationConfig } from '../notifications/types.js';
+import type { OpenCodeBridgeRequest, OpenCodeBridgeResponse, OpenCodeBridgeStreamEvent, OpenCodeBridgeStreamOpen } from '../agents/opencode-bridge.js';
+import type { OpenCodeRuntimeInfo } from '../agents/opencode-runtime.js';
 import type { WideEventFilter } from '../types/events.js';
 import type { SessionLinearIssueSummary } from '../types/lifecycle.js';
 import type { BundleConfigState, BundleConfigSubmission } from '../types/bundle-config.js';
@@ -573,6 +575,40 @@ export function useLocalSession(options: UseLocalSessionOptions = {}) {
     backendRef.current?.setPtyOutputHandler(fn);
   }, []);
 
+  const requestOpenCode = useCallback(async (
+    request: Omit<OpenCodeBridgeRequest, 'requestId'>,
+  ): Promise<OpenCodeBridgeResponse> => {
+    const backend = backendRef.current;
+    if (!backend || typeof (backend as { requestOpenCode?: unknown }).requestOpenCode !== 'function') {
+      throw new SpacesError('OpenCode bridge unavailable', 'SYSTEM_ERROR', 2);
+    }
+    return (backend as unknown as { requestOpenCode: (request: Omit<OpenCodeBridgeRequest, 'requestId'>) => Promise<OpenCodeBridgeResponse> }).requestOpenCode(request);
+  }, []);
+
+  const subscribeOpenCode = useCallback(async (
+    request: Omit<OpenCodeBridgeStreamOpen, 'requestId'>,
+    handler: (event: OpenCodeBridgeStreamEvent) => void,
+  ) => {
+    const backend = backendRef.current;
+    if (!backend || typeof (backend as { subscribeOpenCode?: unknown }).subscribeOpenCode !== 'function') {
+      throw new SpacesError('OpenCode bridge unavailable', 'SYSTEM_ERROR', 2);
+    }
+    return (backend as unknown as {
+      subscribeOpenCode: (
+        request: Omit<OpenCodeBridgeStreamOpen, 'requestId'>,
+        handler: (event: OpenCodeBridgeStreamEvent) => void,
+      ) => Promise<() => Promise<void>>;
+    }).subscribeOpenCode(request, handler);
+  }, []);
+
+  const getOpenCodeRuntimeInfo = useCallback(async (workspaceId: string): Promise<OpenCodeRuntimeInfo> => {
+    const backend = backendRef.current;
+    if (!backend || typeof (backend as { getOpenCodeRuntimeInfo?: unknown }).getOpenCodeRuntimeInfo !== 'function') {
+      throw new SpacesError('OpenCode runtime unavailable', 'SYSTEM_ERROR', 2);
+    }
+    return (backend as unknown as { getOpenCodeRuntimeInfo: (workspaceId: string) => Promise<OpenCodeRuntimeInfo> }).getOpenCodeRuntimeInfo(workspaceId);
+  }, []);
+
   return {
     status: enabled ? (localState?.status ?? 'disconnected') : 'disconnected',
     mode: localState?.mode ?? 'browsing',
@@ -627,5 +663,9 @@ export function useLocalSession(options: UseLocalSessionOptions = {}) {
     send,
     resize,
     setWriteCallback,
+    hasOpenCodeBridge: true,
+    getOpenCodeRuntimeInfo,
+    requestOpenCode,
+    subscribeOpenCode,
   };
 }

--- a/src/hooks/useLocalSession.tui.ts
+++ b/src/hooks/useLocalSession.tui.ts
@@ -667,5 +667,7 @@ export function useLocalSession(options: UseLocalSessionOptions = {}) {
     getOpenCodeRuntimeInfo,
     requestOpenCode,
     subscribeOpenCode,
+    /** Expose the underlying SessionBackend for agent hooks that need the full interface */
+    sessionBackend: backendRef.current as import('../session/backend.js').SessionBackend | null,
   };
 }

--- a/src/integrations/__tests__/apply.test.ts
+++ b/src/integrations/__tests__/apply.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from 'bun:test';
+
+describe('prepareWorkspaceIntegrations', () => {
+  it('returns empty env and requiredIntegrationIds (stub - deferred to issue #70)', async () => {
+    const { prepareWorkspaceIntegrations } = await import('../apply');
+    const result = await prepareWorkspaceIntegrations('demo', '/tmp/demo');
+
+    expect(result.env).toEqual({});
+    expect(result.requiredIntegrationIds).toEqual([]);
+  });
+});

--- a/src/integrations/apply.ts
+++ b/src/integrations/apply.ts
@@ -1,0 +1,15 @@
+export interface PreparedWorkspaceIntegrations {
+  env: Record<string, string>;
+  requiredIntegrationIds: string[];
+}
+
+/**
+ * Stub: integration env injection is deferred to the architecture cleanup (issue #70).
+ * Bundle integration steps are not yet part of the active type system.
+ */
+export async function prepareWorkspaceIntegrations(
+  _projectName: string,
+  _workspacePath: string,
+): Promise<PreparedWorkspaceIntegrations> {
+  return { env: {}, requiredIntegrationIds: [] };
+}

--- a/src/lib/remote-session/__tests__/protocol.test.ts
+++ b/src/lib/remote-session/__tests__/protocol.test.ts
@@ -13,6 +13,9 @@ import {
   type StartProcessRequest,
   type StopProcessRequest,
   type EventsListResponse,
+  type OpenCodeRequest,
+  type OpenCodeResponse,
+  type OpenCodeStreamEventResponse,
   type ProcessStartedResponse,
   type ProcessStoppedResponse,
 } from '../protocol.js';
@@ -152,6 +155,50 @@ describe('round-trip serialization', () => {
     expect(parsed.workspaceId).toBe('project:workspace');
     expect(parsed.processName).toBe('web');
   });
+
+  it('should round-trip an OpenCodeRequest', () => {
+    const original: OpenCodeRequest = {
+      type: 'opencode_request',
+      requestId: 'req-1',
+      workspaceId: 'project:workspace',
+      method: 'GET',
+      path: '/session',
+    };
+    const json = serializeRemoteMessage(original);
+    const parsed = parseRemoteMessage(json) as OpenCodeRequest;
+    expect(parsed.type).toBe('opencode_request');
+    expect(parsed.requestId).toBe('req-1');
+    expect(parsed.workspaceId).toBe('project:workspace');
+    expect(parsed.path).toBe('/session');
+  });
+
+  it('should round-trip an OpenCodeResponse', () => {
+    const original: OpenCodeResponse = {
+      type: 'opencode_response',
+      requestId: 'req-1',
+      status: 200,
+      bodyBase64: 'e30=',
+    };
+    const json = serializeRemoteMessage(original);
+    const parsed = parseRemoteMessage(json) as OpenCodeResponse;
+    expect(parsed.type).toBe('opencode_response');
+    expect(parsed.status).toBe(200);
+    expect(parsed.bodyBase64).toBe('e30=');
+  });
+
+  it('should round-trip an OpenCodeStreamEventResponse', () => {
+    const original: OpenCodeStreamEventResponse = {
+      type: 'opencode_stream_event',
+      requestId: 'req-1',
+      event: 'server.connected',
+      data: '{"ok":true}',
+    };
+    const json = serializeRemoteMessage(original);
+    const parsed = parseRemoteMessage(json) as OpenCodeStreamEventResponse;
+    expect(parsed.type).toBe('opencode_stream_event');
+    expect(parsed.event).toBe('server.connected');
+    expect(parsed.data).toBe('{"ok":true}');
+  });
 });
 
 // ============================================================================
@@ -177,6 +224,18 @@ describe('isBrowseMessage', () => {
       workspacePath: '/tmp',
     };
     expect(isBrowseMessage(msg)).toBe(true);
+  });
+
+  it('should return true for opencode_request', () => {
+    expect(
+      isBrowseMessage({
+        type: 'opencode_request',
+        requestId: 'req-1',
+        workspaceId: 'ws',
+        method: 'GET',
+        path: '/session',
+      }),
+    ).toBe(true);
   });
 
   it('should return true for list_remote_branches', () => {
@@ -246,11 +305,15 @@ describe('ClientToMachineMessage type coverage', () => {
     { type: 'get_events', workspacePath: '/tmp' },
     { type: 'start_process', workspaceId: 'w1', processName: 'web' },
     { type: 'stop_process', workspaceId: 'w1', processName: 'web' },
+    { type: 'opencode_request', requestId: 'req-1', workspaceId: 'w1', method: 'GET', path: '/session' },
+    { type: 'opencode_stream_open', requestId: 'req-2', workspaceId: 'w1', path: '/event' },
+    { type: 'opencode_stream_close', requestId: 'req-2' },
+    { type: 'get_opencode_runtime', workspaceId: 'w1' },
   ];
 
-  it('should include all 24 client message types', () => {
+  it('should include all 28 client message types', () => {
     const types = new Set(clientMessages.map(m => m.type));
-    expect(types.size).toBe(24);
+    expect(types.size).toBe(28);
   });
 
   it('should all parse successfully via round-trip', () => {

--- a/src/lib/remote-session/protocol.ts
+++ b/src/lib/remote-session/protocol.ts
@@ -17,6 +17,13 @@
 
 // Re-export InboxItem from tmux-lite protocol
 export type { InboxItem } from "../tmux-lite/protocol.js";
+
+// Re-export agent state types from AgentEventManager
+export type {
+  AgentStateUpdateDelta,
+  WorkspaceAgentState,
+  AgentSessionSummary,
+} from '../../serve/agent-event-manager.js';
 export type { ReviewOperation, ReviewResult } from "../../types/review.js";
 export type {
   BundleRefreshPlan,
@@ -132,6 +139,36 @@ export interface StopProcessRequest {
   type: "stop_process";
   workspaceId: string;
   processName: string;
+}
+
+export interface OpenCodeRequest {
+  type: 'opencode_request';
+  requestId: string;
+  workspaceId: string;
+  method: 'GET' | 'POST' | 'PATCH' | 'PUT' | 'DELETE';
+  path: string;
+  query?: Record<string, string | number | boolean>;
+  headers?: Record<string, string>;
+  bodyBase64?: string;
+}
+
+export interface OpenCodeStreamOpenRequest {
+  type: 'opencode_stream_open';
+  requestId: string;
+  workspaceId: string;
+  path: string;
+  query?: Record<string, string | number | boolean>;
+  headers?: Record<string, string>;
+}
+
+export interface OpenCodeStreamCloseRequest {
+  type: 'opencode_stream_close';
+  requestId: string;
+}
+
+export interface GetOpenCodeRuntimeRequest {
+  type: 'get_opencode_runtime';
+  workspaceId: string;
 }
 
 /** Request list of projects on the machine */
@@ -596,6 +633,67 @@ export interface ProcessStoppedResponse {
   processName: string;
 }
 
+export interface OpenCodeResponse {
+  type: 'opencode_response';
+  requestId: string;
+  status: number;
+  headers?: Record<string, string>;
+  bodyBase64?: string;
+}
+
+export interface OpenCodeStreamOpenedResponse {
+  type: 'opencode_stream_opened';
+  requestId: string;
+}
+
+export interface OpenCodeStreamEventResponse {
+  type: 'opencode_stream_event';
+  requestId: string;
+  event?: string;
+  data: string;
+  id?: string;
+}
+
+export interface OpenCodeStreamClosedResponse {
+  type: 'opencode_stream_closed';
+  requestId: string;
+}
+
+export interface OpenCodeStreamErrorResponse {
+  type: 'opencode_stream_error';
+  requestId: string;
+  message: string;
+}
+
+export interface OpenCodeRuntimeResponse {
+  type: 'opencode_runtime';
+  workspaceId: string;
+  workspacePath: string;
+  hostname: string;
+  port: number;
+  baseUrl: string;
+  username: string;
+  password: string;
+}
+
+/**
+ * Machine pushes a full snapshot of all workspace agent states on client connect.
+ * This is an unsolicited push from the machine, not a response to a request.
+ */
+export interface AgentStateSnapshotPush {
+  type: 'agent_state_snapshot';
+  workspaces: import('../../serve/agent-event-manager.js').WorkspaceAgentState[];
+}
+
+/**
+ * Machine pushes an incremental agent state delta to all connected clients.
+ * This is an unsolicited push from the machine, not a response to a request.
+ */
+export interface AgentStateUpdatePush {
+  type: 'agent_state_update';
+  delta: import('../../serve/agent-event-manager.js').AgentStateUpdateDelta;
+}
+
 // ============================================================================
 // Union Types
 // ============================================================================
@@ -635,7 +733,11 @@ export type ClientToMachineMessage =
   | ReviewRequest
   | GetEventsRequest
   | StartProcessRequest
-  | StopProcessRequest;
+  | StopProcessRequest
+  | OpenCodeRequest
+  | OpenCodeStreamOpenRequest
+  | OpenCodeStreamCloseRequest
+  | GetOpenCodeRuntimeRequest;
 
 /** All messages from machine to client (browsing mode) */
 export type MachineToClientMessage =
@@ -674,7 +776,15 @@ export type MachineToClientMessage =
   | ReviewResponse
   | EventsListResponse
   | ProcessStartedResponse
-  | ProcessStoppedResponse;
+  | ProcessStoppedResponse
+  | OpenCodeResponse
+  | OpenCodeStreamOpenedResponse
+  | OpenCodeStreamEventResponse
+  | OpenCodeStreamClosedResponse
+  | OpenCodeStreamErrorResponse
+  | OpenCodeRuntimeResponse
+  | AgentStateSnapshotPush
+  | AgentStateUpdatePush;
 
 /** All remote session messages */
 export type RemoteSessionMessage =
@@ -731,7 +841,11 @@ export function isBrowseMessage(msg: RemoteSessionMessage): msg is
   | DeleteProjectRequest
   | GetBundleConfigStateRequest
   | ApplyBundleConfigUpdateRequest
-  | GetEventsRequest {
+  | GetEventsRequest
+  | OpenCodeRequest
+  | OpenCodeStreamOpenRequest
+  | OpenCodeStreamCloseRequest
+  | GetOpenCodeRuntimeRequest {
   return [
     "list_workspaces",
     "list_sessions",
@@ -754,5 +868,9 @@ export function isBrowseMessage(msg: RemoteSessionMessage): msg is
     'get_bundle_config_state',
     'apply_bundle_config_update',
     "get_events",
+    'opencode_request',
+    'opencode_stream_open',
+    'opencode_stream_close',
+    'get_opencode_runtime',
   ].includes(msg.type);
 }

--- a/src/lib/remote-session/session-handler.ts
+++ b/src/lib/remote-session/session-handler.ts
@@ -1892,15 +1892,14 @@ export class RemoteSessionHandler {
         }
       })();
     } catch (error) {
+      // Send error to client BEFORE aborting so the condition isn't short-circuited
+      await this.sendMessage(session, sendResponse, {
+        type: 'opencode_stream_error',
+        requestId: msg.requestId,
+        message: error instanceof Error ? error.message : String(error),
+      });
       controller.abort();
       this.openCodeStreams.delete(streamKey);
-      if (!controller.signal.aborted) {
-        await this.sendMessage(session, sendResponse, {
-          type: 'opencode_stream_error',
-          requestId: msg.requestId,
-          message: error instanceof Error ? error.message : String(error),
-        });
-      }
     }
   }
 

--- a/src/lib/remote-session/session-handler.ts
+++ b/src/lib/remote-session/session-handler.ts
@@ -1799,6 +1799,7 @@ export class RemoteSessionHandler {
           authorization: runtime.authHeader,
         },
         body: msg.bodyBase64 ? Buffer.from(msg.bodyBase64, 'base64') : undefined,
+        signal: AbortSignal.timeout(30_000),
       });
 
       const bodyBuffer = Buffer.from(await response.arrayBuffer());
@@ -1888,7 +1889,10 @@ export class RemoteSessionHandler {
             });
           }
         } finally {
-          this.openCodeStreams.delete(streamKey);
+          // Only delete if this controller is still the registered one (not replaced by a reopen)
+          if (this.openCodeStreams.get(streamKey) === controller) {
+            this.openCodeStreams.delete(streamKey);
+          }
         }
       })();
     } catch (error) {
@@ -1899,7 +1903,9 @@ export class RemoteSessionHandler {
         message: error instanceof Error ? error.message : String(error),
       });
       controller.abort();
-      this.openCodeStreams.delete(streamKey);
+      if (this.openCodeStreams.get(streamKey) === controller) {
+        this.openCodeStreams.delete(streamKey);
+      }
     }
   }
 

--- a/src/lib/remote-session/session-handler.ts
+++ b/src/lib/remote-session/session-handler.ts
@@ -86,6 +86,13 @@ import { readProjectConfig } from "../../core/config.js";
 import { existsSync } from "fs";
 
 import { logger } from "../../utils/logger.js";
+import {
+  createOpenCodeBasicAuthHeader,
+  defaultOpenCodeRuntimeManager,
+  type OpenCodeRuntimeManager,
+} from '../../agents/opencode-runtime.js';
+import { buildOpenCodeUrl } from '../../agents/opencode-bridge.js';
+import { consumeSseStream } from '../../agents/opencode-sse.js';
 
 /**
  * Session state for a connected client
@@ -188,6 +195,7 @@ function matchesWorkspaceIdToken(parsedWorkspaceId: string, workspaceId: string)
 export interface RemoteSessionHandlerOptions {
   processHostDomain?: string;
   onProcessesChanged?: (workspacePath: string) => void | Promise<void>;
+  openCodeRuntimeManager?: OpenCodeRuntimeManager;
 }
 
 /**
@@ -199,10 +207,13 @@ export class RemoteSessionHandler {
   private pendingAttachRuns = new Map<string, AbortController>();
   private processHostDomain?: string;
   private onProcessesChanged?: (workspacePath: string) => void | Promise<void>;
+  private openCodeRuntimeManager: OpenCodeRuntimeManager;
+  private openCodeStreams = new Map<string, AbortController>();
 
   constructor(options: RemoteSessionHandlerOptions = {}) {
     this.processHostDomain = options.processHostDomain;
     this.onProcessesChanged = options.onProcessesChanged;
+    this.openCodeRuntimeManager = options.openCodeRuntimeManager ?? defaultOpenCodeRuntimeManager;
   }
 
   /**
@@ -600,6 +611,38 @@ export class RemoteSessionHandler {
           return;
         }
         await this.handleStopProcess(session, msg.workspaceId, msg.processName, sendResponse);
+        break;
+
+      case 'opencode_request':
+        if (!canManage(session.accessType)) {
+          await this.sendError(session, sendResponse, 'PERMISSION_DENIED', 'Requires full access to proxy OpenCode requests');
+          return;
+        }
+        await this.handleOpenCodeRequest(session, msg, sendResponse);
+        break;
+
+      case 'opencode_stream_open':
+        if (!canManage(session.accessType)) {
+          await this.sendError(session, sendResponse, 'PERMISSION_DENIED', 'Requires full access to proxy OpenCode streams');
+          return;
+        }
+        await this.handleOpenCodeStreamOpen(session, msg, sendResponse);
+        break;
+
+      case 'opencode_stream_close':
+        if (!canManage(session.accessType)) {
+          await this.sendError(session, sendResponse, 'PERMISSION_DENIED', 'Requires full access to proxy OpenCode streams');
+          return;
+        }
+        await this.handleOpenCodeStreamClose(session, msg.requestId, sendResponse);
+        break;
+
+      case 'get_opencode_runtime':
+        if (!canManage(session.accessType)) {
+          await this.sendError(session, sendResponse, 'PERMISSION_DENIED', 'Requires full access to access OpenCode runtime info');
+          return;
+        }
+        await this.handleGetOpenCodeRuntime(session, msg.workspaceId, sendResponse);
         break;
 
       default: {
@@ -1707,6 +1750,200 @@ export class RemoteSessionHandler {
     };
   }
 
+  private buildOpenCodeStreamKey(session: RemoteClientSession, requestId: string): string {
+    return `${session.connectionId}:${requestId}`;
+  }
+
+  private async ensureOpenCodeRuntime(workspaceId: string): Promise<{
+    workspaceId: string;
+    workspacePath: string;
+    baseUrl: string;
+    username: string;
+    password: string;
+    authHeader: string;
+  }> {
+    const workspaces = await scanWorkspaces();
+    const workspace = workspaces.find((item) => matchesWorkspaceId(item, workspaceId));
+    if (!workspace) {
+      throw new Error(`Workspace not found: ${workspaceId}`);
+    }
+
+    const runtime = await this.openCodeRuntimeManager.ensureWorkspaceRuntime({
+      workspaceId: toCanonicalWorkspaceId(workspace),
+      workspacePath: workspace.path,
+      projectName: workspace.projectName,
+    });
+
+    return {
+      workspaceId: runtime.workspaceId,
+      workspacePath: runtime.workspacePath,
+      baseUrl: runtime.baseUrl,
+      username: runtime.username,
+      password: runtime.password,
+      authHeader: createOpenCodeBasicAuthHeader(runtime),
+    };
+  }
+
+  private async handleOpenCodeRequest(
+    session: RemoteClientSession,
+    msg: Extract<ClientToMachineMessage, { type: 'opencode_request' }>,
+    sendResponse: (data: Uint8Array) => void,
+  ): Promise<void> {
+    try {
+      const runtime = await this.ensureOpenCodeRuntime(msg.workspaceId);
+      const url = buildOpenCodeUrl(runtime.baseUrl, msg.path, msg.query);
+      const response = await fetch(url, {
+        method: msg.method,
+        headers: {
+          ...(msg.headers ?? {}),
+          authorization: runtime.authHeader,
+        },
+        body: msg.bodyBase64 ? Buffer.from(msg.bodyBase64, 'base64') : undefined,
+      });
+
+      const bodyBuffer = Buffer.from(await response.arrayBuffer());
+      const responseHeaders: Record<string, string> = {};
+      response.headers.forEach((value, key) => {
+        responseHeaders[key] = value;
+      });
+      await this.sendMessage(session, sendResponse, {
+        type: 'opencode_response',
+        requestId: msg.requestId,
+        status: response.status,
+        headers: responseHeaders,
+        bodyBase64: bodyBuffer.length > 0 ? bodyBuffer.toString('base64') : undefined,
+      });
+    } catch (error) {
+      await this.sendMessage(session, sendResponse, {
+        type: 'opencode_response',
+        requestId: msg.requestId,
+        status: 502,
+        bodyBase64: Buffer.from(JSON.stringify({
+          error: error instanceof Error ? error.message : String(error),
+        })).toString('base64'),
+      });
+    }
+  }
+
+  private async handleOpenCodeStreamOpen(
+    session: RemoteClientSession,
+    msg: Extract<ClientToMachineMessage, { type: 'opencode_stream_open' }>,
+    sendResponse: (data: Uint8Array) => void,
+  ): Promise<void> {
+    const streamKey = this.buildOpenCodeStreamKey(session, msg.requestId);
+    this.openCodeStreams.get(streamKey)?.abort();
+
+    const controller = new AbortController();
+    this.openCodeStreams.set(streamKey, controller);
+
+    try {
+      const runtime = await this.ensureOpenCodeRuntime(msg.workspaceId);
+      const url = buildOpenCodeUrl(runtime.baseUrl, msg.path, msg.query);
+      const response = await fetch(url, {
+        method: 'GET',
+        headers: {
+          accept: 'text/event-stream',
+          ...(msg.headers ?? {}),
+          authorization: runtime.authHeader,
+        },
+        signal: controller.signal,
+      });
+
+      if (!response.ok || !response.body) {
+        throw new Error(`OpenCode stream failed (${response.status})`);
+      }
+
+      const responseBody = response.body;
+
+      await this.sendMessage(session, sendResponse, {
+        type: 'opencode_stream_opened',
+        requestId: msg.requestId,
+      });
+
+      // Detach stream consumption so it does not block the message-processing
+      // loop for this client. Subsequent messages (resize, new requests, etc.)
+      // can still be handled while the SSE stream is live.
+      void (async () => {
+        try {
+          await consumeSseStream(responseBody, async (parsed) => {
+            await this.sendMessage(session, sendResponse, {
+              type: 'opencode_stream_event',
+              requestId: msg.requestId,
+              event: parsed.event,
+              data: parsed.data,
+              id: parsed.id,
+            });
+          });
+
+          await this.sendMessage(session, sendResponse, {
+            type: 'opencode_stream_closed',
+            requestId: msg.requestId,
+          });
+        } catch (error) {
+          if (!controller.signal.aborted) {
+            await this.sendMessage(session, sendResponse, {
+              type: 'opencode_stream_error',
+              requestId: msg.requestId,
+              message: error instanceof Error ? error.message : String(error),
+            });
+          }
+        } finally {
+          this.openCodeStreams.delete(streamKey);
+        }
+      })();
+    } catch (error) {
+      controller.abort();
+      this.openCodeStreams.delete(streamKey);
+      if (!controller.signal.aborted) {
+        await this.sendMessage(session, sendResponse, {
+          type: 'opencode_stream_error',
+          requestId: msg.requestId,
+          message: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
+  }
+
+  private async handleOpenCodeStreamClose(
+    session: RemoteClientSession,
+    requestId: string,
+    sendResponse: (data: Uint8Array) => void,
+  ): Promise<void> {
+    const streamKey = this.buildOpenCodeStreamKey(session, requestId);
+    const controller = this.openCodeStreams.get(streamKey);
+    if (controller) {
+      controller.abort();
+      this.openCodeStreams.delete(streamKey);
+    }
+
+    await this.sendMessage(session, sendResponse, {
+      type: 'opencode_stream_closed',
+      requestId,
+    });
+  }
+
+  private async handleGetOpenCodeRuntime(
+    session: RemoteClientSession,
+    workspaceId: string,
+    sendResponse: (data: Uint8Array) => void,
+  ): Promise<void> {
+    try {
+      const runtime = await this.ensureOpenCodeRuntime(workspaceId);
+      await this.sendMessage(session, sendResponse, {
+        type: 'opencode_runtime',
+        workspaceId: runtime.workspaceId,
+        workspacePath: runtime.workspacePath,
+        hostname: new URL(runtime.baseUrl).hostname,
+        port: Number(new URL(runtime.baseUrl).port),
+        baseUrl: runtime.baseUrl,
+        username: runtime.username,
+        password: runtime.password,
+      });
+    } catch (error) {
+      await this.sendError(session, sendResponse, 'OPENCODE_RUNTIME_FAILED', error instanceof Error ? error.message : String(error), { workspaceId });
+    }
+  }
+
   /**
    * Send an encrypted message to client
    */
@@ -1966,7 +2203,22 @@ export class RemoteSessionHandler {
   /**
    * Cleanup
    */
+  cleanupConnection(connectionId: string): void {
+    for (const [key, controller] of this.openCodeStreams) {
+      if (!key.startsWith(`${connectionId}:`)) {
+        continue;
+      }
+      controller.abort();
+      this.openCodeStreams.delete(key);
+    }
+  }
+
   async cleanup(): Promise<void> {
+    for (const controller of this.openCodeStreams.values()) {
+      controller.abort();
+    }
+    this.openCodeStreams.clear();
+
     // Clean up process schedulers
     for (const timer of this.processSchedulers.values()) {
       clearInterval(timer);

--- a/src/lib/tmux-lite/protocol.ts
+++ b/src/lib/tmux-lite/protocol.ts
@@ -281,12 +281,21 @@ export interface InboxItem {
   id: string;
   sessionId: string;
   sessionName: string;
-  type: 'bell' | 'exit' | 'title' | 'idle' | 'osc';
+  type: 'bell' | 'exit' | 'title' | 'idle' | 'osc'
+      | 'agent_permission' | 'agent_idle' | 'agent_error';
   timestamp: number;
   exitCode?: number;
   context: string;  // The actual message/output
   processTitle?: string;  // What process was running (e.g., "claude", "npm run dev")
   read: boolean;
+  /** Present only for agent_* item types — carries routing metadata for the app layer */
+  agentAction?: {
+    workspaceId: string;
+    agentSessionId: string;    // OpenCode session ID
+    permissionId?: string;     // only for agent_permission
+    permissionTitle?: string;
+    messagePreview?: string;   // for agent_idle
+  };
 }
 
 // ============================================================================

--- a/src/serve/agent-event-manager.ts
+++ b/src/serve/agent-event-manager.ts
@@ -1,0 +1,354 @@
+/**
+ * AgentEventManager
+ *
+ * Machine-side singleton that:
+ * - Subscribes to each workspace's OpenCode /event SSE stream
+ * - Aggregates SessionStatus, pending permissions, and last-message previews
+ * - Pushes AgentStateUpdateDelta to registered handlers (relay broadcast + local UI)
+ *
+ * Clients never open /event SSE themselves for notification purposes.
+ * The raw /event SSE is only used when a user explicitly opens OpenCode web.
+ */
+
+import type { OpenCodeRuntimeInfo } from '../agents/opencode-runtime.js';
+import { createOpenCodeBasicAuthHeader, defaultOpenCodeRuntimeManager, OpenCodeRuntimeManager } from '../agents/opencode-runtime.js';
+import { consumeSseStream } from '../agents/opencode-sse.js';
+import {
+  parseOpenCodeEvent,
+  type SessionStatus,
+  type Permission,
+} from '../agents/opencode-event-types.js';
+
+// ============================================================================
+// Shared agent state types (used by both machine and client)
+// ============================================================================
+
+export interface AgentSessionSummary {
+  id: string;
+  title: string;
+}
+
+export interface WorkspaceAgentState {
+  workspaceId: string;
+  sessions: AgentSessionSummary[];
+  /** sessionId → current status */
+  statuses: Record<string, SessionStatus>;
+  /** sessionId → array of pending permissions */
+  pendingPermissions: Record<string, Permission[]>;
+  /** sessionId → last ~120 chars of most recent assistant text */
+  lastMessages: Record<string, string>;
+}
+
+export type AgentStateUpdateDelta =
+  | { type: 'agent_state_snapshot'; workspaces: Record<string, WorkspaceAgentState> }
+  | { type: 'agent_session_status'; workspaceId: string; sessionId: string; status: SessionStatus }
+  | { type: 'agent_permission_added'; workspaceId: string; sessionId: string; permission: Permission }
+  | { type: 'agent_permission_removed'; workspaceId: string; sessionId: string; permissionId: string }
+  | { type: 'agent_session_error'; workspaceId: string; sessionId: string; errorMessage: string }
+  | { type: 'agent_last_message'; workspaceId: string; sessionId: string; preview: string }
+  | { type: 'agent_session_created'; workspaceId: string; sessionId: string; title: string }
+  | { type: 'agent_session_updated'; workspaceId: string; sessionId: string; title: string }
+  | { type: 'agent_session_deleted'; workspaceId: string; sessionId: string };
+
+// ============================================================================
+// AgentEventManager
+// ============================================================================
+
+const LAST_MESSAGE_MAX_CHARS = 120;
+const LAST_MESSAGE_DEBOUNCE_MS = 300;
+
+export class AgentEventManager {
+  private readonly runtimeManager: OpenCodeRuntimeManager;
+  private readonly workspaceStates = new Map<string, WorkspaceAgentState>();
+  private readonly eventAbortControllers = new Map<string, AbortController>();
+  private readonly handlers = new Set<(delta: AgentStateUpdateDelta) => void>();
+  /** Per-session debounce timer for last-message updates */
+  private readonly lastMessageTimers = new Map<string, ReturnType<typeof setTimeout>>();
+  /** Accumulator for streaming text per session (reset on new assistant message) */
+  private readonly textAccumulators = new Map<string, string>();
+  /** Track previously-seen status to detect busy→idle transitions */
+  private readonly previousStatuses = new Map<string, SessionStatus>();
+
+  constructor(runtimeManager: OpenCodeRuntimeManager) {
+    this.runtimeManager = runtimeManager;
+    runtimeManager.onRuntimeStarted((info) => { void this.subscribeWorkspace(info); });
+    runtimeManager.onRuntimeStopped((workspaceId) => { this.unsubscribeWorkspace(workspaceId); });
+  }
+
+  /**
+   * Initialize from already-running runtimes. Call eagerly at startup.
+   */
+  async initialize(): Promise<void> {
+    const runtimes = this.runtimeManager.listRuntimes();
+    await Promise.allSettled(runtimes.map((info) => this.subscribeWorkspace(info)));
+  }
+
+  /**
+   * Subscribe to state updates. Returns an unsubscribe function.
+   */
+  subscribe(handler: (delta: AgentStateUpdateDelta) => void): () => void {
+    this.handlers.add(handler);
+    return () => { this.handlers.delete(handler); };
+  }
+
+  /**
+   * Get a full snapshot of current state for all workspaces.
+   */
+  getSnapshot(): Record<string, WorkspaceAgentState> {
+    const result: Record<string, WorkspaceAgentState> = {};
+    for (const [workspaceId, state] of this.workspaceStates) {
+      result[workspaceId] = state;
+    }
+    return result;
+  }
+
+  // ============================================================================
+  // Private helpers
+  // ============================================================================
+
+  private emit(delta: AgentStateUpdateDelta): void {
+    for (const handler of this.handlers) {
+      try {
+        handler(delta);
+      } catch {
+        // never let a handler error crash the manager
+      }
+    }
+  }
+
+  private getOrCreateState(workspaceId: string): WorkspaceAgentState {
+    let state = this.workspaceStates.get(workspaceId);
+    if (!state) {
+      state = { workspaceId, sessions: [], statuses: {}, pendingPermissions: {}, lastMessages: {} };
+      this.workspaceStates.set(workspaceId, state);
+    }
+    return state;
+  }
+
+  private async subscribeWorkspace(info: OpenCodeRuntimeInfo): Promise<void> {
+    const { workspaceId } = info;
+
+    // Abort any previous subscription for this workspace
+    this.eventAbortControllers.get(workspaceId)?.abort();
+
+    const controller = new AbortController();
+    this.eventAbortControllers.set(workspaceId, controller);
+
+    // Fetch initial session list + statuses
+    try {
+      await this.fetchInitialState(info);
+    } catch {
+      // Non-fatal — we'll get updates from SSE anyway
+    }
+
+    // Start SSE loop with reconnect
+    void this.runSseLoop(info, controller);
+  }
+
+  private async fetchInitialState(info: OpenCodeRuntimeInfo): Promise<void> {
+    const authHeader = createOpenCodeBasicAuthHeader(info);
+
+    const [sessionsResp, statusesResp] = await Promise.all([
+      fetch(`${info.baseUrl}/session`, { headers: { authorization: authHeader } }),
+      fetch(`${info.baseUrl}/session/status`, { headers: { authorization: authHeader } }),
+    ]);
+
+    const state = this.getOrCreateState(info.workspaceId);
+
+    if (sessionsResp.ok) {
+      const sessions = (await sessionsResp.json()) as Array<{ id: string; title?: string }>;
+      state.sessions = sessions.map((s) => ({ id: s.id, title: s.title ?? s.id }));
+    }
+
+    if (statusesResp.ok) {
+      const statuses = (await statusesResp.json()) as Record<string, SessionStatus>;
+      state.statuses = statuses;
+      for (const [sessionId, status] of Object.entries(statuses)) {
+        this.previousStatuses.set(`${info.workspaceId}:${sessionId}`, status);
+      }
+    }
+  }
+
+  private async runSseLoop(info: OpenCodeRuntimeInfo, controller: AbortController): Promise<void> {
+    const { workspaceId } = info;
+    const authHeader = createOpenCodeBasicAuthHeader(info);
+
+    while (!controller.signal.aborted) {
+      try {
+        const response = await fetch(`${info.baseUrl}/event`, {
+          headers: {
+            accept: 'text/event-stream',
+            authorization: authHeader,
+          },
+          signal: controller.signal,
+        });
+
+        if (!response.ok || !response.body) {
+          // Wait before retrying
+          await new Promise<void>((resolve) => {
+            const timer = setTimeout(resolve, 3000);
+            controller.signal.addEventListener('abort', () => { clearTimeout(timer); resolve(); }, { once: true });
+          });
+          continue;
+        }
+
+        await consumeSseStream(response.body, async (parsed) => {
+          if (!parsed.data || parsed.data === '[DONE]') return;
+          const evt = parseOpenCodeEvent(parsed.data);
+          if (evt) {
+            this.handleOpenCodeEvent(workspaceId, evt);
+          }
+        });
+      } catch (error) {
+        if (controller.signal.aborted) break;
+        // Connection dropped — wait 2s then retry
+        await new Promise<void>((resolve) => {
+          const timer = setTimeout(resolve, 2000);
+          controller.signal.addEventListener('abort', () => { clearTimeout(timer); resolve(); }, { once: true });
+        });
+      }
+    }
+  }
+
+  private unsubscribeWorkspace(workspaceId: string): void {
+    this.eventAbortControllers.get(workspaceId)?.abort();
+    this.eventAbortControllers.delete(workspaceId);
+    this.workspaceStates.delete(workspaceId);
+  }
+
+  private handleOpenCodeEvent(workspaceId: string, event: NonNullable<ReturnType<typeof parseOpenCodeEvent>>): void {
+    const state = this.getOrCreateState(workspaceId);
+    // Use a raw object cast since the OpenCodeEvent union has a catch-all and
+    // TypeScript can't narrow discriminants against it reliably.
+    const raw = event as { type: string; properties: Record<string, unknown> };
+
+    switch (raw.type) {
+      case 'session.status': {
+        const props = raw.properties as { sessionID: string; status: SessionStatus };
+        const { sessionID, status } = props;
+        const prevKey = `${workspaceId}:${sessionID}`;
+        const prev = this.previousStatuses.get(prevKey);
+        state.statuses[sessionID] = status;
+        this.previousStatuses.set(prevKey, status);
+        this.emit({ type: 'agent_session_status', workspaceId, sessionId: sessionID, status });
+
+        // Reset text accumulator on new busy turn so each turn gets a fresh preview
+        if (status.type === 'busy') {
+          this.textAccumulators.delete(`${workspaceId}:${sessionID}`);
+        }
+
+        // busy→idle transition: also emit the last accumulated message preview
+        if (prev?.type === 'busy' && status.type === 'idle') {
+          const preview = state.lastMessages[sessionID] ?? '';
+          if (preview) {
+            this.emit({ type: 'agent_last_message', workspaceId, sessionId: sessionID, preview });
+          }
+        }
+        break;
+      }
+
+      case 'permission.updated': {
+        const permission = raw.properties as unknown as Permission;
+        const sessionID = permission.sessionID;
+        if (!state.pendingPermissions[sessionID]) {
+          state.pendingPermissions[sessionID] = [];
+        }
+        const existing = state.pendingPermissions[sessionID].findIndex((p) => p.id === permission.id);
+        if (existing === -1) {
+          // New permission — add to cache and notify
+          state.pendingPermissions[sessionID].push(permission);
+          this.emit({ type: 'agent_permission_added', workspaceId, sessionId: sessionID, permission });
+        } else {
+          // Update to existing permission — update cache only, no duplicate notification
+          state.pendingPermissions[sessionID][existing] = permission;
+        }
+        break;
+      }
+
+      case 'permission.replied': {
+        const props = raw.properties as { sessionID: string; permissionID: string; response: string };
+        const { sessionID, permissionID } = props;
+        if (state.pendingPermissions[sessionID]) {
+          state.pendingPermissions[sessionID] = state.pendingPermissions[sessionID].filter(
+            (p) => p.id !== permissionID,
+          );
+        }
+        this.emit({ type: 'agent_permission_removed', workspaceId, sessionId: sessionID, permissionId: permissionID });
+        break;
+      }
+
+      case 'session.error': {
+        const props = raw.properties as { sessionID?: string; error?: { data?: { message?: string } } };
+        if (!props.sessionID) break;
+        const errorMsg = props.error?.data?.message ?? 'Unknown error';
+        this.emit({ type: 'agent_session_error', workspaceId, sessionId: props.sessionID, errorMessage: errorMsg });
+        break;
+      }
+
+      case 'session.created': {
+        const props = raw.properties as { info: { id: string; title?: string } };
+        const { id, title } = props.info;
+        const titleOrId = title ?? id;
+        if (!state.sessions.some((s) => s.id === id)) {
+          state.sessions.push({ id, title: titleOrId });
+        }
+        this.emit({ type: 'agent_session_created', workspaceId, sessionId: id, title: titleOrId });
+        break;
+      }
+
+      case 'session.updated': {
+        const props = raw.properties as { info: { id: string; title?: string } };
+        const { id, title } = props.info;
+        const titleOrId = title ?? id;
+        const idx = state.sessions.findIndex((s) => s.id === id);
+        if (idx !== -1) state.sessions[idx] = { id, title: titleOrId };
+        this.emit({ type: 'agent_session_updated', workspaceId, sessionId: id, title: titleOrId });
+        break;
+      }
+
+      case 'session.deleted': {
+        const props = raw.properties as { info: { id: string } };
+        const { id } = props.info;
+        state.sessions = state.sessions.filter((s) => s.id !== id);
+        delete state.statuses[id];
+        delete state.pendingPermissions[id];
+        delete state.lastMessages[id];
+        this.previousStatuses.delete(`${workspaceId}:${id}`);
+        this.textAccumulators.delete(`${workspaceId}:${id}`);
+        this.emit({ type: 'agent_session_deleted', workspaceId, sessionId: id });
+        break;
+      }
+
+      case 'message.part.updated': {
+        const props = raw.properties as {
+          part: { sessionID: string; type: string };
+          delta?: string;
+        };
+        const { part, delta } = props;
+        if (part.type !== 'text' || !delta) break;
+        const accKey = `${workspaceId}:${part.sessionID}`;
+        const current = this.textAccumulators.get(accKey) ?? '';
+        const updated = (current + delta).slice(-LAST_MESSAGE_MAX_CHARS);
+        this.textAccumulators.set(accKey, updated);
+        state.lastMessages[part.sessionID] = updated;
+
+        // Debounce the last_message emit
+        const existingTimer = this.lastMessageTimers.get(accKey);
+        if (existingTimer) clearTimeout(existingTimer);
+        this.lastMessageTimers.set(
+          accKey,
+          setTimeout(() => {
+            this.lastMessageTimers.delete(accKey);
+            this.emit({ type: 'agent_last_message', workspaceId, sessionId: part.sessionID, preview: updated });
+          }, LAST_MESSAGE_DEBOUNCE_MS),
+        );
+        break;
+      }
+
+      default:
+        break;
+    }
+  }
+}
+
+export const defaultAgentEventManager = new AgentEventManager(defaultOpenCodeRuntimeManager);

--- a/src/serve/client-session-manager.ts
+++ b/src/serve/client-session-manager.ts
@@ -16,6 +16,8 @@ import { encodeControl, encodePTY, parseFrames, decodeControl, FrameType, type S
 import { RemoteSessionHandler, type RemoteClientSession } from "../lib/remote-session/index.js";
 import { STREAM_ID, canWrite, type ServeOptions, type ClientSession, type ServeEventHandler, type HandshakeMessageEnvelope } from "./types.js";
 import { createBufferedSocketWriter } from "../utils/bun-socket-writer.js";
+import { serializeRemoteMessage } from "../lib/remote-session/protocol.js";
+import type { AgentStateUpdateDelta, WorkspaceAgentState } from "./agent-event-manager.js";
 
 // ============================================================================
 // ClientSessionManager Class
@@ -611,6 +613,7 @@ export class ClientSessionManager {
 
     // Cleanup handshake state
     this.handshakeHandler.cleanup(connectionId);
+    this.remoteSessionHandler.cleanupConnection(connectionId);
 
     // Remove send callback
     this.sendCallbacks.delete(connectionId);
@@ -620,6 +623,54 @@ export class ClientSessionManager {
     this.sessions.delete(connectionId);
 
     this.emit({ type: "client_disconnected", connectionId, reason });
+  }
+
+  /**
+   * Send a full agent state snapshot to a specific authenticated client.
+   * Called when a new client completes the handshake.
+   */
+  async sendAgentStateSnapshot(connectionId: string, workspaces: Record<string, WorkspaceAgentState>): Promise<void> {
+    const session = this.sessions.get(connectionId);
+    if (!session?.sessionKeys || session.state !== 'browsing') return;
+    try {
+      const msg = serializeRemoteMessage({
+        type: 'agent_state_snapshot',
+        workspaces: Object.values(workspaces),
+      });
+      const data = new TextEncoder().encode(msg);
+      const frame = await createFrame(0, data, session.sessionKeys.sendKey);
+      const sendToClient = this.createSendCallback(connectionId);
+      sendToClient(Buffer.from(frame));
+    } catch {
+      // Non-fatal — client can request a refresh
+    }
+  }
+
+  /**
+   * Broadcast an agent state delta to all authenticated browsing clients.
+   * Called by AgentEventManager whenever state changes.
+   */
+  async broadcastAgentStateUpdate(delta: AgentStateUpdateDelta): Promise<void> {
+    const msg = serializeRemoteMessage({ type: 'agent_state_update', delta });
+    const data = new TextEncoder().encode(msg);
+    const promises: Promise<void>[] = [];
+
+    for (const [connectionId, session] of this.sessions) {
+      if (session.state !== 'browsing' || !session.sessionKeys) continue;
+      promises.push(
+        (async () => {
+          try {
+            const frame = await createFrame(0, data, session.sessionKeys!.sendKey);
+            const sendToClient = this.createSendCallback(connectionId);
+            sendToClient(Buffer.from(frame));
+          } catch {
+            // Non-fatal — skip this client
+          }
+        })(),
+      );
+    }
+
+    await Promise.allSettled(promises);
   }
 
   /**

--- a/src/session/__tests__/backend-manager.test.ts
+++ b/src/session/__tests__/backend-manager.test.ts
@@ -12,6 +12,7 @@ import type {
 import type { BackendEvent } from '../events';
 import type { BundleRefreshPlan, BundleRefreshSubmission } from '../../types/bundle-refresh';
 import type { BundleConfigState, BundleConfigSubmission } from '../../types/bundle-config';
+import type { AgentStateUpdateDelta } from '../../serve/agent-event-manager';
 
 class FakeBackend implements SessionBackend {
   readonly descriptor: BackendDescriptor;
@@ -88,6 +89,11 @@ class FakeBackend implements SessionBackend {
   async sendReviewRequest(): Promise<never> {
     throw new Error('not implemented');
   }
+  subscribeAgentState(_handler: (delta: AgentStateUpdateDelta) => void): () => void { return () => {}; }
+  getAgentStateSnapshot(): Record<string, never> { return {}; }
+  async respondToAgentPermission(): Promise<boolean> { return false; }
+  async getAgentSessionPreference(_workspaceId: string): Promise<null> { return null; }
+  async setAgentSessionPreference(_workspaceId: string, _sessionId: string): Promise<void> {}
 }
 
 describe('BackendManager', () => {

--- a/src/session/__tests__/useRemoteSessionClient.test.ts
+++ b/src/session/__tests__/useRemoteSessionClient.test.ts
@@ -2,6 +2,7 @@ import { afterAll, beforeAll, describe, expect, it } from 'bun:test'
 import { act, renderHook } from '@testing-library/react'
 import { Window } from 'happy-dom'
 import type { NotificationConfig } from '../../notifications/types.js'
+import type { AgentStateUpdateDelta } from '../../serve/agent-event-manager.js'
 import type {
   AttachSessionParams,
   BackendDescriptor,
@@ -253,6 +254,12 @@ class FakeRemoteBackend implements RemoteSessionPtyBackend {
   async undismissReplay(replayId: string): Promise<void> {
     this.undismissReplayCalls.push(replayId)
   }
+
+  subscribeAgentState(_handler: (delta: AgentStateUpdateDelta) => void): () => void { return () => {}; }
+  getAgentStateSnapshot(): Record<string, never> { return {}; }
+  async respondToAgentPermission(): Promise<boolean> { return false; }
+  async getAgentSessionPreference(_workspaceId: string): Promise<null> { return null; }
+  async setAgentSessionPreference(_workspaceId: string, _sessionId: string): Promise<void> {}
 
   async writePtyData(data: Uint8Array): Promise<void> {
     this.ptyWrites.push(new Uint8Array(data))

--- a/src/session/backend.ts
+++ b/src/session/backend.ts
@@ -7,6 +7,13 @@ import type {
   TerminalSnapshot,
 } from '../lib/tmux-lite/replay/index.js';
 import type {
+  OpenCodeBridgeRequest,
+  OpenCodeBridgeResponse,
+  OpenCodeBridgeStreamEvent,
+  OpenCodeBridgeStreamOpen,
+} from '../agents/opencode-bridge.js';
+import type { OpenCodeRuntimeInfo } from '../agents/opencode-runtime.js';
+import type {
   BundleRefreshPlan,
   BundleRefreshSubmission,
 } from '../types/bundle-refresh.js';
@@ -18,6 +25,7 @@ import type { ReviewOperation, ReviewResult } from '../types/review.js';
 import type { WideEventFilter } from '../types/events.js';
 import type { SessionLinearIssueSummary, WorkspaceSource } from '../types/lifecycle.js';
 import type { ConfirmStepResult, SpacesBundle } from '../types/bundle.js';
+import type { AgentStateUpdateDelta, WorkspaceAgentState } from '../serve/agent-event-manager.js';
 
 export type BackendKey = string;
 export type BackendKind = 'local' | 'remote';
@@ -183,6 +191,35 @@ export interface SessionBackend {
   undismissReplay?(replayId: string): Promise<void>;
 
   onEvent(handler: (event: BackendEvent) => void): () => void;
+
+  /** Subscribe to agent state deltas. Returns an unsubscribe function. */
+  subscribeAgentState(handler: (delta: AgentStateUpdateDelta) => void): () => void;
+  /** Get the current full agent state snapshot (all workspaces). */
+  getAgentStateSnapshot(): Record<string, WorkspaceAgentState>;
+  /**
+   * Respond to an OpenCode permission request.
+   * workspaceId identifies which workspace's OpenCode runtime handles this.
+   */
+  respondToAgentPermission(
+    workspaceId: string,
+    agentSessionId: string,
+    permissionId: string,
+    response: 'allow' | 'deny',
+  ): Promise<boolean>;
+
+  /** Retrieve the persisted last-selected agent session ID for a workspace. */
+  getAgentSessionPreference(workspaceId: string): Promise<string | null>;
+  /** Persist the selected agent session ID for a workspace. */
+  setAgentSessionPreference(workspaceId: string, sessionId: string): Promise<void>;
+}
+
+export interface OpenCodeBridgeBackend {
+  getOpenCodeRuntimeInfo?(workspaceId: string): Promise<OpenCodeRuntimeInfo>;
+  requestOpenCode(request: Omit<OpenCodeBridgeRequest, 'requestId'>): Promise<OpenCodeBridgeResponse>;
+  subscribeOpenCode(
+    request: Omit<OpenCodeBridgeStreamOpen, 'requestId'>,
+    handler: (event: OpenCodeBridgeStreamEvent) => void,
+  ): Promise<() => Promise<void>>;
 }
 
 export type { ReplayFrameTarget, ReplayInfo, ReplayTimeline, TerminalSnapshot };

--- a/src/session/backends/local-session-backend.ts
+++ b/src/session/backends/local-session-backend.ts
@@ -79,6 +79,7 @@ import type {
   CreateWorkspaceParams,
   DeleteProjectParams,
   DeleteWorkspaceParams,
+  OpenCodeBridgeBackend,
   SessionBackend,
 } from '../backend.js';
 import type { BackendEvent } from '../events.js';
@@ -109,6 +110,20 @@ import { loadSavedEventFilters } from '../../lib/events/filters.js';
 import { readProjectConfig } from '../../core/config.js';
 import { existsSync } from 'fs';
 import type { TerminalSnapshot } from '../backend.js';
+import {
+  buildOpenCodeUrl,
+  decodeBridgeBody,
+  type OpenCodeBridgeRequest,
+  type OpenCodeBridgeResponse,
+  type OpenCodeBridgeStreamEvent,
+  type OpenCodeBridgeStreamOpen,
+} from '../../agents/opencode-bridge.js';
+import { consumeSseStream } from '../../agents/opencode-sse.js';
+import { createOpenCodeBasicAuthHeader, defaultOpenCodeRuntimeManager } from '../../agents/opencode-runtime.js';
+import { defaultAgentEventManager, type AgentStateUpdateDelta, type WorkspaceAgentState } from '../../serve/agent-event-manager.js';
+import { OpenCodeClient } from '../../agents/opencode-client.js';
+import { readFile, writeFile, mkdir } from 'node:fs/promises';
+import { join } from 'node:path';
 
 export interface LocalSessionBackendDependencies {
   listSessions: typeof listSessions;
@@ -413,7 +428,7 @@ function buildDeps(
   };
 }
 
-export class LocalSessionBackend implements SessionBackend {
+export class LocalSessionBackend implements SessionBackend, OpenCodeBridgeBackend {
   readonly descriptor: BackendDescriptor;
   private readonly deps: LocalSessionBackendDependencies;
   private readonly handlers = new Set<(event: BackendEvent) => void>();
@@ -625,6 +640,107 @@ export class LocalSessionBackend implements SessionBackend {
 
   async undismissReplay(replayId: string): Promise<void> {
     this.deps.undismissReplay(replayId);
+  }
+
+  async requestOpenCode(request: Omit<OpenCodeBridgeRequest, 'requestId'>): Promise<OpenCodeBridgeResponse> {
+    const workspaces = await this.deps.scanWorkspaces();
+    const workspace = workspaces.find((item) => matchesWorkspaceId(item, request.workspaceId));
+    if (!workspace) {
+      throw new Error(`Workspace not found: ${request.workspaceId}`);
+    }
+
+    const runtime = await defaultOpenCodeRuntimeManager.ensureWorkspaceRuntime({
+      workspaceId: toCanonicalWorkspaceId(workspace),
+      workspacePath: workspace.path,
+      projectName: workspace.projectName,
+    });
+
+    const response = await fetch(buildOpenCodeUrl(runtime.baseUrl, request.path, request.query), {
+      method: request.method,
+      headers: {
+        ...(request.headers ?? {}),
+        authorization: createOpenCodeBasicAuthHeader(runtime),
+      },
+      body: request.bodyBase64 ? Buffer.from(request.bodyBase64, 'base64') : undefined,
+    });
+
+    const headers: Record<string, string> = {};
+    response.headers.forEach((value, key) => {
+      headers[key] = value;
+    });
+
+    const body = Buffer.from(await response.arrayBuffer());
+    return {
+      requestId: crypto.randomUUID(),
+      status: response.status,
+      headers,
+      bodyBase64: body.length > 0 ? body.toString('base64') : undefined,
+    };
+  }
+
+  async getOpenCodeRuntimeInfo(workspaceId: string) {
+    const workspaces = await this.deps.scanWorkspaces();
+    const workspace = workspaces.find((item) => matchesWorkspaceId(item, workspaceId));
+    if (!workspace) {
+      throw new Error(`Workspace not found: ${workspaceId}`);
+    }
+
+    return defaultOpenCodeRuntimeManager.ensureWorkspaceRuntime({
+      workspaceId: toCanonicalWorkspaceId(workspace),
+      workspacePath: workspace.path,
+      projectName: workspace.projectName,
+    });
+  }
+
+  async subscribeOpenCode(
+    request: Omit<OpenCodeBridgeStreamOpen, 'requestId'>,
+    handler: (event: OpenCodeBridgeStreamEvent) => void,
+  ): Promise<() => Promise<void>> {
+    const workspaces = await this.deps.scanWorkspaces();
+    const workspace = workspaces.find((item) => matchesWorkspaceId(item, request.workspaceId));
+    if (!workspace) {
+      throw new Error(`Workspace not found: ${request.workspaceId}`);
+    }
+
+    const runtime = await defaultOpenCodeRuntimeManager.ensureWorkspaceRuntime({
+      workspaceId: toCanonicalWorkspaceId(workspace),
+      workspacePath: workspace.path,
+      projectName: workspace.projectName,
+    });
+
+    const controller = new AbortController();
+    const streamRequestId = crypto.randomUUID();
+    const response = await fetch(buildOpenCodeUrl(runtime.baseUrl, request.path, request.query), {
+      method: 'GET',
+      headers: {
+        accept: 'text/event-stream',
+        ...(request.headers ?? {}),
+        authorization: createOpenCodeBasicAuthHeader(runtime),
+      },
+      signal: controller.signal,
+    });
+
+    if (!response.ok || !response.body) {
+      throw new Error(`Failed to open OpenCode stream (${response.status})`);
+    }
+
+    void consumeSseStream(response.body, async (event) => {
+      handler({
+        requestId: streamRequestId,
+        event: event.event,
+        data: event.data,
+        id: event.id,
+      });
+    }).catch((error) => {
+      this.emit({
+        type: 'error',
+        message: error instanceof Error ? error.message : String(error),
+      });
+    });
+
+    return async () => {
+      controller.abort();
+    };
   }
 
   async createProject(params: CreateProjectParams): Promise<void> {
@@ -1401,5 +1517,83 @@ export class LocalSessionBackend implements SessionBackend {
     for (const handler of this.handlers) {
       handler(event);
     }
+  }
+
+  // ============================================================================
+  // Agent state — backed by defaultAgentEventManager
+  // ============================================================================
+
+  subscribeAgentState(handler: (delta: AgentStateUpdateDelta) => void): () => void {
+    return defaultAgentEventManager.subscribe(handler);
+  }
+
+  getAgentStateSnapshot(): Record<string, WorkspaceAgentState> {
+    return defaultAgentEventManager.getSnapshot();
+  }
+
+  async respondToAgentPermission(
+    workspaceId: string,
+    agentSessionId: string,
+    permissionId: string,
+    response: 'allow' | 'deny',
+  ): Promise<boolean> {
+    // We don't need the workspace path here — we just need the runtime
+    const runtime = await defaultOpenCodeRuntimeManager.getWorkspaceRuntime(workspaceId);
+    if (!runtime) return false;
+    const client = new OpenCodeClient({
+      baseUrl: runtime.baseUrl,
+      fetch: (input, init) =>
+        fetch(input as RequestInfo, {
+          ...init,
+          headers: {
+            ...(init?.headers ?? {}),
+            authorization: createOpenCodeBasicAuthHeader(runtime),
+          },
+        }),
+    });
+    return client.respondToPermission(agentSessionId, permissionId, response);
+  }
+
+  // ============================================================================
+  // Agent session preferences — persisted to ~/.gitspace/.agent-sessions.json
+  // ============================================================================
+
+  private get agentPrefsPath(): string {
+    const home = process.env.HOME ?? process.env.USERPROFILE ?? '/tmp';
+    return join(home, 'gitspace', '.agent-sessions.json');
+  }
+
+  private agentPrefsCache: Record<string, string> | null = null;
+
+  private async loadAgentPrefs(): Promise<Record<string, string>> {
+    if (this.agentPrefsCache) return this.agentPrefsCache;
+    try {
+      const raw = await readFile(this.agentPrefsPath, 'utf8');
+      this.agentPrefsCache = JSON.parse(raw) as Record<string, string>;
+    } catch {
+      this.agentPrefsCache = {};
+    }
+    return this.agentPrefsCache!;
+  }
+
+  private async saveAgentPrefs(prefs: Record<string, string>): Promise<void> {
+    this.agentPrefsCache = prefs;
+    try {
+      await mkdir(join(this.agentPrefsPath, '..'), { recursive: true });
+      await writeFile(this.agentPrefsPath, JSON.stringify(prefs, null, 2), 'utf8');
+    } catch {
+      // Non-fatal — preference persistence is best-effort
+    }
+  }
+
+  async getAgentSessionPreference(workspaceId: string): Promise<string | null> {
+    const prefs = await this.loadAgentPrefs();
+    return prefs[workspaceId] ?? null;
+  }
+
+  async setAgentSessionPreference(workspaceId: string, sessionId: string): Promise<void> {
+    const prefs = await this.loadAgentPrefs();
+    prefs[workspaceId] = sessionId;
+    await this.saveAgentPrefs(prefs);
   }
 }

--- a/src/session/backends/remote-session-backend.ts
+++ b/src/session/backends/remote-session-backend.ts
@@ -52,6 +52,14 @@ import {
   type SessionCtrl,
   type StartProcessRequest,
   type StopProcessRequest,
+  type OpenCodeRequest,
+  type OpenCodeResponse,
+  type OpenCodeStreamCloseRequest,
+  type OpenCodeStreamEventResponse,
+  type OpenCodeStreamOpenRequest,
+  type OpenCodeStreamOpenedResponse,
+  type OpenCodeStreamClosedResponse,
+  type OpenCodeStreamErrorResponse,
   type UpdateNotificationConfigRequest,
   type WorkspaceCreatedResponse,
   type GetReplayAnsiRequest,
@@ -82,9 +90,19 @@ import type {
   CreateWorkspaceParams,
   DeleteProjectParams,
   DeleteWorkspaceParams,
+  OpenCodeBridgeBackend,
   SessionBackend,
 } from '../backend.js';
 import type { BackendEvent } from '../events.js';
+import type {
+  OpenCodeBridgeRequest,
+  OpenCodeBridgeResponse,
+  OpenCodeBridgeStreamEvent,
+  OpenCodeBridgeStreamOpen,
+} from '../../agents/opencode-bridge.js';
+import type { OpenCodeRuntimeInfo } from '../../agents/opencode-runtime.js';
+import type { AgentStateUpdateDelta, WorkspaceAgentState } from '../../serve/agent-event-manager.js';
+import type { AgentStateSnapshotPush, AgentStateUpdatePush } from '../../lib/remote-session/protocol.js';
 
 const DEFAULT_CONTROL_STREAM_ID = 1;
 const DEFAULT_DELETE_WORKSPACE_TIMEOUT_MS = 30000;
@@ -247,6 +265,14 @@ const MACHINE_TO_CLIENT_TYPES = new Set<string>([
   'events_list',
   'process_started',
   'process_stopped',
+  'opencode_response',
+  'opencode_stream_opened',
+  'opencode_stream_event',
+  'opencode_stream_closed',
+  'opencode_stream_error',
+  'opencode_runtime',
+  'agent_state_snapshot',
+  'agent_state_update',
 ]);
 
 function isHandshakeEnvelope(value: unknown): value is HandshakeEnvelope {
@@ -356,7 +382,7 @@ function toWorkspaceDeleteErrorCode(code: string | undefined): WorkspaceDeleteEr
 }
 
 export class RemoteSessionBackend<TSocket, THandshakeState, TServerHello, TServerAuth>
-  implements SessionBackend {
+  implements SessionBackend, OpenCodeBridgeBackend {
   readonly descriptor: BackendDescriptor;
 
   private readonly socket: TSocket;
@@ -522,6 +548,23 @@ export class RemoteSessionBackend<TSocket, THandshakeState, TServerHello, TServe
   private pendingPtyChunks: Uint8Array[] = [];
   private pendingUtf8Bytes = new Uint8Array(0);
   private pendingEventChunks = new Map<string, PendingEventsChunk>();
+  private pendingOpenCodeRequests = new Map<string, {
+    resolve: (response: OpenCodeBridgeResponse) => void;
+    reject: (error: Error) => void;
+    timeout: ReturnType<typeof setTimeout>;
+  }>();
+  private openCodeStreamHandlers = new Map<string, (event: OpenCodeBridgeStreamEvent) => void>();
+  private pendingOpenCodeRuntimeInfo = new Map<string, {
+    workspaceId: string;
+    resolve: (info: OpenCodeRuntimeInfo) => void;
+    reject: (error: Error) => void;
+    timeout: ReturnType<typeof setTimeout>;
+  }>();
+  private pendingOpenCodeStreamOpen = new Map<string, {
+    resolve: () => void;
+    reject: (error: Error) => void;
+    timeout: ReturnType<typeof setTimeout>;
+  }>();
 
   constructor(options: RemoteSessionBackendOptions<TSocket, THandshakeState, TServerHello, TServerAuth>) {
     this.descriptor = options.descriptor;
@@ -845,6 +888,125 @@ export class RemoteSessionBackend<TSocket, THandshakeState, TServerHello, TServe
         }
         clearTimeout(pending.timeout);
         this.pendingUndismissReplay = null;
+        pending.reject(error instanceof Error ? error : new Error(String(error)));
+      });
+    });
+  }
+
+  async requestOpenCode(request: Omit<OpenCodeBridgeRequest, 'requestId'>): Promise<OpenCodeBridgeResponse> {
+    const requestId = crypto.randomUUID();
+    const command: OpenCodeRequest = {
+      type: 'opencode_request',
+      requestId,
+      ...request,
+    };
+
+    return new Promise<OpenCodeBridgeResponse>((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        const pending = this.pendingOpenCodeRequests.get(requestId);
+        if (!pending) {
+          return;
+        }
+        this.pendingOpenCodeRequests.delete(requestId);
+        reject(new Error(`Timed out waiting for OpenCode response (${request.path})`));
+      }, DEFAULT_LIFECYCLE_TIMEOUT_MS);
+
+      this.pendingOpenCodeRequests.set(requestId, { resolve, reject, timeout });
+
+      void this.sendCommand(command).catch((error) => {
+        const pending = this.pendingOpenCodeRequests.get(requestId);
+        if (!pending) {
+          return;
+        }
+        clearTimeout(pending.timeout);
+        this.pendingOpenCodeRequests.delete(requestId);
+        pending.reject(error instanceof Error ? error : new Error(String(error)));
+      });
+    });
+  }
+
+  async getOpenCodeRuntimeInfo(workspaceId: string): Promise<OpenCodeRuntimeInfo> {
+    const requestId = crypto.randomUUID();
+    const command = {
+      type: 'get_opencode_runtime' as const,
+      workspaceId,
+    };
+
+    return new Promise<OpenCodeRuntimeInfo>((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        const pending = this.pendingOpenCodeRuntimeInfo.get(requestId);
+        if (!pending) {
+          return;
+        }
+        this.pendingOpenCodeRuntimeInfo.delete(requestId);
+        reject(new Error(`Timed out waiting for OpenCode runtime info (${workspaceId})`));
+      }, DEFAULT_LIFECYCLE_TIMEOUT_MS);
+
+      this.pendingOpenCodeRuntimeInfo.set(requestId, {
+        workspaceId,
+        resolve,
+        reject,
+        timeout,
+      });
+
+      void this.sendCommand(command).catch((error) => {
+        const pending = this.pendingOpenCodeRuntimeInfo.get(requestId);
+        if (!pending) {
+          return;
+        }
+        clearTimeout(pending.timeout);
+        this.pendingOpenCodeRuntimeInfo.delete(requestId);
+        pending.reject(error instanceof Error ? error : new Error(String(error)));
+      });
+    });
+  }
+
+  async subscribeOpenCode(
+    request: Omit<OpenCodeBridgeStreamOpen, 'requestId'>,
+    handler: (event: OpenCodeBridgeStreamEvent) => void,
+  ): Promise<() => Promise<void>> {
+    const requestId = crypto.randomUUID();
+    const command: OpenCodeStreamOpenRequest = {
+      type: 'opencode_stream_open',
+      requestId,
+      ...request,
+    };
+
+    return new Promise<() => Promise<void>>((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        const pending = this.pendingOpenCodeStreamOpen.get(requestId);
+        if (!pending) {
+          return;
+        }
+        this.pendingOpenCodeStreamOpen.delete(requestId);
+        this.openCodeStreamHandlers.delete(requestId);
+        reject(new Error(`Timed out opening OpenCode stream (${request.path})`));
+      }, DEFAULT_LIFECYCLE_TIMEOUT_MS);
+
+      this.openCodeStreamHandlers.set(requestId, handler);
+      this.pendingOpenCodeStreamOpen.set(requestId, {
+        resolve: () => {
+          resolve(async () => {
+            const closeCommand: OpenCodeStreamCloseRequest = {
+              type: 'opencode_stream_close',
+              requestId,
+            };
+            this.openCodeStreamHandlers.delete(requestId);
+            await this.sendCommand(closeCommand);
+          });
+        },
+        reject,
+        timeout,
+      });
+
+      void this.sendCommand(command).catch((error) => {
+        const pending = this.pendingOpenCodeStreamOpen.get(requestId);
+        if (!pending) {
+          return;
+        }
+        clearTimeout(pending.timeout);
+        this.pendingOpenCodeStreamOpen.delete(requestId);
+        this.openCodeStreamHandlers.delete(requestId);
         pending.reject(error instanceof Error ? error : new Error(String(error)));
       });
     });
@@ -1870,6 +2032,30 @@ export class RemoteSessionBackend<TSocket, THandshakeState, TServerHello, TServe
           processName: message.processName,
         });
         return;
+      case 'opencode_response':
+        this.resolveOpenCodeRequest(message);
+        return;
+      case 'opencode_stream_opened':
+        this.resolveOpenCodeStreamOpened(message);
+        return;
+      case 'opencode_stream_event':
+        this.handleOpenCodeStreamEvent(message);
+        return;
+      case 'opencode_stream_closed':
+        this.handleOpenCodeStreamClosed(message);
+        return;
+      case 'opencode_stream_error':
+        this.handleOpenCodeStreamError(message);
+        return;
+      case 'opencode_runtime':
+        this.resolveOpenCodeRuntimeInfo(message);
+        return;
+      case 'agent_state_snapshot':
+        this.handleAgentStateSnapshot(message as unknown as AgentStateSnapshotPush);
+        return;
+      case 'agent_state_update':
+        this.handleAgentStateUpdate(message as unknown as AgentStateUpdatePush);
+        return;
       case 'error':
         this.rejectPendingBundleRefreshRequests(message.message);
         this.rejectPendingGithubRepoList(message.message);
@@ -1884,6 +2070,9 @@ export class RemoteSessionBackend<TSocket, THandshakeState, TServerHello, TServe
         this.rejectPendingReplayTimeline(message.message, undefined, true);
         this.rejectPendingDismissReplay(message.message, undefined, true);
         this.rejectPendingUndismissReplay(message.message, undefined, true);
+        this.rejectPendingOpenCodeRuntimeInfo(message.message, message.workspaceId);
+        this.rejectPendingOpenCodeRequests(message.message);
+        this.rejectPendingOpenCodeStreams(message.message);
         if (message.workspaceId) {
           this.rejectPendingWorkspaceDelete(message.code, message.message, message.workspaceId);
         }
@@ -2045,6 +2234,120 @@ export class RemoteSessionBackend<TSocket, THandshakeState, TServerHello, TServe
     clearTimeout(pending.timeout);
     this.pendingGithubRepos = null;
     pending.reject(new Error(message));
+  }
+
+  private resolveOpenCodeRequest(message: OpenCodeResponse): void {
+    const pending = this.pendingOpenCodeRequests.get(message.requestId);
+    if (!pending) {
+      return;
+    }
+
+    clearTimeout(pending.timeout);
+    this.pendingOpenCodeRequests.delete(message.requestId);
+    pending.resolve({
+      requestId: message.requestId,
+      status: message.status,
+      headers: message.headers,
+      bodyBase64: message.bodyBase64,
+    });
+  }
+
+  private resolveOpenCodeStreamOpened(message: OpenCodeStreamOpenedResponse): void {
+    const pending = this.pendingOpenCodeStreamOpen.get(message.requestId);
+    if (!pending) {
+      return;
+    }
+
+    clearTimeout(pending.timeout);
+    this.pendingOpenCodeStreamOpen.delete(message.requestId);
+    pending.resolve();
+  }
+
+  private handleOpenCodeStreamEvent(message: OpenCodeStreamEventResponse): void {
+    const handler = this.openCodeStreamHandlers.get(message.requestId);
+    if (!handler) {
+      return;
+    }
+
+    handler({
+      requestId: message.requestId,
+      event: message.event,
+      data: message.data,
+      id: message.id,
+    });
+  }
+
+  private handleOpenCodeStreamClosed(message: OpenCodeStreamClosedResponse): void {
+    const pending = this.pendingOpenCodeStreamOpen.get(message.requestId);
+    if (pending) {
+      clearTimeout(pending.timeout);
+      this.pendingOpenCodeStreamOpen.delete(message.requestId);
+      pending.reject(new Error('OpenCode stream closed before opening'));
+    }
+    this.openCodeStreamHandlers.delete(message.requestId);
+  }
+
+  private handleOpenCodeStreamError(message: OpenCodeStreamErrorResponse): void {
+    const pending = this.pendingOpenCodeStreamOpen.get(message.requestId);
+    if (pending) {
+      clearTimeout(pending.timeout);
+      this.pendingOpenCodeStreamOpen.delete(message.requestId);
+      this.openCodeStreamHandlers.delete(message.requestId);
+      pending.reject(new Error(message.message));
+      return;
+    }
+
+    this.openCodeStreamHandlers.delete(message.requestId);
+    this.emit({ type: 'error', message: message.message });
+  }
+
+  private resolveOpenCodeRuntimeInfo(message: Extract<MachineToClientMessage, { type: 'opencode_runtime' }>): void {
+    for (const [requestId, pending] of this.pendingOpenCodeRuntimeInfo) {
+      if (!workspaceIdsMatch(pending.workspaceId, message.workspaceId)) {
+        continue;
+      }
+      clearTimeout(pending.timeout);
+      this.pendingOpenCodeRuntimeInfo.delete(requestId);
+      pending.resolve({
+        workspaceId: message.workspaceId,
+        workspacePath: message.workspacePath,
+        hostname: message.hostname,
+        port: message.port,
+        baseUrl: message.baseUrl,
+        username: message.username,
+        password: message.password,
+        startedAt: new Date().toISOString(),
+      });
+      return;
+    }
+  }
+
+  private rejectPendingOpenCodeRequests(message: string): void {
+    for (const [requestId, pending] of this.pendingOpenCodeRequests) {
+      clearTimeout(pending.timeout);
+      this.pendingOpenCodeRequests.delete(requestId);
+      pending.reject(new Error(message));
+    }
+  }
+
+  private rejectPendingOpenCodeRuntimeInfo(message: string, workspaceId?: string): void {
+    for (const [requestId, pending] of this.pendingOpenCodeRuntimeInfo) {
+      if (workspaceId && !workspaceIdsMatch(pending.workspaceId, workspaceId)) {
+        continue;
+      }
+      clearTimeout(pending.timeout);
+      this.pendingOpenCodeRuntimeInfo.delete(requestId);
+      pending.reject(new Error(message));
+    }
+  }
+
+  private rejectPendingOpenCodeStreams(message: string): void {
+    for (const [requestId, pending] of this.pendingOpenCodeStreamOpen) {
+      clearTimeout(pending.timeout);
+      this.pendingOpenCodeStreamOpen.delete(requestId);
+      this.openCodeStreamHandlers.delete(requestId);
+      pending.reject(new Error(message));
+    }
   }
 
   private rejectPendingRemoteBranches(
@@ -2611,9 +2914,131 @@ export class RemoteSessionBackend<TSocket, THandshakeState, TServerHello, TServe
     this.rejectPendingDismissReplay('Remote session disconnected', undefined, true);
     this.rejectPendingUndismissReplay('Remote session disconnected', undefined, true);
     this.rejectPendingWorkspaceDelete('DELETE_FAILED', 'Remote session disconnected', undefined, true);
+    this.rejectPendingOpenCodeRuntimeInfo('Remote session disconnected');
+    this.rejectPendingOpenCodeRequests('Remote session disconnected');
+    this.rejectPendingOpenCodeStreams('Remote session disconnected');
     this.rejectAllPendingReviewRequests('Remote session disconnected');
     this.connectPromise = null;
     this.connectResolve = null;
     this.connectReject = null;
+  }
+
+  // ============================================================================
+  // Agent state — backed by machine-pushed messages
+  // ============================================================================
+
+  private agentStateCache: Record<string, WorkspaceAgentState> = {};
+  private agentStateHandlers = new Set<(delta: AgentStateUpdateDelta) => void>();
+
+  private handleAgentStateSnapshot(msg: AgentStateSnapshotPush): void {
+    this.agentStateCache = {};
+    for (const workspace of msg.workspaces) {
+      this.agentStateCache[workspace.workspaceId] = workspace;
+    }
+    // Emit a snapshot delta so subscribers can refresh
+    const snapshot: AgentStateUpdateDelta = {
+      type: 'agent_state_snapshot',
+      workspaces: this.agentStateCache,
+    };
+    for (const handler of this.agentStateHandlers) {
+      try { handler(snapshot); } catch { /* non-fatal */ }
+    }
+  }
+
+  private handleAgentStateUpdate(msg: AgentStateUpdatePush): void {
+    const delta = msg.delta;
+    // Apply delta to local cache
+    if ('workspaceId' in delta && 'sessionId' in delta) {
+      const state = this.agentStateCache[delta.workspaceId];
+      if (state) {
+        switch (delta.type) {
+          case 'agent_session_status':
+            state.statuses[delta.sessionId] = delta.status;
+            break;
+          case 'agent_permission_added':
+            if (!state.pendingPermissions[delta.sessionId]) state.pendingPermissions[delta.sessionId] = [];
+            state.pendingPermissions[delta.sessionId].push(delta.permission);
+            break;
+          case 'agent_permission_removed':
+            if (state.pendingPermissions[delta.sessionId]) {
+              state.pendingPermissions[delta.sessionId] = state.pendingPermissions[delta.sessionId].filter(
+                (p) => p.id !== delta.permissionId,
+              );
+            }
+            break;
+          case 'agent_last_message':
+            state.lastMessages[delta.sessionId] = delta.preview;
+            break;
+          case 'agent_session_created':
+            if (!state.sessions.some((s) => s.id === delta.sessionId)) {
+              state.sessions.push({ id: delta.sessionId, title: delta.title });
+            }
+            break;
+          case 'agent_session_updated': {
+            const idx = state.sessions.findIndex((s) => s.id === delta.sessionId);
+            if (idx !== -1) state.sessions[idx] = { id: delta.sessionId, title: delta.title };
+            break;
+          }
+          case 'agent_session_deleted':
+            state.sessions = state.sessions.filter((s) => s.id !== delta.sessionId);
+            break;
+        }
+      }
+    }
+    for (const handler of this.agentStateHandlers) {
+      try { handler(delta); } catch { /* non-fatal */ }
+    }
+  }
+
+  subscribeAgentState(handler: (delta: AgentStateUpdateDelta) => void): () => void {
+    this.agentStateHandlers.add(handler);
+    return () => { this.agentStateHandlers.delete(handler); };
+  }
+
+  getAgentStateSnapshot(): Record<string, WorkspaceAgentState> {
+    return this.agentStateCache;
+  }
+
+  async respondToAgentPermission(
+    workspaceId: string,
+    agentSessionId: string,
+    permissionId: string,
+    response: 'allow' | 'deny',
+  ): Promise<boolean> {
+    // Tunnel the permission response through the existing opencode_request bridge
+    const resp = await this.requestOpenCode({
+      workspaceId,
+      method: 'POST',
+      path: `/session/${encodeURIComponent(agentSessionId)}/permissions/${encodeURIComponent(permissionId)}`,
+      headers: { 'content-type': 'application/json' },
+      bodyBase64: Buffer.from(JSON.stringify({ response })).toString('base64'),
+    });
+    try {
+      return JSON.parse(Buffer.from(resp.bodyBase64 ?? '', 'base64').toString('utf8')) as boolean;
+    } catch {
+      return resp.status >= 200 && resp.status < 300;
+    }
+  }
+
+  // ============================================================================
+  // Agent session preferences — stored via requestOpenCode (relay-tunneled)
+  // Note: Preferences for remote machines are stored locally in the client,
+  // not on the remote machine, since they're UI state, not workspace state.
+  // ============================================================================
+
+  private remoteAgentPrefsCache: Record<string, string> = {};
+
+  async getAgentSessionPreference(workspaceId: string): Promise<string | null> {
+    return this.remoteAgentPrefsCache[workspaceId] ?? null;
+  }
+
+  async setAgentSessionPreference(workspaceId: string, sessionId: string): Promise<void> {
+    this.remoteAgentPrefsCache[workspaceId] = sessionId;
+    // Best-effort: also persist to localStorage if available (web context)
+    try {
+      if (typeof localStorage !== 'undefined') {
+        localStorage.setItem(`gssh:agent-session:${workspaceId}`, sessionId);
+      }
+    } catch { /* non-fatal */ }
   }
 }

--- a/src/session/index.ts
+++ b/src/session/index.ts
@@ -10,6 +10,7 @@ export type {
   CreateWorkspaceParams,
   DeleteProjectParams,
   DeleteWorkspaceParams,
+  OpenCodeBridgeBackend,
 } from './backend.js';
 
 export type {

--- a/src/session/useRemoteSessionClient.ts
+++ b/src/session/useRemoteSessionClient.ts
@@ -156,6 +156,8 @@ export interface UseRemoteSessionClientReturn<ConnectParams> {
     handler: (event: OpenCodeBridgeStreamEvent) => void,
   ) => Promise<() => Promise<void>>;
   getOpenCodeRuntimeInfo: (workspaceId: string) => Promise<OpenCodeRuntimeInfo>;
+  /** The underlying SessionBackend for agent hooks that need the full interface */
+  sessionBackend: SessionBackend | null;
 }
 
 function defaultStatusMapper(
@@ -697,6 +699,8 @@ export function useRemoteSessionClient<ConnectParams>(
     requestOpenCode,
     subscribeOpenCode,
     getOpenCodeRuntimeInfo,
+    /** Expose the underlying SessionBackend for agent hooks that need the full interface */
+    sessionBackend: backendRef.current as SessionBackend | null,
   }), [
     status,
     activeBackendState,

--- a/src/session/useRemoteSessionClient.ts
+++ b/src/session/useRemoteSessionClient.ts
@@ -9,6 +9,8 @@ import type {
   WorkspaceInfo,
 } from '../lib/remote-session/protocol.js';
 import type { NotificationConfig } from '../notifications/types.js';
+import type { OpenCodeBridgeRequest, OpenCodeBridgeResponse, OpenCodeBridgeStreamEvent, OpenCodeBridgeStreamOpen } from '../agents/opencode-bridge.js';
+import type { OpenCodeRuntimeInfo } from '../agents/opencode-runtime.js';
 import type {
   AttachSessionParams,
   BackendKey,
@@ -18,6 +20,7 @@ import type {
   CreateWorkspaceParams,
   DeleteProjectParams,
   DeleteWorkspaceParams,
+  OpenCodeBridgeBackend,
   SessionBackend,
 } from './backend.js';
 import type { ScriptRuntimeState, BackendSessionState } from './types.js';
@@ -51,6 +54,9 @@ export interface RemoteSessionPtyBackend extends SessionBackend {
   setPtyOutputHandler?: (handler: ((data: Uint8Array) => void) | null) => void;
   writePtyData?: (data: Uint8Array) => Promise<void>;
   resizePty?: (cols: number, rows: number) => Promise<void>;
+  getOpenCodeRuntimeInfo?: OpenCodeBridgeBackend['getOpenCodeRuntimeInfo'];
+  requestOpenCode?: OpenCodeBridgeBackend['requestOpenCode'];
+  subscribeOpenCode?: OpenCodeBridgeBackend['subscribeOpenCode'];
 }
 
 export interface UseRemoteSessionClientOptions<ConnectParams> {
@@ -143,6 +149,13 @@ export interface UseRemoteSessionClientReturn<ConnectParams> {
   getReplayTimeline: (replayId: string) => Promise<ReplayTimeline>;
   dismissReplay: (replayId: string) => Promise<void>;
   undismissReplay: (replayId: string) => Promise<void>;
+  hasOpenCodeBridge: boolean;
+  requestOpenCode: (request: Omit<OpenCodeBridgeRequest, 'requestId'>) => Promise<OpenCodeBridgeResponse>;
+  subscribeOpenCode: (
+    request: Omit<OpenCodeBridgeStreamOpen, 'requestId'>,
+    handler: (event: OpenCodeBridgeStreamEvent) => void,
+  ) => Promise<() => Promise<void>>;
+  getOpenCodeRuntimeInfo: (workspaceId: string) => Promise<OpenCodeRuntimeInfo>;
 }
 
 function defaultStatusMapper(
@@ -570,6 +583,35 @@ export function useRemoteSessionClient<ConnectParams>(
     await engine.undismissReplay(backendKey, replayId);
   }, [engine]);
 
+  const requestOpenCode = useCallback(async (
+    request: Omit<OpenCodeBridgeRequest, 'requestId'>,
+  ): Promise<OpenCodeBridgeResponse> => {
+    const backend = backendRef.current;
+    if (!backend?.requestOpenCode) {
+      throw new Error('OpenCode bridge unavailable for current backend');
+    }
+    return backend.requestOpenCode(request);
+  }, []);
+
+  const subscribeOpenCode = useCallback(async (
+    request: Omit<OpenCodeBridgeStreamOpen, 'requestId'>,
+    handler: (event: OpenCodeBridgeStreamEvent) => void,
+  ): Promise<() => Promise<void>> => {
+    const backend = backendRef.current;
+    if (!backend?.subscribeOpenCode) {
+      throw new Error('OpenCode bridge unavailable for current backend');
+    }
+    return backend.subscribeOpenCode(request, handler);
+  }, []);
+
+  const getOpenCodeRuntimeInfo = useCallback(async (workspaceId: string): Promise<OpenCodeRuntimeInfo> => {
+    const backend = backendRef.current;
+    if (!backend?.getOpenCodeRuntimeInfo) {
+      throw new Error('OpenCode runtime info unavailable for current backend');
+    }
+    return backend.getOpenCodeRuntimeInfo(workspaceId);
+  }, []);
+
   useEffect(() => {
     return () => {
       const backendKey = activeBackendKeyRef.current;
@@ -651,6 +693,10 @@ export function useRemoteSessionClient<ConnectParams>(
     getReplayTimeline,
     dismissReplay,
     undismissReplay,
+    hasOpenCodeBridge: Boolean(backendRef.current?.requestOpenCode && backendRef.current?.subscribeOpenCode),
+    requestOpenCode,
+    subscribeOpenCode,
+    getOpenCodeRuntimeInfo,
   }), [
     status,
     activeBackendState,
@@ -696,5 +742,8 @@ export function useRemoteSessionClient<ConnectParams>(
     getReplayTimeline,
     dismissReplay,
     undismissReplay,
+    requestOpenCode,
+    subscribeOpenCode,
+    getOpenCodeRuntimeInfo,
   ]);
 }

--- a/src/utils/__tests__/onboarding.test.ts
+++ b/src/utils/__tests__/onboarding.test.ts
@@ -180,6 +180,7 @@ describe('onboarding', () => {
       expect(result.completed).toBe(false);
       expect(result.cancelledAt).toBe('welcome');
     });
+
   });
 
   describe('runOnboarding with previous values', () => {

--- a/src/utils/onboarding.ts
+++ b/src/utils/onboarding.ts
@@ -77,9 +77,9 @@ export async function runOnboarding(
 
     // Store values and metadata by step type
     if (step.type === 'secret') {
-      result.secretValues[step.configKey] = stepResult;
+      result.secretValues[step.configKey] = stepResult as string;
     } else if (step.type === 'input') {
-      result.inputValues[step.configKey] = stepResult;
+      result.inputValues[step.configKey] = stepResult as string;
     } else if (step.type === 'confirm') {
       const confirmResult: ConfirmStepResult = {
         status: stepResult === SKIP_OPTIONAL_CONFIRM ? 'skipped' : 'passed',
@@ -98,7 +98,10 @@ export async function runOnboarding(
  * Execute a single onboarding step
  * Returns collected value or null if cancelled
  */
-async function executeStep(step: OnboardingStep, options: OnboardingOptions): Promise<string | null> {
+async function executeStep(
+  step: OnboardingStep,
+  options: OnboardingOptions,
+): Promise<string | null> {
   switch (step.type) {
     case 'info':
       return executeInfoStep();

--- a/web/main.tsx
+++ b/web/main.tsx
@@ -3,6 +3,10 @@ import { createRoot } from "react-dom/client";
 import "./index.css";
 import App from "../src/app.web";
 
+if ('serviceWorker' in navigator) {
+  void navigator.serviceWorker.register('/service-worker.js');
+}
+
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
     <App />

--- a/web/public/service-worker.js
+++ b/web/public/service-worker.js
@@ -1,0 +1,215 @@
+const AGENT_UI_PREFIX = '/agent-ui/'
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(self.skipWaiting())
+})
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(self.clients.claim())
+})
+
+self.addEventListener('fetch', (event) => {
+  const url = new URL(event.request.url)
+  if (url.origin !== self.location.origin) {
+    return
+  }
+
+  const context = resolveAgentContext(event.request)
+  if (!context) {
+    return
+  }
+
+  event.respondWith(handleAgentRequest(event.request, context))
+})
+
+function resolveAgentContext(request) {
+  const url = new URL(request.url)
+  if (url.pathname.startsWith(AGENT_UI_PREFIX)) {
+    const segments = url.pathname.slice(AGENT_UI_PREFIX.length).split('/')
+    if (segments.length < 3) {
+      return null
+    }
+    const [machineId, workspaceId, ...rest] = segments
+    const upstreamPath = `/${rest.join('/')}`
+    return {
+      machineId: decodeURIComponent(machineId),
+      workspaceId: decodeURIComponent(workspaceId),
+      path: upstreamPath === '/' ? '/' : upstreamPath,
+      query: Object.fromEntries(url.searchParams.entries()),
+      isStream: request.headers.get('accept')?.includes('text/event-stream') || upstreamPath.endsWith('/event'),
+    }
+  }
+
+  if (!request.referrer) {
+    return null
+  }
+
+  try {
+    const referrer = new URL(request.referrer)
+    if (!referrer.pathname.startsWith(AGENT_UI_PREFIX)) {
+      return null
+    }
+    const refSegments = referrer.pathname.slice(AGENT_UI_PREFIX.length).split('/')
+    if (refSegments.length < 3) {
+      return null
+    }
+    const [machineId, workspaceId] = refSegments
+    return {
+      machineId: decodeURIComponent(machineId),
+      workspaceId: decodeURIComponent(workspaceId),
+      path: url.pathname,
+      query: Object.fromEntries(url.searchParams.entries()),
+      isStream: request.headers.get('accept')?.includes('text/event-stream') || url.pathname.endsWith('/event'),
+    }
+  } catch {
+    return null
+  }
+}
+
+async function pickClient() {
+  const clients = await self.clients.matchAll({ type: 'window', includeUncontrolled: true })
+  return clients.find((client) => client.visibilityState === 'visible') || clients[0] || null
+}
+
+async function proxyViaPage(payload) {
+  const client = await pickClient()
+  if (!client) {
+    return { ok: false, status: 503, error: 'No active GitSpace web client available' }
+  }
+
+  const channel = new MessageChannel()
+  const responsePromise = new Promise((resolve, reject) => {
+    channel.port1.onmessage = (event) => resolve(event.data)
+    channel.port1.onmessageerror = () => reject(new Error('Message channel error'))
+  })
+
+  client.postMessage(payload, [channel.port2])
+  return responsePromise
+}
+
+async function handleAgentRequest(request, context) {
+  const headers = {}
+  request.headers.forEach((value, key) => {
+    headers[key] = value
+  })
+
+  if (context.isStream) {
+    const stream = new ReadableStream({
+      async start(controller) {
+        const encoder = new TextEncoder()
+        const client = await pickClient()
+        if (!client) {
+          controller.close()
+          return
+        }
+
+        const channel = new MessageChannel()
+        let unsubscribe = false
+
+        channel.port1.onmessage = (event) => {
+          const data = event.data
+          if (!data || typeof data !== 'object') {
+            return
+          }
+          if (data.type === 'stream-open') {
+            return
+          }
+          if (data.type === 'stream-event') {
+            const lines = []
+            if (data.id) lines.push(`id: ${data.id}`)
+            if (data.event) lines.push(`event: ${data.event}`)
+            for (const line of String(data.data ?? '').split('\n')) {
+              lines.push(`data: ${line}`)
+            }
+            lines.push('')
+            controller.enqueue(encoder.encode(`${lines.join('\n')}\n`))
+            return
+          }
+          if (data.type === 'stream-error') {
+            controller.error(new Error(data.message || 'Agent stream failed'))
+            return
+          }
+          if (data.type === 'stream-close') {
+            controller.close()
+          }
+        }
+
+        client.postMessage({
+          type: 'gitspace-agent-proxy-request',
+          mode: 'stream',
+          machineId: context.machineId,
+          workspaceId: context.workspaceId,
+          path: context.path,
+          query: context.query,
+          headers,
+        }, [channel.port2])
+
+        this.cancel = () => {
+          if (unsubscribe) return
+          unsubscribe = true
+          channel.port1.postMessage({ type: 'stream-close' })
+        }
+      },
+      cancel() {
+        if (typeof this.cancel === 'function') {
+          this.cancel()
+        }
+      },
+    })
+
+    return new Response(stream, {
+      headers: {
+        'content-type': 'text/event-stream; charset=utf-8',
+        'cache-control': 'no-cache',
+        connection: 'keep-alive',
+      },
+    })
+  }
+
+  const bodyBuffer = request.method === 'GET' || request.method === 'HEAD'
+    ? null
+    : await request.arrayBuffer()
+
+  const proxyResponse = await proxyViaPage({
+    type: 'gitspace-agent-proxy-request',
+    mode: 'request',
+    machineId: context.machineId,
+    workspaceId: context.workspaceId,
+    method: request.method,
+    path: context.path,
+    query: context.query,
+    headers,
+    bodyBase64: bodyBuffer ? arrayBufferToBase64(bodyBuffer) : undefined,
+  })
+
+  if (!proxyResponse || proxyResponse.ok === false) {
+    return new Response(proxyResponse?.error || 'Agent proxy unavailable', {
+      status: proxyResponse?.status || 502,
+      headers: { 'content-type': 'text/plain; charset=utf-8' },
+    })
+  }
+
+  const responseHeaders = new Headers(proxyResponse.headers || {})
+  return new Response(proxyResponse.bodyBase64 ? base64ToUint8Array(proxyResponse.bodyBase64) : null, {
+    status: proxyResponse.status || 200,
+    headers: responseHeaders,
+  })
+}
+
+function arrayBufferToBase64(buffer) {
+  const bytes = new Uint8Array(buffer)
+  let binary = ''
+  for (let i = 0; i < bytes.length; i += 1) {
+    binary += String.fromCharCode(bytes[i])
+  }
+  return btoa(binary)
+}
+
+function base64ToUint8Array(base64) {
+  const binary = atob(base64)
+  const bytes = new Uint8Array(binary.length)
+  for (let i = 0; i < binary.length; i += 1) {
+    bytes[i] = binary.charCodeAt(i)
+  }
+  return bytes
+}


### PR DESCRIPTION
## Summary

Workspace-scoped OpenCode agent sessions with remote TUI/web access, machine-side event aggregation, and a notification pipeline for permissions, idle, and error states.

### Agent runtime
- Lazy-start `opencode web` per workspace with ephemeral Basic Auth (ports 41k–51k)
- Runtime lifecycle hooks as callback Set (multiple consumers)
- Health-check polling with retry on stale/crashed entries

### Agent event system (machine-side)
- `AgentEventManager` subscribes to each runtime's `/event` SSE stream
- Aggregates session list, statuses, pending permissions, last-message previews
- Pushes `AgentStateUpdateDelta` to all connected clients via relay
- Sends full snapshot on new client authentication

### Session management
- Session picker with status badges, Resume option, Abort for running sessions
- Session persistence across restarts (localStorage on web, disk on TUI)
- Preselect-from-inbox for direct session open from notifications

### Notification pipeline
- `agentNotificationToInboxItem` converts agent events to InboxItems
- Extended `InboxItem` with `agent_permission | agent_idle | agent_error` types
- Permission flow: Allow / Deny / Dismiss across all 3 surfaces (local TUI, remote TUI, web)
- `⚡ N` badge on SpacesBrowser agents tree item

### Protocol
- `agent_state_snapshot` + `agent_state_update` push messages
- `opencode_runtime` added to `MACHINE_TO_CLIENT_TYPES`

### Web
- Service worker proxy for same-origin iframe embedding of OpenCode web UI
- Isomorphic base64url encoding (Buffer for Bun, btoa for browser)

### Integration scaffolding
- `integrations/apply.ts` stubbed to no-op (full integration system deferred to #70)
- All integration references removed from UI, commands, and onboarding flow

## Testing
- `bun run typecheck` — clean
- `bun test` — 1198 pass (93 pre-existing failures tracked in #75)
- `bun test src/agents/` — all agent tests pass

## Review fixes applied
- Duplicate session entry in picker, useMemo for agentSessionCounts, SSE spec compliance
- Stream key race condition, fetch timeout, persisted session reset on workspace switch
- Unsafe `SessionBackend` casts replaced with properly typed `sessionBackend` property
- Permission counts memoized, bridge cache scoped by backend identity