### PR TITLE
fix: patch bun.lock with missing platform packages after publish

### DIFF
--- a/.github/workflows/publish-prerelease.yml
+++ b/.github/workflows/publish-prerelease.yml
@@ -160,6 +160,9 @@ jobs:
       - name: Regenerate bun.lock for released version
         run: bun install --lockfile-only --ignore-scripts
 
+      - name: Patch lockfile with all platform packages
+        run: bun scripts/patch-lockfile-platforms.ts
+
       - name: Validate lockfile sync
         run: bun run check:lockfile-sync
 

--- a/scripts/patch-lockfile-platforms.ts
+++ b/scripts/patch-lockfile-platforms.ts
@@ -1,0 +1,129 @@
+/**
+ * Patches bun.lock to include all @gitspace/* platform packages.
+ *
+ * `bun install --lockfile-only` skips optional dependencies whose os/cpu
+ * don't match the current machine (e.g. linux-arm64 is dropped on an
+ * x64 runner).  This script detects missing entries, fetches the
+ * integrity hash from the npm registry, and inserts them back so the
+ * committed lockfile works for every platform.
+ */
+
+import { readFileSync, writeFileSync } from 'fs';
+import { execSync } from 'child_process';
+import { join } from 'path';
+import { fileURLToPath } from 'url';
+
+const ROOT = join(fileURLToPath(new URL('.', import.meta.url)), '..');
+
+// ---------------------------------------------------------------------------
+// Platform metadata – must match what scripts/build.ts writes to each
+// platform package.json
+// ---------------------------------------------------------------------------
+
+const PLATFORM_META: Record<string, { os: string; cpu: string; binName: string }> = {
+  '@gitspace/darwin-arm64': { os: 'darwin', cpu: 'arm64', binName: 'gssh-darwin-arm64' },
+  '@gitspace/darwin-x64': { os: 'darwin', cpu: 'x64', binName: 'gssh-darwin-x64' },
+  '@gitspace/linux-x64': { os: 'linux', cpu: 'x64', binName: 'gssh-linux-x64' },
+  '@gitspace/linux-arm64': { os: 'linux', cpu: 'arm64', binName: 'gssh-linux-arm64' },
+};
+
+// ---------------------------------------------------------------------------
+
+type PackageJson = {
+  version: string;
+  optionalDependencies?: Record<string, string>;
+};
+
+function readJsonFile<T>(path: string): T {
+  return JSON.parse(readFileSync(path, 'utf-8')) as T;
+}
+
+function fetchIntegrity(name: string, version: string): string {
+  try {
+    return execSync(`npm view ${name}@${version} dist.integrity`, {
+      encoding: 'utf-8',
+      timeout: 30_000,
+    }).trim();
+  } catch {
+    console.error(`✗ Failed to fetch integrity for ${name}@${version} from npm`);
+    process.exit(1);
+  }
+}
+
+// ---------------------------------------------------------------------------
+
+const pkg = readJsonFile<PackageJson>(join(ROOT, 'package.json'));
+const lockPath = join(ROOT, 'bun.lock');
+let lockContent = readFileSync(lockPath, 'utf-8');
+
+const optionalDeps = pkg.optionalDependencies ?? {};
+let patchCount = 0;
+
+for (const [name, version] of Object.entries(optionalDeps)) {
+  if (!name.startsWith('@gitspace/')) continue;
+
+  const meta = PLATFORM_META[name];
+  if (!meta) {
+    console.log(`⚠ No known platform metadata for ${name}, skipping`);
+    continue;
+  }
+
+  // Quick check: does the correct descriptor already exist?
+  const escapedDescriptor = `${name}@${version}`.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  if (new RegExp(`"${escapedDescriptor}"`).test(lockContent)) {
+    console.log(`✓ ${name}@${version} present in bun.lock`);
+    continue;
+  }
+
+  // Entry is missing or has wrong version – fetch integrity and patch
+  console.log(`⚠ ${name}@${version} missing from bun.lock, patching…`);
+  const integrity = fetchIntegrity(name, version);
+  const newEntry = `    "${name}": ["${name}@${version}", "", { "os": "${meta.os}", "cpu": "${meta.cpu}", "bin": { "${meta.binName}": "bin/gssh" } }, "${integrity}"],`;
+
+  const lines = lockContent.split('\n');
+  let replaced = false;
+  let insertIndex = -1;
+  let inPackages = false;
+
+  for (let i = 0; i < lines.length; i++) {
+    if (lines[i].trimStart().startsWith('"packages"')) {
+      inPackages = true;
+      continue;
+    }
+    if (!inPackages) continue;
+
+    const lineMatch = lines[i].match(/^\s+"([^"]+)":\s*\[/);
+    if (lineMatch) {
+      const entryName = lineMatch[1];
+      if (entryName === name) {
+        // Replace existing entry (wrong version)
+        lines[i] = newEntry;
+        replaced = true;
+        break;
+      }
+      if (entryName > name && insertIndex === -1) {
+        insertIndex = i;
+        // Don't break – the exact entry might appear later (shouldn't, but safe)
+      }
+    }
+  }
+
+  if (!replaced) {
+    if (insertIndex === -1) {
+      console.error(`✗ Could not find insertion point in bun.lock for ${name}`);
+      process.exit(1);
+    }
+    // Insert the entry followed by a blank line (matches bun.lock formatting)
+    lines.splice(insertIndex, 0, newEntry, '');
+  }
+
+  lockContent = lines.join('\n');
+  patchCount++;
+}
+
+if (patchCount > 0) {
+  writeFileSync(lockPath, lockContent);
+  console.log(`\n✓ Patched ${patchCount} missing platform package(s) into bun.lock`);
+} else {
+  console.log('\n✓ All platform packages already present in bun.lock');
+}

--- a/scripts/patch-lockfile-platforms.ts
+++ b/scripts/patch-lockfile-platforms.ts
@@ -38,16 +38,35 @@ function readJsonFile<T>(path: string): T {
   return JSON.parse(readFileSync(path, 'utf-8')) as T;
 }
 
+function sleep(ms: number): void {
+  execSync(`sleep ${ms / 1000}`, { timeout: ms + 5_000 });
+}
+
+const MAX_RETRIES = 5;
+const INITIAL_DELAY_MS = 2_000;
+
 function fetchIntegrity(name: string, version: string): string {
-  try {
-    return execSync(`npm view ${name}@${version} dist.integrity`, {
-      encoding: 'utf-8',
-      timeout: 30_000,
-    }).trim();
-  } catch {
-    console.error(`✗ Failed to fetch integrity for ${name}@${version} from npm`);
-    process.exit(1);
+  let lastError: unknown;
+  for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
+    if (attempt > 0) {
+      const delay = INITIAL_DELAY_MS * 2 ** (attempt - 1);
+      console.log(`  ↻ Retry ${attempt}/${MAX_RETRIES - 1} for ${name}@${version} in ${delay / 1000}s…`);
+      sleep(delay);
+    }
+    try {
+      const result = execSync(`npm view ${name}@${version} dist.integrity`, {
+        encoding: 'utf-8',
+        timeout: 30_000,
+      }).trim();
+      if (result.length > 0) return result;
+      lastError = new Error('npm returned empty integrity');
+    } catch (e) {
+      lastError = e;
+    }
   }
+  console.error(`✗ Failed to fetch integrity for ${name}@${version} after ${MAX_RETRIES} attempts`);
+  console.error(lastError);
+  process.exit(1);
 }
 
 // ---------------------------------------------------------------------------
@@ -64,8 +83,8 @@ for (const [name, version] of Object.entries(optionalDeps)) {
 
   const meta = PLATFORM_META[name];
   if (!meta) {
-    console.log(`⚠ No known platform metadata for ${name}, skipping`);
-    continue;
+    console.error(`✗ No platform metadata for ${name} — add it to PLATFORM_META in this script`);
+    process.exit(1);
   }
 
   // Quick check: does the correct descriptor already exist?

--- a/scripts/patch-lockfile-platforms.ts
+++ b/scripts/patch-lockfile-platforms.ts
@@ -9,7 +9,7 @@
  */
 
 import { readFileSync, writeFileSync } from 'fs';
-import { execSync } from 'child_process';
+import { execFileSync } from 'child_process';
 import { join } from 'path';
 import { fileURLToPath } from 'url';
 
@@ -39,7 +39,7 @@ function readJsonFile<T>(path: string): T {
 }
 
 function sleep(ms: number): void {
-  execSync(`sleep ${ms / 1000}`, { timeout: ms + 5_000 });
+  execFileSync('sleep', [`${ms / 1000}`], { timeout: ms + 5_000 });
 }
 
 const MAX_RETRIES = 5;
@@ -54,10 +54,11 @@ function fetchIntegrity(name: string, version: string): string {
       sleep(delay);
     }
     try {
-      const result = execSync(`npm view ${name}@${version} dist.integrity`, {
-        encoding: 'utf-8',
-        timeout: 30_000,
-      }).trim();
+      const result = execFileSync(
+        'npm',
+        ['view', `${name}@${version}`, 'dist.integrity'],
+        { encoding: 'utf-8', timeout: 30_000 },
+      ).trim();
       if (result.length > 0) return result;
       lastError = new Error('npm returned empty integrity');
     } catch (e) {
@@ -103,6 +104,7 @@ for (const [name, version] of Object.entries(optionalDeps)) {
   let replaced = false;
   let insertIndex = -1;
   let inPackages = false;
+  let packagesEndIndex = -1;
 
   for (let i = 0; i < lines.length; i++) {
     if (lines[i].trimStart().startsWith('"packages"')) {
@@ -110,6 +112,12 @@ for (const [name, version] of Object.entries(optionalDeps)) {
       continue;
     }
     if (!inPackages) continue;
+
+    // Detect the closing brace of the packages object
+    if (/^\s*\}/.test(lines[i])) {
+      packagesEndIndex = i;
+      break;
+    }
 
     const lineMatch = lines[i].match(/^\s+"([^"]+)":\s*\[/);
     if (lineMatch) {
@@ -122,15 +130,19 @@ for (const [name, version] of Object.entries(optionalDeps)) {
       }
       if (entryName > name && insertIndex === -1) {
         insertIndex = i;
-        // Don't break – the exact entry might appear later (shouldn't, but safe)
       }
     }
   }
 
   if (!replaced) {
+    // Fall back to appending before the closing brace of packages
     if (insertIndex === -1) {
-      console.error(`✗ Could not find insertion point in bun.lock for ${name}`);
-      process.exit(1);
+      if (packagesEndIndex !== -1) {
+        insertIndex = packagesEndIndex;
+      } else {
+        console.error(`✗ Could not find insertion point in bun.lock for ${name}`);
+        process.exit(1);
+      }
     }
     // Insert the entry followed by a blank line (matches bun.lock formatting)
     lines.splice(insertIndex, 0, newEntry, '');


### PR DESCRIPTION
## Summary

- **Root cause**: `bun install --lockfile-only` on x64 Linux drops `@gitspace/linux-arm64` from `bun.lock` because bun filters optional dependencies by CPU architecture (same OS, different CPU → excluded)
- **Fix**: Added `scripts/patch-lockfile-platforms.ts` that runs after `bun install --lockfile-only` in the publish workflow — detects missing `@gitspace/*` entries, fetches their integrity hash from npm, and inserts them at the correct position in the lockfile
- **Fixes**: [Publish Prerelease failure](https://github.com/inKibra/gitspace.sh/actions/runs/23092443118/job/67079309480) where `check:lockfile-sync` failed with `@gitspace/linux-arm64 missing`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the release automation and mutates `bun.lock` by parsing/inserting entries and fetching integrity data from npm, which could fail or produce incorrect lockfile output if formats/registry responses change.
> 
> **Overview**
> **Fixes prerelease publishing failures caused by missing platform optional deps in `bun.lock`.** After `bun install --lockfile-only`, the workflow now runs a new `scripts/patch-lockfile-platforms.ts` step to restore any dropped `@gitspace/*` platform package entries.
> 
> The patch script scans `package.json` `optionalDependencies`, detects missing or mismatched `@gitspace/*` entries in the `"packages"` section of `bun.lock`, fetches `dist.integrity` from npm with retries, and inserts/replaces the lockfile entries with the correct `os`/`cpu`/`bin` metadata before running `check:lockfile-sync`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b33bce4ca4f8345740255062ea0a59614a76661d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Release workflow now patches the lockfile to ensure platform-specific packages are present before validation, improving consistency of prerelease artifacts across OS/CPU platforms.
  * Automated patching fetches and records package integrity and inserts missing platform entries, reducing release failures due to absent platform packages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->