### PR TITLE
refactor: client-side replay rendering with checkpoint+events frames

### DIFF
--- a/src/agents/opencode-attach.ts
+++ b/src/agents/opencode-attach.ts
@@ -1,4 +1,4 @@
-import { buildAuthenticatedOpenCodeUrl, type OpenCodeRuntimeInfo } from './opencode-runtime.js';
+import { buildAuthenticatedOpenCodeUrl, type OpenCodeRuntimeInfo } from './opencode-runtime-shared.js';
 
 export function buildOpenCodeAttachUrlCommand(url: string, sessionId?: string): {
   command: string;

--- a/src/agents/opencode-runtime-shared.ts
+++ b/src/agents/opencode-runtime-shared.ts
@@ -1,0 +1,31 @@
+export interface OpenCodeRuntimeTarget {
+  workspaceId: string;
+  workspacePath: string;
+  projectName?: string;
+}
+
+export interface OpenCodeRuntimeInfo {
+  workspaceId: string;
+  workspacePath: string;
+  hostname: string;
+  port: number;
+  baseUrl: string;
+  username: string;
+  password: string;
+  startedAt: string;
+}
+
+export function buildAuthenticatedOpenCodeUrl(
+  info: Pick<OpenCodeRuntimeInfo, 'hostname' | 'port' | 'username' | 'password'>,
+): string {
+  const url = new URL(`http://${info.hostname}:${info.port}`);
+  url.username = info.username;
+  url.password = info.password;
+  return url.toString();
+}
+
+export function createOpenCodeBasicAuthHeader(
+  info: Pick<OpenCodeRuntimeInfo, 'username' | 'password'>,
+): string {
+  return `Basic ${Buffer.from(`${info.username}:${info.password}`).toString('base64')}`;
+}

--- a/src/agents/opencode-runtime.ts
+++ b/src/agents/opencode-runtime.ts
@@ -1,34 +1,41 @@
 import { createHash, randomBytes } from 'node:crypto';
 import { setTimeout as delay } from 'node:timers/promises';
 import { prepareWorkspaceIntegrations } from '../integrations/apply.js';
+import {
+  buildAuthenticatedOpenCodeUrl,
+  createOpenCodeBasicAuthHeader,
+  type OpenCodeRuntimeInfo,
+  type OpenCodeRuntimeTarget,
+} from './opencode-runtime-shared.js';
 
-export interface OpenCodeRuntimeTarget {
-  workspaceId: string;
-  workspacePath: string;
-  projectName?: string;
-}
-
-export interface OpenCodeRuntimeInfo {
-  workspaceId: string;
-  workspacePath: string;
-  hostname: string;
-  port: number;
-  baseUrl: string;
-  username: string;
-  password: string;
-  startedAt: string;
-}
-
-export function buildAuthenticatedOpenCodeUrl(info: Pick<OpenCodeRuntimeInfo, 'hostname' | 'port' | 'username' | 'password'>): string {
-  const url = new URL(`http://${info.hostname}:${info.port}`);
-  url.username = info.username;
-  url.password = info.password;
-  return url.toString();
-}
+export type { OpenCodeRuntimeInfo, OpenCodeRuntimeTarget } from './opencode-runtime-shared.js';
 
 interface RuntimeEntry {
   info: OpenCodeRuntimeInfo;
-  process: ReturnType<typeof Bun.spawn>;
+  process: OpenCodeRuntimeProcess;
+}
+
+interface OpenCodeRuntimeProcess {
+  exitCode: number | null;
+  kill(): void;
+}
+
+interface BunSpawnAPI {
+  spawn(options: {
+    cmd: string[];
+    cwd: string;
+    env: Record<string, string | undefined>;
+    stdout: 'ignore';
+    stderr: 'ignore';
+  }): OpenCodeRuntimeProcess;
+}
+
+function getBunSpawn(): BunSpawnAPI['spawn'] {
+  const bun = (globalThis as typeof globalThis & { Bun?: BunSpawnAPI }).Bun;
+  if (!bun) {
+    throw new Error('OpenCode runtime requires Bun.spawn');
+  }
+  return bun.spawn.bind(bun);
 }
 
 function hashToPort(workspaceId: string): number {
@@ -40,15 +47,11 @@ function createPassword(): string {
   return randomBytes(24).toString('base64url');
 }
 
-function buildBasicAuth(username: string, password: string): string {
-  return `Basic ${Buffer.from(`${username}:${password}`).toString('base64')}`;
-}
-
 async function checkHealth(info: OpenCodeRuntimeInfo): Promise<boolean> {
   try {
     const response = await fetch(`${info.baseUrl}/global/health`, {
       headers: {
-        authorization: buildBasicAuth(info.username, info.password),
+        authorization: createOpenCodeBasicAuthHeader(info),
       },
     });
     return response.ok;
@@ -138,7 +141,8 @@ export class OpenCodeRuntimeManager {
         continue;
       }
 
-      const child = Bun.spawn({
+      const spawn = getBunSpawn();
+      const child = spawn({
         cmd: ['opencode', 'web', '--hostname', '127.0.0.1', '--port', String(port)],
         cwd: target.workspacePath,
         env: {
@@ -194,6 +198,4 @@ export class OpenCodeRuntimeManager {
 
 export const defaultOpenCodeRuntimeManager = new OpenCodeRuntimeManager();
 
-export function createOpenCodeBasicAuthHeader(info: Pick<OpenCodeRuntimeInfo, 'username' | 'password'>): string {
-  return buildBasicAuth(info.username, info.password);
-}
+export { buildAuthenticatedOpenCodeUrl, createOpenCodeBasicAuthHeader };

--- a/src/agents/opencode-web.ts
+++ b/src/agents/opencode-web.ts
@@ -1,4 +1,4 @@
-import { buildAuthenticatedOpenCodeUrl, type OpenCodeRuntimeInfo } from './opencode-runtime.js';
+import { buildAuthenticatedOpenCodeUrl, type OpenCodeRuntimeInfo } from './opencode-runtime-shared.js';
 
 export function encodeWorkspacePathForRoute(workspacePath: string): string {
   // Isomorphic: Buffer for Bun/Node, TextEncoder+btoa for browser

--- a/src/app.tui.tsx
+++ b/src/app.tui.tsx
@@ -1248,7 +1248,7 @@ function App({ relayConfig, remoteIdentity, onQuit, keyboardMode }: AppProps) {
   }, [activeReplay?.dismissedAt]);
 
   const loadReplayFrame = useCallback((replayId: string, target?: { atMs?: number; atSeq?: number }) => {
-    return Promise.resolve(getReplayFrameOffline(replayId, target));
+    return Promise.resolve().then(() => getReplayFrameOffline(replayId, target));
   }, []);
 
   const loadReplayTimeline = useCallback((replayId: string) => {

--- a/src/app.tui.tsx
+++ b/src/app.tui.tsx
@@ -21,7 +21,7 @@ import { ScriptTerminal } from './components/ScriptTerminal.tui.js';
 import { ReplayTerminal } from './components/ReplayTerminal.tui.js';
 import { ProjectOnboardingStepTUI } from './components/ProjectOnboardingStep.tui.js';
 import {
-  getReplayAnsiBufferOffline,
+  getReplayFrameOffline,
   getReplayTimelineOffline,
   dismissReplayOffline,
   undismissReplayOffline,
@@ -1247,8 +1247,8 @@ function App({ relayConfig, remoteIdentity, onQuit, keyboardMode }: AppProps) {
     activeReplayDismissedRef.current = Boolean(activeReplay?.dismissedAt);
   }, [activeReplay?.dismissedAt]);
 
-  const loadReplayAnsi = useCallback((replayId: string, target?: { atMs?: number; atSeq?: number }) => {
-    return getReplayAnsiBufferOffline(replayId, target);
+  const loadReplayFrame = useCallback((replayId: string, target?: { atMs?: number; atSeq?: number }) => {
+    return Promise.resolve(getReplayFrameOffline(replayId, target));
   }, []);
 
   const loadReplayTimeline = useCallback((replayId: string) => {
@@ -2362,7 +2362,7 @@ function App({ relayConfig, remoteIdentity, onQuit, keyboardMode }: AppProps) {
         <Toaster position="top-right" />
         <ReplayTerminal
           replay={activeReplay}
-          loadReplayAnsi={loadReplayAnsi}
+          loadReplayFrame={loadReplayFrame}
           loadReplayTimeline={loadReplayTimeline}
           onBack={() => {
             setActiveReplay(null);

--- a/src/app.web.tsx
+++ b/src/app.web.tsx
@@ -1579,6 +1579,41 @@ export default function App() {
   }
 
   if (view === 'replay' && activeReplay) {
+    if (terminal.status !== 'established' || terminal.mode !== 'browsing') {
+      const statusMessage = {
+        disconnected: 'Disconnected',
+        connecting: 'Connecting to relay...',
+        connected: 'Connected, authenticating...',
+        handshaking: 'Establishing secure connection...',
+        established: 'Connected!',
+        error: 'Connection failed',
+      }[terminal.status];
+
+      return (
+        <>
+          <div className="h-screen w-screen flex flex-col items-center justify-center bg-[#0d1117] px-4">
+            <div className="text-center">
+              <div className="text-lg text-[#e6edf3] mb-2">
+                Loading replay for <span className="text-[#58a6ff]">{activeReplay.sessionName}</span>
+              </div>
+              <div className="text-sm text-[#8b949e]">{statusMessage}</div>
+              <button
+                onClick={() => {
+                  setView('terminal');
+                  setActiveReplay(null);
+                }}
+                className="mt-4 px-6 py-3 text-base bg-[#21262d] hover:bg-[#30363d] rounded-lg text-[#e6edf3] min-h-[48px] border border-[#30363d]"
+              >
+                Back to Workspaces
+              </button>
+            </div>
+          </div>
+          <FlowWeb flow={flow} />
+          <Toaster theme="dark" position="top-right" richColors />
+        </>
+      );
+    }
+
     return (
       <>
         <ReplayTerminalWeb

--- a/src/app.web.tsx
+++ b/src/app.web.tsx
@@ -834,8 +834,8 @@ export default function App() {
     }
   }, [activeReplay?.replayId, flow, refreshReplayList, terminal]);
 
-  const loadReplayAnsi = useCallback((replayId: string, target?: { atMs?: number; atSeq?: number }) => {
-    return terminal.getReplayAnsi(replayId, target);
+  const loadReplayFrame = useCallback((replayId: string, target?: { atMs?: number; atSeq?: number }) => {
+    return terminal.getReplayFrame(replayId, target);
   }, [terminal]);
 
   const loadReplayTimeline = useCallback((replayId: string) => {
@@ -1584,7 +1584,7 @@ export default function App() {
         <ReplayTerminalWeb
           replay={activeReplay}
           machineLabel={selectedMachine?.label || selectedMachine?.machineId}
-          loadReplayAnsi={loadReplayAnsi}
+          loadReplayFrame={loadReplayFrame}
           loadReplayTimeline={loadReplayTimeline}
           onBack={() => {
             setView('terminal');
@@ -1596,6 +1596,7 @@ export default function App() {
               const replay = terminal.replays.find((item) => item.replayId === replayId) ?? activeReplay;
               return toggleReplayDismissed(replay);
             }}
+          onCleanup={terminal.cancelPendingReplayRequests}
         />
         <FlowWeb flow={flow} />
         <Toaster theme="dark" position="top-right" richColors />

--- a/src/commands/__tests__/serve-owner-binding.test.ts
+++ b/src/commands/__tests__/serve-owner-binding.test.ts
@@ -3,11 +3,13 @@ import { existsSync, mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
+  bindControlRelayIdentity,
   bindControlOwner,
   ensureControlStore,
   getControlOwnerIdentityId,
   getVaultMeta,
   listVaultMachines,
+  readControlMeta,
   setVaultMeta,
   upsertVaultMachine,
 } from '../../relay/control/store.js';
@@ -94,6 +96,28 @@ describe('ensureServeOwnerBindingForStartup', () => {
       expect(getControlOwnerIdentityId()).toBe('owner-a');
       expect(getVaultMeta('owner_user_root_id')).toBe('owner-a');
       expect(listVaultMachines()).toHaveLength(0);
+    });
+  });
+
+  test('takeover also clears pinned relay identity even when owner already matches', async () => {
+    await withIsolatedEnv(async () => {
+      bindControlOwner('owner-a');
+      setVaultMeta('owner_user_root_id', 'owner-a');
+      bindControlRelayIdentity({
+        relayIdentityId: 'relay-old',
+        relaySigningPublicKey: 'old-key',
+        relayFingerprint: 'old:fingerprint',
+      });
+
+      const result = await ensureServeOwnerBindingForStartup('owner-a', {
+        takeover: true,
+        yes: true,
+      });
+
+      expect(result).toEqual({ tookOver: true });
+      expect(getControlOwnerIdentityId()).toBe('owner-a');
+      expect(readControlMeta().relayIdentityId).toBeUndefined();
+      expect(readControlMeta().relayFingerprint).toBeUndefined();
     });
   });
 });

--- a/src/commands/connect.ts
+++ b/src/commands/connect.ts
@@ -133,7 +133,7 @@ export async function verifyClientRelayTrust(
     logger.error(`Received:  ${relayIdentity.fingerprint}`);
     logger.log('');
     throw new SpacesError(
-      'Relay identity mismatch - possible security threat. Remove the old entry from trusted relays and retry only if expected.',
+      'Relay identity mismatch - possible security threat. Remove the old entry from ~/gitspace/.identity/trusted-relays.json and retry only if expected.',
       'USER_ERROR',
       1,
     );

--- a/src/commands/host.ts
+++ b/src/commands/host.ts
@@ -223,6 +223,27 @@ async function logApiFailure(context: string, response: Response): Promise<void>
   logger.error(`${context}: ${response.status} ${response.statusText}${bodyPreview}`);
 }
 
+async function throwIfInvalidDeviceFingerprint(response: Response): Promise<void> {
+  if (response.status !== 401) {
+    return;
+  }
+
+  const body = (await response.clone().text().catch(() => '')).trim();
+  if (!body.includes('Invalid device fingerprint')) {
+    return;
+  }
+
+  throw new SpacesError(
+    [
+      'Authentication is bound to a different machine identity.',
+      '',
+      'Run `gssh user auth login` again to register the current device fingerprint with gitspace.sh.',
+    ].join('\n'),
+    'USER_ERROR',
+    1,
+  );
+}
+
 export function getTunnelTokenKey(subdomain: string): string {
   return `TUNNEL_TOKEN_${normalizeSubdomain(subdomain)}`;
 }
@@ -301,6 +322,7 @@ export async function syncHostConfig(interactive: boolean = false): Promise<Host
   try {
     const res = await fetch(`${API_BASE}/subdomains`, { headers });
     if (!res.ok) {
+      await throwIfInvalidDeviceFingerprint(res);
       report.subdomain = errorCheck(
         `Could not list subdomains (${res.status} ${res.statusText}).`,
         'gssh user host status',
@@ -449,6 +471,7 @@ export async function listAccountSubdomains(): Promise<AccountSubdomain[]> {
   const res = await fetch(`${API_BASE}/subdomains`, { headers });
 
   if (!res.ok) {
+    await throwIfInvalidDeviceFingerprint(res);
     await logApiFailure('Failed to list subdomains', res);
     throw new SpacesError(`Failed to list subdomains: ${res.statusText}`, 'SYSTEM_ERROR', 2);
   }
@@ -733,6 +756,7 @@ export async function hostList(): Promise<void> {
   const res = await fetch(`${API_BASE}/subdomains`, { headers });
 
   if (!res.ok) {
+    await throwIfInvalidDeviceFingerprint(res);
     throw new SpacesError(
       `Failed to list subdomains: ${res.statusText}`,
       'SYSTEM_ERROR'
@@ -817,6 +841,7 @@ export async function hostStatus(): Promise<void> {
     const res = await fetch(`${API_BASE}/subdomains`, { headers });
 
     if (!res.ok) {
+      await throwIfInvalidDeviceFingerprint(res);
       logger.log('Could not fetch subdomains');
       return;
     }

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -87,6 +87,7 @@ import {
   bindControlRelayIdentity,
   bindControlOwner,
   ensureControlStore,
+  readControlMeta,
   getControlOwnerIdentityId,
   getVaultMeta,
   resetControlStore,
@@ -135,11 +136,21 @@ export async function ensureServeOwnerBindingForStartup(
 
   const currentVaultOwner = getVaultMeta('owner_user_root_id');
   const currentControlOwner = getControlOwnerIdentityId();
+  const controlMeta = readControlMeta();
+  const hasPinnedRelayIdentity = Boolean(
+    controlMeta.relayIdentityId || controlMeta.relaySigningPublicKey || controlMeta.relayFingerprint,
+  );
 
   const needsTakeover = (currentVaultOwner && currentVaultOwner !== ownerUserRootId)
     || (currentControlOwner && currentControlOwner !== ownerUserRootId);
 
-  if (needsTakeover) {
+  const shouldForceResetForTakeover = Boolean(
+    options.takeover
+    && !needsTakeover
+    && (currentVaultOwner || currentControlOwner || hasPinnedRelayIdentity),
+  );
+
+  if (needsTakeover || shouldForceResetForTakeover) {
     if (!options.takeover) {
       const mismatchMessage = [
         'Persisted relay control state belongs to a different identity.',
@@ -161,7 +172,9 @@ export async function ensureServeOwnerBindingForStartup(
 
     if (!options.yes) {
       const confirmed = await promptConfirm(
-        'Persisted relay control state belongs to a different identity. Clear it and rebind this machine to the current recovered identity?',
+        needsTakeover
+          ? 'Persisted relay control state belongs to a different identity. Clear it and rebind this machine to the current recovered identity?'
+          : 'Clear persisted relay control state and relay identity pins before starting machine serve?',
         false,
       );
       if (!confirmed) {
@@ -169,7 +182,11 @@ export async function ensureServeOwnerBindingForStartup(
       }
     }
 
-    logger.warning('Clearing persisted relay control state and rebinding machine serve ownership to the current identity.');
+    logger.warning(
+      needsTakeover
+        ? 'Clearing persisted relay control state and rebinding machine serve ownership to the current identity.'
+        : 'Clearing persisted relay control state and relay identity pins before machine serve startup.',
+    );
     resetControlStore();
     ensureControlStore();
     bindControlOwner(ownerUserRootId);

--- a/src/components/RemoteMachineScreen.tui.tsx
+++ b/src/components/RemoteMachineScreen.tui.tsx
@@ -537,8 +537,8 @@ export function RemoteMachineScreen({ machine, relayUrl, identity, onBack }: Rem
     activeReplayDismissedRef.current = Boolean(activeReplay?.dismissedAt);
   }, [activeReplay?.dismissedAt]);
 
-  const loadReplayAnsi = useCallback((replayId: string, target?: { atMs?: number; atSeq?: number }) => {
-    return remote.getReplayAnsi(replayId, target).then((bytes) => Buffer.from(bytes));
+  const loadReplayFrame = useCallback((replayId: string, target?: { atMs?: number; atSeq?: number }) => {
+    return remote.getReplayFrame(replayId, target);
   }, [remote]);
 
   const loadReplayTimeline = useCallback((replayId: string) => {
@@ -1092,12 +1092,13 @@ export function RemoteMachineScreen({ machine, relayUrl, identity, onBack }: Rem
       <Fragment>
         <ReplayTerminal
           replay={activeReplay}
-          loadReplayAnsi={loadReplayAnsi}
+          loadReplayFrame={loadReplayFrame}
           loadReplayTimeline={loadReplayTimeline}
           onBack={() => {
             setActiveReplay(null);
           }}
           onDismiss={activeReplay.status === 'running' ? undefined : handleReplayDismiss}
+          onCleanup={remote.cancelPendingReplayRequests}
         />
         <FlowTUI flow={flow} />
       </Fragment>

--- a/src/components/ReplayTerminal.tui.tsx
+++ b/src/components/ReplayTerminal.tui.tsx
@@ -308,17 +308,24 @@ export function ReplayTerminal({
     }
   }, [onDismiss, onBack, replay.replayId]);
 
+  /** Invalidate any in-flight frame load so its completion is discarded. */
+  const invalidatePendingFrameLoad = useCallback(() => {
+    frameRequestIdRef.current += 1;
+    setFrameLoading(false);
+  }, []);
+
   const stepReplay = useCallback((direction: -1 | 1, count = 1) => {
     if (!timeline || timeline.steps.length === 0) {
       return;
     }
 
+    invalidatePendingFrameLoad();
     setIsPlaying(false);
     setCurrentStepIndex((index) => {
       const resolvedIndex = index < 0 ? timeline.steps.length - 1 : index;
       return clamp(resolvedIndex + (direction * count), 0, timeline.steps.length - 1);
     });
-  }, [timeline]);
+  }, [invalidatePendingFrameLoad, timeline]);
 
   const adjustPlaybackSpeed = useCallback((direction: -1 | 1, count = 1) => {
     setPlaybackSpeedIndex((index) => clamp(index + (direction * count), 0, PLAYBACK_SPEEDS.length - 1));
@@ -334,21 +341,26 @@ export function ReplayTerminal({
       return;
     }
 
+    // When restarting from the end, invalidate so the old frame load is discarded
+    invalidatePendingFrameLoad();
+    currentCheckpointIdRef.current = null;
+    currentSeqRef.current = 0;
     setCurrentStepIndex((index) => index >= timeline.steps.length - 1 ? 0 : Math.max(0, index));
     setIsPlaying(true);
-  }, [isPlaying, timeline]);
+  }, [invalidatePendingFrameLoad, isPlaying, timeline]);
 
   const jumpToBoundary = useCallback((direction: 'start' | 'end') => {
     if (!timeline || timeline.steps.length === 0) {
       return;
     }
 
+    invalidatePendingFrameLoad();
     setIsPlaying(false);
     // Reset checkpoint tracking on jump so we get a full frame
     currentCheckpointIdRef.current = null;
     currentSeqRef.current = 0;
     setCurrentStepIndex(direction === 'start' ? 0 : timeline.steps.length - 1);
-  }, [timeline]);
+  }, [invalidatePendingFrameLoad, timeline]);
 
   useKeyboard((key) => {
     if (key.name === 'escape' || key.raw === 'q') {

--- a/src/components/ReplayTerminal.tui.tsx
+++ b/src/components/ReplayTerminal.tui.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { extend, useKeyboard } from '@opentui/react';
 import { GhosttyTerminalRenderable } from 'ghostty-opentui/terminal-buffer';
 import type {
+  ReplayFrame,
   ReplayFrameTarget,
   ReplayTimeline,
 } from '../lib/tmux-lite/replay/index.js';
@@ -14,6 +15,9 @@ import {
   clamp,
   targetKey,
   toFrameTarget,
+  applyReplayFrame,
+  frameCheckpointId,
+  frameLastSeq,
 } from './replay-utils.js';
 
 extend({ 'ghostty-terminal': GhosttyTerminalRenderable });
@@ -29,8 +33,7 @@ const COLORS = {
   playing: '#3fb950',
 };
 
-const LOADING_REPLAY_BUFFER = Buffer.from('\x1b[2J\x1b[H\x1b[2;37mLoading replay...\x1b[0m');
-const EMPTY_REPLAY_BUFFER = Buffer.from('\x1b[2J\x1b[H\x1b[2;37m(empty replay)\x1b[0m');
+const INITIAL_ANSI = Buffer.from('\x1b[2J\x1b[H\x1b[2;37mLoading replay...\x1b[0m');
 
 function formatAge(timestamp: number): string {
   const age = Math.max(0, Math.floor((Date.now() - timestamp) / 1000));
@@ -63,25 +66,26 @@ function padLabel(value: string, width: number): string {
 
 export interface ReplayTerminalProps {
   replay: ReplayInfo;
-  loadReplayAnsi: (replayId: string, target?: ReplayFrameTarget) => Promise<Buffer>;
+  loadReplayFrame: (replayId: string, target?: ReplayFrameTarget) => Promise<ReplayFrame>;
   loadReplayTimeline: (replayId: string) => Promise<ReplayTimeline>;
   onBack: () => void;
   onDismiss?: (replayId: string) => boolean | void | Promise<boolean | void>;
+  onCleanup?: () => void;
 }
 
 export function ReplayTerminal({
   replay,
-  loadReplayAnsi,
+  loadReplayFrame,
   loadReplayTimeline,
   onBack,
   onDismiss,
+  onCleanup,
 }: ReplayTerminalProps) {
   const latestFallbackTarget = useMemo<ReplayFrameTarget>(() => ({
     atMs: replay.durationMs,
     atSeq: replay.lastSeq,
   }), [replay.durationMs, replay.lastSeq]);
 
-  const [content, setContent] = useState<Buffer | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [reloadKey, setReloadKey] = useState(0);
   const [termSize, setTermSize] = useState(getTerminalSize);
@@ -92,12 +96,24 @@ export function ReplayTerminal({
   const [frameLoading, setFrameLoading] = useState(true);
   const [isPlaying, setIsPlaying] = useState(false);
   const [playbackSpeedIndex, setPlaybackSpeedIndex] = useState(DEFAULT_PLAYBACK_SPEED_INDEX);
-  const contentRef = useRef<Buffer | null>(null);
+  const [terminalMounted, setTerminalMounted] = useState(false);
+  const terminalRef = useRef<GhosttyTerminalRenderable | null>(null);
   const frameRequestIdRef = useRef(0);
+  const currentCheckpointIdRef = useRef<string | null>(null);
+  const currentSeqRef = useRef(0);
+  const hasContentRef = useRef(false);
 
-  useEffect(() => {
-    contentRef.current = content;
-  }, [content]);
+  const feedTerminal = useCallback((data: string | Uint8Array) => {
+    const terminal = terminalRef.current;
+    if (!terminal) {
+      return;
+    }
+    if (typeof data === 'string') {
+      terminal.feed(Buffer.from(data, 'utf-8'));
+    } else {
+      terminal.feed(Buffer.from(data));
+    }
+  }, []);
 
   const currentStep = timeline && currentStepIndex >= 0
     ? timeline.steps[currentStepIndex] ?? null
@@ -111,24 +127,32 @@ export function ReplayTerminal({
 
   const loadFrame = useCallback(async (
     target: ReplayFrameTarget,
-    options: { preserveContent: boolean },
   ): Promise<void> => {
     const requestId = ++frameRequestIdRef.current;
     setFrameLoading(true);
     setError(null);
 
-    if (!options.preserveContent && !contentRef.current) {
-      setContent(LOADING_REPLAY_BUFFER);
-    }
-
     try {
-      const bytes = await loadReplayAnsi(replay.replayId, target);
+      const frame = await loadReplayFrame(replay.replayId, target);
       if (frameRequestIdRef.current !== requestId) {
         return;
       }
 
-      setContent(bytes.length > 0 ? Buffer.from(bytes) : EMPTY_REPLAY_BUFFER);
+      if (frame.events.length === 0 && !frame.checkpoint) {
+        feedTerminal('\x1b[2J\x1b[H\x1b[2;37m(empty replay)\x1b[0m');
+      } else {
+        applyReplayFrame(
+          frame,
+          feedTerminal,
+          currentCheckpointIdRef.current,
+          currentSeqRef.current,
+        );
+      }
+
+      currentCheckpointIdRef.current = frameCheckpointId(frame);
+      currentSeqRef.current = frameLastSeq(frame);
       setLoadedTargetKey(targetKey(target));
+      hasContentRef.current = true;
       setError(null);
     } catch (loadError) {
       if (frameRequestIdRef.current !== requestId) {
@@ -138,26 +162,32 @@ export function ReplayTerminal({
       const message = loadError instanceof Error ? loadError.message : String(loadError);
       setError(message);
 
-      if (!contentRef.current || !options.preserveContent) {
-        setContent(Buffer.from(`\x1b[2J\x1b[H\x1b[31mFailed to load replay\x1b[0m\r\n\r\n${message}`));
+      if (!hasContentRef.current) {
+        feedTerminal(`\x1b[2J\x1b[H\x1b[31mFailed to load replay\x1b[0m\r\n\r\n${message}`);
       }
     } finally {
       if (frameRequestIdRef.current === requestId) {
         setFrameLoading(false);
       }
     }
-  }, [loadReplayAnsi, replay.replayId]);
+  }, [feedTerminal, loadReplayFrame, replay.replayId]);
 
   useEffect(() => {
+    if (!terminalMounted) {
+      return;
+    }
+
     let cancelled = false;
     frameRequestIdRef.current += 1;
+    currentCheckpointIdRef.current = null;
+    currentSeqRef.current = 0;
     setIsPlaying(false);
     setPlaybackSpeedIndex(DEFAULT_PLAYBACK_SPEED_INDEX);
     setTimeline(null);
     setCurrentStepIndex(-1);
     setLoadedTargetKey(null);
     setError(null);
-    setContent(null);
+    hasContentRef.current = false;
     setTimelineLoading(true);
     setFrameLoading(true);
 
@@ -184,7 +214,7 @@ export function ReplayTerminal({
         ? nextTimeline.steps[initialStepIndex] ?? null
         : null;
 
-      await loadFrame(toFrameTarget(initialStep, latestFallbackTarget), { preserveContent: false });
+      await loadFrame(toFrameTarget(initialStep, latestFallbackTarget));
       if (cancelled) {
         return;
       }
@@ -197,16 +227,17 @@ export function ReplayTerminal({
     return () => {
       cancelled = true;
       frameRequestIdRef.current += 1;
+      onCleanup?.();
     };
-  }, [latestFallbackTarget, loadFrame, loadReplayTimeline, reloadKey, replay.replayId]);
+  }, [latestFallbackTarget, loadFrame, loadReplayTimeline, onCleanup, reloadKey, replay.replayId, terminalMounted]);
 
   useEffect(() => {
-    if (!timeline || currentStepIndex < 0 || currentTargetKey === loadedTargetKey) {
+    if (!timeline || currentStepIndex < 0 || currentTargetKey === loadedTargetKey || frameLoading) {
       return;
     }
 
-    void loadFrame(currentTarget, { preserveContent: true });
-  }, [currentStepIndex, currentTarget, currentTargetKey, loadFrame, loadedTargetKey, timeline]);
+    void loadFrame(currentTarget);
+  }, [currentStepIndex, currentTarget, currentTargetKey, frameLoading, loadFrame, loadedTargetKey, timeline]);
 
   useEffect(() => {
     const handleResize = () => setTermSize(getTerminalSize());
@@ -309,6 +340,9 @@ export function ReplayTerminal({
     }
 
     setIsPlaying(false);
+    // Reset checkpoint tracking on jump so we get a full frame
+    currentCheckpointIdRef.current = null;
+    currentSeqRef.current = 0;
     setCurrentStepIndex(direction === 'start' ? 0 : timeline.steps.length - 1);
   }, [timeline]);
 
@@ -376,7 +410,6 @@ export function ReplayTerminal({
   const visibleStepIndex = timeline && currentStepIndex >= 0
     ? clamp(currentStepIndex, 0, Math.max(0, timeline.steps.length - 1))
     : totalSteps;
-  const frame = content ?? LOADING_REPLAY_BUFFER;
   const transportHint = isPlaying
     ? '[Space] Pause  [←/→] Speed  [Shift+←/→] More  [Home/End] Jump'
     : '[Space] Play  [←/→] Step  [Shift+←/→] Skip  [Home/End] Jump';
@@ -415,11 +448,18 @@ export function ReplayTerminal({
       </box>
       <scrollbox flexGrow={1} stickyStart="bottom">
         <ghostty-terminal
+          ref={(el: GhosttyTerminalRenderable | null) => {
+            const wasNull = terminalRef.current === null;
+            terminalRef.current = el;
+            if (el && wasNull) {
+              queueMicrotask(() => setTerminalMounted(true));
+            }
+          }}
           persistent={true}
           showCursor={false}
           cols={termSize.cols}
           rows={termSize.rows}
-          ansi={frame}
+          ansi={INITIAL_ANSI}
         />
       </scrollbox>
     </box>

--- a/src/components/ReplayTerminal.tui.tsx
+++ b/src/components/ReplayTerminal.tui.tsx
@@ -103,6 +103,11 @@ export function ReplayTerminal({
   const currentCheckpointIdRef = useRef<string | null>(null);
   const currentSeqRef = useRef(0);
   const hasContentRef = useRef(false);
+  const onCleanupRef = useRef(onCleanup);
+
+  useEffect(() => {
+    onCleanupRef.current = onCleanup;
+  }, [onCleanup]);
 
   const feedTerminal = useCallback((data: string | Uint8Array) => {
     const terminal = terminalRef.current;
@@ -231,9 +236,9 @@ export function ReplayTerminal({
     return () => {
       cancelled = true;
       frameRequestIdRef.current += 1;
-      onCleanup?.();
+      onCleanupRef.current?.();
     };
-  }, [latestFallbackTarget, loadFrame, loadReplayTimeline, onCleanup, reloadKey, replay.replayId, terminalMounted]);
+  }, [latestFallbackTarget, loadFrame, loadReplayTimeline, reloadKey, replay.replayId, terminalMounted]);
 
   useEffect(() => {
     if (!timeline || currentStepIndex < 0 || currentTargetKey === loadedTargetKey || frameLoading || currentTargetKey === erroredTargetKey) {

--- a/src/components/ReplayTerminal.tui.tsx
+++ b/src/components/ReplayTerminal.tui.tsx
@@ -101,6 +101,7 @@ export function ReplayTerminal({
   const [terminalMounted, setTerminalMounted] = useState(false);
   const terminalRef = useRef<GhosttyTerminalRenderable | null>(null);
   const frameRequestIdRef = useRef(0);
+  const currentStepIndexRef = useRef(currentStepIndex);
   const currentCheckpointIdRef = useRef<string | null>(null);
   const currentSeqRef = useRef(0);
   const hasContentRef = useRef(false);
@@ -119,6 +120,10 @@ export function ReplayTerminal({
   useEffect(() => {
     loadReplayTimelineRef.current = loadReplayTimeline;
   }, [loadReplayTimeline]);
+
+  useEffect(() => {
+    currentStepIndexRef.current = currentStepIndex;
+  }, [currentStepIndex]);
 
   const feedTerminal = useCallback((data: string | Uint8Array) => {
     const terminal = terminalRef.current;
@@ -375,7 +380,7 @@ export function ReplayTerminal({
       return;
     }
 
-    const atEnd = currentStepIndex >= timeline.steps.length - 1;
+    const atEnd = currentStepIndexRef.current >= timeline.steps.length - 1;
     if (atEnd) {
       // Restarting from the end — invalidate and reset checkpoint tracking
       invalidatePendingFrameLoad();
@@ -386,7 +391,7 @@ export function ReplayTerminal({
       setCurrentStepIndex((index) => Math.max(0, index));
     }
     setIsPlaying(true);
-  }, [currentStepIndex, invalidatePendingFrameLoad, isPlaying, timeline]);
+  }, [invalidatePendingFrameLoad, isPlaying, timeline]);
 
   const jumpToBoundary = useCallback((direction: 'start' | 'end') => {
     if (!timeline || timeline.steps.length === 0) {

--- a/src/components/ReplayTerminal.tui.tsx
+++ b/src/components/ReplayTerminal.tui.tsx
@@ -346,18 +346,18 @@ export function ReplayTerminal({
       return;
     }
 
-    setCurrentStepIndex((index) => {
-      if (index >= timeline.steps.length - 1) {
-        // Restarting from the end — invalidate and reset checkpoint tracking
-        invalidatePendingFrameLoad();
-        currentCheckpointIdRef.current = null;
-        currentSeqRef.current = 0;
-        return 0;
-      }
-      return Math.max(0, index);
-    });
+    const atEnd = currentStepIndex >= timeline.steps.length - 1;
+    if (atEnd) {
+      // Restarting from the end — invalidate and reset checkpoint tracking
+      invalidatePendingFrameLoad();
+      currentCheckpointIdRef.current = null;
+      currentSeqRef.current = 0;
+      setCurrentStepIndex(0);
+    } else {
+      setCurrentStepIndex((index) => Math.max(0, index));
+    }
     setIsPlaying(true);
-  }, [invalidatePendingFrameLoad, isPlaying, timeline]);
+  }, [currentStepIndex, invalidatePendingFrameLoad, isPlaying, timeline]);
 
   const jumpToBoundary = useCallback((direction: 'start' | 'end') => {
     if (!timeline || timeline.steps.length === 0) {

--- a/src/components/ReplayTerminal.tui.tsx
+++ b/src/components/ReplayTerminal.tui.tsx
@@ -232,12 +232,12 @@ export function ReplayTerminal({
   }, [latestFallbackTarget, loadFrame, loadReplayTimeline, onCleanup, reloadKey, replay.replayId, terminalMounted]);
 
   useEffect(() => {
-    if (!timeline || currentStepIndex < 0 || currentTargetKey === loadedTargetKey || frameLoading) {
+    if (!timeline || currentStepIndex < 0 || currentTargetKey === loadedTargetKey || frameLoading || error) {
       return;
     }
 
     void loadFrame(currentTarget);
-  }, [currentStepIndex, currentTarget, currentTargetKey, frameLoading, loadFrame, loadedTargetKey, timeline]);
+  }, [currentStepIndex, currentTarget, currentTargetKey, error, frameLoading, loadFrame, loadedTargetKey, timeline]);
 
   useEffect(() => {
     const handleResize = () => setTermSize(getTerminalSize());

--- a/src/components/ReplayTerminal.tui.tsx
+++ b/src/components/ReplayTerminal.tui.tsx
@@ -359,12 +359,12 @@ export function ReplayTerminal({
     currentCheckpointIdRef.current = null;
     currentSeqRef.current = 0;
 
-    const currentSeq = currentTarget.atSeq ?? replay.lastSeq;
+    const currentSeq = timeline.steps[currentStepIndexRef.current]?.seq ?? replay.lastSeq;
     const nextIndex = findCheckpointStepIndex(timeline, currentSeq, direction);
     if (nextIndex >= 0) {
       setCurrentStepIndex(nextIndex);
     }
-  }, [currentTarget.atSeq, invalidatePendingFrameLoad, replay.lastSeq, timeline]);
+  }, [invalidatePendingFrameLoad, replay.lastSeq, timeline]);
 
   const adjustPlaybackSpeed = useCallback((direction: -1 | 1, count = 1) => {
     setPlaybackSpeedIndex((index) => clamp(index + (direction * count), 0, PLAYBACK_SPEEDS.length - 1));

--- a/src/components/ReplayTerminal.tui.tsx
+++ b/src/components/ReplayTerminal.tui.tsx
@@ -169,6 +169,7 @@ export function ReplayTerminal({
       const message = loadError instanceof Error ? loadError.message : String(loadError);
       setError(message);
       setErroredTargetKey(targetKey(target));
+      setIsPlaying(false);
 
       if (!hasContentRef.current) {
         feedTerminal(`\x1b[2J\x1b[H\x1b[31mFailed to load replay\x1b[0m\r\n\r\n${message}`);

--- a/src/components/ReplayTerminal.tui.tsx
+++ b/src/components/ReplayTerminal.tui.tsx
@@ -341,11 +341,16 @@ export function ReplayTerminal({
       return;
     }
 
-    // When restarting from the end, invalidate so the old frame load is discarded
-    invalidatePendingFrameLoad();
-    currentCheckpointIdRef.current = null;
-    currentSeqRef.current = 0;
-    setCurrentStepIndex((index) => index >= timeline.steps.length - 1 ? 0 : Math.max(0, index));
+    setCurrentStepIndex((index) => {
+      if (index >= timeline.steps.length - 1) {
+        // Restarting from the end — invalidate and reset checkpoint tracking
+        invalidatePendingFrameLoad();
+        currentCheckpointIdRef.current = null;
+        currentSeqRef.current = 0;
+        return 0;
+      }
+      return Math.max(0, index);
+    });
     setIsPlaying(true);
   }, [invalidatePendingFrameLoad, isPlaying, timeline]);
 

--- a/src/components/ReplayTerminal.tui.tsx
+++ b/src/components/ReplayTerminal.tui.tsx
@@ -10,7 +10,6 @@ import type { ReplayInfo } from './SpacesBrowser.js';
 import {
   PLAYBACK_SPEEDS,
   DEFAULT_PLAYBACK_SPEED_INDEX,
-  FAST_SCRUB_STEP_COUNT,
   formatReplayTime,
   clamp,
   targetKey,
@@ -18,6 +17,8 @@ import {
   applyReplayFrame,
   frameCheckpointId,
   frameLastSeq,
+  findCheckpointStepIndex,
+  getCheckpointPosition,
 } from './replay-utils.js';
 
 extend({ 'ghostty-terminal': GhosttyTerminalRenderable });
@@ -343,6 +344,23 @@ export function ReplayTerminal({
     });
   }, [invalidatePendingFrameLoad, timeline]);
 
+  const jumpCheckpoint = useCallback((direction: -1 | 1) => {
+    if (!timeline || timeline.steps.length === 0) {
+      return;
+    }
+
+    invalidatePendingFrameLoad();
+    setIsPlaying(false);
+    currentCheckpointIdRef.current = null;
+    currentSeqRef.current = 0;
+
+    const currentSeq = currentTarget.atSeq ?? replay.lastSeq;
+    const nextIndex = findCheckpointStepIndex(timeline, currentSeq, direction);
+    if (nextIndex >= 0) {
+      setCurrentStepIndex(nextIndex);
+    }
+  }, [currentTarget.atSeq, invalidatePendingFrameLoad, replay.lastSeq, timeline]);
+
   const adjustPlaybackSpeed = useCallback((direction: -1 | 1, count = 1) => {
     setPlaybackSpeedIndex((index) => clamp(index + (direction * count), 0, PLAYBACK_SPEEDS.length - 1));
   }, []);
@@ -410,18 +428,42 @@ export function ReplayTerminal({
     }
     if (key.name === 'left') {
       if (isPlaying) {
-        adjustPlaybackSpeed(-1, key.shift ? 2 : 1);
+        if (key.shift) {
+          jumpCheckpoint(-1);
+        } else {
+          adjustPlaybackSpeed(-1, 1);
+        }
       } else {
-        stepReplay(-1, key.shift ? FAST_SCRUB_STEP_COUNT : 1);
+        if (key.shift) {
+          jumpCheckpoint(-1);
+        } else {
+          stepReplay(-1, 1);
+        }
       }
       return;
     }
     if (key.name === 'right') {
       if (isPlaying) {
-        adjustPlaybackSpeed(1, key.shift ? 2 : 1);
+        if (key.shift) {
+          jumpCheckpoint(1);
+        } else {
+          adjustPlaybackSpeed(1, 1);
+        }
       } else {
-        stepReplay(1, key.shift ? FAST_SCRUB_STEP_COUNT : 1);
+        if (key.shift) {
+          jumpCheckpoint(1);
+        } else {
+          stepReplay(1, 1);
+        }
       }
+      return;
+    }
+    if (key.name === 'up' && isPlaying) {
+      adjustPlaybackSpeed(1, 1);
+      return;
+    }
+    if (key.name === 'down' && isPlaying) {
+      adjustPlaybackSpeed(-1, 1);
     }
   });
 
@@ -447,9 +489,10 @@ export function ReplayTerminal({
   const visibleStepIndex = timeline && currentStepIndex >= 0
     ? clamp(currentStepIndex, 0, Math.max(0, timeline.steps.length - 1))
     : totalSteps;
+  const checkpointPosition = getCheckpointPosition(timeline, currentTarget.atSeq ?? replay.lastSeq);
   const transportHint = isPlaying
-    ? '[Space] Pause  [←/→] Speed  [Shift+←/→] More  [Home/End] Jump'
-    : '[Space] Play  [←/→] Step  [Shift+←/→] Skip  [Home/End] Jump';
+    ? '[Space] Pause  [↑/↓] Speed  [Shift+←/→] Checkpoint  [Home/End] Jump'
+    : '[Space] Play  [←/→] Event  [Shift+←/→] Checkpoint  [Home/End] Jump';
   const speedLabel = `${playbackSpeed.toFixed(playbackSpeed < 1 ? 2 : 1)}x`;
   const timeWidth = Math.max(formatReplayTime(totalTimeMs).length, formatReplayTime(0).length);
   const timeLabel = `${padLabel(formatReplayTime(activeTimeMs), timeWidth)}/${formatReplayTime(totalTimeMs)}`;
@@ -474,6 +517,7 @@ export function ReplayTerminal({
           <text fg={COLORS.textDim}> ({statusLabel.state}){statusLabel.age}</text>
           <text fg={COLORS.textDim}>  {timeLabel}</text>
           <text fg={COLORS.textDim}>  {stepLabel}</text>
+          {checkpointPosition && <text fg={COLORS.textDim}>  ckpt {checkpointPosition.current}/{checkpointPosition.total}</text>}
           <text fg={isPlaying ? COLORS.playing : COLORS.textMuted}>  {isPlaying ? '[playing]' : '[paused]'}</text>
           <text fg={COLORS.loading}>  {paddedSpeedLabel}</text>
           {(timelineLoading || frameLoading) && <text fg={COLORS.loading}> [loading]</text>}

--- a/src/components/ReplayTerminal.tui.tsx
+++ b/src/components/ReplayTerminal.tui.tsx
@@ -92,6 +92,7 @@ export function ReplayTerminal({
   const [timeline, setTimeline] = useState<ReplayTimeline | null>(null);
   const [currentStepIndex, setCurrentStepIndex] = useState(-1);
   const [loadedTargetKey, setLoadedTargetKey] = useState<string | null>(null);
+  const [erroredTargetKey, setErroredTargetKey] = useState<string | null>(null);
   const [timelineLoading, setTimelineLoading] = useState(true);
   const [frameLoading, setFrameLoading] = useState(true);
   const [isPlaying, setIsPlaying] = useState(false);
@@ -152,6 +153,7 @@ export function ReplayTerminal({
       currentCheckpointIdRef.current = frameCheckpointId(frame);
       currentSeqRef.current = frameLastSeq(frame);
       setLoadedTargetKey(targetKey(target));
+      setErroredTargetKey(null);
       hasContentRef.current = true;
       setError(null);
     } catch (loadError) {
@@ -161,6 +163,7 @@ export function ReplayTerminal({
 
       const message = loadError instanceof Error ? loadError.message : String(loadError);
       setError(message);
+      setErroredTargetKey(targetKey(target));
 
       if (!hasContentRef.current) {
         feedTerminal(`\x1b[2J\x1b[H\x1b[31mFailed to load replay\x1b[0m\r\n\r\n${message}`);
@@ -186,6 +189,7 @@ export function ReplayTerminal({
     setTimeline(null);
     setCurrentStepIndex(-1);
     setLoadedTargetKey(null);
+    setErroredTargetKey(null);
     setError(null);
     hasContentRef.current = false;
     setTimelineLoading(true);
@@ -232,12 +236,12 @@ export function ReplayTerminal({
   }, [latestFallbackTarget, loadFrame, loadReplayTimeline, onCleanup, reloadKey, replay.replayId, terminalMounted]);
 
   useEffect(() => {
-    if (!timeline || currentStepIndex < 0 || currentTargetKey === loadedTargetKey || frameLoading || error) {
+    if (!timeline || currentStepIndex < 0 || currentTargetKey === loadedTargetKey || frameLoading || currentTargetKey === erroredTargetKey) {
       return;
     }
 
     void loadFrame(currentTarget);
-  }, [currentStepIndex, currentTarget, currentTargetKey, error, frameLoading, loadFrame, loadedTargetKey, timeline]);
+  }, [currentStepIndex, currentTarget, currentTargetKey, erroredTargetKey, frameLoading, loadFrame, loadedTargetKey, timeline]);
 
   useEffect(() => {
     const handleResize = () => setTermSize(getTerminalSize());

--- a/src/components/ReplayTerminal.tui.tsx
+++ b/src/components/ReplayTerminal.tui.tsx
@@ -104,10 +104,20 @@ export function ReplayTerminal({
   const currentSeqRef = useRef(0);
   const hasContentRef = useRef(false);
   const onCleanupRef = useRef(onCleanup);
+  const loadReplayFrameRef = useRef(loadReplayFrame);
+  const loadReplayTimelineRef = useRef(loadReplayTimeline);
 
   useEffect(() => {
     onCleanupRef.current = onCleanup;
   }, [onCleanup]);
+
+  useEffect(() => {
+    loadReplayFrameRef.current = loadReplayFrame;
+  }, [loadReplayFrame]);
+
+  useEffect(() => {
+    loadReplayTimelineRef.current = loadReplayTimeline;
+  }, [loadReplayTimeline]);
 
   const feedTerminal = useCallback((data: string | Uint8Array) => {
     const terminal = terminalRef.current;
@@ -139,7 +149,7 @@ export function ReplayTerminal({
     setError(null);
 
     try {
-      const frame = await loadReplayFrame(replay.replayId, target);
+      const frame = await loadReplayFrameRef.current(replay.replayId, target);
       if (frameRequestIdRef.current !== requestId) {
         return;
       }
@@ -179,7 +189,7 @@ export function ReplayTerminal({
         setFrameLoading(false);
       }
     }
-  }, [feedTerminal, loadReplayFrame, replay.replayId]);
+  }, [feedTerminal, replay.replayId]);
 
   useEffect(() => {
     if (!terminalMounted) {
@@ -205,7 +215,7 @@ export function ReplayTerminal({
       let nextTimeline: ReplayTimeline | null = null;
 
       try {
-        nextTimeline = await loadReplayTimeline(replay.replayId);
+        nextTimeline = await loadReplayTimelineRef.current(replay.replayId);
       } catch (timelineError) {
         if (cancelled) {
           return;
@@ -239,7 +249,7 @@ export function ReplayTerminal({
       frameRequestIdRef.current += 1;
       onCleanupRef.current?.();
     };
-  }, [latestFallbackTarget, loadFrame, loadReplayTimeline, reloadKey, replay.replayId, terminalMounted]);
+  }, [latestFallbackTarget, loadFrame, reloadKey, replay.replayId, terminalMounted]);
 
   useEffect(() => {
     if (!timeline || currentStepIndex < 0 || currentTargetKey === loadedTargetKey || frameLoading || currentTargetKey === erroredTargetKey) {

--- a/src/components/ReplayTerminal.web.tsx
+++ b/src/components/ReplayTerminal.web.tsx
@@ -50,6 +50,7 @@ export function ReplayTerminalWeb({
   const [timeline, setTimeline] = useState<ReplayTimeline | null>(null);
   const [currentStepIndex, setCurrentStepIndex] = useState(-1);
   const [loadedTargetKey, setLoadedTargetKey] = useState<string | null>(null);
+  const [erroredTargetKey, setErroredTargetKey] = useState<string | null>(null);
   const [timelineLoading, setTimelineLoading] = useState(true);
   const [frameLoading, setFrameLoading] = useState(true);
   const [isPlaying, setIsPlaying] = useState(false);
@@ -116,6 +117,7 @@ export function ReplayTerminalWeb({
       currentCheckpointIdRef.current = frameCheckpointId(frame);
       currentSeqRef.current = frameLastSeq(frame);
       setLoadedTargetKey(targetKey(target));
+      setErroredTargetKey(null);
       hasContentRef.current = true;
       setError(null);
     } catch (loadError) {
@@ -125,6 +127,7 @@ export function ReplayTerminalWeb({
 
       const message = loadError instanceof Error ? loadError.message : String(loadError);
       setError(message);
+      setErroredTargetKey(targetKey(target));
 
       if (!hasContentRef.current) {
         feedTerminal(`\x1b[2J\x1b[H\x1b[31mFailed to load replay\x1b[0m\r\n\r\n${message}`);
@@ -150,6 +153,7 @@ export function ReplayTerminalWeb({
     setTimeline(null);
     setCurrentStepIndex(-1);
     setLoadedTargetKey(null);
+    setErroredTargetKey(null);
     setError(null);
     hasContentRef.current = false;
     setTimelineLoading(true);
@@ -196,12 +200,12 @@ export function ReplayTerminalWeb({
   }, [latestFallbackTarget, loadFrame, loadReplayTimeline, onCleanup, reloadKey, replay.replayId, writer]);
 
   useEffect(() => {
-    if (!timeline || currentStepIndex < 0 || currentTargetKey === loadedTargetKey || frameLoading || error) {
+    if (!timeline || currentStepIndex < 0 || currentTargetKey === loadedTargetKey || frameLoading || currentTargetKey === erroredTargetKey) {
       return;
     }
 
     void loadFrame(currentTarget);
-  }, [currentStepIndex, currentTarget, currentTargetKey, error, frameLoading, loadFrame, loadedTargetKey, timeline]);
+  }, [currentStepIndex, currentTarget, currentTargetKey, erroredTargetKey, frameLoading, loadFrame, loadedTargetKey, timeline]);
 
   useEffect(() => {
     if (!isPlaying) {

--- a/src/components/ReplayTerminal.web.tsx
+++ b/src/components/ReplayTerminal.web.tsx
@@ -1,6 +1,6 @@
 /** @jsxImportSource react */
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import type { ReplayFrameTarget, ReplayInfo, ReplayTimeline } from '../lib/tmux-lite/replay/index.js';
+import type { ReplayFrame, ReplayFrameTarget, ReplayInfo, ReplayTimeline } from '../lib/tmux-lite/replay/index.js';
 import { SessionTerminal } from './SessionTerminal.web';
 import {
   PLAYBACK_SPEEDS,
@@ -10,38 +10,40 @@ import {
   clamp,
   targetKey,
   toFrameTarget,
+  applyReplayFrame,
+  frameCheckpointId,
+  frameLastSeq,
 } from './replay-utils.js';
 
 function encodeAnsi(text: string): Uint8Array {
   return new TextEncoder().encode(text);
 }
 
-const LOADING_REPLAY_ANSI = encodeAnsi('\x1b[2J\x1b[H\x1b[2;37mLoading replay...\x1b[0m');
-const EMPTY_REPLAY_ANSI = encodeAnsi('\x1b[2J\x1b[H\x1b[2;37m(empty replay)\x1b[0m');
-
 export interface ReplayTerminalWebProps {
   replay: ReplayInfo;
   machineLabel?: string;
-  loadReplayAnsi: (replayId: string, target?: ReplayFrameTarget) => Promise<Uint8Array>;
+  loadReplayFrame: (replayId: string, target?: ReplayFrameTarget) => Promise<ReplayFrame>;
   loadReplayTimeline: (replayId: string) => Promise<ReplayTimeline>;
   onBack: () => void;
   onDismiss?: (replayId: string) => boolean | void | Promise<boolean | void>;
+  onCleanup?: () => void;
 }
 
 export function ReplayTerminalWeb({
   replay,
   machineLabel,
-  loadReplayAnsi,
+  loadReplayFrame,
   loadReplayTimeline,
   onBack,
   onDismiss,
+  onCleanup,
 }: ReplayTerminalWebProps) {
   const latestFallbackTarget = useMemo<ReplayFrameTarget>(() => ({
     atMs: replay.durationMs,
     atSeq: replay.lastSeq,
   }), [replay.durationMs, replay.lastSeq]);
 
-  const [content, setContent] = useState<Uint8Array | null>(null);
+  const hasContentRef = useRef(false);
   const [writer, setWriter] = useState<((data: Uint8Array) => void) | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [reloadKey, setReloadKey] = useState(0);
@@ -52,22 +54,29 @@ export function ReplayTerminalWeb({
   const [frameLoading, setFrameLoading] = useState(true);
   const [isPlaying, setIsPlaying] = useState(false);
   const [playbackSpeedIndex, setPlaybackSpeedIndex] = useState(DEFAULT_PLAYBACK_SPEED_INDEX);
-  const contentRef = useRef<Uint8Array | null>(null);
   const frameRequestIdRef = useRef(0);
+  const writerRef = useRef<((data: Uint8Array) => void) | null>(null);
+  const currentCheckpointIdRef = useRef<string | null>(null);
+  const currentSeqRef = useRef(0);
 
   useEffect(() => {
-    contentRef.current = content;
-  }, [content]);
-
-  useEffect(() => {
-    if (!writer || !content) {
-      return;
-    }
-    writer(content);
-  }, [content, writer]);
+    writerRef.current = writer;
+  }, [writer]);
 
   const setWriteCallback = useCallback((fn: ((data: Uint8Array) => void) | null) => {
     setWriter(() => fn);
+  }, []);
+
+  const feedTerminal = useCallback((data: string | Uint8Array) => {
+    const w = writerRef.current;
+    if (!w) {
+      return;
+    }
+    if (typeof data === 'string') {
+      w(encodeAnsi(data));
+    } else {
+      w(data);
+    }
   }, []);
 
   const currentStep = timeline && currentStepIndex >= 0
@@ -82,24 +91,32 @@ export function ReplayTerminalWeb({
 
   const loadFrame = useCallback(async (
     target: ReplayFrameTarget,
-    options: { preserveContent: boolean },
   ): Promise<void> => {
     const requestId = ++frameRequestIdRef.current;
     setFrameLoading(true);
     setError(null);
 
-    if (!options.preserveContent && !contentRef.current) {
-      setContent(LOADING_REPLAY_ANSI);
-    }
-
     try {
-      const bytes = await loadReplayAnsi(replay.replayId, target);
+      const frame = await loadReplayFrame(replay.replayId, target);
       if (frameRequestIdRef.current !== requestId) {
         return;
       }
 
-      setContent(bytes.length > 0 ? new Uint8Array(bytes) : EMPTY_REPLAY_ANSI);
+      if (frame.events.length === 0 && !frame.checkpoint) {
+        feedTerminal('\x1b[2J\x1b[H\x1b[2;37m(empty replay)\x1b[0m');
+      } else {
+        applyReplayFrame(
+          frame,
+          feedTerminal,
+          currentCheckpointIdRef.current,
+          currentSeqRef.current,
+        );
+      }
+
+      currentCheckpointIdRef.current = frameCheckpointId(frame);
+      currentSeqRef.current = frameLastSeq(frame);
       setLoadedTargetKey(targetKey(target));
+      hasContentRef.current = true;
       setError(null);
     } catch (loadError) {
       if (frameRequestIdRef.current !== requestId) {
@@ -109,26 +126,32 @@ export function ReplayTerminalWeb({
       const message = loadError instanceof Error ? loadError.message : String(loadError);
       setError(message);
 
-      if (!contentRef.current || !options.preserveContent) {
-        setContent(encodeAnsi(`\x1b[2J\x1b[H\x1b[31mFailed to load replay\x1b[0m\r\n\r\n${message}`));
+      if (!hasContentRef.current) {
+        feedTerminal(`\x1b[2J\x1b[H\x1b[31mFailed to load replay\x1b[0m\r\n\r\n${message}`);
       }
     } finally {
       if (frameRequestIdRef.current === requestId) {
         setFrameLoading(false);
       }
     }
-  }, [loadReplayAnsi, replay.replayId]);
+  }, [feedTerminal, loadReplayFrame, replay.replayId]);
 
   useEffect(() => {
+    if (!writer) {
+      return;
+    }
+
     let cancelled = false;
     frameRequestIdRef.current += 1;
+    currentCheckpointIdRef.current = null;
+    currentSeqRef.current = 0;
     setIsPlaying(false);
     setPlaybackSpeedIndex(DEFAULT_PLAYBACK_SPEED_INDEX);
     setTimeline(null);
     setCurrentStepIndex(-1);
     setLoadedTargetKey(null);
     setError(null);
-    setContent(null);
+    hasContentRef.current = false;
     setTimelineLoading(true);
     setFrameLoading(true);
 
@@ -155,7 +178,7 @@ export function ReplayTerminalWeb({
         ? nextTimeline.steps[initialStepIndex] ?? null
         : null;
 
-      await loadFrame(toFrameTarget(initialStep, latestFallbackTarget), { preserveContent: false });
+      await loadFrame(toFrameTarget(initialStep, latestFallbackTarget));
       if (cancelled) {
         return;
       }
@@ -168,16 +191,17 @@ export function ReplayTerminalWeb({
     return () => {
       cancelled = true;
       frameRequestIdRef.current += 1;
+      onCleanup?.();
     };
-  }, [latestFallbackTarget, loadFrame, loadReplayTimeline, reloadKey, replay.replayId]);
+  }, [latestFallbackTarget, loadFrame, loadReplayTimeline, onCleanup, reloadKey, replay.replayId, writer]);
 
   useEffect(() => {
-    if (!timeline || currentStepIndex < 0 || currentTargetKey === loadedTargetKey) {
+    if (!timeline || currentStepIndex < 0 || currentTargetKey === loadedTargetKey || frameLoading) {
       return;
     }
 
-    void loadFrame(currentTarget, { preserveContent: true });
-  }, [currentStepIndex, currentTarget, currentTargetKey, loadFrame, loadedTargetKey, timeline]);
+    void loadFrame(currentTarget);
+  }, [currentStepIndex, currentTarget, currentTargetKey, frameLoading, loadFrame, loadedTargetKey, timeline]);
 
   useEffect(() => {
     if (!isPlaying) {
@@ -267,6 +291,9 @@ export function ReplayTerminalWeb({
     }
 
     setIsPlaying(false);
+    // Reset checkpoint tracking on jump so we get a full frame
+    currentCheckpointIdRef.current = null;
+    currentSeqRef.current = 0;
     setCurrentStepIndex(direction === 'start' ? 0 : timeline.steps.length - 1);
   }, [timeline]);
 

--- a/src/components/ReplayTerminal.web.tsx
+++ b/src/components/ReplayTerminal.web.tsx
@@ -133,6 +133,7 @@ export function ReplayTerminalWeb({
       const message = loadError instanceof Error ? loadError.message : String(loadError);
       setError(message);
       setErroredTargetKey(targetKey(target));
+      setIsPlaying(false);
 
       if (!hasContentRef.current) {
         feedTerminal(`\x1b[2J\x1b[H\x1b[31mFailed to load replay\x1b[0m\r\n\r\n${message}`);

--- a/src/components/ReplayTerminal.web.tsx
+++ b/src/components/ReplayTerminal.web.tsx
@@ -2,6 +2,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { ReplayFrame, ReplayFrameTarget, ReplayInfo, ReplayTimeline } from '../lib/tmux-lite/replay/index.js';
 import { SessionTerminal } from './SessionTerminal.web';
+import { replayDebug } from './replay-debug.web.js';
 import {
   PLAYBACK_SPEEDS,
   DEFAULT_PLAYBACK_SPEED_INDEX,
@@ -18,29 +19,6 @@ import {
 
 function encodeAnsi(text: string): Uint8Array {
   return new TextEncoder().encode(text);
-}
-
-function isReplayDebugEnabled(): boolean {
-  if (typeof window === 'undefined') {
-    return false;
-  }
-  try {
-    return window.localStorage.getItem('gssh:debug:replay') === '1'
-      || new URLSearchParams(window.location.search).has('debugReplay');
-  } catch {
-    return false;
-  }
-}
-
-function replayDebug(message: string, details?: Record<string, unknown>): void {
-  if (!isReplayDebugEnabled()) {
-    return;
-  }
-  if (details) {
-    console.debug(`[replay:web] ${message}`, details);
-  } else {
-    console.debug(`[replay:web] ${message}`);
-  }
 }
 
 export interface ReplayTerminalWebProps {

--- a/src/components/ReplayTerminal.web.tsx
+++ b/src/components/ReplayTerminal.web.tsx
@@ -58,6 +58,7 @@ export function ReplayTerminalWeb({
   const [isPlaying, setIsPlaying] = useState(false);
   const [playbackSpeedIndex, setPlaybackSpeedIndex] = useState(DEFAULT_PLAYBACK_SPEED_INDEX);
   const frameRequestIdRef = useRef(0);
+  const currentStepIndexRef = useRef(currentStepIndex);
   const writerRef = useRef<((data: Uint8Array) => void) | null>(null);
   const currentCheckpointIdRef = useRef<string | null>(null);
   const currentSeqRef = useRef(0);
@@ -81,6 +82,10 @@ export function ReplayTerminalWeb({
   useEffect(() => {
     loadReplayTimelineRef.current = loadReplayTimeline;
   }, [loadReplayTimeline]);
+
+  useEffect(() => {
+    currentStepIndexRef.current = currentStepIndex;
+  }, [currentStepIndex]);
 
   const setWriteCallback = useCallback((fn: ((data: Uint8Array) => void) | null) => {
     setWriter(() => fn);
@@ -380,7 +385,7 @@ export function ReplayTerminalWeb({
       return;
     }
 
-    const atEnd = currentStepIndex >= timeline.steps.length - 1;
+    const atEnd = currentStepIndexRef.current >= timeline.steps.length - 1;
     if (atEnd) {
       // Restarting from the end — invalidate and reset checkpoint tracking
       invalidatePendingFrameLoad();
@@ -391,7 +396,7 @@ export function ReplayTerminalWeb({
       setCurrentStepIndex((index) => Math.max(0, index));
     }
     setIsPlaying(true);
-  }, [currentStepIndex, invalidatePendingFrameLoad, isPlaying, timeline]);
+  }, [invalidatePendingFrameLoad, isPlaying, timeline]);
 
   const jumpToBoundary = useCallback((direction: 'start' | 'end') => {
     if (!timeline || timeline.steps.length === 0) {

--- a/src/components/ReplayTerminal.web.tsx
+++ b/src/components/ReplayTerminal.web.tsx
@@ -364,12 +364,12 @@ export function ReplayTerminalWeb({
     currentCheckpointIdRef.current = null;
     currentSeqRef.current = 0;
 
-    const currentSeq = currentTarget.atSeq ?? replay.lastSeq;
+    const currentSeq = timeline.steps[currentStepIndexRef.current]?.seq ?? replay.lastSeq;
     const nextIndex = findCheckpointStepIndex(timeline, currentSeq, direction);
     if (nextIndex >= 0) {
       setCurrentStepIndex(nextIndex);
     }
-  }, [currentTarget.atSeq, invalidatePendingFrameLoad, replay.lastSeq, timeline]);
+  }, [invalidatePendingFrameLoad, replay.lastSeq, timeline]);
 
   const adjustPlaybackSpeed = useCallback((direction: -1 | 1, count = 1) => {
     setPlaybackSpeedIndex((index) => clamp(index + (direction * count), 0, PLAYBACK_SPEEDS.length - 1));

--- a/src/components/ReplayTerminal.web.tsx
+++ b/src/components/ReplayTerminal.web.tsx
@@ -297,18 +297,18 @@ export function ReplayTerminalWeb({
       return;
     }
 
-    setCurrentStepIndex((index) => {
-      if (index >= timeline.steps.length - 1) {
-        // Restarting from the end — invalidate and reset checkpoint tracking
-        invalidatePendingFrameLoad();
-        currentCheckpointIdRef.current = null;
-        currentSeqRef.current = 0;
-        return 0;
-      }
-      return Math.max(0, index);
-    });
+    const atEnd = currentStepIndex >= timeline.steps.length - 1;
+    if (atEnd) {
+      // Restarting from the end — invalidate and reset checkpoint tracking
+      invalidatePendingFrameLoad();
+      currentCheckpointIdRef.current = null;
+      currentSeqRef.current = 0;
+      setCurrentStepIndex(0);
+    } else {
+      setCurrentStepIndex((index) => Math.max(0, index));
+    }
     setIsPlaying(true);
-  }, [invalidatePendingFrameLoad, isPlaying, timeline]);
+  }, [currentStepIndex, invalidatePendingFrameLoad, isPlaying, timeline]);
 
   const jumpToBoundary = useCallback((direction: 'start' | 'end') => {
     if (!timeline || timeline.steps.length === 0) {

--- a/src/components/ReplayTerminal.web.tsx
+++ b/src/components/ReplayTerminal.web.tsx
@@ -59,10 +59,15 @@ export function ReplayTerminalWeb({
   const writerRef = useRef<((data: Uint8Array) => void) | null>(null);
   const currentCheckpointIdRef = useRef<string | null>(null);
   const currentSeqRef = useRef(0);
+  const onCleanupRef = useRef(onCleanup);
 
   useEffect(() => {
     writerRef.current = writer;
   }, [writer]);
+
+  useEffect(() => {
+    onCleanupRef.current = onCleanup;
+  }, [onCleanup]);
 
   const setWriteCallback = useCallback((fn: ((data: Uint8Array) => void) | null) => {
     setWriter(() => fn);
@@ -195,9 +200,9 @@ export function ReplayTerminalWeb({
     return () => {
       cancelled = true;
       frameRequestIdRef.current += 1;
-      onCleanup?.();
+      onCleanupRef.current?.();
     };
-  }, [latestFallbackTarget, loadFrame, loadReplayTimeline, onCleanup, reloadKey, replay.replayId, writer]);
+  }, [latestFallbackTarget, loadFrame, loadReplayTimeline, reloadKey, replay.replayId, writer]);
 
   useEffect(() => {
     if (!timeline || currentStepIndex < 0 || currentTargetKey === loadedTargetKey || frameLoading || currentTargetKey === erroredTargetKey) {

--- a/src/components/ReplayTerminal.web.tsx
+++ b/src/components/ReplayTerminal.web.tsx
@@ -196,12 +196,12 @@ export function ReplayTerminalWeb({
   }, [latestFallbackTarget, loadFrame, loadReplayTimeline, onCleanup, reloadKey, replay.replayId, writer]);
 
   useEffect(() => {
-    if (!timeline || currentStepIndex < 0 || currentTargetKey === loadedTargetKey || frameLoading) {
+    if (!timeline || currentStepIndex < 0 || currentTargetKey === loadedTargetKey || frameLoading || error) {
       return;
     }
 
     void loadFrame(currentTarget);
-  }, [currentStepIndex, currentTarget, currentTargetKey, frameLoading, loadFrame, loadedTargetKey, timeline]);
+  }, [currentStepIndex, currentTarget, currentTargetKey, error, frameLoading, loadFrame, loadedTargetKey, timeline]);
 
   useEffect(() => {
     if (!isPlaying) {

--- a/src/components/ReplayTerminal.web.tsx
+++ b/src/components/ReplayTerminal.web.tsx
@@ -292,11 +292,16 @@ export function ReplayTerminalWeb({
       return;
     }
 
-    // When restarting from the end, invalidate so the old frame load is discarded
-    invalidatePendingFrameLoad();
-    currentCheckpointIdRef.current = null;
-    currentSeqRef.current = 0;
-    setCurrentStepIndex((index) => index >= timeline.steps.length - 1 ? 0 : Math.max(0, index));
+    setCurrentStepIndex((index) => {
+      if (index >= timeline.steps.length - 1) {
+        // Restarting from the end — invalidate and reset checkpoint tracking
+        invalidatePendingFrameLoad();
+        currentCheckpointIdRef.current = null;
+        currentSeqRef.current = 0;
+        return 0;
+      }
+      return Math.max(0, index);
+    });
     setIsPlaying(true);
   }, [invalidatePendingFrameLoad, isPlaying, timeline]);
 

--- a/src/components/ReplayTerminal.web.tsx
+++ b/src/components/ReplayTerminal.web.tsx
@@ -60,6 +60,8 @@ export function ReplayTerminalWeb({
   const currentCheckpointIdRef = useRef<string | null>(null);
   const currentSeqRef = useRef(0);
   const onCleanupRef = useRef(onCleanup);
+  const loadReplayFrameRef = useRef(loadReplayFrame);
+  const loadReplayTimelineRef = useRef(loadReplayTimeline);
 
   useEffect(() => {
     writerRef.current = writer;
@@ -68,6 +70,14 @@ export function ReplayTerminalWeb({
   useEffect(() => {
     onCleanupRef.current = onCleanup;
   }, [onCleanup]);
+
+  useEffect(() => {
+    loadReplayFrameRef.current = loadReplayFrame;
+  }, [loadReplayFrame]);
+
+  useEffect(() => {
+    loadReplayTimelineRef.current = loadReplayTimeline;
+  }, [loadReplayTimeline]);
 
   const setWriteCallback = useCallback((fn: ((data: Uint8Array) => void) | null) => {
     setWriter(() => fn);
@@ -103,7 +113,7 @@ export function ReplayTerminalWeb({
     setError(null);
 
     try {
-      const frame = await loadReplayFrame(replay.replayId, target);
+      const frame = await loadReplayFrameRef.current(replay.replayId, target);
       if (frameRequestIdRef.current !== requestId) {
         return;
       }
@@ -143,7 +153,7 @@ export function ReplayTerminalWeb({
         setFrameLoading(false);
       }
     }
-  }, [feedTerminal, loadReplayFrame, replay.replayId]);
+  }, [feedTerminal, replay.replayId]);
 
   useEffect(() => {
     if (!writer) {
@@ -169,7 +179,7 @@ export function ReplayTerminalWeb({
       let nextTimeline: ReplayTimeline | null = null;
 
       try {
-        nextTimeline = await loadReplayTimeline(replay.replayId);
+        nextTimeline = await loadReplayTimelineRef.current(replay.replayId);
       } catch (timelineError) {
         if (cancelled) {
           return;
@@ -203,7 +213,7 @@ export function ReplayTerminalWeb({
       frameRequestIdRef.current += 1;
       onCleanupRef.current?.();
     };
-  }, [latestFallbackTarget, loadFrame, loadReplayTimeline, reloadKey, replay.replayId, writer]);
+  }, [latestFallbackTarget, loadFrame, reloadKey, replay.replayId, writer]);
 
   useEffect(() => {
     if (!timeline || currentStepIndex < 0 || currentTargetKey === loadedTargetKey || frameLoading || currentTargetKey === erroredTargetKey) {

--- a/src/components/ReplayTerminal.web.tsx
+++ b/src/components/ReplayTerminal.web.tsx
@@ -5,7 +5,6 @@ import { SessionTerminal } from './SessionTerminal.web';
 import {
   PLAYBACK_SPEEDS,
   DEFAULT_PLAYBACK_SPEED_INDEX,
-  FAST_SCRUB_STEP_COUNT,
   formatReplayTime,
   clamp,
   targetKey,
@@ -13,10 +12,35 @@ import {
   applyReplayFrame,
   frameCheckpointId,
   frameLastSeq,
+  findCheckpointStepIndex,
+  getCheckpointPosition,
 } from './replay-utils.js';
 
 function encodeAnsi(text: string): Uint8Array {
   return new TextEncoder().encode(text);
+}
+
+function isReplayDebugEnabled(): boolean {
+  if (typeof window === 'undefined') {
+    return false;
+  }
+  try {
+    return window.localStorage.getItem('gssh:debug:replay') === '1'
+      || new URLSearchParams(window.location.search).has('debugReplay');
+  } catch {
+    return false;
+  }
+}
+
+function replayDebug(message: string, details?: Record<string, unknown>): void {
+  if (!isReplayDebugEnabled()) {
+    return;
+  }
+  if (details) {
+    console.debug(`[replay:web] ${message}`, details);
+  } else {
+    console.debug(`[replay:web] ${message}`);
+  }
 }
 
 export interface ReplayTerminalWebProps {
@@ -65,6 +89,7 @@ export function ReplayTerminalWeb({
 
   useEffect(() => {
     writerRef.current = writer;
+    replayDebug('writer-updated', { writerReady: Boolean(writer) });
   }, [writer]);
 
   useEffect(() => {
@@ -112,21 +137,64 @@ export function ReplayTerminalWeb({
     setFrameLoading(true);
     setError(null);
 
+    replayDebug('loadFrame:start', {
+      replayId: replay.replayId,
+      requestId,
+      target,
+      writerReady: Boolean(writerRef.current),
+      previousCheckpointId: currentCheckpointIdRef.current,
+      previousSeq: currentSeqRef.current,
+    });
+
     try {
       const frame = await loadReplayFrameRef.current(replay.replayId, target);
       if (frameRequestIdRef.current !== requestId) {
+        replayDebug('loadFrame:stale-response-discarded', {
+          replayId: replay.replayId,
+          requestId,
+          target,
+        });
         return;
       }
+
+      replayDebug('loadFrame:frame-received', {
+        replayId: replay.replayId,
+        requestId,
+        checkpointId: frame.checkpoint?.checkpointId ?? null,
+        checkpointSeq: frame.checkpoint?.seq ?? null,
+        checkpointAnsiChars: frame.checkpoint?.ansi.length ?? 0,
+        events: frame.events.length,
+        firstEventSeq: frame.events[0]?.seq ?? null,
+        lastEventSeq: frame.events.length > 0 ? frame.events[frame.events.length - 1]?.seq ?? null : null,
+      });
 
       if (frame.events.length === 0 && !frame.checkpoint) {
         feedTerminal('\x1b[2J\x1b[H\x1b[2;37m(empty replay)\x1b[0m');
       } else {
-        applyReplayFrame(
-          frame,
-          feedTerminal,
-          currentCheckpointIdRef.current,
-          currentSeqRef.current,
-        );
+        try {
+          applyReplayFrame(
+            frame,
+            feedTerminal,
+            currentCheckpointIdRef.current,
+            currentSeqRef.current,
+          );
+        } catch (error) {
+          console.error('[replay:web] applyReplayFrame failed', {
+            replayId: replay.replayId,
+            requestId,
+            target,
+            previousCheckpointId: currentCheckpointIdRef.current,
+            previousSeq: currentSeqRef.current,
+            frameCheckpointId: frame.checkpoint?.checkpointId ?? null,
+            frameCheckpointSeq: frame.checkpoint?.seq ?? null,
+            frameEvents: frame.events.length,
+            firstEventSeq: frame.events[0]?.seq ?? null,
+            lastEventSeq: frame.events.length > 0 ? frame.events[frame.events.length - 1]?.seq ?? null : null,
+            writerReady: Boolean(writerRef.current),
+            error,
+          });
+          throw error;
+        }
       }
 
       currentCheckpointIdRef.current = frameCheckpointId(frame);
@@ -141,6 +209,15 @@ export function ReplayTerminalWeb({
       }
 
       const message = loadError instanceof Error ? loadError.message : String(loadError);
+      console.error('[replay:web] loadFrame failed', {
+        replayId: replay.replayId,
+        requestId,
+        target,
+        previousCheckpointId: currentCheckpointIdRef.current,
+        previousSeq: currentSeqRef.current,
+        writerReady: Boolean(writerRef.current),
+        error: loadError,
+      });
       setError(message);
       setErroredTargetKey(targetKey(target));
       setIsPlaying(false);
@@ -294,6 +371,23 @@ export function ReplayTerminalWeb({
     });
   }, [invalidatePendingFrameLoad, timeline]);
 
+  const jumpCheckpoint = useCallback((direction: -1 | 1) => {
+    if (!timeline || timeline.steps.length === 0) {
+      return;
+    }
+
+    invalidatePendingFrameLoad();
+    setIsPlaying(false);
+    currentCheckpointIdRef.current = null;
+    currentSeqRef.current = 0;
+
+    const currentSeq = currentTarget.atSeq ?? replay.lastSeq;
+    const nextIndex = findCheckpointStepIndex(timeline, currentSeq, direction);
+    if (nextIndex >= 0) {
+      setCurrentStepIndex(nextIndex);
+    }
+  }, [currentTarget.atSeq, invalidatePendingFrameLoad, replay.lastSeq, timeline]);
+
   const adjustPlaybackSpeed = useCallback((direction: -1 | 1, count = 1) => {
     setPlaybackSpeedIndex((index) => clamp(index + (direction * count), 0, PLAYBACK_SPEEDS.length - 1));
   }, []);
@@ -386,9 +480,17 @@ export function ReplayTerminalWeb({
       if (event.key === 'ArrowLeft') {
         event.preventDefault();
         if (isPlaying) {
-          adjustPlaybackSpeed(-1, event.shiftKey ? 2 : 1);
+          if (event.shiftKey) {
+            jumpCheckpoint(-1);
+          } else {
+            adjustPlaybackSpeed(-1, 1);
+          }
         } else {
-          stepReplay(-1, event.shiftKey ? FAST_SCRUB_STEP_COUNT : 1);
+          if (event.shiftKey) {
+            jumpCheckpoint(-1);
+          } else {
+            stepReplay(-1, 1);
+          }
         }
         return;
       }
@@ -396,16 +498,36 @@ export function ReplayTerminalWeb({
       if (event.key === 'ArrowRight') {
         event.preventDefault();
         if (isPlaying) {
-          adjustPlaybackSpeed(1, event.shiftKey ? 2 : 1);
+          if (event.shiftKey) {
+            jumpCheckpoint(1);
+          } else {
+            adjustPlaybackSpeed(1, 1);
+          }
         } else {
-          stepReplay(1, event.shiftKey ? FAST_SCRUB_STEP_COUNT : 1);
+          if (event.shiftKey) {
+            jumpCheckpoint(1);
+          } else {
+            stepReplay(1, 1);
+          }
         }
+        return;
+      }
+
+      if (event.key === 'ArrowUp' && isPlaying) {
+        event.preventDefault();
+        adjustPlaybackSpeed(1, 1);
+        return;
+      }
+
+      if (event.key === 'ArrowDown' && isPlaying) {
+        event.preventDefault();
+        adjustPlaybackSpeed(-1, 1);
       }
     };
 
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [adjustPlaybackSpeed, handleDismiss, isPlaying, jumpToBoundary, onBack, onDismiss, stepReplay, togglePlayback]);
+  }, [adjustPlaybackSpeed, handleDismiss, isPlaying, jumpCheckpoint, jumpToBoundary, onBack, onDismiss, stepReplay, togglePlayback]);
 
   const totalTimeMs = timeline?.latestTimeMs ?? replay.durationMs;
   const activeTimeMs = currentTarget.atMs ?? totalTimeMs;
@@ -413,13 +535,14 @@ export function ReplayTerminalWeb({
   const visibleStepIndex = timeline && currentStepIndex >= 0
     ? clamp(currentStepIndex, 0, Math.max(0, timeline.steps.length - 1))
     : totalSteps;
+  const checkpointPosition = getCheckpointPosition(timeline, currentTarget.atSeq ?? replay.lastSeq);
   const speedLabel = `${playbackSpeed.toFixed(playbackSpeed < 1 ? 2 : 1)}x`;
   const activeTimeLabel = formatReplayTime(activeTimeMs);
   const totalTimeLabel = formatReplayTime(totalTimeMs);
   const stepLabel = `${visibleStepIndex}/${totalSteps}`;
   const transportHint = isPlaying
-    ? '[Space] Pause  [←/→] Speed  [Shift+←/→] More'
-    : '[Space] Play  [←/→] Step  [Shift+←/→] Skip';
+    ? '[Space] Pause  [↑/↓] Speed  [Shift+←/→] Checkpoint'
+    : '[Space] Play  [←/→] Event  [Shift+←/→] Checkpoint';
 
   return (
     <div className="w-screen h-screen flex flex-col bg-[#0d1117] overflow-hidden">
@@ -446,6 +569,7 @@ export function ReplayTerminalWeb({
                 <span>{totalTimeLabel}</span>
               </span>
               <span className="inline-flex min-w-[7ch] justify-end">{stepLabel}</span>
+              {checkpointPosition && <span className="inline-flex min-w-[10ch] justify-end">ckpt {checkpointPosition.current}/{checkpointPosition.total}</span>}
               <span className={`inline-flex min-w-[9ch] justify-end ${isPlaying ? 'text-[#3fb950]' : 'text-[#8b949e]'}`}>
                 {isPlaying ? '[playing]' : '[paused]'}
               </span>

--- a/src/components/ReplayTerminal.web.tsx
+++ b/src/components/ReplayTerminal.web.tsx
@@ -259,17 +259,24 @@ export function ReplayTerminalWeb({
     timelineLoading,
   ]);
 
+  /** Invalidate any in-flight frame load so its completion is discarded. */
+  const invalidatePendingFrameLoad = useCallback(() => {
+    frameRequestIdRef.current += 1;
+    setFrameLoading(false);
+  }, []);
+
   const stepReplay = useCallback((direction: -1 | 1, count = 1) => {
     if (!timeline || timeline.steps.length === 0) {
       return;
     }
 
+    invalidatePendingFrameLoad();
     setIsPlaying(false);
     setCurrentStepIndex((index) => {
       const resolvedIndex = index < 0 ? timeline.steps.length - 1 : index;
       return clamp(resolvedIndex + (direction * count), 0, timeline.steps.length - 1);
     });
-  }, [timeline]);
+  }, [invalidatePendingFrameLoad, timeline]);
 
   const adjustPlaybackSpeed = useCallback((direction: -1 | 1, count = 1) => {
     setPlaybackSpeedIndex((index) => clamp(index + (direction * count), 0, PLAYBACK_SPEEDS.length - 1));
@@ -285,21 +292,26 @@ export function ReplayTerminalWeb({
       return;
     }
 
+    // When restarting from the end, invalidate so the old frame load is discarded
+    invalidatePendingFrameLoad();
+    currentCheckpointIdRef.current = null;
+    currentSeqRef.current = 0;
     setCurrentStepIndex((index) => index >= timeline.steps.length - 1 ? 0 : Math.max(0, index));
     setIsPlaying(true);
-  }, [isPlaying, timeline]);
+  }, [invalidatePendingFrameLoad, isPlaying, timeline]);
 
   const jumpToBoundary = useCallback((direction: 'start' | 'end') => {
     if (!timeline || timeline.steps.length === 0) {
       return;
     }
 
+    invalidatePendingFrameLoad();
     setIsPlaying(false);
     // Reset checkpoint tracking on jump so we get a full frame
     currentCheckpointIdRef.current = null;
     currentSeqRef.current = 0;
     setCurrentStepIndex(direction === 'start' ? 0 : timeline.steps.length - 1);
-  }, [timeline]);
+  }, [invalidatePendingFrameLoad, timeline]);
 
   const handleDismiss = useCallback(async () => {
     const shouldGoBack = await onDismiss?.(replay.replayId);

--- a/src/components/SessionTerminal.web.tsx
+++ b/src/components/SessionTerminal.web.tsx
@@ -47,6 +47,18 @@ const SCROLL_THRESHOLD = 10; // pixels before we consider it a scroll vs tap
 const SCROLL_ACCUMULATOR_THRESHOLD = 30; // pixels of accumulated delta before sending scroll
 const TAP_MOVE_THRESHOLD = 10; // max movement to still count as a tap
 
+function isReplayDebugEnabled(): boolean {
+  if (typeof window === 'undefined') {
+    return false;
+  }
+  try {
+    return window.localStorage.getItem('gssh:debug:replay') === '1'
+      || new URLSearchParams(window.location.search).has('debugReplay');
+  } catch {
+    return false;
+  }
+}
+
 function configureMobileHelperTextarea(textarea: HTMLTextAreaElement): void {
   textarea.setAttribute('autocorrect', 'on');
   textarea.setAttribute('autocomplete', 'on');
@@ -393,8 +405,36 @@ export const SessionTerminal = forwardRef<SessionTerminalHandle, Props>(function
         setWriteCallback((data: Uint8Array) => {
           const wasScrolledUp = term.viewportY > 0;
           const viewportBefore = term.viewportY;
+          const chunk = new Uint8Array(data);
 
-          term.write(new TextDecoder().decode(data));
+          if (chunk.byteLength === 0) {
+            return;
+          }
+
+          try {
+            if (isReplayDebugEnabled()) {
+              console.debug('[session-terminal:web] write chunk', {
+                byteLength: chunk.byteLength,
+                preview: Array.from(chunk.slice(0, 16)),
+                viewportY: term.viewportY,
+                cols: term.cols,
+                rows: term.rows,
+              });
+            }
+
+            term.write(new TextDecoder().decode(chunk));
+          } catch (error) {
+            console.error('[session-terminal:web] term.write failed', {
+              byteLength: chunk.byteLength,
+              byteOffset: chunk.byteOffset,
+              preview: Array.from(chunk.slice(0, 32)),
+              viewportY: term.viewportY,
+              cols: term.cols,
+              rows: term.rows,
+              error,
+            });
+            throw error;
+          }
 
           if (wasScrolledUp && term.viewportY === 0) {
             requestAnimationFrame(() => {

--- a/src/components/SessionTerminal.web.tsx
+++ b/src/components/SessionTerminal.web.tsx
@@ -5,6 +5,7 @@ import {
   type PageDirection,
 } from './session-terminal-page-navigation.js';
 import { isIOSDevice } from '../utils/device.web.js';
+import { isReplayDebugEnabled } from './replay-debug.web.js';
 
 interface Props {
   onData: (data: Uint8Array) => void;
@@ -46,18 +47,6 @@ interface TerminalViewportLike {
 const SCROLL_THRESHOLD = 10; // pixels before we consider it a scroll vs tap
 const SCROLL_ACCUMULATOR_THRESHOLD = 30; // pixels of accumulated delta before sending scroll
 const TAP_MOVE_THRESHOLD = 10; // max movement to still count as a tap
-
-function isReplayDebugEnabled(): boolean {
-  if (typeof window === 'undefined') {
-    return false;
-  }
-  try {
-    return window.localStorage.getItem('gssh:debug:replay') === '1'
-      || new URLSearchParams(window.location.search).has('debugReplay');
-  } catch {
-    return false;
-  }
-}
 
 function configureMobileHelperTextarea(textarea: HTMLTextAreaElement): void {
   textarea.setAttribute('autocorrect', 'on');

--- a/src/components/__tests__/ReplayTerminal.tui.test.tsx
+++ b/src/components/__tests__/ReplayTerminal.tui.test.tsx
@@ -187,10 +187,11 @@ describe('ReplayTerminal TUI', () => {
       mockInput.pressArrow('right', { shift: true });
     });
     await renderAndFlush(renderOnce);
-    expect(captureCharFrame()).toContain('frame:1200:3');
+    expect(captureCharFrame()).toContain('frame:500:2');
+    expect(captureCharFrame()).toContain('ckpt 2/2');
   });
 
-  it('plays in real time and lets arrows adjust playback speed while playing', async () => {
+  it('plays in real time and lets up/down adjust playback speed while playing', async () => {
     jest.useFakeTimers();
 
     const loadReplayFrame = mock(async (_replayId: string, target?: ReplayFrameTarget) => makeFrame(target));
@@ -227,7 +228,7 @@ describe('ReplayTerminal TUI', () => {
     expect(captureCharFrame()).toContain('frame:200:1');
 
     await act(async () => {
-      mockInput.pressArrow('right');
+      mockInput.pressArrow('up');
     });
     await renderAndFlush(renderOnce);
     expect(captureCharFrame()).toContain('1.5x');

--- a/src/components/__tests__/ReplayTerminal.tui.test.tsx
+++ b/src/components/__tests__/ReplayTerminal.tui.test.tsx
@@ -3,7 +3,7 @@ import { testRender } from '@opentui/react/test-utils';
 import { act, useState } from 'react';
 import { ReplayTerminal } from '../ReplayTerminal.tui.js';
 import type { ReplayInfo } from '../SpacesBrowser.js';
-import type { ReplayFrameTarget, ReplayTimeline } from '../../lib/tmux-lite/replay/index.js';
+import type { ReplayFrame, ReplayFrameTarget, ReplayTimeline } from '../../lib/tmux-lite/replay/index.js';
 
 function makeReplay(overrides: Partial<ReplayInfo> = {}): ReplayInfo {
   return {
@@ -44,19 +44,30 @@ function makeTimeline(overrides: Partial<ReplayTimeline> = {}): ReplayTimeline {
   };
 }
 
-function frameLabel(target?: ReplayFrameTarget): Buffer {
-  return Buffer.from(`frame:${target?.atMs ?? -1}:${target?.atSeq ?? -1}`);
+function textToBase64(text: string): string {
+  return Buffer.from(text, 'utf-8').toString('base64');
+}
+
+function makeFrame(target?: ReplayFrameTarget): ReplayFrame {
+  const label = `frame:${target?.atMs ?? -1}:${target?.atSeq ?? -1}`;
+  return {
+    replayId: 'replay-1',
+    checkpoint: null,
+    events: [
+      { seq: target?.atSeq ?? 0, t: target?.atMs ?? 0, type: 'output', data: textToBase64(label) },
+    ],
+  };
 }
 
 async function renderAndFlush(renderOnce: () => Promise<void>) {
-  await act(async () => {
-    await renderOnce();
-    await Promise.resolve();
-    await Promise.resolve();
-  });
-  await act(async () => {
-    await renderOnce();
-  });
+  // Allow terminal mount microtask + async frame loads to settle
+  for (let i = 0; i < 5; i++) {
+    await act(async () => {
+      await renderOnce();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+  }
 }
 
 let destroyRenderer: (() => void) | null = null;
@@ -74,13 +85,13 @@ afterEach(async () => {
 
 describe('ReplayTerminal TUI', () => {
   it('shows restore hint for dismissed replays', async () => {
-    const loadReplayAnsi = mock(async (replayId: string, target?: ReplayFrameTarget) => frameLabel(target));
+    const loadReplayFrame = mock(async (_replayId: string, target?: ReplayFrameTarget) => makeFrame(target));
     const loadReplayTimeline = mock(async () => makeTimeline());
 
     const { renderer, renderOnce, captureCharFrame } = await testRender(
       <ReplayTerminal
         replay={makeReplay({ dismissedAt: Date.now() - 1_000, dismissedBy: 'tester' })}
-        loadReplayAnsi={loadReplayAnsi}
+        loadReplayFrame={loadReplayFrame}
         loadReplayTimeline={loadReplayTimeline}
         onBack={mock(() => {})}
         onDismiss={mock(async () => {})}
@@ -97,7 +108,7 @@ describe('ReplayTerminal TUI', () => {
   });
 
   it('does not reload the replay on unrelated parent rerenders', async () => {
-    const loadReplayAnsi = mock(async (replayId: string, target?: ReplayFrameTarget) => frameLabel(target));
+    const loadReplayFrame = mock(async (_replayId: string, target?: ReplayFrameTarget) => makeFrame(target));
     const loadReplayTimeline = mock(async () => makeTimeline());
 
     let bump = () => {};
@@ -109,7 +120,7 @@ describe('ReplayTerminal TUI', () => {
       return (
         <ReplayTerminal
           replay={makeReplay()}
-          loadReplayAnsi={loadReplayAnsi}
+          loadReplayFrame={loadReplayFrame}
           loadReplayTimeline={loadReplayTimeline}
           onBack={mock(() => {})}
         />
@@ -123,7 +134,7 @@ describe('ReplayTerminal TUI', () => {
     destroyRenderer = () => renderer.destroy();
 
     await renderAndFlush(renderOnce);
-    expect(loadReplayAnsi).toHaveBeenCalledTimes(1);
+    expect(loadReplayFrame).toHaveBeenCalledTimes(1);
     expect(captureCharFrame()).toContain('frame:1200:3');
 
     await act(async () => {
@@ -131,19 +142,19 @@ describe('ReplayTerminal TUI', () => {
     });
     await renderAndFlush(renderOnce);
 
-    expect(loadReplayAnsi).toHaveBeenCalledTimes(1);
+    expect(loadReplayFrame).toHaveBeenCalledTimes(1);
     expect(captureCharFrame()).toContain('frame:1200:3');
     expect(captureCharFrame()).not.toContain('Loading replay');
   });
 
   it('steps through replay points when paused', async () => {
-    const loadReplayAnsi = mock(async (replayId: string, target?: ReplayFrameTarget) => frameLabel(target));
+    const loadReplayFrame = mock(async (_replayId: string, target?: ReplayFrameTarget) => makeFrame(target));
     const loadReplayTimeline = mock(async () => makeTimeline());
 
     const { renderer, renderOnce, mockInput, captureCharFrame } = await testRender(
       <ReplayTerminal
         replay={makeReplay()}
-        loadReplayAnsi={loadReplayAnsi}
+        loadReplayFrame={loadReplayFrame}
         loadReplayTimeline={loadReplayTimeline}
         onBack={mock(() => {})}
       />,
@@ -182,13 +193,13 @@ describe('ReplayTerminal TUI', () => {
   it('plays in real time and lets arrows adjust playback speed while playing', async () => {
     jest.useFakeTimers();
 
-    const loadReplayAnsi = mock(async (replayId: string, target?: ReplayFrameTarget) => frameLabel(target));
+    const loadReplayFrame = mock(async (_replayId: string, target?: ReplayFrameTarget) => makeFrame(target));
     const loadReplayTimeline = mock(async () => makeTimeline());
 
     const { renderer, renderOnce, mockInput, captureCharFrame } = await testRender(
       <ReplayTerminal
         replay={makeReplay()}
-        loadReplayAnsi={loadReplayAnsi}
+        loadReplayFrame={loadReplayFrame}
         loadReplayTimeline={loadReplayTimeline}
         onBack={mock(() => {})}
       />,

--- a/src/components/replay-debug.web.ts
+++ b/src/components/replay-debug.web.ts
@@ -1,0 +1,24 @@
+export function isReplayDebugEnabled(): boolean {
+  if (typeof window === 'undefined') {
+    return false;
+  }
+
+  try {
+    return window.localStorage.getItem('gssh:debug:replay') === '1'
+      || new URLSearchParams(window.location.search).has('debugReplay');
+  } catch {
+    return false;
+  }
+}
+
+export function replayDebug(message: string, details?: Record<string, unknown>): void {
+  if (!isReplayDebugEnabled()) {
+    return;
+  }
+
+  if (details) {
+    console.debug(`[replay:web] ${message}`, details);
+  } else {
+    console.debug(`[replay:web] ${message}`);
+  }
+}

--- a/src/components/replay-utils.ts
+++ b/src/components/replay-utils.ts
@@ -174,7 +174,7 @@ export function applyReplayFrame(
   write: (data: string | Uint8Array) => void,
   previousCheckpointId: string | null,
   fromSeq: number,
-): string | null {
+): void {
   const checkpointId = frame.checkpoint?.checkpointId ?? null;
   // Two null checkpoints count as "same" only if we've already applied events (fromSeq > 0),
   // otherwise it's a fresh load that needs a terminal reset.
@@ -204,8 +204,6 @@ export function applyReplayFrame(
       applyFrameEvent(event, write);
     }
   }
-
-  return checkpointId;
 }
 
 function applyFrameEvent(

--- a/src/components/replay-utils.ts
+++ b/src/components/replay-utils.ts
@@ -194,6 +194,7 @@ export function applyReplayFrame(
     // Different checkpoint, backward step, or first load — reset and replay from checkpoint
     write(TERMINAL_RESET);
     if (frame.checkpoint) {
+      write(resizeSequence(frame.checkpoint.cols, frame.checkpoint.rows));
       const checkpointBytes = decodeBase64(frame.checkpoint.ansi);
       if (checkpointBytes.byteLength > 0) {
         write(checkpointBytes);

--- a/src/components/replay-utils.ts
+++ b/src/components/replay-utils.ts
@@ -124,7 +124,9 @@ export function applyReplayFrame(
   fromSeq: number,
 ): string | null {
   const checkpointId = frame.checkpoint?.checkpointId ?? null;
-  const sameCheckpoint = checkpointId !== null && checkpointId === previousCheckpointId;
+  // Two null checkpoints count as "same" only if we've already applied events (fromSeq > 0),
+  // otherwise it's a fresh load that needs a terminal reset.
+  const sameCheckpoint = checkpointId === previousCheckpointId && (checkpointId !== null || fromSeq > 0);
   const lastEventSeq = frame.events.length > 0 ? frame.events[frame.events.length - 1]!.seq : 0;
   const isForward = sameCheckpoint && lastEventSeq > fromSeq;
 

--- a/src/components/replay-utils.ts
+++ b/src/components/replay-utils.ts
@@ -3,6 +3,8 @@
  */
 
 import type {
+  ReplayFrame,
+  ReplayFrameEvent,
   ReplayFrameTarget,
   ReplayTimelineStep,
 } from '../lib/tmux-lite/replay/index.js';
@@ -68,4 +70,104 @@ export function toFrameTarget(step: ReplayTimelineStep | null, fallback: ReplayF
 
 export function clamp(value: number, min: number, max: number): number {
   return Math.min(max, Math.max(min, value));
+}
+
+// ============================================================================
+// Replay frame application
+// ============================================================================
+
+const TERMINAL_RESET = '\x1bc\x1b[2J\x1b[H';
+
+/**
+ * Decode base64 string to binary data.
+ * Works in both Node.js (Buffer) and browser (atob) environments.
+ */
+function decodeBase64(data: string): Uint8Array {
+  if (typeof Buffer !== 'undefined') {
+    return Buffer.from(data, 'base64');
+  }
+  const binary = atob(data);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes;
+}
+
+/**
+ * Build ANSI resize sequence (DECSET 8-bit control).
+ */
+function resizeSequence(cols: number, rows: number): string {
+  return `\x1b[8;${rows};${cols}t`;
+}
+
+/**
+ * Get the checkpoint ID from a replay frame (null if no checkpoint).
+ */
+export function frameCheckpointId(frame: ReplayFrame): string | null {
+  return frame.checkpoint?.checkpointId ?? null;
+}
+
+/**
+ * Apply a replay frame to a terminal write function.
+ *
+ * If `previousCheckpointId` matches the frame's checkpoint, skips re-writing
+ * the checkpoint ANSI and only applies events after `fromSeq`.
+ * Otherwise, resets the terminal, writes the checkpoint, then applies all events.
+ *
+ * Returns the checkpoint ID that was applied.
+ */
+export function applyReplayFrame(
+  frame: ReplayFrame,
+  write: (data: string | Uint8Array) => void,
+  previousCheckpointId: string | null,
+  fromSeq: number,
+): string | null {
+  const checkpointId = frame.checkpoint?.checkpointId ?? null;
+  const sameCheckpoint = checkpointId !== null && checkpointId === previousCheckpointId;
+
+  if (!sameCheckpoint) {
+    // Different checkpoint (or no previous) — reset and write full checkpoint
+    write(TERMINAL_RESET);
+    if (frame.checkpoint) {
+      const checkpointBytes = decodeBase64(frame.checkpoint.ansi);
+      write(checkpointBytes);
+    }
+    // Apply all events
+    for (const event of frame.events) {
+      applyFrameEvent(event, write);
+    }
+  } else {
+    // Same checkpoint — only apply events after our current position
+    for (const event of frame.events) {
+      if (event.seq <= fromSeq) {
+        continue;
+      }
+      applyFrameEvent(event, write);
+    }
+  }
+
+  return checkpointId;
+}
+
+function applyFrameEvent(
+  event: ReplayFrameEvent,
+  write: (data: string | Uint8Array) => void,
+): void {
+  if (event.type === 'output' && event.data) {
+    write(decodeBase64(event.data));
+  } else if (event.type === 'resize' && event.cols !== undefined && event.rows !== undefined) {
+    write(resizeSequence(event.cols, event.rows));
+  }
+}
+
+/**
+ * Get the last seq number from a replay frame's events,
+ * falling back to the checkpoint seq or 0.
+ */
+export function frameLastSeq(frame: ReplayFrame): number {
+  if (frame.events.length > 0) {
+    return frame.events[frame.events.length - 1]!.seq;
+  }
+  return frame.checkpoint?.seq ?? 0;
 }

--- a/src/components/replay-utils.ts
+++ b/src/components/replay-utils.ts
@@ -125,24 +125,25 @@ export function applyReplayFrame(
 ): string | null {
   const checkpointId = frame.checkpoint?.checkpointId ?? null;
   const sameCheckpoint = checkpointId !== null && checkpointId === previousCheckpointId;
+  const lastEventSeq = frame.events.length > 0 ? frame.events[frame.events.length - 1]!.seq : 0;
+  const isForward = sameCheckpoint && lastEventSeq > fromSeq;
 
-  if (!sameCheckpoint) {
-    // Different checkpoint (or no previous) — reset and write full checkpoint
+  if (sameCheckpoint && isForward) {
+    // Same checkpoint, forward step — only apply events after our current position
+    for (const event of frame.events) {
+      if (event.seq <= fromSeq) {
+        continue;
+      }
+      applyFrameEvent(event, write);
+    }
+  } else {
+    // Different checkpoint, backward step, or first load — reset and replay from checkpoint
     write(TERMINAL_RESET);
     if (frame.checkpoint) {
       const checkpointBytes = decodeBase64(frame.checkpoint.ansi);
       write(checkpointBytes);
     }
-    // Apply all events
     for (const event of frame.events) {
-      applyFrameEvent(event, write);
-    }
-  } else {
-    // Same checkpoint — only apply events after our current position
-    for (const event of frame.events) {
-      if (event.seq <= fromSeq) {
-        continue;
-      }
       applyFrameEvent(event, write);
     }
   }

--- a/src/components/replay-utils.ts
+++ b/src/components/replay-utils.ts
@@ -6,6 +6,7 @@ import type {
   ReplayFrame,
   ReplayFrameEvent,
   ReplayFrameTarget,
+  ReplayTimeline,
   ReplayTimelineStep,
 } from '../lib/tmux-lite/replay/index.js';
 
@@ -15,7 +16,6 @@ import type {
 
 export const PLAYBACK_SPEEDS = [0.25, 0.5, 1, 1.5, 2, 4] as const;
 export const DEFAULT_PLAYBACK_SPEED_INDEX = 2;
-export const FAST_SCRUB_STEP_COUNT = 5;
 
 // ============================================================================
 // Formatting
@@ -72,6 +72,53 @@ export function clamp(value: number, min: number, max: number): number {
   return Math.min(max, Math.max(min, value));
 }
 
+export function findCheckpointStepIndex(
+  timeline: ReplayTimeline,
+  currentSeq: number,
+  direction: -1 | 1,
+): number {
+  if (timeline.steps.length === 0) {
+    return -1;
+  }
+
+  const checkpoint = direction < 0
+    ? [...timeline.checkpointSteps].reverse().find((step) => step.seq < currentSeq)
+    : timeline.checkpointSteps.find((step) => step.seq > currentSeq);
+
+  if (!checkpoint) {
+    return direction < 0 ? 0 : timeline.steps.length - 1;
+  }
+
+  const stepIndex = timeline.steps.findIndex(
+    (step) => step.seq >= checkpoint.seq && step.timeMs >= checkpoint.timeMs,
+  );
+
+  return stepIndex >= 0 ? stepIndex : (direction < 0 ? 0 : timeline.steps.length - 1);
+}
+
+export function getCheckpointPosition(
+  timeline: ReplayTimeline | null,
+  currentSeq: number,
+): { current: number; total: number } | null {
+  if (!timeline || timeline.checkpointSteps.length === 0) {
+    return null;
+  }
+
+  let current = 0;
+  for (const checkpoint of timeline.checkpointSteps) {
+    if (checkpoint.seq <= currentSeq) {
+      current += 1;
+    } else {
+      break;
+    }
+  }
+
+  return {
+    current,
+    total: timeline.checkpointSteps.length,
+  };
+}
+
 // ============================================================================
 // Replay frame application
 // ============================================================================
@@ -83,15 +130,20 @@ const TERMINAL_RESET = '\x1bc\x1b[2J\x1b[H';
  * Works in both Node.js (Buffer) and browser (atob) environments.
  */
 function decodeBase64(data: string): Uint8Array {
+  if (typeof atob === 'function') {
+    const binary = atob(data);
+    const bytes = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i++) {
+      bytes[i] = binary.charCodeAt(i);
+    }
+    return bytes;
+  }
+
   if (typeof Buffer !== 'undefined') {
-    return Buffer.from(data, 'base64');
+    return new Uint8Array(Buffer.from(data, 'base64'));
   }
-  const binary = atob(data);
-  const bytes = new Uint8Array(binary.length);
-  for (let i = 0; i < binary.length; i++) {
-    bytes[i] = binary.charCodeAt(i);
-  }
-  return bytes;
+
+  throw new Error('No base64 decoder available');
 }
 
 /**
@@ -143,7 +195,9 @@ export function applyReplayFrame(
     write(TERMINAL_RESET);
     if (frame.checkpoint) {
       const checkpointBytes = decodeBase64(frame.checkpoint.ansi);
-      write(checkpointBytes);
+      if (checkpointBytes.byteLength > 0) {
+        write(checkpointBytes);
+      }
     }
     for (const event of frame.events) {
       applyFrameEvent(event, write);
@@ -158,7 +212,10 @@ function applyFrameEvent(
   write: (data: string | Uint8Array) => void,
 ): void {
   if (event.type === 'output' && event.data) {
-    write(decodeBase64(event.data));
+    const bytes = decodeBase64(event.data);
+    if (bytes.byteLength > 0) {
+      write(bytes);
+    }
   } else if (event.type === 'resize' && event.cols !== undefined && event.rows !== undefined) {
     write(resizeSequence(event.cols, event.rows));
   }

--- a/src/lib/remote-session/protocol.ts
+++ b/src/lib/remote-session/protocol.ts
@@ -437,6 +437,7 @@ export interface ErrorResponse {
   message: string;
   workspaceId?: string;
   projectName?: string;
+  requestId?: string;
 }
 
 /** Project information */

--- a/src/lib/remote-session/protocol.ts
+++ b/src/lib/remote-session/protocol.ts
@@ -41,7 +41,7 @@ export type {
   ConfirmStepResult,
   SpacesBundle,
 } from '../../types/bundle.js';
-export type { ReplayFrameTarget, ReplayInfo, ReplayTimeline } from '../tmux-lite/replay/types.js';
+export type { ReplayFrame, ReplayFrameTarget, ReplayInfo, ReplayTimeline } from '../tmux-lite/replay/types.js';
 
 // Re-export attached mode control types from tmux-lite
 // These are used in attached mode for resize/detach/attach-init
@@ -69,9 +69,9 @@ export interface ListReplaysRequest {
   includeDismissed?: boolean;
 }
 
-/** Request ANSI replay bytes for Ghostty/web rendering */
-export interface GetReplayAnsiRequest {
-  type: 'get_replay_ansi';
+/** Request a replay frame (checkpoint + events) for client-side rendering */
+export interface GetReplayFrameRequest {
+  type: 'get_replay_frame';
   replayId: string;
   atMs?: number;
   atSeq?: number;
@@ -381,12 +381,11 @@ export interface ReplayListResponse {
   replays: import('../tmux-lite/replay/types.js').ReplayInfo[];
 }
 
-/** Response with replay ANSI payload */
-export interface ReplayAnsiResponse {
-  type: 'replay_ansi';
+/** Response with replay frame (checkpoint + events for client-side rendering) */
+export interface ReplayFrameResponse {
+  type: 'replay_frame';
   replayId: string;
-  data: string;
-  encoding: 'base64';
+  frame: import('../tmux-lite/replay/types.js').ReplayFrame;
 }
 
 /** Response with replay timeline metadata */
@@ -703,7 +702,7 @@ export type ClientToMachineMessage =
   | ListWorkspacesRequest
   | ListSessionsRequest
   | ListReplaysRequest
-  | GetReplayAnsiRequest
+  | GetReplayFrameRequest
   | GetReplayTimelineRequest
   | DismissReplayRequest
   | UndismissReplayRequest
@@ -744,7 +743,7 @@ export type MachineToClientMessage =
   | WorkspaceListResponse
   | SessionListResponse
   | ReplayListResponse
-  | ReplayAnsiResponse
+  | ReplayFrameResponse
   | ReplayTimelineResponse
   | ReplayDismissedResponse
   | ReplayUndismissedResponse
@@ -824,7 +823,7 @@ export function isBrowseMessage(msg: RemoteSessionMessage): msg is
   | ListWorkspacesRequest
   | ListSessionsRequest
   | ListReplaysRequest
-  | GetReplayAnsiRequest
+  | GetReplayFrameRequest
   | GetReplayTimelineRequest
   | DismissReplayRequest
   | UndismissReplayRequest
@@ -850,7 +849,7 @@ export function isBrowseMessage(msg: RemoteSessionMessage): msg is
     "list_workspaces",
     "list_sessions",
     'list_replays',
-    'get_replay_ansi',
+    'get_replay_frame',
     'get_replay_timeline',
     'dismiss_replay',
     'undismiss_replay',

--- a/src/lib/remote-session/protocol.ts
+++ b/src/lib/remote-session/protocol.ts
@@ -73,6 +73,7 @@ export interface ListReplaysRequest {
 export interface GetReplayFrameRequest {
   type: 'get_replay_frame';
   replayId: string;
+  requestId: string;
   atMs?: number;
   atSeq?: number;
 }
@@ -385,6 +386,7 @@ export interface ReplayListResponse {
 export interface ReplayFrameResponse {
   type: 'replay_frame';
   replayId: string;
+  requestId: string;
   frame: import('../tmux-lite/replay/types.js').ReplayFrame;
 }
 

--- a/src/lib/remote-session/protocol.ts
+++ b/src/lib/remote-session/protocol.ts
@@ -388,6 +388,8 @@ export interface ReplayFrameResponse {
   replayId: string;
   requestId: string;
   frame: import('../tmux-lite/replay/types.js').ReplayFrame;
+  chunkIndex?: number;
+  totalChunks?: number;
 }
 
 /** Response with replay timeline metadata */

--- a/src/lib/remote-session/session-handler.ts
+++ b/src/lib/remote-session/session-handler.ts
@@ -292,7 +292,7 @@ export class RemoteSessionHandler {
         break;
 
       case 'get_replay_frame':
-        await this.handleGetReplayFrame(session, msg.replayId, msg.atMs, msg.atSeq, sendResponse);
+        await this.handleGetReplayFrame(session, msg.replayId, msg.requestId, msg.atMs, msg.atSeq, sendResponse);
         break;
 
       case 'get_replay_timeline':
@@ -784,6 +784,7 @@ export class RemoteSessionHandler {
   private async handleGetReplayFrame(
     session: RemoteClientSession,
     replayId: string,
+    requestId: string,
     atMs: number | undefined,
     atSeq: number | undefined,
     sendResponse: (data: Uint8Array) => void,
@@ -803,6 +804,7 @@ export class RemoteSessionHandler {
     await this.sendMessage(session, sendResponse, {
       type: 'replay_frame',
       replayId,
+      requestId,
       frame,
     });
   }

--- a/src/lib/remote-session/session-handler.ts
+++ b/src/lib/remote-session/session-handler.ts
@@ -829,7 +829,8 @@ export class RemoteSessionHandler {
     let chunkSizeBytes = basePayloadSize(frame.checkpoint);
     for (const [index, event] of frame.events.entries()) {
       const eventSizeBytes = eventJsonSizes[index] ?? 0;
-      const candidateSize = chunkSizeBytes + eventSizeBytes + (chunk.length > 0 ? 1 : 0);
+      const hasEventsBeforePush = chunk.length > 0;
+      const candidateSize = chunkSizeBytes + eventSizeBytes + (hasEventsBeforePush ? 1 : 0);
       if (candidateSize > maxPayloadBytes && chunk.length > 0) {
         chunks.push(chunk);
         chunk = [];
@@ -837,7 +838,7 @@ export class RemoteSessionHandler {
       }
 
       chunk.push(event);
-      chunkSizeBytes += eventSizeBytes + (chunk.length > 1 ? 1 : 0);
+      chunkSizeBytes += eventSizeBytes + (hasEventsBeforePush ? 1 : 0);
     }
 
     if (chunk.length > 0 || chunks.length === 0) {

--- a/src/lib/remote-session/session-handler.ts
+++ b/src/lib/remote-session/session-handler.ts
@@ -791,12 +791,12 @@ export class RemoteSessionHandler {
   ): Promise<void> {
     const manifest = readReplayManifest(replayId);
     if (!manifest) {
-      await this.sendError(session, sendResponse, 'NOT_FOUND', `Replay not found: ${replayId}`);
+      await this.sendError(session, sendResponse, 'NOT_FOUND', `Replay not found: ${replayId}`, { requestId });
       return;
     }
 
     if (!canAccessReplayForSession(session.accessType, session.grantedSessionId, manifest)) {
-      await this.sendError(session, sendResponse, 'PERMISSION_DENIED', 'Not authorized to access this replay');
+      await this.sendError(session, sendResponse, 'PERMISSION_DENIED', 'Not authorized to access this replay', { requestId });
       return;
     }
 
@@ -1972,7 +1972,7 @@ export class RemoteSessionHandler {
     sendResponse: (data: Uint8Array) => void,
     code: string,
     message: string,
-    options?: { workspaceId?: string; projectName?: string }
+    options?: { workspaceId?: string; projectName?: string; requestId?: string }
   ): Promise<void> {
     await this.sendMessage(session, sendResponse, {
       type: "error",
@@ -1980,6 +1980,7 @@ export class RemoteSessionHandler {
       message,
       workspaceId: options?.workspaceId,
       projectName: options?.projectName,
+      requestId: options?.requestId,
     });
   }
 

--- a/src/lib/remote-session/session-handler.ts
+++ b/src/lib/remote-session/session-handler.ts
@@ -823,21 +823,21 @@ export class RemoteSessionHandler {
     });
 
     const chunks: ReplayFrame['events'][] = [];
+    const eventJsonSizes = frame.events.map((event) => Buffer.byteLength(JSON.stringify(event)));
+    const basePayloadSize = (checkpoint: ReplayFrame['checkpoint'] | null) => Buffer.byteLength(JSON.stringify(buildPayload([], 0, 1, checkpoint)));
     let chunk: ReplayFrame['events'] = [];
-    for (const event of frame.events) {
-      chunk.push(event);
-      const checkpoint = chunks.length === 0 ? frame.checkpoint : null;
-      const payloadSize = Buffer.byteLength(JSON.stringify(buildPayload(chunk, 0, 1, checkpoint)));
-      if (payloadSize > maxPayloadBytes) {
-        if (chunk.length === 1) {
-          chunks.push(chunk);
-          chunk = [];
-          continue;
-        }
-        const last = chunk.pop();
+    let chunkSizeBytes = basePayloadSize(frame.checkpoint);
+    for (const [index, event] of frame.events.entries()) {
+      const eventSizeBytes = eventJsonSizes[index] ?? 0;
+      const candidateSize = chunkSizeBytes + eventSizeBytes + (chunk.length > 0 ? 1 : 0);
+      if (candidateSize > maxPayloadBytes && chunk.length > 0) {
         chunks.push(chunk);
-        chunk = last ? [last] : [];
+        chunk = [];
+        chunkSizeBytes = basePayloadSize(null);
       }
+
+      chunk.push(event);
+      chunkSizeBytes += eventSizeBytes + (chunk.length > 1 ? 1 : 0);
     }
 
     if (chunk.length > 0 || chunks.length === 0) {

--- a/src/lib/remote-session/session-handler.ts
+++ b/src/lib/remote-session/session-handler.ts
@@ -34,6 +34,7 @@ import {
   dismissReplayOffline,
   undismissReplayOffline,
 } from '../tmux-lite/replay/service.js';
+import type { ReplayFrame } from '../tmux-lite/replay/types.js';
 import { readReplayManifest } from '../tmux-lite/replay/store.js';
 
 // Import project loading
@@ -801,12 +802,52 @@ export class RemoteSessionHandler {
     }
 
     const frame = getReplayFrameOffline(replayId, { atMs, atSeq });
-    await this.sendMessage(session, sendResponse, {
-      type: 'replay_frame',
+
+    const maxPayloadBytes = 900_000;
+    const buildPayload = (
+      events: ReplayFrame['events'],
+      chunkIndex: number,
+      totalChunks: number,
+      checkpoint: ReplayFrame['checkpoint'] | null,
+    ) => ({
+      type: 'replay_frame' as const,
       replayId,
       requestId,
-      frame,
+      frame: {
+        replayId,
+        checkpoint,
+        events,
+      },
+      chunkIndex,
+      totalChunks,
     });
+
+    const chunks: ReplayFrame['events'][] = [];
+    let chunk: ReplayFrame['events'] = [];
+    for (const event of frame.events) {
+      chunk.push(event);
+      const checkpoint = chunks.length === 0 ? frame.checkpoint : null;
+      const payloadSize = Buffer.byteLength(JSON.stringify(buildPayload(chunk, 0, 1, checkpoint)));
+      if (payloadSize > maxPayloadBytes) {
+        if (chunk.length === 1) {
+          chunks.push(chunk);
+          chunk = [];
+          continue;
+        }
+        const last = chunk.pop();
+        chunks.push(chunk);
+        chunk = last ? [last] : [];
+      }
+    }
+
+    if (chunk.length > 0 || chunks.length === 0) {
+      chunks.push(chunk);
+    }
+
+    const totalChunks = chunks.length;
+    for (let i = 0; i < totalChunks; i += 1) {
+      await this.sendMessage(session, sendResponse, buildPayload(chunks[i] ?? [], i, totalChunks, i === 0 ? frame.checkpoint : null));
+    }
   }
 
   private async handleGetReplayTimeline(

--- a/src/lib/remote-session/session-handler.ts
+++ b/src/lib/remote-session/session-handler.ts
@@ -829,12 +829,14 @@ export class RemoteSessionHandler {
     let chunkSizeBytes = basePayloadSize(frame.checkpoint);
     for (const [index, event] of frame.events.entries()) {
       const eventSizeBytes = eventJsonSizes[index] ?? 0;
-      const hasEventsBeforePush = chunk.length > 0;
-      const candidateSize = chunkSizeBytes + eventSizeBytes + (hasEventsBeforePush ? 1 : 0);
+      let hasEventsBeforePush = chunk.length > 0;
+      let candidateSize = chunkSizeBytes + eventSizeBytes + (hasEventsBeforePush ? 1 : 0);
       if (candidateSize > maxPayloadBytes && chunk.length > 0) {
         chunks.push(chunk);
         chunk = [];
         chunkSizeBytes = basePayloadSize(null);
+        hasEventsBeforePush = false;
+        candidateSize = chunkSizeBytes + eventSizeBytes;
       }
 
       chunk.push(event);

--- a/src/lib/remote-session/session-handler.ts
+++ b/src/lib/remote-session/session-handler.ts
@@ -29,7 +29,7 @@ import {
 } from "../tmux-lite/cli";
 import {
   listReplaysOffline,
-  getReplayAnsiBufferOffline,
+  getReplayFrameOffline,
   getReplayTimelineOffline,
   dismissReplayOffline,
   undismissReplayOffline,
@@ -291,8 +291,8 @@ export class RemoteSessionHandler {
         await this.handleListReplays(session, msg.workspaceId, msg.includeDismissed, sendResponse);
         break;
 
-      case 'get_replay_ansi':
-        await this.handleGetReplayAnsi(session, msg.replayId, msg.atMs, msg.atSeq, sendResponse);
+      case 'get_replay_frame':
+        await this.handleGetReplayFrame(session, msg.replayId, msg.atMs, msg.atSeq, sendResponse);
         break;
 
       case 'get_replay_timeline':
@@ -781,7 +781,7 @@ export class RemoteSessionHandler {
     });
   }
 
-  private async handleGetReplayAnsi(
+  private async handleGetReplayFrame(
     session: RemoteClientSession,
     replayId: string,
     atMs: number | undefined,
@@ -799,12 +799,11 @@ export class RemoteSessionHandler {
       return;
     }
 
-    const ansi = await getReplayAnsiBufferOffline(replayId, { atMs, atSeq });
+    const frame = getReplayFrameOffline(replayId, { atMs, atSeq });
     await this.sendMessage(session, sendResponse, {
-      type: 'replay_ansi',
+      type: 'replay_frame',
       replayId,
-      data: Buffer.from(ansi).toString('base64'),
-      encoding: 'base64',
+      frame,
     });
   }
 

--- a/src/lib/tmux-lite/replay/service.ts
+++ b/src/lib/tmux-lite/replay/service.ts
@@ -279,8 +279,12 @@ export function getReplayFrameOffline(
   }
 
   const checkpoints = listReplayCheckpoints(replayId);
-  const events = readReplayEvents(replayId);
-  const latestTimeMs = getLatestReplayTime(manifest.stats.durationMs, checkpoints, events);
+  // Use manifest durationMs + checkpoint times to determine latest time
+  // without reading the full events file
+  const latestCheckpointTime = checkpoints.length > 0
+    ? checkpoints[checkpoints.length - 1]?.t ?? 0
+    : 0;
+  const latestTimeMs = Math.max(manifest.stats.durationMs, latestCheckpointTime);
   const targetMs = target.atMs === undefined
     ? latestTimeMs
     : Math.max(0, Math.min(target.atMs, latestTimeMs));

--- a/src/lib/tmux-lite/replay/service.ts
+++ b/src/lib/tmux-lite/replay/service.ts
@@ -16,7 +16,9 @@ import { extractStyledRows, writeReplayScreenshot, type StyledRow, type StyledSp
 import {
   listReplayInfos,
   listReplayCheckpoints,
+  readReplayCheckpoint,
   readReplayEvents,
+  readReplayEventSlice,
   readReplayManifest,
   dismissReplay,
   undismissReplay,
@@ -26,6 +28,7 @@ import {
   type ReplayListFilter,
 } from './store.js';
 import type {
+  ReplayFrame,
   ReplayFrameTarget,
   ReplayInfo,
   ReplayTimeline,
@@ -259,6 +262,61 @@ export async function getReplayAnsiBufferOffline(
   } finally {
     state.xterm.dispose();
   }
+}
+
+// ============================================================================
+// Frame (checkpoint + event slice — no server-side reconstruction)
+// ============================================================================
+
+export function getReplayFrameOffline(
+  replayId: string,
+  target: ReplayFrameTarget = {},
+): ReplayFrame {
+  const manifest = readReplayManifest(replayId);
+  if (!manifest) {
+    logger.error(`[replay.service] Replay manifest not found: ${replayId}`);
+    throw new SpacesError(`Replay manifest not found: ${replayId}`, 'USER_ERROR', 1);
+  }
+
+  const checkpoints = listReplayCheckpoints(replayId);
+  const events = readReplayEvents(replayId);
+  const latestTimeMs = getLatestReplayTime(manifest.stats.durationMs, checkpoints, events);
+  const targetMs = target.atMs === undefined
+    ? latestTimeMs
+    : Math.max(0, Math.min(target.atMs, latestTimeMs));
+  const targetSeq = target.atSeq;
+
+  // Find the nearest prior checkpoint
+  const checkpoint = [...checkpoints]
+    .reverse()
+    .find((entry) => entry.t < targetMs || (entry.t === targetMs && (targetSeq === undefined || entry.seq <= targetSeq)));
+
+  let frameCheckpoint: ReplayFrame['checkpoint'] = null;
+  let fromSeq = 0;
+
+  if (checkpoint) {
+    const record = readReplayCheckpoint(replayId, checkpoint.checkpointId);
+    if (record) {
+      frameCheckpoint = {
+        checkpointId: checkpoint.checkpointId,
+        seq: checkpoint.seq,
+        t: checkpoint.t,
+        cols: checkpoint.terminal.cols,
+        rows: checkpoint.terminal.rows,
+        ansi: Buffer.from(record.ansi, 'utf-8').toString('base64'),
+      };
+      fromSeq = checkpoint.seq;
+    }
+  }
+
+  // Read only the events between the checkpoint and the target
+  const frameEvents = readReplayEventSlice(replayId, fromSeq, targetMs, targetSeq);
+
+  return {
+    replayId,
+    checkpoint: frameCheckpoint,
+    events: frameEvents,
+  };
 }
 
 // ============================================================================

--- a/src/lib/tmux-lite/replay/service.ts
+++ b/src/lib/tmux-lite/replay/service.ts
@@ -279,15 +279,12 @@ export function getReplayFrameOffline(
   }
 
   const checkpoints = listReplayCheckpoints(replayId);
-  // Use manifest durationMs + checkpoint times to determine latest time
-  // without reading the full events file
-  const latestCheckpointTime = checkpoints.length > 0
-    ? checkpoints[checkpoints.length - 1]?.t ?? 0
-    : 0;
-  const latestTimeMs = Math.max(manifest.stats.durationMs, latestCheckpointTime);
+  // When no target is specified, use a very large time so readReplayEventSlice
+  // includes all events. We avoid reading the full events file just to compute
+  // the exact latest time — the event slice reader will stop at EOF naturally.
   const targetMs = target.atMs === undefined
-    ? latestTimeMs
-    : Math.max(0, Math.min(target.atMs, latestTimeMs));
+    ? Number.MAX_SAFE_INTEGER
+    : Math.max(0, target.atMs);
   const targetSeq = target.atSeq;
 
   // Find the nearest prior checkpoint

--- a/src/lib/tmux-lite/replay/store.ts
+++ b/src/lib/tmux-lite/replay/store.ts
@@ -406,8 +406,8 @@ export function readReplayEvents(replayId: string): ReplayEvent[] {
 
 /**
  * Read a slice of replay events that affect terminal rendering (output + resize only).
- * Skips events with seq <= fromSeq and stops at the target boundary.
- * Returns early without reading the rest of the file.
+ * Skips events with seq <= fromSeq and stops iterating at the target boundary.
+ * Note: the full events file is read into memory; the early exit only applies to parsing.
  */
 export function readReplayEventSlice(
   replayId: string,

--- a/src/lib/tmux-lite/replay/store.ts
+++ b/src/lib/tmux-lite/replay/store.ts
@@ -404,6 +404,67 @@ export function readReplayEvents(replayId: string): ReplayEvent[] {
   return events;
 }
 
+/**
+ * Read a slice of replay events that affect terminal rendering (output + resize only).
+ * Skips events with seq <= fromSeq and stops at the target boundary.
+ * Returns early without reading the rest of the file.
+ */
+export function readReplayEventSlice(
+  replayId: string,
+  fromSeq: number,
+  targetMs?: number,
+  targetSeq?: number,
+): import('./types.js').ReplayFrameEvent[] {
+  assertValidReplayId(replayId);
+  const raw = readTextFile(getReplayEventsPath(replayId));
+  if (!raw) {
+    return [];
+  }
+
+  const result: import('./types.js').ReplayFrameEvent[] = [];
+  for (const line of raw.split('\n')) {
+    if (line.trim().length === 0) {
+      continue;
+    }
+
+    let value: Record<string, unknown>;
+    try {
+      value = JSON.parse(line);
+    } catch {
+      continue;
+    }
+
+    const seq = value.seq as number;
+    const t = value.t as number;
+    if (typeof seq !== 'number' || typeof t !== 'number') {
+      continue;
+    }
+
+    // Skip events at or before the checkpoint
+    if (seq <= fromSeq) {
+      continue;
+    }
+
+    // Stop at target boundary
+    if (targetMs !== undefined && t > targetMs) {
+      break;
+    }
+    if (targetMs !== undefined && targetSeq !== undefined && t === targetMs && seq > targetSeq) {
+      break;
+    }
+
+    const type = value.type as string;
+    if (type === 'output' && typeof value.data === 'string') {
+      result.push({ seq, t, type: 'output', data: value.data });
+    } else if (type === 'resize' && typeof value.cols === 'number' && typeof value.rows === 'number') {
+      result.push({ seq, t, type: 'resize', cols: value.cols, rows: value.rows });
+    }
+    // Skip input, marker, title, process-title, exit — they don't affect terminal rendering
+  }
+
+  return result;
+}
+
 function getReplayCheckpointAnsiGzPath(replayId: string, checkpointId: string): string {
   return getReplayCheckpointAnsiPath(replayId, checkpointId) + '.gz';
 }

--- a/src/lib/tmux-lite/replay/types.ts
+++ b/src/lib/tmux-lite/replay/types.ts
@@ -173,6 +173,30 @@ export interface ReplayTimeline {
   checkpointSteps: ReplayTimelineStep[];
 }
 
+export interface ReplayFrameEvent {
+  seq: number;
+  t: number;
+  type: 'output' | 'resize';
+  data?: string;   // base64 for output
+  cols?: number;
+  rows?: number;
+}
+
+export interface ReplayFrameCheckpoint {
+  checkpointId: string;
+  seq: number;
+  t: number;
+  cols: number;
+  rows: number;
+  ansi: string;  // base64-encoded checkpoint ANSI (xterm serialization)
+}
+
+export interface ReplayFrame {
+  replayId: string;
+  checkpoint: ReplayFrameCheckpoint | null;
+  events: ReplayFrameEvent[];
+}
+
 export interface TerminalSnapshot {
   version: typeof REPLAY_FORMAT_VERSION;
   replayId: string;

--- a/src/lib/tmux-lite/server.ts
+++ b/src/lib/tmux-lite/server.ts
@@ -66,6 +66,7 @@ const SERVER_START_TIME = Date.now();
 const RECORD_REPLAY_INPUT = process.env.TMUX_LITE_REPLAY_RECORD_INPUT === "1";
 const REPLAY_CHECKPOINT_MIN_INTERVAL_MS = 2000;
 const REPLAY_CHECKPOINT_BYTE_INTERVAL = 128 * 1024;
+const REPLAY_CHECKPOINT_OUTPUT_EVENT_INTERVAL = 256;
 
 // Load notification config (with fallback to defaults)
 let notificationConfig: NotificationConfig;
@@ -122,6 +123,7 @@ interface ReplayRuntime {
   checkpointCount: number;
   lastCheckpointAt: number;
   bytesSinceCheckpoint: number;
+  outputEventsSinceCheckpoint: number;
 }
 
 interface SessionData {
@@ -551,6 +553,7 @@ function createReplayRuntime(
       checkpointCount: 0,
       lastCheckpointAt: startedAt,
       bytesSinceCheckpoint: 0,
+      outputEventsSinceCheckpoint: 0,
     };
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
@@ -687,6 +690,7 @@ function writeReplayCheckpointNow(session: SessionData): void {
     replay.checkpointCount++;
     replay.lastCheckpointAt = Date.now();
     replay.bytesSinceCheckpoint = 0;
+    replay.outputEventsSinceCheckpoint = 0;
     syncReplayManifest(session);
   } catch (error) {
     disableReplay(session, error);
@@ -701,7 +705,10 @@ function scheduleReplayCheckpoint(session: SessionData, force = false): void {
 
   const now = Date.now();
   if (!force) {
-    if (replay.bytesSinceCheckpoint < REPLAY_CHECKPOINT_BYTE_INTERVAL) {
+    if (
+      replay.bytesSinceCheckpoint < REPLAY_CHECKPOINT_BYTE_INTERVAL
+      && replay.outputEventsSinceCheckpoint < REPLAY_CHECKPOINT_OUTPUT_EVENT_INTERVAL
+    ) {
       return;
     }
     if (now - replay.lastCheckpointAt < REPLAY_CHECKPOINT_MIN_INTERVAL_MS) {
@@ -996,11 +1003,16 @@ function createPtyDataHandler(
     const session = sessions.get(id);
     if (!session) return;
 
-    recordReplayEvent(session, {
-      type: "output",
-      encoding: "base64",
-      data: data.toString("base64"),
-    });
+    if (data.length > 0) {
+      recordReplayEvent(session, {
+        type: "output",
+        encoding: "base64",
+        data: data.toString("base64"),
+      });
+      if (session.replay) {
+        session.replay.outputEventsSinceCheckpoint += 1;
+      }
+    }
     if (session.replay) {
       session.replay.bytesSinceCheckpoint += data.length;
       scheduleReplayCheckpoint(session);

--- a/src/relay/control/store.ts
+++ b/src/relay/control/store.ts
@@ -283,7 +283,12 @@ export function bindControlRelayIdentity(
 
     if (!sameIdentityId || !sameSigningKey || !sameFingerprint) {
       throw new SpacesError(
-        `Control relay identity mismatch. Pinned relay '${currentRelayFingerprint ?? currentRelayIdentityId}', current relay '${input.relayFingerprint}'.`,
+        [
+          `Control relay identity mismatch. Pinned relay '${currentRelayFingerprint ?? currentRelayIdentityId}', current relay '${input.relayFingerprint}'.`,
+          '',
+          'This relay pin is stored in ~/gitspace/.relay/control/control.db, not the trusted relay list.',
+          'If this relay change is expected, re-run `gssh machine serve start --takeover` to clear persisted control state and re-bind to the current relay.',
+        ].join('\n'),
         'USER_ERROR',
         1
       );

--- a/src/session/__tests__/local-session-backend.test.ts
+++ b/src/session/__tests__/local-session-backend.test.ts
@@ -1234,18 +1234,24 @@ describe('LocalSessionBackend', () => {
     });
   });
 
-  it('returns replay ansi and delegates dismiss / undismiss', async () => {
+  it('returns replay frame and delegates dismiss / undismiss', async () => {
     const dismissCalls: string[] = [];
     const undismissCalls: string[] = [];
+    const mockFrame = {
+      replayId: 'replay-1',
+      checkpoint: null,
+      events: [{ seq: 1, t: 10, type: 'output' as const, data: 'dGVzdA==' }],
+    };
     const deps: Partial<LocalSessionBackendDependencies> = {
-      getReplayAnsi: async () => Buffer.from([0x1b, 0x5b, 0x33, 0x31, 0x6d]),
+      getReplayFrame: () => mockFrame,
       dismissReplay: (replayId) => { dismissCalls.push(replayId); },
       undismissReplay: (replayId) => { undismissCalls.push(replayId); },
     };
 
     const backend = new LocalSessionBackend({ deps });
-    const ansi = await backend.getReplayAnsi('replay-1');
-    expect(Array.from(ansi)).toEqual([0x1b, 0x5b, 0x33, 0x31, 0x6d]);
+    const frame = await backend.getReplayFrame('replay-1');
+    expect(frame.replayId).toBe('replay-1');
+    expect(frame.events).toHaveLength(1);
 
     await backend.dismissReplay('replay-1');
     await backend.undismissReplay('replay-1');

--- a/src/session/__tests__/remote-session-backend.test.ts
+++ b/src/session/__tests__/remote-session-backend.test.ts
@@ -429,16 +429,20 @@ describe('RemoteSessionBackend', () => {
     };
     const framePromise = backend.getReplayFrame('replay-1', { atMs: 50, atSeq: 2 });
     await Bun.sleep(0);
-    expect(decodeRelayDataCommand(cryptoAdapter, socket.sent[socket.sent.length - 1])).toEqual({
+    const sentCommand = decodeRelayDataCommand(cryptoAdapter, socket.sent[socket.sent.length - 1]) as Record<string, unknown>;
+    expect(sentCommand).toEqual({
       type: 'get_replay_frame',
       replayId: 'replay-1',
+      requestId: expect.any(String),
       atMs: 50,
       atSeq: 2,
     });
+    const requestId = sentCommand.requestId as string;
     socket.handlers?.onMessage(
       makeRelayDataPayload(cryptoAdapter, {
         type: 'replay_frame',
         replayId: 'replay-1',
+        requestId,
         frame: mockFrame,
       })
     );

--- a/src/session/__tests__/remote-session-backend.test.ts
+++ b/src/session/__tests__/remote-session-backend.test.ts
@@ -422,23 +422,27 @@ describe('RemoteSessionBackend', () => {
 
     await connectAndHandshake(backend, socket);
 
-    const ansiPromise = backend.getReplayAnsi('replay-1', { atMs: 50, atSeq: 2 });
+    const mockFrame = {
+      replayId: 'replay-1',
+      checkpoint: null,
+      events: [{ seq: 2, t: 50, type: 'output' as const, data: 'dGVzdA==' }],
+    };
+    const framePromise = backend.getReplayFrame('replay-1', { atMs: 50, atSeq: 2 });
     await Bun.sleep(0);
     expect(decodeRelayDataCommand(cryptoAdapter, socket.sent[socket.sent.length - 1])).toEqual({
-      type: 'get_replay_ansi',
+      type: 'get_replay_frame',
       replayId: 'replay-1',
       atMs: 50,
       atSeq: 2,
     });
     socket.handlers?.onMessage(
       makeRelayDataPayload(cryptoAdapter, {
-        type: 'replay_ansi',
+        type: 'replay_frame',
         replayId: 'replay-1',
-        data: cryptoAdapter.encodeBase64(new Uint8Array([1, 2, 3])),
-        encoding: 'base64',
+        frame: mockFrame,
       })
     );
-    await expect(ansiPromise).resolves.toEqual(new Uint8Array([1, 2, 3]));
+    await expect(framePromise).resolves.toEqual(mockFrame);
 
     const dismissPromise = backend.dismissReplay('replay-1');
     await Bun.sleep(0);

--- a/src/session/__tests__/useRemoteSessionClient.test.ts
+++ b/src/session/__tests__/useRemoteSessionClient.test.ts
@@ -231,9 +231,13 @@ class FakeRemoteBackend implements RemoteSessionPtyBackend {
     throw new Error('not implemented')
   }
 
-  async getReplayAnsi(replayId: string, target?: ReplayFrameTarget): Promise<Uint8Array> {
+  async getReplayFrame(replayId: string, target?: ReplayFrameTarget): Promise<import('../backend.js').ReplayFrame> {
     this.replayAnsiCalls.push({ replayId, target })
-    return new Uint8Array([1, 2, 3])
+    return {
+      replayId,
+      checkpoint: null,
+      events: [{ seq: 1, t: 10, type: 'output' as const, data: 'dGVzdA==' }],
+    }
   }
 
   async getReplayTimeline(replayId: string): Promise<ReplayTimeline> {
@@ -519,7 +523,7 @@ describe('useRemoteSessionClient', () => {
           holdWhenIdleMs: 12000,
         },
       })
-      await result.current.getReplayAnsi('replay-1', { atMs: 50 })
+      await result.current.getReplayFrame('replay-1', { atMs: 50 })
       await result.current.getReplayTimeline('replay-1')
       await result.current.dismissReplay('replay-1')
       await result.current.undismissReplay('replay-1')

--- a/src/session/backend.ts
+++ b/src/session/backend.ts
@@ -135,7 +135,6 @@ export interface SessionBackend {
   attachSession(params: AttachSessionParams): Promise<void>;
   detachSession(): Promise<void>;
   cancelPendingScripts?(): Promise<void>;
-  cancelPendingReplayRequests?(): void;
 
   killSession(sessionId: string): Promise<void>;
   deleteWorkspace(

--- a/src/session/backend.ts
+++ b/src/session/backend.ts
@@ -1,6 +1,7 @@
 import type { NotificationConfig } from '../notifications/types.js';
 import type { BackendEvent } from './events.js';
 import type {
+  ReplayFrame,
   ReplayFrameTarget,
   ReplayInfo,
   ReplayTimeline,
@@ -134,6 +135,7 @@ export interface SessionBackend {
   attachSession(params: AttachSessionParams): Promise<void>;
   detachSession(): Promise<void>;
   cancelPendingScripts?(): Promise<void>;
+  cancelPendingReplayRequests?(): void;
 
   killSession(sessionId: string): Promise<void>;
   deleteWorkspace(
@@ -185,8 +187,9 @@ export interface SessionBackend {
     includeScrollback?: boolean,
     trimTrailingBlankRows?: boolean,
   ): Promise<string>;
-  getReplayAnsi?(replayId: string, target?: ReplayFrameTarget): Promise<Uint8Array>;
+  getReplayFrame?(replayId: string, target?: ReplayFrameTarget): Promise<ReplayFrame>;
   getReplayTimeline?(replayId: string): Promise<ReplayTimeline>;
+  cancelPendingReplayRequests?(): void;
   dismissReplay?(replayId: string): Promise<void>;
   undismissReplay?(replayId: string): Promise<void>;
 
@@ -222,4 +225,4 @@ export interface OpenCodeBridgeBackend {
   ): Promise<() => Promise<void>>;
 }
 
-export type { ReplayFrameTarget, ReplayInfo, ReplayTimeline, TerminalSnapshot };
+export type { ReplayFrame, ReplayFrameTarget, ReplayInfo, ReplayTimeline, TerminalSnapshot };

--- a/src/session/backends/local-session-backend.ts
+++ b/src/session/backends/local-session-backend.ts
@@ -21,7 +21,7 @@ import {
   listReplaysOffline,
   getReplaySnapshotOffline,
   getReplayTextOffline,
-  getReplayAnsiBufferOffline,
+  getReplayFrameOffline,
   getReplayTimelineOffline,
   dismissReplayOffline,
   undismissReplayOffline,
@@ -138,7 +138,7 @@ export interface LocalSessionBackendDependencies {
   getReplaySnapshot: typeof getReplaySnapshotOffline;
   getReplayText: typeof getReplayTextOffline;
   getReplayMarkdown: typeof getReplayMarkdown;
-  getReplayAnsi: typeof getReplayAnsiBufferOffline;
+  getReplayFrame: typeof getReplayFrameOffline;
   getReplayTimeline: typeof getReplayTimelineOffline;
   dismissReplay: typeof dismissReplayOffline;
   undismissReplay: typeof undismissReplayOffline;
@@ -400,7 +400,7 @@ function buildDeps(
     getReplaySnapshot: getReplaySnapshotOffline,
     getReplayText: getReplayTextOffline,
     getReplayMarkdown,
-    getReplayAnsi: getReplayAnsiBufferOffline,
+    getReplayFrame: getReplayFrameOffline,
     getReplayTimeline: getReplayTimelineOffline,
     dismissReplay: dismissReplayOffline,
     undismissReplay: undismissReplayOffline,
@@ -626,8 +626,8 @@ export class LocalSessionBackend implements SessionBackend, OpenCodeBridgeBacken
     });
   }
 
-  async getReplayAnsi(replayId: string, target?: import('../backend.js').ReplayFrameTarget): Promise<Uint8Array> {
-    return this.deps.getReplayAnsi(replayId, target);
+  async getReplayFrame(replayId: string, target?: import('../backend.js').ReplayFrameTarget): Promise<import('../backend.js').ReplayFrame> {
+    return this.deps.getReplayFrame(replayId, target);
   }
 
   async getReplayTimeline(replayId: string): Promise<import('../backend.js').ReplayTimeline> {

--- a/src/session/backends/remote-session-backend.ts
+++ b/src/session/backends/remote-session-backend.ts
@@ -160,6 +160,14 @@ interface PendingEventsChunk {
   receivedAtMs: number;
 }
 
+interface PendingReplayFrameChunk {
+  replayId: string;
+  totalChunks: number;
+  checkpoint: import('../backend.js').ReplayFrame['checkpoint'] | null;
+  chunks: Map<number, import('../backend.js').ReplayFrame['events']>;
+  receivedAtMs: number;
+}
+
 export interface RemoteSessionSocketHandlers {
   onOpen: () => void;
   onClose: (info?: { code?: number; reason?: string }) => void;
@@ -550,6 +558,7 @@ export class RemoteSessionBackend<TSocket, THandshakeState, TServerHello, TServe
   private pendingPtyChunks: Uint8Array[] = [];
   private pendingUtf8Bytes = new Uint8Array(0);
   private pendingEventChunks = new Map<string, PendingEventsChunk>();
+  private pendingReplayFrameChunks = new Map<string, PendingReplayFrameChunk>();
   private pendingOpenCodeRequests = new Map<string, {
     resolve: (response: OpenCodeBridgeResponse) => void;
     reject: (error: Error) => void;
@@ -2516,6 +2525,51 @@ export class RemoteSessionBackend<TSocket, THandshakeState, TServerHello, TServe
   }
 
   private resolveReplayFrame(message: ReplayFrameResponse): void {
+    const totalChunks = message.totalChunks ?? 1;
+    const chunkIndex = message.chunkIndex ?? 0;
+    if (totalChunks > 1) {
+      this.prunePendingReplayFrameChunks();
+      const pendingChunk = this.pendingReplayFrameChunks.get(message.requestId) ?? {
+        replayId: message.replayId,
+        totalChunks,
+        checkpoint: null,
+        chunks: new Map<number, import('../backend.js').ReplayFrame['events']>(),
+        receivedAtMs: Date.now(),
+      };
+      pendingChunk.replayId = message.replayId;
+      pendingChunk.totalChunks = totalChunks;
+      pendingChunk.receivedAtMs = Date.now();
+      if (message.frame.checkpoint) {
+        pendingChunk.checkpoint = message.frame.checkpoint;
+      }
+      pendingChunk.chunks.set(chunkIndex, message.frame.events);
+      this.pendingReplayFrameChunks.set(message.requestId, pendingChunk);
+
+      if (pendingChunk.chunks.size < pendingChunk.totalChunks) {
+        return;
+      }
+
+      const mergedEvents: import('../backend.js').ReplayFrame['events'] = [];
+      for (let idx = 0; idx < pendingChunk.totalChunks; idx += 1) {
+        const chunk = pendingChunk.chunks.get(idx);
+        if (!chunk) {
+          return;
+        }
+        mergedEvents.push(...chunk);
+      }
+      this.pendingReplayFrameChunks.delete(message.requestId);
+      message = {
+        ...message,
+        totalChunks: 1,
+        chunkIndex: 0,
+        frame: {
+          replayId: message.replayId,
+          checkpoint: pendingChunk.checkpoint,
+          events: mergedEvents,
+        },
+      };
+    }
+
     const pending = this.pendingReplayFrame;
     if (!pending || pending.requestId !== message.requestId) {
       // Stale response for a cancelled or superseded request — discard
@@ -2621,6 +2675,15 @@ export class RemoteSessionBackend<TSocket, THandshakeState, TServerHello, TServe
     for (const [requestId, pending] of this.pendingEventChunks) {
       if (nowMs - pending.receivedAtMs > ttlMs) {
         this.pendingEventChunks.delete(requestId);
+      }
+    }
+  }
+
+  private prunePendingReplayFrameChunks(nowMs = Date.now()): void {
+    const ttlMs = 30_000;
+    for (const [requestId, pending] of this.pendingReplayFrameChunks) {
+      if (nowMs - pending.receivedAtMs > ttlMs) {
+        this.pendingReplayFrameChunks.delete(requestId);
       }
     }
   }

--- a/src/session/backends/remote-session-backend.ts
+++ b/src/session/backends/remote-session-backend.ts
@@ -2999,6 +2999,7 @@ export class RemoteSessionBackend<TSocket, THandshakeState, TServerHello, TServe
     this.pendingPtyChunks = [];
     this.pendingUtf8Bytes = new Uint8Array(0);
     this.pendingEventChunks.clear();
+    this.pendingReplayFrameChunks.clear();
     this.rejectPendingBundleRefreshRequests('Remote session disconnected');
     this.rejectPendingGithubRepoList('Remote session disconnected');
     this.rejectPendingRemoteBranches('Remote session disconnected', undefined, true);

--- a/src/session/backends/remote-session-backend.ts
+++ b/src/session/backends/remote-session-backend.ts
@@ -2093,7 +2093,7 @@ export class RemoteSessionBackend<TSocket, THandshakeState, TServerHello, TServe
         this.rejectPendingCancelProject(message.message, message.projectName);
         this.rejectPendingWorkspaceCreate(message.message, message.workspaceId, message.projectName);
         this.rejectPendingProjectDelete(message.message, message.projectName);
-        this.rejectPendingReplayFrame(message.message, undefined, true);
+        this.rejectPendingReplayFrame(message.message, { requestId: message.requestId, force: !message.requestId });
         this.rejectPendingReplayTimeline(message.message, undefined, true);
         this.rejectPendingDismissReplay(message.message, undefined, true);
         this.rejectPendingUndismissReplay(message.message, undefined, true);
@@ -2536,13 +2536,21 @@ export class RemoteSessionBackend<TSocket, THandshakeState, TServerHello, TServe
     pending.resolve(message.timeline);
   }
 
-  private rejectPendingReplayFrame(message: string, replayId?: string, force = false): void {
+  private rejectPendingReplayFrame(message: string, options?: { replayId?: string; requestId?: string; force?: boolean }): void {
     const pending = this.pendingReplayFrame;
     if (!pending) {
       return;
     }
-    if (!force && replayId && pending.replayId !== replayId) {
-      return;
+    const force = options?.force ?? false;
+    if (!force) {
+      // If requestId is provided, match on that (most precise)
+      if (options?.requestId && pending.requestId !== options.requestId) {
+        return;
+      }
+      // Otherwise fall back to replayId match
+      if (!options?.requestId && options?.replayId && pending.replayId !== options.replayId) {
+        return;
+      }
     }
     clearTimeout(pending.timeout);
     this.pendingReplayFrame = null;
@@ -2937,7 +2945,7 @@ export class RemoteSessionBackend<TSocket, THandshakeState, TServerHello, TServe
     this.rejectPendingCancelProject('Remote session disconnected', undefined, true);
     this.rejectPendingWorkspaceCreate('Remote session disconnected', undefined, undefined, true);
     this.rejectPendingProjectDelete('Remote session disconnected', undefined, true);
-    this.rejectPendingReplayFrame('Remote session disconnected', undefined, true);
+    this.rejectPendingReplayFrame('Remote session disconnected', { force: true });
     this.rejectPendingReplayTimeline('Remote session disconnected', undefined, true);
     this.rejectPendingDismissReplay('Remote session disconnected', undefined, true);
     this.rejectPendingUndismissReplay('Remote session disconnected', undefined, true);

--- a/src/session/backends/remote-session-backend.ts
+++ b/src/session/backends/remote-session-backend.ts
@@ -775,11 +775,7 @@ export class RemoteSessionBackend<TSocket, THandshakeState, TServerHello, TServe
   }
 
   cancelPendingReplayRequests(): void {
-    if (this.pendingReplayFrame) {
-      clearTimeout(this.pendingReplayFrame.timeout);
-      this.pendingReplayFrame.reject(new Error('Replay frame request cancelled'));
-      this.pendingReplayFrame = null;
-    }
+    this.cancelPendingReplayFrame();
     if (this.pendingReplayTimeline) {
       clearTimeout(this.pendingReplayTimeline.timeout);
       this.pendingReplayTimeline.reject(new Error('Replay timeline request cancelled'));

--- a/src/session/backends/remote-session-backend.ts
+++ b/src/session/backends/remote-session-backend.ts
@@ -512,9 +512,11 @@ export class RemoteSessionBackend<TSocket, THandshakeState, TServerHello, TServe
     reject: (error: Error) => void;
     timeout: ReturnType<typeof setTimeout>;
   }>();
+  private replayFrameRequestSeq = 0;
   private pendingReplayFrame:
     | {
         replayId: string;
+        requestId: string;
         resolve: (frame: import('../backend.js').ReplayFrame) => void;
         reject: (error: Error) => void;
         timeout: ReturnType<typeof setTimeout>;
@@ -799,23 +801,25 @@ export class RemoteSessionBackend<TSocket, THandshakeState, TServerHello, TServe
       this.cancelPendingReplayFrame();
     }
 
+    const requestId = `rf-${++this.replayFrameRequestSeq}-${Date.now().toString(36)}`;
     const command: GetReplayFrameRequest = {
       type: 'get_replay_frame',
       replayId,
+      requestId,
       atMs: target?.atMs,
       atSeq: target?.atSeq,
     };
     return new Promise<import('../backend.js').ReplayFrame>((resolve, reject) => {
       const timeout = setTimeout(() => {
         const pending = this.pendingReplayFrame;
-        if (!pending || pending.replayId !== replayId) {
+        if (!pending || pending.requestId !== requestId) {
           return;
         }
         this.pendingReplayFrame = null;
         pending.reject(new Error(`Timed out waiting for replay frame (${replayId})`));
       }, DEFAULT_LIFECYCLE_TIMEOUT_MS);
 
-      const pendingEntry = { replayId, resolve, reject, timeout };
+      const pendingEntry = { replayId, requestId, resolve, reject, timeout };
       this.pendingReplayFrame = pendingEntry;
 
       void this.sendCommand(command).catch((error) => {
@@ -2517,7 +2521,8 @@ export class RemoteSessionBackend<TSocket, THandshakeState, TServerHello, TServe
 
   private resolveReplayFrame(message: ReplayFrameResponse): void {
     const pending = this.pendingReplayFrame;
-    if (!pending || pending.replayId !== message.replayId) {
+    if (!pending || pending.requestId !== message.requestId) {
+      // Stale response for a cancelled or superseded request — discard
       return;
     }
     clearTimeout(pending.timeout);

--- a/src/session/backends/remote-session-backend.ts
+++ b/src/session/backends/remote-session-backend.ts
@@ -775,7 +775,7 @@ export class RemoteSessionBackend<TSocket, THandshakeState, TServerHello, TServe
   cancelPendingReplayRequests(): void {
     if (this.pendingReplayFrame) {
       clearTimeout(this.pendingReplayFrame.timeout);
-      this.pendingReplayFrame.reject(new Error('Replay ANSI request cancelled'));
+      this.pendingReplayFrame.reject(new Error('Replay frame request cancelled'));
       this.pendingReplayFrame = null;
     }
     if (this.pendingReplayTimeline) {
@@ -785,10 +785,18 @@ export class RemoteSessionBackend<TSocket, THandshakeState, TServerHello, TServe
     }
   }
 
+  private cancelPendingReplayFrame(): void {
+    if (this.pendingReplayFrame) {
+      clearTimeout(this.pendingReplayFrame.timeout);
+      this.pendingReplayFrame.reject(new Error('Replay frame request cancelled'));
+      this.pendingReplayFrame = null;
+    }
+  }
+
   async getReplayFrame(replayId: string, target?: ReplayFrameTarget): Promise<import('../backend.js').ReplayFrame> {
     if (this.pendingReplayFrame) {
-      // Cancel stale in-flight request so we can start a fresh one
-      this.cancelPendingReplayRequests();
+      // Cancel only the stale frame request, not timeline
+      this.cancelPendingReplayFrame();
     }
 
     const command: GetReplayFrameRequest = {
@@ -807,16 +815,17 @@ export class RemoteSessionBackend<TSocket, THandshakeState, TServerHello, TServe
         pending.reject(new Error(`Timed out waiting for replay frame (${replayId})`));
       }, DEFAULT_LIFECYCLE_TIMEOUT_MS);
 
-      this.pendingReplayFrame = { replayId, resolve, reject, timeout };
+      const pendingEntry = { replayId, resolve, reject, timeout };
+      this.pendingReplayFrame = pendingEntry;
 
       void this.sendCommand(command).catch((error) => {
-        const pending = this.pendingReplayFrame;
-        if (!pending) {
+        // Guard against stale send failures cancelling a newer request
+        if (this.pendingReplayFrame !== pendingEntry) {
           return;
         }
-        clearTimeout(pending.timeout);
+        clearTimeout(pendingEntry.timeout);
         this.pendingReplayFrame = null;
-        pending.reject(error instanceof Error ? error : new Error(String(error)));
+        pendingEntry.reject(error instanceof Error ? error : new Error(String(error)));
       });
     });
   }

--- a/src/session/backends/remote-session-backend.ts
+++ b/src/session/backends/remote-session-backend.ts
@@ -45,7 +45,7 @@ import {
   type ProjectDeletedResponse,
   type RemoteBranchListResponse,
   type ScriptOutputResponse,
-  type ReplayAnsiResponse,
+  type ReplayFrameResponse,
   type ReplayTimelineResponse,
   type ReplayDismissedResponse,
   type ReplayUndismissedResponse,
@@ -62,7 +62,7 @@ import {
   type OpenCodeStreamErrorResponse,
   type UpdateNotificationConfigRequest,
   type WorkspaceCreatedResponse,
-  type GetReplayAnsiRequest,
+  type GetReplayFrameRequest,
   type DismissReplayRequest,
   type UndismissReplayRequest,
 } from '../../lib/remote-session/protocol.js';
@@ -232,7 +232,7 @@ const MACHINE_TO_CLIENT_TYPES = new Set<string>([
   'workspace_list',
   'session_list',
   'replay_list',
-  'replay_ansi',
+  'replay_frame',
   'replay_timeline',
   'replay_dismissed',
   'replay_undismissed',
@@ -512,10 +512,10 @@ export class RemoteSessionBackend<TSocket, THandshakeState, TServerHello, TServe
     reject: (error: Error) => void;
     timeout: ReturnType<typeof setTimeout>;
   }>();
-  private pendingReplayAnsi:
+  private pendingReplayFrame:
     | {
         replayId: string;
-        resolve: (data: Uint8Array) => void;
+        resolve: (frame: import('../backend.js').ReplayFrame) => void;
         reject: (error: Error) => void;
         timeout: ReturnType<typeof setTimeout>;
       }
@@ -772,36 +772,50 @@ export class RemoteSessionBackend<TSocket, THandshakeState, TServerHello, TServe
     await this.sendCommand(command);
   }
 
-  async getReplayAnsi(replayId: string, target?: ReplayFrameTarget): Promise<Uint8Array> {
-    if (this.pendingReplayAnsi) {
-      throw new Error('Replay ANSI request already in progress');
+  cancelPendingReplayRequests(): void {
+    if (this.pendingReplayFrame) {
+      clearTimeout(this.pendingReplayFrame.timeout);
+      this.pendingReplayFrame.reject(new Error('Replay ANSI request cancelled'));
+      this.pendingReplayFrame = null;
+    }
+    if (this.pendingReplayTimeline) {
+      clearTimeout(this.pendingReplayTimeline.timeout);
+      this.pendingReplayTimeline.reject(new Error('Replay timeline request cancelled'));
+      this.pendingReplayTimeline = null;
+    }
+  }
+
+  async getReplayFrame(replayId: string, target?: ReplayFrameTarget): Promise<import('../backend.js').ReplayFrame> {
+    if (this.pendingReplayFrame) {
+      // Cancel stale in-flight request so we can start a fresh one
+      this.cancelPendingReplayRequests();
     }
 
-    const command: GetReplayAnsiRequest = {
-      type: 'get_replay_ansi',
+    const command: GetReplayFrameRequest = {
+      type: 'get_replay_frame',
       replayId,
       atMs: target?.atMs,
       atSeq: target?.atSeq,
     };
-    return new Promise<Uint8Array>((resolve, reject) => {
+    return new Promise<import('../backend.js').ReplayFrame>((resolve, reject) => {
       const timeout = setTimeout(() => {
-        const pending = this.pendingReplayAnsi;
+        const pending = this.pendingReplayFrame;
         if (!pending || pending.replayId !== replayId) {
           return;
         }
-        this.pendingReplayAnsi = null;
-        pending.reject(new Error(`Timed out waiting for replay ANSI (${replayId})`));
+        this.pendingReplayFrame = null;
+        pending.reject(new Error(`Timed out waiting for replay frame (${replayId})`));
       }, DEFAULT_LIFECYCLE_TIMEOUT_MS);
 
-      this.pendingReplayAnsi = { replayId, resolve, reject, timeout };
+      this.pendingReplayFrame = { replayId, resolve, reject, timeout };
 
       void this.sendCommand(command).catch((error) => {
-        const pending = this.pendingReplayAnsi;
+        const pending = this.pendingReplayFrame;
         if (!pending) {
           return;
         }
         clearTimeout(pending.timeout);
-        this.pendingReplayAnsi = null;
+        this.pendingReplayFrame = null;
         pending.reject(error instanceof Error ? error : new Error(String(error)));
       });
     });
@@ -809,7 +823,11 @@ export class RemoteSessionBackend<TSocket, THandshakeState, TServerHello, TServe
 
   async getReplayTimeline(replayId: string): Promise<ReplayTimeline> {
     if (this.pendingReplayTimeline) {
-      throw new Error('Replay timeline request already in progress');
+      // Cancel stale in-flight request so we can start a fresh one
+      const pending = this.pendingReplayTimeline;
+      clearTimeout(pending.timeout);
+      pending.reject(new Error('Replay timeline request cancelled'));
+      this.pendingReplayTimeline = null;
     }
 
     const command: GetReplayTimelineRequest = { type: 'get_replay_timeline', replayId };
@@ -1928,8 +1946,8 @@ export class RemoteSessionBackend<TSocket, THandshakeState, TServerHello, TServe
       case 'replay_list':
         this.emit({ type: 'replays', replays: message.replays });
         return;
-      case 'replay_ansi':
-        this.resolveReplayAnsi(message);
+      case 'replay_frame':
+        this.resolveReplayFrame(message);
         return;
       case 'replay_timeline':
         this.resolveReplayTimeline(message);
@@ -2066,7 +2084,7 @@ export class RemoteSessionBackend<TSocket, THandshakeState, TServerHello, TServe
         this.rejectPendingCancelProject(message.message, message.projectName);
         this.rejectPendingWorkspaceCreate(message.message, message.workspaceId, message.projectName);
         this.rejectPendingProjectDelete(message.message, message.projectName);
-        this.rejectPendingReplayAnsi(message.message, undefined, true);
+        this.rejectPendingReplayFrame(message.message, undefined, true);
         this.rejectPendingReplayTimeline(message.message, undefined, true);
         this.rejectPendingDismissReplay(message.message, undefined, true);
         this.rejectPendingUndismissReplay(message.message, undefined, true);
@@ -2488,14 +2506,14 @@ export class RemoteSessionBackend<TSocket, THandshakeState, TServerHello, TServe
     pending.reject(new Error(message));
   }
 
-  private resolveReplayAnsi(message: ReplayAnsiResponse): void {
-    const pending = this.pendingReplayAnsi;
+  private resolveReplayFrame(message: ReplayFrameResponse): void {
+    const pending = this.pendingReplayFrame;
     if (!pending || pending.replayId !== message.replayId) {
       return;
     }
     clearTimeout(pending.timeout);
-    this.pendingReplayAnsi = null;
-    pending.resolve(this.crypto.decodeBase64(message.data));
+    this.pendingReplayFrame = null;
+    pending.resolve(message.frame);
   }
 
   private resolveReplayTimeline(message: ReplayTimelineResponse): void {
@@ -2508,8 +2526,8 @@ export class RemoteSessionBackend<TSocket, THandshakeState, TServerHello, TServe
     pending.resolve(message.timeline);
   }
 
-  private rejectPendingReplayAnsi(message: string, replayId?: string, force = false): void {
-    const pending = this.pendingReplayAnsi;
+  private rejectPendingReplayFrame(message: string, replayId?: string, force = false): void {
+    const pending = this.pendingReplayFrame;
     if (!pending) {
       return;
     }
@@ -2517,7 +2535,7 @@ export class RemoteSessionBackend<TSocket, THandshakeState, TServerHello, TServe
       return;
     }
     clearTimeout(pending.timeout);
-    this.pendingReplayAnsi = null;
+    this.pendingReplayFrame = null;
     pending.reject(new Error(message));
   }
 
@@ -2909,7 +2927,7 @@ export class RemoteSessionBackend<TSocket, THandshakeState, TServerHello, TServe
     this.rejectPendingCancelProject('Remote session disconnected', undefined, true);
     this.rejectPendingWorkspaceCreate('Remote session disconnected', undefined, undefined, true);
     this.rejectPendingProjectDelete('Remote session disconnected', undefined, true);
-    this.rejectPendingReplayAnsi('Remote session disconnected', undefined, true);
+    this.rejectPendingReplayFrame('Remote session disconnected', undefined, true);
     this.rejectPendingReplayTimeline('Remote session disconnected', undefined, true);
     this.rejectPendingDismissReplay('Remote session disconnected', undefined, true);
     this.rejectPendingUndismissReplay('Remote session disconnected', undefined, true);

--- a/src/session/useRemoteSessionClient.ts
+++ b/src/session/useRemoteSessionClient.ts
@@ -100,6 +100,7 @@ export interface UseRemoteSessionClientReturn<ConnectParams> {
   attachSession: (params: AttachSessionParams) => void;
   detachSession: () => void;
   cancelPendingScripts: () => void;
+  cancelPendingReplayRequests: () => void;
   selectProject: (projectName: string | null) => void;
 
   killSession: (sessionId: string) => void;
@@ -145,7 +146,7 @@ export interface UseRemoteSessionClientReturn<ConnectParams> {
   startProcess: (workspaceId: string, processName: string, instance?: number) => Promise<void>;
   stopProcess: (workspaceId: string, processName: string) => Promise<void>;
   requestEvents: (workspacePath: string, filter?: WideEventFilter, limit?: number, sinceMs?: number) => void;
-  getReplayAnsi: (replayId: string, target?: ReplayFrameTarget) => Promise<Uint8Array>;
+  getReplayFrame: (replayId: string, target?: ReplayFrameTarget) => Promise<import('../lib/tmux-lite/replay/types.js').ReplayFrame>;
   getReplayTimeline: (replayId: string) => Promise<ReplayTimeline>;
   dismissReplay: (replayId: string) => Promise<void>;
   undismissReplay: (replayId: string) => Promise<void>;
@@ -366,6 +367,10 @@ export function useRemoteSessionClient<ConnectParams>(
     void withActiveBackend((backendKey) => engine.cancelPendingScripts(backendKey));
   }, [engine, withActiveBackend]);
 
+  const cancelPendingReplayRequests = useCallback(() => {
+    void withActiveBackend(async (backendKey) => engine.cancelPendingReplayRequests(backendKey));
+  }, [engine, withActiveBackend]);
+
   const selectProject = useCallback(
     (projectName: string | null) => {
       setSelectedProjectName(projectName);
@@ -553,12 +558,12 @@ export function useRemoteSessionClient<ConnectParams>(
     );
   }, [engine, withActiveBackend]);
 
-  const getReplayAnsi = useCallback(async (replayId: string, target?: ReplayFrameTarget): Promise<Uint8Array> => {
+  const getReplayFrame = useCallback(async (replayId: string, target?: ReplayFrameTarget): Promise<import('../lib/tmux-lite/replay/types.js').ReplayFrame> => {
     const backendKey = activeBackendKeyRef.current;
     if (!backendKey) {
-      throw createMissingBackendError(`getReplayAnsi(${replayId})`);
+      throw createMissingBackendError(`getReplayFrame(${replayId})`);
     }
-    return engine.getReplayAnsi(backendKey, replayId, target);
+    return engine.getReplayFrame(backendKey, replayId, target);
   }, [engine]);
 
   const getReplayTimeline = useCallback(async (replayId: string): Promise<ReplayTimeline> => {
@@ -658,6 +663,7 @@ export function useRemoteSessionClient<ConnectParams>(
     attachSession,
     detachSession,
     cancelPendingScripts,
+    cancelPendingReplayRequests,
     selectProject,
 
     killSession,
@@ -691,7 +697,7 @@ export function useRemoteSessionClient<ConnectParams>(
     startProcess,
     stopProcess,
     requestEvents,
-    getReplayAnsi,
+    getReplayFrame,
     getReplayTimeline,
     dismissReplay,
     undismissReplay,
@@ -723,6 +729,7 @@ export function useRemoteSessionClient<ConnectParams>(
     attachSession,
     detachSession,
     cancelPendingScripts,
+    cancelPendingReplayRequests,
     selectProject,
     killSession,
     deleteWorkspace,
@@ -742,7 +749,7 @@ export function useRemoteSessionClient<ConnectParams>(
     startProcess,
     stopProcess,
     requestEvents,
-    getReplayAnsi,
+    getReplayFrame,
     getReplayTimeline,
     dismissReplay,
     undismissReplay,

--- a/src/session/useSessionEngine.ts
+++ b/src/session/useSessionEngine.ts
@@ -392,6 +392,8 @@ export function useSessionEngine() {
   const cancelPendingReplayRequests = useCallback((backendKey: BackendKey) => {
     void withBackend(backendKey, async (backend) => {
       backend.cancelPendingReplayRequests?.();
+    }).catch(() => {
+      // Best-effort cleanup; backend may already be disconnected.
     });
   }, [withBackend]);
 

--- a/src/session/useSessionEngine.ts
+++ b/src/session/useSessionEngine.ts
@@ -389,6 +389,12 @@ export function useSessionEngine() {
     });
   }, [withBackend]);
 
+  const cancelPendingReplayRequests = useCallback((backendKey: BackendKey) => {
+    void withBackend(backendKey, async (backend) => {
+      backend.cancelPendingReplayRequests?.();
+    });
+  }, [withBackend]);
+
   const killSession = useCallback(async (backendKey: BackendKey, sessionId: string) => {
     await withBackend(backendKey, (backend) => backend.killSession(sessionId));
   }, [withBackend]);
@@ -620,22 +626,22 @@ export function useSessionEngine() {
     return markdown;
   }, [withBackend]);
 
-  const getReplayAnsi = useCallback(async (
+  const getReplayFrame = useCallback(async (
     backendKey: BackendKey,
     replayId: string,
     target?: import('./backend.js').ReplayFrameTarget,
   ) => {
-    let ansi: Uint8Array | null = null;
+    let frame: import('./backend.js').ReplayFrame | null = null;
     await withBackend(backendKey, async (backend) => {
-      if (!backend.getReplayAnsi) {
-        throw new SpacesError('Replay ANSI rendering is not supported by this backend', 'SYSTEM_ERROR', 2);
+      if (!backend.getReplayFrame) {
+        throw new SpacesError('Replay frame is not supported by this backend', 'SYSTEM_ERROR', 2);
       }
-      ansi = await backend.getReplayAnsi(replayId, target);
+      frame = await backend.getReplayFrame(replayId, target);
     });
-    if (!ansi) {
-      throw new SpacesError('Replay ANSI was not returned by backend', 'SYSTEM_ERROR', 2);
+    if (!frame) {
+      throw new SpacesError('Replay frame was not returned by backend', 'SYSTEM_ERROR', 2);
     }
-    return ansi;
+    return frame;
   }, [withBackend]);
 
   const getReplayTimeline = useCallback(async (
@@ -702,6 +708,7 @@ export function useSessionEngine() {
     attachSession,
     detachSession,
     cancelPendingScripts,
+    cancelPendingReplayRequests,
     killSession,
     deleteWorkspace,
     getBundleRefreshPlan,
@@ -723,7 +730,7 @@ export function useSessionEngine() {
     getReplaySnapshot,
     getReplayText,
     getReplayMarkdown,
-    getReplayAnsi,
+    getReplayFrame,
     getReplayTimeline,
     dismissReplay,
     undismissReplay,
@@ -750,6 +757,7 @@ export function useSessionEngine() {
     attachSession,
     detachSession,
     cancelPendingScripts,
+    cancelPendingReplayRequests,
     killSession,
     deleteWorkspace,
     getBundleRefreshPlan,
@@ -769,7 +777,7 @@ export function useSessionEngine() {
     getReplaySnapshot,
     getReplayText,
     getReplayMarkdown,
-    getReplayAnsi,
+    getReplayFrame,
     getReplayTimeline,
     dismissReplay,
     undismissReplay,


### PR DESCRIPTION
## Summary

- Replaces server-side xterm reconstruction with client-side rendering: the machine sends raw checkpoint ANSI + event slices instead of reconstructing terminal state for every frame request
- Fixes "Replay ANSI request already in progress" errors by adding `cancelPendingReplayRequests` and auto-cancelling stale in-flight requests on the remote backend
- Forward stepping within the same checkpoint is now near-instant (just feeds new events to the terminal)

## Changes

- **New types**: `ReplayFrame`, `ReplayFrameEvent`, `ReplayFrameCheckpoint` for the checkpoint+events payload
- **New store function**: `readReplayEventSlice` reads only output/resize events between two seq boundaries with early exit
- **New service function**: `getReplayFrameOffline` reads checkpoint from disk + event slice (no xterm-headless)
- **Protocol rename**: `get_replay_ansi`/`replay_ansi` → `get_replay_frame`/`replay_frame`
- **Backend rename**: `getReplayAnsi` → `getReplayFrame` across backend interface, engine, session client
- **TUI terminal**: Uses ref+feed pattern (like SessionTerminal) for incremental event application
- **Web terminal**: Uses writer callback for incremental application
- **Client-side checkpoint caching**: Tracks current checkpoint ID; same-checkpoint steps skip re-writing checkpoint ANSI
- **Cancel fix**: `cancelPendingReplayRequests()` on remote backend, called on terminal unmount via `onCleanup` prop
- **frameLoading guard**: Prevents concurrent frame requests during rapid scrubbing

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk due to a cross-cutting protocol/API change from `getReplayAnsi` to `getReplayFrame` affecting TUI/web clients, remote-session protocol, and backend request/cancellation logic; bugs could surface as replay playback regressions or stuck requests.
> 
> **Overview**
> Reworks replay playback to **render client-side from structured `ReplayFrame` payloads** (checkpoint ANSI + output/resize event slices) instead of requesting pre-reconstructed ANSI buffers, updating the replay protocol (`get_replay_frame`/`replay_frame`) and all session backend APIs accordingly.
> 
> Adds incremental frame application and checkpoint-aware seeking/stepping in both TUI and web replay terminals, plus **request cancellation/cleanup hooks** (`cancelPendingReplayRequests`, `onCleanup`) to avoid stale/in-flight replay loads and “request already in progress” failures.
> 
> Improves replay data plumbing: introduces frame/event/checkpoint types, reads event slices from storage (`readReplayEventSlice`), serves offline frames (`getReplayFrameOffline`) with response chunking, and tightens checkpoint creation heuristics in the tmux-lite server to consider output-event counts.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 60cd6116f047e7ff336db61cb2d503bb2942e2e8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Replay terminal adds a cleanup/cancel hook to abort pending replay loads.

* **Updates**
  * Replays now stream structured frames (checkpoint + events) for incremental rendering, proper resize handling, and more consistent seek/playback.
  * Loader behavior standardized to always return Promises; public APIs expose cancel-for-replay capabilities.
  * New utilities apply frames and normalize terminal streaming.

* **Tests**
  * Tests updated to use frame-shaped fixtures and new helpers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->