### PR TITLE
fix: harden remote agent session sync and recovery

### DIFF
--- a/src/agents/__tests__/agent-session-actions.test.ts
+++ b/src/agents/__tests__/agent-session-actions.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it, mock } from 'bun:test';
+import { openAgentSession } from '../agent-session-actions';
+
+interface ConfirmOptions {
+  onConfirm: () => Promise<void> | void;
+  onCancel?: () => Promise<void> | void;
+  title: string;
+  message: string;
+}
+
+describe('openAgentSession', () => {
+  it('attaches immediately when takeover is not required', async () => {
+    const attachAgentSession = mock(async () => {});
+    const persistAgentSessionSelection = mock(() => {});
+    const clearViewOnly = mock(() => {});
+
+    await openAgentSession({
+      flow: { showConfirm: mock(() => {}) },
+      workspaceId: 'proj:ws-1',
+      agentSessionId: 'agent-1',
+      persistAgentSessionSelection,
+      clearViewOnly,
+      checkAgentSessionTakeover: mock(async () => ({ requiresTakeover: false })),
+      attachAgentSession,
+    });
+
+    expect(persistAgentSessionSelection).toHaveBeenCalledWith('proj:ws-1', 'agent-1');
+    expect(clearViewOnly).toHaveBeenCalledTimes(1);
+    expect(attachAgentSession).toHaveBeenCalledWith('proj:ws-1', 'agent-1', undefined);
+  });
+
+  it('prompts before taking over an attached agent terminal', async () => {
+    const attachAgentSession = mock(async () => {});
+    const persistAgentSessionSelection = mock(() => {});
+    const clearViewOnly = mock(() => {});
+    let confirmOptions: ConfirmOptions | null = null;
+
+    const pending = openAgentSession({
+      flow: {
+        showConfirm: mock((options) => {
+          confirmOptions = options as ConfirmOptions;
+        }),
+      },
+      workspaceId: 'proj:ws-1',
+      agentSessionId: 'agent-1',
+      persistAgentSessionSelection,
+      clearViewOnly,
+      checkAgentSessionTakeover: mock(async () => ({
+        requiresTakeover: true,
+        sessionName: 'agent:ws-1:1234abcd',
+      })),
+      attachAgentSession,
+    });
+
+    await Bun.sleep(0);
+
+    expect(confirmOptions).not.toBeNull();
+    expect(confirmOptions!.title).toBe('Take Over Agent Terminal?');
+    expect(confirmOptions!.message).toContain('agent:ws-1:1234abcd');
+    expect(attachAgentSession).not.toHaveBeenCalled();
+
+    await confirmOptions!.onConfirm();
+    await pending;
+
+    expect(persistAgentSessionSelection).toHaveBeenCalledWith('proj:ws-1', 'agent-1');
+    expect(clearViewOnly).toHaveBeenCalledTimes(1);
+    expect(attachAgentSession).toHaveBeenCalledWith('proj:ws-1', 'agent-1', { force: true });
+  });
+});

--- a/src/agents/__tests__/remote-agent-browser.test.ts
+++ b/src/agents/__tests__/remote-agent-browser.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'bun:test';
+import { collectAgentSessionCounts, collectWorkspaceSyncIds } from '../remote-agent-browser';
+
+describe('remote-agent-browser', () => {
+  it('counts snapshot-only sessions', () => {
+    expect(collectAgentSessionCounts({
+      sessionsByWorkspace: {},
+      workspaceStates: {},
+      snapshotByWorkspace: {
+        'proj:ws-1': {
+          sessions: [{ id: 'agent-1' }, { id: 'agent-2' }],
+        },
+      },
+    })).toEqual({
+      'proj:ws-1': 2,
+    });
+  });
+
+  it('collects sync workspace ids from all workspaces plus UI context', () => {
+    expect(collectWorkspaceSyncIds(
+      [{ id: 'proj:ws-1' }, { id: 'proj:ws-2' }],
+      ['proj:ws-3'],
+      'proj:ws-4',
+    )).toEqual([
+      'proj:ws-1',
+      'proj:ws-2',
+      'proj:ws-3',
+      'proj:ws-4',
+    ]);
+  });
+});

--- a/src/agents/__tests__/useWorkspaceAgentEvents.test.ts
+++ b/src/agents/__tests__/useWorkspaceAgentEvents.test.ts
@@ -1,0 +1,82 @@
+import { afterAll, beforeAll, describe, expect, it } from 'bun:test';
+import { act, renderHook } from '@testing-library/react';
+import { Window } from 'happy-dom';
+import { useWorkspaceAgentEvents } from '../useWorkspaceAgentEvents';
+import type { SessionBackend } from '../../session/backend';
+import type { AgentStateUpdateDelta } from '../../serve/agent-event-manager';
+
+const domWindow = new Window();
+const originalWindow = globalThis.window;
+const originalDocument = globalThis.document;
+
+beforeAll(() => {
+  // @ts-expect-error test DOM setup
+  globalThis.window = domWindow;
+  // @ts-expect-error test DOM setup
+  globalThis.document = domWindow.document;
+});
+
+afterAll(() => {
+  globalThis.window = originalWindow;
+  globalThis.document = originalDocument;
+});
+
+class FakeAgentEventsBackend implements Partial<SessionBackend> {
+  private handlers = new Set<(delta: AgentStateUpdateDelta) => void>();
+
+  getAgentStateSnapshot() {
+    return {
+      'proj:ws-1': {
+        workspaceId: 'proj:ws-1',
+        sessions: [{ id: 'agent-1', title: 'Agent 1' }],
+        statuses: { 'agent-1': { type: 'idle' as const } },
+        pendingPermissions: {},
+        lastMessages: {},
+      },
+    };
+  }
+
+  subscribeAgentState(handler: (delta: AgentStateUpdateDelta) => void) {
+    this.handlers.add(handler);
+    return () => {
+      this.handlers.delete(handler);
+    };
+  }
+
+  async respondToAgentPermission() { return true; }
+
+  emit(delta: AgentStateUpdateDelta) {
+    for (const handler of this.handlers) {
+      handler(delta);
+    }
+  }
+}
+
+describe('useWorkspaceAgentEvents', () => {
+  it('clears agent error state after a recovery status update', async () => {
+    const backend = new FakeAgentEventsBackend();
+    const { result } = renderHook(() => useWorkspaceAgentEvents({ backend: backend as unknown as SessionBackend }));
+
+    await act(async () => {
+      backend.emit({
+        type: 'agent_session_error',
+        workspaceId: 'proj:ws-1',
+        sessionId: 'agent-1',
+        errorMessage: 'boom',
+      });
+    });
+
+    expect(result.current.workspaceStates['proj:ws-1']['agent-1'].errorMessage).toBe('boom');
+
+    await act(async () => {
+      backend.emit({
+        type: 'agent_session_status',
+        workspaceId: 'proj:ws-1',
+        sessionId: 'agent-1',
+        status: { type: 'busy' },
+      });
+    });
+
+    expect(result.current.workspaceStates['proj:ws-1']['agent-1'].errorMessage).toBeUndefined();
+  });
+});

--- a/src/agents/__tests__/useWorkspaceAgentEvents.test.ts
+++ b/src/agents/__tests__/useWorkspaceAgentEvents.test.ts
@@ -3,7 +3,7 @@ import { act, renderHook } from '@testing-library/react';
 import { Window } from 'happy-dom';
 import { useWorkspaceAgentEvents } from '../useWorkspaceAgentEvents';
 import type { SessionBackend } from '../../session/backend';
-import type { AgentStateUpdateDelta } from '../../serve/agent-event-manager';
+import type { AgentStateUpdateDelta, WorkspaceAgentState } from '../../serve/agent-event-manager';
 
 const domWindow = new Window();
 const originalWindow = globalThis.window;
@@ -23,17 +23,18 @@ afterAll(() => {
 
 class FakeAgentEventsBackend implements Partial<SessionBackend> {
   private handlers = new Set<(delta: AgentStateUpdateDelta) => void>();
+  private snapshot: Record<string, WorkspaceAgentState> = {
+    'proj:ws-1': {
+      workspaceId: 'proj:ws-1',
+      sessions: [{ id: 'agent-1', title: 'Agent 1' }],
+      statuses: { 'agent-1': { type: 'idle' as const } },
+      pendingPermissions: {},
+      lastMessages: {},
+    },
+  };
 
-  getAgentStateSnapshot() {
-    return {
-      'proj:ws-1': {
-        workspaceId: 'proj:ws-1',
-        sessions: [{ id: 'agent-1', title: 'Agent 1' }],
-        statuses: { 'agent-1': { type: 'idle' as const } },
-        pendingPermissions: {},
-        lastMessages: {},
-      },
-    };
+  getAgentStateSnapshot(): Record<string, WorkspaceAgentState> {
+    return this.snapshot;
   }
 
   subscribeAgentState(handler: (delta: AgentStateUpdateDelta) => void) {
@@ -48,6 +49,13 @@ class FakeAgentEventsBackend implements Partial<SessionBackend> {
   emit(delta: AgentStateUpdateDelta) {
     for (const handler of this.handlers) {
       handler(delta);
+    }
+  }
+
+  emitSnapshot(snapshot: Record<string, WorkspaceAgentState>) {
+    this.snapshot = snapshot;
+    for (const handler of this.handlers) {
+      handler({ type: 'agent_state_snapshot', workspaces: snapshot });
     }
   }
 }
@@ -78,5 +86,31 @@ describe('useWorkspaceAgentEvents', () => {
     });
 
     expect(result.current.workspaceStates['proj:ws-1']['agent-1'].errorMessage).toBeUndefined();
+  });
+
+  it('replaces workspace state when a full snapshot broadcast arrives', async () => {
+    const backend = new FakeAgentEventsBackend();
+    const { result } = renderHook(() => useWorkspaceAgentEvents({ backend: backend as unknown as SessionBackend }));
+
+    await act(async () => {
+      backend.emitSnapshot({
+        'proj:ws-2': {
+          workspaceId: 'proj:ws-2',
+          sessions: [{ id: 'agent-2', title: 'Agent 2' }],
+          statuses: { 'agent-2': { type: 'busy' } },
+          pendingPermissions: {},
+          lastMessages: { 'agent-2': 'Working...' },
+        },
+      });
+    });
+
+    expect(result.current.workspaceStates).toEqual({
+      'proj:ws-2': {
+        'agent-2': expect.objectContaining({
+          status: { type: 'busy' },
+          lastMessagePreview: 'Working...',
+        }),
+      },
+    });
   });
 });

--- a/src/agents/__tests__/useWorkspaceAgentSessions.test.ts
+++ b/src/agents/__tests__/useWorkspaceAgentSessions.test.ts
@@ -23,10 +23,14 @@ afterAll(() => {
 
 class FakeAgentBackend implements Partial<SessionBackend> {
   sessionsByWorkspace = new Map<string, Array<{ id: string; title: string; updatedAt?: string }>>();
+  knownSessionsByWorkspace = new Map<string, Array<{ id: string; title: string; updatedAt?: string; closed?: boolean }>>();
   statusByWorkspace = new Map<string, Record<string, SessionStatus>>();
 
   constructor() {
     this.sessionsByWorkspace.set('proj:ws-1', [
+      { id: 'agent-1', title: 'Investigate auth', updatedAt: '2026-03-15T00:00:00.000Z' },
+    ]);
+    this.knownSessionsByWorkspace.set('proj:ws-1', [
       { id: 'agent-1', title: 'Investigate auth', updatedAt: '2026-03-15T00:00:00.000Z' },
     ]);
     this.statusByWorkspace.set('proj:ws-1', {
@@ -50,7 +54,7 @@ class FakeAgentBackend implements Partial<SessionBackend> {
   }
 
   async getKnownAgentSessions(workspaceId: string) {
-    return this.sessionsByWorkspace.get(workspaceId) ?? [];
+    return this.knownSessionsByWorkspace.get(workspaceId) ?? [];
   }
 
   async listAgentSessions(workspaceId: string) {
@@ -67,6 +71,16 @@ class FakeAgentBackend implements Partial<SessionBackend> {
   async abortAgentSession(workspaceId: string, sessionId: string) {
     const sessions = this.sessionsByWorkspace.get(workspaceId) ?? [];
     this.sessionsByWorkspace.set(workspaceId, sessions.filter((session) => session.id !== sessionId));
+    const knownSessions = this.knownSessionsByWorkspace.get(workspaceId) ?? [];
+    this.knownSessionsByWorkspace.set(workspaceId, knownSessions.map((session) => (
+      session.id === sessionId ? { ...session, closed: true } : session
+    )));
+    return true;
+  }
+
+  async clearAgentSession(workspaceId: string, sessionId: string) {
+    const knownSessions = this.knownSessionsByWorkspace.get(workspaceId) ?? [];
+    this.knownSessionsByWorkspace.set(workspaceId, knownSessions.filter((session) => session.id !== sessionId));
     return true;
   }
 }
@@ -106,6 +120,41 @@ describe('useWorkspaceAgentSessions', () => {
     await act(async () => {
       await result.current.loadWorkspaceSessions('proj:ws-1');
       await result.current.abortSession('proj:ws-1', 'agent-1');
+    });
+
+    expect(result.current.sessionsByWorkspace['proj:ws-1']).toEqual([
+      expect.objectContaining({ id: 'agent-1', closed: true }),
+    ]);
+  });
+
+  it('preserves known sessions when live refresh is temporarily empty', async () => {
+    const backend = new FakeAgentBackend();
+    backend.knownSessionsByWorkspace.set('proj:ws-1', [
+      { id: 'agent-1', title: 'Investigate auth', updatedAt: '2026-03-15T00:00:00.000Z' },
+    ]);
+    backend.sessionsByWorkspace.set('proj:ws-1', []);
+    const { result } = renderHook(() => useWorkspaceAgentSessions({ backend: backend as unknown as SessionBackend }));
+
+    await act(async () => {
+      await result.current.loadWorkspaceSessions('proj:ws-1');
+    });
+
+    expect(result.current.sessionsByWorkspace['proj:ws-1']).toEqual([
+      expect.objectContaining({ id: 'agent-1', title: 'Investigate auth' }),
+    ]);
+  });
+
+  it('clears closed sessions from workspace history', async () => {
+    const backend = new FakeAgentBackend();
+    backend.knownSessionsByWorkspace.set('proj:ws-1', [
+      { id: 'agent-1', title: 'Investigate auth', updatedAt: '2026-03-15T00:00:00.000Z', closed: true },
+    ]);
+    backend.sessionsByWorkspace.set('proj:ws-1', []);
+    const { result } = renderHook(() => useWorkspaceAgentSessions({ backend: backend as unknown as SessionBackend }));
+
+    await act(async () => {
+      await result.current.loadWorkspaceSessions('proj:ws-1');
+      await result.current.clearSession('proj:ws-1', 'agent-1');
     });
 
     expect(result.current.sessionsByWorkspace['proj:ws-1']).toEqual([]);

--- a/src/agents/agent-session-actions.ts
+++ b/src/agents/agent-session-actions.ts
@@ -6,11 +6,13 @@ interface AgentSessionSummaryLike {
 }
 
 interface AttachAgentSessionOptions {
+  flow: Pick<UseFlowReturn, 'showConfirm'>;
   workspaceId: string;
   agentSessionId: string;
   persistAgentSessionSelection: (workspaceId: string, sessionId: string) => void;
   clearViewOnly: () => void;
-  attachAgentSession: (workspaceId: string, agentSessionId: string) => Promise<void>;
+  checkAgentSessionTakeover: (workspaceId: string, agentSessionId: string) => Promise<{ requiresTakeover: boolean; sessionName?: string }>;
+  attachAgentSession: (workspaceId: string, agentSessionId: string, options?: { force?: boolean }) => Promise<void>;
   afterAttach?: () => void | Promise<void>;
 }
 
@@ -58,10 +60,35 @@ export function findCreatedAgentSession(
 }
 
 export async function openAgentSession(options: AttachAgentSessionOptions): Promise<void> {
-  options.persistAgentSessionSelection(options.workspaceId, options.agentSessionId);
-  options.clearViewOnly();
-  await options.attachAgentSession(options.workspaceId, options.agentSessionId);
-  await options.afterAttach?.();
+  const takeover = await options.checkAgentSessionTakeover(options.workspaceId, options.agentSessionId);
+  const runAttach = async (force?: boolean) => {
+    options.persistAgentSessionSelection(options.workspaceId, options.agentSessionId);
+    options.clearViewOnly();
+    await options.attachAgentSession(options.workspaceId, options.agentSessionId, force ? { force } : undefined);
+    await options.afterAttach?.();
+  };
+
+  if (takeover.requiresTakeover) {
+    await new Promise<void>((resolve) => {
+      options.flow.showConfirm({
+        title: 'Take Over Agent Terminal?',
+        message: `${takeover.sessionName ?? 'This agent terminal'} is already open in another client. Taking over will disconnect that viewer.`,
+        variant: 'warning',
+        confirmLabel: 'Take Over',
+        cancelLabel: 'Cancel',
+        onConfirm: async () => {
+          await runAttach(true);
+          resolve();
+        },
+        onCancel: () => {
+          resolve();
+        },
+      });
+    });
+    return;
+  }
+
+  await runAttach();
 }
 
 export function promptCreateAgentSession(options: PromptCreateAgentSessionOptions): void {

--- a/src/agents/agent-session-actions.ts
+++ b/src/agents/agent-session-actions.ts
@@ -11,7 +11,7 @@ interface AttachAgentSessionOptions {
   agentSessionId: string;
   persistAgentSessionSelection: (workspaceId: string, sessionId: string) => void;
   clearViewOnly: () => void;
-  checkAgentSessionTakeover: (workspaceId: string, agentSessionId: string) => Promise<{ requiresTakeover: boolean; sessionName?: string }>;
+  checkAgentSessionTakeover?: (workspaceId: string, agentSessionId: string) => Promise<{ requiresTakeover: boolean; sessionName?: string }>;
   attachAgentSession: (workspaceId: string, agentSessionId: string, options?: { force?: boolean }) => Promise<void>;
   afterAttach?: () => void | Promise<void>;
 }
@@ -60,7 +60,9 @@ export function findCreatedAgentSession(
 }
 
 export async function openAgentSession(options: AttachAgentSessionOptions): Promise<void> {
-  const takeover = await options.checkAgentSessionTakeover(options.workspaceId, options.agentSessionId);
+  const takeover = options.checkAgentSessionTakeover
+    ? await options.checkAgentSessionTakeover(options.workspaceId, options.agentSessionId)
+    : { requiresTakeover: false };
   const runAttach = async (force?: boolean) => {
     options.persistAgentSessionSelection(options.workspaceId, options.agentSessionId);
     options.clearViewOnly();
@@ -69,6 +71,7 @@ export async function openAgentSession(options: AttachAgentSessionOptions): Prom
   };
 
   if (takeover.requiresTakeover) {
+    let attachPromise: Promise<void> | null = null;
     await new Promise<void>((resolve) => {
       options.flow.showConfirm({
         title: 'Take Over Agent Terminal?',
@@ -76,15 +79,18 @@ export async function openAgentSession(options: AttachAgentSessionOptions): Prom
         variant: 'warning',
         confirmLabel: 'Take Over',
         cancelLabel: 'Cancel',
-        onConfirm: async () => {
-          await runAttach(true);
+        onConfirm: () => {
           resolve();
+          attachPromise = runAttach(true);
         },
         onCancel: () => {
           resolve();
         },
       });
     });
+    if (attachPromise) {
+      await attachPromise;
+    }
     return;
   }
 

--- a/src/agents/opencode-coordinator.ts
+++ b/src/agents/opencode-coordinator.ts
@@ -162,11 +162,16 @@ export class OpenCodeCoordinator {
         // best effort
       }
     }
-    try {
-      await this.refreshAgentSessions(target);
-    } finally {
-      await markStoredSessionClosed(target.workspaceId, agentSessionId);
+    if (aborted) {
+      try {
+        await this.refreshAgentSessions(target);
+      } finally {
+        await markStoredSessionClosed(target.workspaceId, agentSessionId);
+      }
+      return aborted;
     }
+
+    await this.refreshAgentSessions(target);
     return aborted;
   }
 

--- a/src/agents/opencode-coordinator.ts
+++ b/src/agents/opencode-coordinator.ts
@@ -162,8 +162,8 @@ export class OpenCodeCoordinator {
         // best effort
       }
     }
-    await markStoredSessionClosed(target.workspaceId, agentSessionId);
     await this.refreshAgentSessions(target);
+    await markStoredSessionClosed(target.workspaceId, agentSessionId);
     return aborted;
   }
 
@@ -227,7 +227,9 @@ export class OpenCodeCoordinator {
           terminalSessionName: existingById.name,
           lastKnownStatus: existingById.exitCode === undefined ? undefined : 'closed',
         });
-        return existingById;
+        if (existingById.exitCode === undefined) {
+          return existingById;
+        }
       }
     }
 
@@ -240,7 +242,9 @@ export class OpenCodeCoordinator {
         terminalSessionName: existing.name,
         lastKnownStatus: existing.exitCode === undefined ? undefined : 'closed',
       });
-      return existing;
+      if (existing.exitCode === undefined) {
+        return existing;
+      }
     }
 
     return null;

--- a/src/agents/opencode-coordinator.ts
+++ b/src/agents/opencode-coordinator.ts
@@ -162,8 +162,11 @@ export class OpenCodeCoordinator {
         // best effort
       }
     }
-    await this.refreshAgentSessions(target);
-    await markStoredSessionClosed(target.workspaceId, agentSessionId);
+    try {
+      await this.refreshAgentSessions(target);
+    } finally {
+      await markStoredSessionClosed(target.workspaceId, agentSessionId);
+    }
     return aborted;
   }
 
@@ -199,7 +202,18 @@ export class OpenCodeCoordinator {
     agentSessionId: string,
     options: { force?: boolean } = {},
   ): Promise<TmuxSession> {
-    const key = `${target.workspaceId}:${agentSessionId}:${options.force === true ? 'force' : 'default'}`;
+    const existing = await this.findExistingAgentTerminalSession(target, agentSessionId);
+    if (existing) {
+      if (existing.attached && options.force !== true) {
+        throw new AgentSessionTakeoverRequiredError(
+          `Agent session is already open in ${existing.name}. Taking over will disconnect the current viewer.`,
+          { sessionName: existing.name },
+        );
+      }
+      return existing;
+    }
+
+    const key = `${target.workspaceId}:${agentSessionId}`;
     const inFlight = this.inflightTerminalSessions.get(key);
     if (inFlight) {
       return inFlight;

--- a/src/agents/opencode-coordinator.ts
+++ b/src/agents/opencode-coordinator.ts
@@ -1,10 +1,12 @@
-import { createSession as createTmuxSession, listSessions as listTmuxSessions } from '../lib/tmux-lite/cli.js';
+import { createSession as createTmuxSession, killSession as killTmuxSession, listSessions as listTmuxSessions } from '../lib/tmux-lite/cli.js';
 import type { Session as TmuxSession } from '../lib/tmux-lite/protocol.js';
 import { OpenCodeClient, type OpenCodeSessionRecord } from './opencode-client.js';
 import { createOpenCodeBasicAuthHeader, defaultOpenCodeRuntimeManager } from './opencode-runtime.js';
 import type { OpenCodeRuntimeInfo, OpenCodeRuntimeTarget } from './opencode-types.js';
 import { normalizeWorkspacePath } from './opencode-runtime-shared.js';
 import {
+  deleteStoredSession,
+  markStoredSessionClosed,
   readStoredSessionHistory,
   replaceStoredSessions,
   upsertStoredSession,
@@ -22,6 +24,17 @@ export interface AgentSessionSummary {
   workspaceId: string;
   title: string;
   updatedAt?: string;
+  closed?: boolean;
+}
+
+export class AgentSessionTakeoverRequiredError extends Error {
+  readonly sessionName?: string;
+
+  constructor(message: string, options: { sessionName?: string } = {}) {
+    super(message);
+    this.name = 'AgentSessionTakeoverRequiredError';
+    this.sessionName = options.sessionName;
+  }
 }
 
 function buildAgentTerminalSessionName(target: AgentWorkspaceTarget, agentSessionId: string): string {
@@ -63,6 +76,7 @@ function normalizeOpenCodeSession(target: AgentWorkspaceTarget, session: OpenCod
     createdAt,
     updatedAt,
     lastSeenAt: new Date().toISOString(),
+    lastKnownStatus: undefined,
   };
 }
 
@@ -80,6 +94,7 @@ function toSummaries(workspaceId: string, sessions: Record<string, StoredWorkspa
       workspaceId,
       title: session.title,
       updatedAt: session.updatedAt ?? session.lastSeenAt,
+      closed: session.lastKnownStatus === 'closed',
     }));
 }
 
@@ -138,24 +153,66 @@ export class OpenCodeCoordinator {
   async abortAgentSession(target: AgentWorkspaceTarget, agentSessionId: string): Promise<boolean> {
     const runtime = await this.ensureRuntime(target);
     const client = createClient(runtime);
-    return client.abortSession(agentSessionId);
+    const aborted = await client.abortSession(agentSessionId);
+    const existing = await this.findExistingAgentTerminalSession(target, agentSessionId);
+    if (existing) {
+      try {
+        await killTmuxSession(existing.id);
+      } catch {
+        // best effort
+      }
+    }
+    await markStoredSessionClosed(target.workspaceId, agentSessionId);
+    await this.refreshAgentSessions(target);
+    return aborted;
   }
 
-  async ensureAgentTerminalSession(target: AgentWorkspaceTarget, agentSessionId: string): Promise<TmuxSession> {
-    const key = `${target.workspaceId}:${agentSessionId}`;
+  async clearAgentSession(target: AgentWorkspaceTarget, agentSessionId: string): Promise<boolean> {
+    const existing = await this.findExistingAgentTerminalSession(target, agentSessionId);
+    if (existing) {
+      try {
+        await killTmuxSession(existing.id);
+      } catch {
+        // best effort
+      }
+    }
+    await deleteStoredSession(target.workspaceId, agentSessionId);
+    return true;
+  }
+
+  async checkAgentSessionTakeover(
+    target: AgentWorkspaceTarget,
+    agentSessionId: string,
+  ): Promise<{ requiresTakeover: boolean; sessionName?: string }> {
+    const existing = await this.findExistingAgentTerminalSession(target, agentSessionId);
+    if (!existing?.attached) {
+      return { requiresTakeover: false };
+    }
+    return {
+      requiresTakeover: true,
+      sessionName: existing.name,
+    };
+  }
+
+  async ensureAgentTerminalSession(
+    target: AgentWorkspaceTarget,
+    agentSessionId: string,
+    options: { force?: boolean } = {},
+  ): Promise<TmuxSession> {
+    const key = `${target.workspaceId}:${agentSessionId}:${options.force === true ? 'force' : 'default'}`;
     const inFlight = this.inflightTerminalSessions.get(key);
     if (inFlight) {
       return inFlight;
     }
 
-    const ensurePromise = this.ensureAgentTerminalSessionInternal(target, agentSessionId).finally(() => {
+    const ensurePromise = this.ensureAgentTerminalSessionInternal(target, agentSessionId, options).finally(() => {
       this.inflightTerminalSessions.delete(key);
     });
     this.inflightTerminalSessions.set(key, ensurePromise);
     return ensurePromise;
   }
 
-  private async ensureAgentTerminalSessionInternal(target: AgentWorkspaceTarget, agentSessionId: string): Promise<TmuxSession> {
+  private async findExistingAgentTerminalSession(target: AgentWorkspaceTarget, agentSessionId: string): Promise<TmuxSession | null> {
     const history = await readStoredSessionHistory(target.workspaceId);
     const record = history.sessions[agentSessionId];
     const sessions = await listTmuxSessions();
@@ -163,6 +220,13 @@ export class OpenCodeCoordinator {
     if (record?.terminalSessionId) {
       const existingById = sessions.find((session) => session.id === record.terminalSessionId);
       if (existingById && isAgentTmuxSession(existingById, target.workspaceId, agentSessionId)) {
+        await upsertStoredSession(target.workspaceId, {
+          id: agentSessionId,
+          title: record?.title ?? agentSessionId,
+          terminalSessionId: existingById.id,
+          terminalSessionName: existingById.name,
+          lastKnownStatus: existingById.exitCode === undefined ? undefined : 'closed',
+        });
         return existingById;
       }
     }
@@ -174,7 +238,29 @@ export class OpenCodeCoordinator {
         title: record?.title ?? agentSessionId,
         terminalSessionId: existing.id,
         terminalSessionName: existing.name,
+        lastKnownStatus: existing.exitCode === undefined ? undefined : 'closed',
       });
+      return existing;
+    }
+
+    return null;
+  }
+
+  private async ensureAgentTerminalSessionInternal(
+    target: AgentWorkspaceTarget,
+    agentSessionId: string,
+    options: { force?: boolean },
+  ): Promise<TmuxSession> {
+    const history = await readStoredSessionHistory(target.workspaceId);
+    const record = history.sessions[agentSessionId];
+    const existing = await this.findExistingAgentTerminalSession(target, agentSessionId);
+    if (existing) {
+      if (existing.attached && options.force !== true) {
+        throw new AgentSessionTakeoverRequiredError(
+          `Agent session is already open in ${existing.name}. Taking over will disconnect the current viewer.`,
+          { sessionName: existing.name },
+        );
+      }
       return existing;
     }
 
@@ -204,6 +290,7 @@ export class OpenCodeCoordinator {
       title: record?.title ?? agentSessionId,
       terminalSessionId: session.id,
       terminalSessionName: session.name,
+      lastKnownStatus: undefined,
     });
     return session;
   }

--- a/src/agents/opencode-store.ts
+++ b/src/agents/opencode-store.ts
@@ -150,14 +150,45 @@ export async function replaceStoredSessions(
   await withWorkspaceWriteLock(workspaceId, async () => {
     const existing = await readStoredSessionHistory(workspaceId);
     const next: Record<string, StoredWorkspaceAgentSession> = {};
+    const seenIds = new Set<string>();
     for (const session of sessions) {
+      seenIds.add(session.id);
       next[session.id] = {
         ...existing.sessions[session.id],
         ...session,
+        lastKnownStatus: session.lastKnownStatus,
         lastSeenAt: session.lastSeenAt ?? new Date().toISOString(),
       };
     }
+    for (const [sessionId, stored] of Object.entries(existing.sessions)) {
+      if (seenIds.has(sessionId)) {
+        continue;
+      }
+      next[sessionId] = {
+        ...stored,
+        lastKnownStatus: 'closed',
+        lastSeenAt: new Date().toISOString(),
+      };
+    }
     await writeStoredSessionHistory({ workspaceId, sessions: next });
+  });
+}
+
+export async function markStoredSessionClosed(workspaceId: string, sessionId: string): Promise<void> {
+  await withWorkspaceWriteLock(workspaceId, async () => {
+    const history = await readStoredSessionHistory(workspaceId);
+    const existing = history.sessions[sessionId];
+    if (!existing) {
+      return;
+    }
+    history.sessions[sessionId] = {
+      ...existing,
+      lastKnownStatus: 'closed',
+      lastSeenAt: new Date().toISOString(),
+      terminalSessionId: undefined,
+      terminalSessionName: undefined,
+    };
+    await writeStoredSessionHistory(history);
   });
 }
 

--- a/src/agents/opencode-store.ts
+++ b/src/agents/opencode-store.ts
@@ -168,6 +168,8 @@ export async function replaceStoredSessions(
         ...stored,
         lastKnownStatus: 'closed',
         lastSeenAt: new Date().toISOString(),
+        terminalSessionId: undefined,
+        terminalSessionName: undefined,
       };
     }
     await writeStoredSessionHistory({ workspaceId, sessions: next });

--- a/src/agents/remote-agent-browser.ts
+++ b/src/agents/remote-agent-browser.ts
@@ -1,0 +1,47 @@
+export interface AgentBrowserWorkspaceRef {
+  id: string;
+}
+
+export interface AgentBrowserSnapshot {
+  sessions: Array<{ id: string }>;
+}
+
+export function collectAgentSessionCounts(options: {
+  sessionsByWorkspace: Record<string, Array<{ id: string }>>;
+  workspaceStates: Record<string, Record<string, unknown>>;
+  snapshotByWorkspace: Record<string, AgentBrowserSnapshot>;
+}): Record<string, number> {
+  const counts: Record<string, number> = {};
+
+  for (const [workspaceId, sessions] of Object.entries(options.sessionsByWorkspace)) {
+    counts[workspaceId] = Math.max(counts[workspaceId] ?? 0, sessions.length);
+  }
+
+  for (const [workspaceId, sessions] of Object.entries(options.workspaceStates)) {
+    counts[workspaceId] = Math.max(counts[workspaceId] ?? 0, Object.keys(sessions).length);
+  }
+
+  for (const [workspaceId, snapshot] of Object.entries(options.snapshotByWorkspace)) {
+    counts[workspaceId] = Math.max(counts[workspaceId] ?? 0, snapshot.sessions.length);
+  }
+
+  return counts;
+}
+
+export function collectWorkspaceSyncIds(
+  workspaces: AgentBrowserWorkspaceRef[],
+  expandedWorkspaceIds: string[] = [],
+  selectedWorkspaceId: string | null = null,
+): string[] {
+  const workspaceIds = new Set(workspaces.map((workspace) => workspace.id));
+
+  for (const workspaceId of expandedWorkspaceIds) {
+    workspaceIds.add(workspaceId);
+  }
+
+  if (selectedWorkspaceId) {
+    workspaceIds.add(selectedWorkspaceId);
+  }
+
+  return Array.from(workspaceIds);
+}

--- a/src/agents/useWorkspaceAgentEvents.ts
+++ b/src/agents/useWorkspaceAgentEvents.ts
@@ -178,6 +178,7 @@ export function useWorkspaceAgentEvents({
                 }),
                 status,
                 lastActivityAt: Date.now(),
+                errorMessage: undefined,
               },
             };
 
@@ -211,6 +212,7 @@ export function useWorkspaceAgentEvents({
                   [permission.id]: permission,
                 },
                 lastActivityAt: Date.now(),
+                errorMessage: undefined,
               },
             };
             onNotificationRef.current?.({
@@ -232,7 +234,7 @@ export function useWorkspaceAgentEvents({
               const { [permissionId]: _removed, ...rest } = existing.pendingPermissions;
               next[workspaceId] = {
                 ...next[workspaceId],
-                [sessionId]: { ...existing, pendingPermissions: rest },
+                [sessionId]: { ...existing, pendingPermissions: rest, errorMessage: undefined },
               };
             }
             break;
@@ -271,7 +273,7 @@ export function useWorkspaceAgentEvents({
             if (existing) {
               next[workspaceId] = {
                 ...next[workspaceId],
-                [sessionId]: { ...existing, lastMessagePreview: preview },
+                [sessionId]: { ...existing, lastMessagePreview: preview, errorMessage: undefined },
               };
             }
             break;
@@ -288,6 +290,7 @@ export function useWorkspaceAgentEvents({
                   pendingPermissions: {},
                   lastMessagePreview: '',
                   lastActivityAt: Date.now(),
+                  errorMessage: undefined,
                 },
               };
             }
@@ -297,6 +300,13 @@ export function useWorkspaceAgentEvents({
           case 'agent_session_updated': {
             const { sessionId, title } = delta;
             sessionTitlesRef.current[`${workspaceId}:${sessionId}`] = title;
+            const existing = next[workspaceId]?.[sessionId];
+            if (existing) {
+              next[workspaceId] = {
+                ...next[workspaceId],
+                [sessionId]: { ...existing, errorMessage: undefined },
+              };
+            }
             break;
           }
 

--- a/src/agents/useWorkspaceAgentEvents.ts
+++ b/src/agents/useWorkspaceAgentEvents.ts
@@ -62,17 +62,23 @@ export interface UseWorkspaceAgentEventsResult {
 
 function buildLiveStateFromWorkspace(workspace: WorkspaceAgentState): Record<string, AgentSessionLiveState> {
   const result: Record<string, AgentSessionLiveState> = {};
-  for (const session of workspace.sessions) {
-    const status: SessionStatus = workspace.statuses[session.id] ?? { type: 'idle' };
-    const permissions = workspace.pendingPermissions[session.id] ?? [];
+  const sessionIds = new Set<string>([
+    ...workspace.sessions.map((session) => session.id),
+    ...Object.keys(workspace.statuses),
+    ...Object.keys(workspace.pendingPermissions),
+    ...Object.keys(workspace.lastMessages),
+  ]);
+  for (const sessionId of sessionIds) {
+    const status: SessionStatus = workspace.statuses[sessionId] ?? { type: 'idle' };
+    const permissions = workspace.pendingPermissions[sessionId] ?? [];
     const pendingMap: Record<string, Permission> = {};
     for (const p of permissions) {
       pendingMap[p.id] = p;
     }
-    result[session.id] = {
+    result[sessionId] = {
       status,
       pendingPermissions: pendingMap,
-      lastMessagePreview: workspace.lastMessages[session.id] ?? '',
+      lastMessagePreview: workspace.lastMessages[sessionId] ?? '',
       lastActivityAt: Date.now(),
     };
   }

--- a/src/agents/useWorkspaceAgentSessions.ts
+++ b/src/agents/useWorkspaceAgentSessions.ts
@@ -103,8 +103,8 @@ export function useWorkspaceAgentSessions(options: UseWorkspaceAgentSessionsOpti
             setSessionsByWorkspace((current) => ({
               ...current,
               [workspaceId]: liveMapped.length > 0
-                ? mergeSessions(knownMapped, liveMapped)
-                : knownMapped,
+                ? mergeSessions(current[workspaceId] ?? [], liveMapped)
+                : (current[workspaceId] ?? knownMapped),
             }));
           })
           .catch((err) => setError(err instanceof Error ? err.message : String(err)))

--- a/src/agents/useWorkspaceAgentSessions.ts
+++ b/src/agents/useWorkspaceAgentSessions.ts
@@ -80,11 +80,17 @@ export function useWorkspaceAgentSessions(options: UseWorkspaceAgentSessionsOpti
     return snapshot[workspaceId]?.sessions ?? [];
   }, [options.backend]);
 
-  const loadWorkspaceSessions = useCallback(async (workspaceId: string) => {
+  const loadWorkspaceSessions = useCallback(async (
+    workspaceId: string,
+    options: { updateSelection?: boolean } = {},
+  ) => {
     const getKnownAgentSessions = requireAgentMethod('getKnownAgentSessions');
     const listAgentSessions = requireAgentMethod('listAgentSessions');
-    setLoadingWorkspaceId(workspaceId);
-    setActiveWorkspaceId(workspaceId);
+    const shouldUpdateSelection = options.updateSelection !== false;
+    if (shouldUpdateSelection) {
+      setLoadingWorkspaceId(workspaceId);
+      setActiveWorkspaceId(workspaceId);
+    }
     setError(null);
 
     try {
@@ -108,7 +114,11 @@ export function useWorkspaceAgentSessions(options: UseWorkspaceAgentSessionsOpti
             }));
           })
           .catch((err) => setError(err instanceof Error ? err.message : String(err)))
-          .finally(() => setLoadingWorkspaceId((current) => (current === workspaceId ? null : current)));
+          .finally(() => {
+            if (shouldUpdateSelection) {
+              setLoadingWorkspaceId((current) => (current === workspaceId ? null : current));
+            }
+          });
         return knownMapped;
       }
 
@@ -124,7 +134,9 @@ export function useWorkspaceAgentSessions(options: UseWorkspaceAgentSessionsOpti
       setError(message);
       throw err;
     } finally {
-      setLoadingWorkspaceId((current) => (current === workspaceId ? null : current));
+      if (shouldUpdateSelection) {
+        setLoadingWorkspaceId((current) => (current === workspaceId ? null : current));
+      }
     }
   }, [getPendingPermissionMap, getSnapshotSessions, getStatusMap, requireAgentMethod]);
 
@@ -158,7 +170,9 @@ export function useWorkspaceAgentSessions(options: UseWorkspaceAgentSessionsOpti
 
   const syncWorkspaceSessions = useCallback(async (workspaceIds: string[]) => {
     const uniqueWorkspaceIds = Array.from(new Set(workspaceIds.filter(Boolean)));
-    const results = await Promise.allSettled(uniqueWorkspaceIds.map((workspaceId) => loadWorkspaceSessions(workspaceId)));
+    const results = await Promise.allSettled(
+      uniqueWorkspaceIds.map((workspaceId) => loadWorkspaceSessions(workspaceId, { updateSelection: false })),
+    );
     const rejection = results.find((result): result is PromiseRejectedResult => result.status === 'rejected');
     if (rejection) {
       throw rejection.reason;

--- a/src/agents/useWorkspaceAgentSessions.ts
+++ b/src/agents/useWorkspaceAgentSessions.ts
@@ -7,6 +7,7 @@ export interface AgentSessionInfo {
   workspaceId: string;
   title: string;
   updatedAt?: string;
+  closed?: boolean;
   status?: SessionStatus;
   pendingPermissionCount?: number;
   errorMessage?: string;
@@ -18,7 +19,7 @@ export interface UseWorkspaceAgentSessionsOptions {
 
 function mapSessions(
   workspaceId: string,
-  sessions: Array<{ id: string; title: string; updatedAt?: string }>,
+  sessions: Array<{ id: string; title: string; updatedAt?: string; closed?: boolean }>,
   statusMap: Record<string, SessionStatus>,
   pendingPermissionMap: Record<string, unknown[]>,
 ): AgentSessionInfo[] {
@@ -27,9 +28,24 @@ function mapSessions(
     workspaceId,
     title: session.title,
     updatedAt: session.updatedAt,
+    closed: session.closed,
     status: statusMap[session.id],
     pendingPermissionCount: pendingPermissionMap[session.id]?.length ?? 0,
   }));
+}
+
+function mergeSessions(existing: AgentSessionInfo[], next: AgentSessionInfo[]): AgentSessionInfo[] {
+  const combined = new Map<string, AgentSessionInfo>();
+  for (const session of existing) {
+    combined.set(session.id, session);
+  }
+  for (const session of next) {
+    combined.set(session.id, {
+      ...(combined.get(session.id) ?? {}),
+      ...session,
+    });
+  }
+  return Array.from(combined.values()).sort((a, b) => (b.updatedAt ?? '').localeCompare(a.updatedAt ?? ''));
 }
 
 export function useWorkspaceAgentSessions(options: UseWorkspaceAgentSessionsOptions) {
@@ -59,6 +75,11 @@ export function useWorkspaceAgentSessions(options: UseWorkspaceAgentSessionsOpti
     return snapshot[workspaceId]?.pendingPermissions ?? {};
   }, [options.backend]);
 
+  const getSnapshotSessions = useCallback((workspaceId: string) => {
+    const snapshot = options.backend?.getAgentStateSnapshot() ?? {};
+    return snapshot[workspaceId]?.sessions ?? [];
+  }, [options.backend]);
+
   const loadWorkspaceSessions = useCallback(async (workspaceId: string) => {
     const getKnownAgentSessions = requireAgentMethod('getKnownAgentSessions');
     const listAgentSessions = requireAgentMethod('listAgentSessions');
@@ -68,15 +89,22 @@ export function useWorkspaceAgentSessions(options: UseWorkspaceAgentSessionsOpti
 
     try {
       const known = await getKnownAgentSessions(workspaceId);
-      const knownMapped = mapSessions(workspaceId, known, getStatusMap(workspaceId), getPendingPermissionMap(workspaceId));
+      const snapshotMapped = mapSessions(workspaceId, getSnapshotSessions(workspaceId), getStatusMap(workspaceId), getPendingPermissionMap(workspaceId));
+      const knownMapped = mergeSessions(
+        snapshotMapped,
+        mapSessions(workspaceId, known, getStatusMap(workspaceId), getPendingPermissionMap(workspaceId)),
+      );
 
       if (knownMapped.length > 0) {
         setSessionsByWorkspace((current) => ({ ...current, [workspaceId]: knownMapped }));
         void listAgentSessions(workspaceId)
           .then((live) => {
+            const liveMapped = mapSessions(workspaceId, live, getStatusMap(workspaceId), getPendingPermissionMap(workspaceId));
             setSessionsByWorkspace((current) => ({
               ...current,
-              [workspaceId]: mapSessions(workspaceId, live, getStatusMap(workspaceId), getPendingPermissionMap(workspaceId)),
+              [workspaceId]: liveMapped.length > 0
+                ? mergeSessions(knownMapped, liveMapped)
+                : knownMapped,
             }));
           })
           .catch((err) => setError(err instanceof Error ? err.message : String(err)))
@@ -85,7 +113,10 @@ export function useWorkspaceAgentSessions(options: UseWorkspaceAgentSessionsOpti
       }
 
       const live = await listAgentSessions(workspaceId);
-      const mapped = mapSessions(workspaceId, live, getStatusMap(workspaceId), getPendingPermissionMap(workspaceId));
+      const mapped = mergeSessions(
+        snapshotMapped,
+        mapSessions(workspaceId, live, getStatusMap(workspaceId), getPendingPermissionMap(workspaceId)),
+      );
       setSessionsByWorkspace((current) => ({ ...current, [workspaceId]: mapped }));
       return mapped;
     } catch (err) {
@@ -95,7 +126,7 @@ export function useWorkspaceAgentSessions(options: UseWorkspaceAgentSessionsOpti
     } finally {
       setLoadingWorkspaceId((current) => (current === workspaceId ? null : current));
     }
-  }, [getPendingPermissionMap, getStatusMap, requireAgentMethod]);
+  }, [getPendingPermissionMap, getSnapshotSessions, getStatusMap, requireAgentMethod]);
 
   const createSession = useCallback(async (workspaceId: string, title?: string) => {
     const createAgentSession = requireAgentMethod('createAgentSession');
@@ -107,13 +138,32 @@ export function useWorkspaceAgentSessions(options: UseWorkspaceAgentSessionsOpti
 
   const abortSession = useCallback(async (workspaceId: string, sessionId: string) => {
     const abortAgentSession = requireAgentMethod('abortAgentSession');
-    const listAgentSessions = requireAgentMethod('listAgentSessions');
     await abortAgentSession(workspaceId, sessionId);
-    const sessions = await listAgentSessions(workspaceId);
-    const mapped = mapSessions(workspaceId, sessions, getStatusMap(workspaceId), getPendingPermissionMap(workspaceId));
-    setSessionsByWorkspace((current) => ({ ...current, [workspaceId]: mapped }));
-    return mapped;
-  }, [getPendingPermissionMap, getStatusMap, requireAgentMethod]);
+    return loadWorkspaceSessions(workspaceId);
+  }, [loadWorkspaceSessions, requireAgentMethod]);
+
+  const clearSession = useCallback(async (workspaceId: string, sessionId: string) => {
+    const clearAgentSession = requireAgentMethod('clearAgentSession');
+    await clearAgentSession(workspaceId, sessionId);
+    let nextSessions: AgentSessionInfo[] = [];
+    setSessionsByWorkspace((current) => ({
+      ...current,
+      [workspaceId]: (() => {
+        nextSessions = (current[workspaceId] ?? []).filter((session) => session.id !== sessionId);
+        return nextSessions;
+      })(),
+    }));
+    return nextSessions;
+  }, [requireAgentMethod]);
+
+  const syncWorkspaceSessions = useCallback(async (workspaceIds: string[]) => {
+    const uniqueWorkspaceIds = Array.from(new Set(workspaceIds.filter(Boolean)));
+    const results = await Promise.allSettled(uniqueWorkspaceIds.map((workspaceId) => loadWorkspaceSessions(workspaceId)));
+    const rejection = results.find((result): result is PromiseRejectedResult => result.status === 'rejected');
+    if (rejection) {
+      throw rejection.reason;
+    }
+  }, [loadWorkspaceSessions]);
 
   const sessions = useMemo(() => {
     if (!activeWorkspaceId) {
@@ -130,7 +180,9 @@ export function useWorkspaceAgentSessions(options: UseWorkspaceAgentSessionsOpti
     error,
     setActiveWorkspaceId,
     loadWorkspaceSessions,
+    syncWorkspaceSessions,
     createSession,
     abortSession,
+    clearSession,
   };
 }

--- a/src/agents/useWorkspaceAgentSessions.ts
+++ b/src/agents/useWorkspaceAgentSessions.ts
@@ -82,11 +82,11 @@ export function useWorkspaceAgentSessions(options: UseWorkspaceAgentSessionsOpti
 
   const loadWorkspaceSessions = useCallback(async (
     workspaceId: string,
-    options: { updateSelection?: boolean } = {},
+    loadOptions: { updateSelection?: boolean } = {},
   ) => {
     const getKnownAgentSessions = requireAgentMethod('getKnownAgentSessions');
     const listAgentSessions = requireAgentMethod('listAgentSessions');
-    const shouldUpdateSelection = options.updateSelection !== false;
+    const shouldUpdateSelection = loadOptions.updateSelection !== false;
     if (shouldUpdateSelection) {
       setLoadingWorkspaceId(workspaceId);
       setActiveWorkspaceId(workspaceId);

--- a/src/app.tui.tsx
+++ b/src/app.tui.tsx
@@ -1404,11 +1404,11 @@ function App({ relayConfig, remoteIdentity, onQuit, keyboardMode }: AppProps) {
     expandedWorkspaceIds: string[];
     selectedWorkspaceId: string | null;
   }) => {
-    const workspaceIds = new Set(expandedWorkspaceIds);
-    if (selectedWorkspaceId) {
-      workspaceIds.add(selectedWorkspaceId);
-    }
-    await Promise.all(Array.from(workspaceIds).map((workspaceId) => workspaceAgentSessions.loadWorkspaceSessions(workspaceId)));
+    const workspaceIds = Array.from(new Set([
+      ...expandedWorkspaceIds,
+      ...(selectedWorkspaceId ? [selectedWorkspaceId] : []),
+    ]));
+    await workspaceAgentSessions.syncWorkspaceSessions(workspaceIds);
   }, [workspaceAgentSessions]);
 
   // Spaces browser hook
@@ -2275,8 +2275,8 @@ function App({ relayConfig, remoteIdentity, onQuit, keyboardMode }: AppProps) {
               confirmLabel: 'Clear',
               cancelLabel: 'Cancel',
               variant: 'warning',
-              onConfirm: () => {
-                void workspaceAgentSessions.clearSession(selected.workspaceId, selected.session.id);
+              onConfirm: async () => {
+                await workspaceAgentSessions.clearSession(selected.workspaceId, selected.session.id);
               },
             });
           }
@@ -2305,8 +2305,8 @@ function App({ relayConfig, remoteIdentity, onQuit, keyboardMode }: AppProps) {
               confirmLabel: 'Close',
               cancelLabel: 'Cancel',
               variant: 'warning',
-              onConfirm: () => {
-                void workspaceAgentSessions.abortSession(selected.workspaceId, selected.session.id);
+              onConfirm: async () => {
+                await workspaceAgentSessions.abortSession(selected.workspaceId, selected.session.id);
               },
             });
           }

--- a/src/app.tui.tsx
+++ b/src/app.tui.tsx
@@ -1397,6 +1397,8 @@ function App({ relayConfig, remoteIdentity, onQuit, keyboardMode }: AppProps) {
     return merged;
   }, [agentEvents.workspaceStates, localBackend, workspaceAgentSessions.sessionsByWorkspace]);
 
+  const syncWorkspaceAgentSessions = workspaceAgentSessions.syncWorkspaceSessions;
+
   const refreshAgentSessions = useCallback(async ({
     expandedWorkspaceIds,
     selectedWorkspaceId,
@@ -1404,10 +1406,10 @@ function App({ relayConfig, remoteIdentity, onQuit, keyboardMode }: AppProps) {
     expandedWorkspaceIds: string[];
     selectedWorkspaceId: string | null;
   }) => {
-    await workspaceAgentSessions.syncWorkspaceSessions(
+    await syncWorkspaceAgentSessions(
       collectWorkspaceSyncIds(workspaceInfos, expandedWorkspaceIds, selectedWorkspaceId),
     );
-  }, [workspaceAgentSessions, workspaceInfos]);
+  }, [syncWorkspaceAgentSessions, workspaceInfos]);
 
   // Spaces browser hook
   const spacesBrowserProps = useSpacesBrowser({

--- a/src/app.tui.tsx
+++ b/src/app.tui.tsx
@@ -75,6 +75,8 @@ import type { NotificationConfig, NotificationTypeConfig } from './types/config.
 import { getDefaultBranch } from './core/git.js';
 import { extractRepoName } from './utils/sanitize.js';
 import { logger } from './utils/logger.js';
+import { writeCrashLog } from './utils/crash-log.js';
+import { restoreTuiTerminalState } from './utils/tui-terminal-cleanup.js';
 
 // Script execution
 import { listAllRepos, cloneRepository } from './core/github.js';
@@ -432,6 +434,27 @@ function App({ relayConfig, remoteIdentity, onQuit, keyboardMode }: AppProps) {
     applyBundleRefresh: applyLocalBundleRefresh,
     resolveProjectName: resolveLocalWorkspaceProjectName,
   });
+  const lastLocalCommandErrorRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!localCommandError) {
+      lastLocalCommandErrorRef.current = null;
+      return;
+    }
+    if (localCommandError.code !== 'SESSION_TAKEN_OVER') {
+      return;
+    }
+    const key = `${localCommandError.code}:${localCommandError.message}`;
+    if (lastLocalCommandErrorRef.current === key) {
+      return;
+    }
+    lastLocalCommandErrorRef.current = key;
+    flow.showMessage({
+      title: 'Session Taken Over',
+      message: localCommandError.message,
+      variant: 'warning',
+    });
+  }, [flow, localCommandError]);
 
   const {
     attach: attachLocal,
@@ -1278,7 +1301,7 @@ function App({ relayConfig, remoteIdentity, onQuit, keyboardMode }: AppProps) {
   }, [localBackend]);
 
   const attachFromInboxSessionId = useCallback(async (sessionId: string) => {
-    if (!localBackend?.attachAgentSession) {
+    if (!localBackend?.attachAgentSession || !localBackend.checkAgentSessionTakeover) {
       throw new Error('Agent attach unavailable');
     }
     await handleInboxSessionSelection({
@@ -1291,10 +1314,12 @@ function App({ relayConfig, remoteIdentity, onQuit, keyboardMode }: AppProps) {
       },
       openAgentSession: async (workspaceId, agentSessionId) => {
         await openAgentSession({
+          flow,
           workspaceId,
           agentSessionId,
           persistAgentSessionSelection,
           clearViewOnly: () => setIsViewOnlySession(false),
+          checkAgentSessionTakeover: localBackend.checkAgentSessionTakeover!.bind(localBackend),
           attachAgentSession: localBackend.attachAgentSession!.bind(localBackend),
           afterAttach: async () => {
             dispatch({ type: 'SET_VIEW', view: 'terminal' });
@@ -1348,6 +1373,16 @@ function App({ relayConfig, remoteIdentity, onQuit, keyboardMode }: AppProps) {
       const combined = new Map<string, (typeof baseSessions)[number]>();
       for (const session of snapshotSessions) combined.set(session.id, session);
       for (const session of baseSessions) combined.set(session.id, session);
+      for (const sessionId of Object.keys(liveStates)) {
+        if (!combined.has(sessionId)) {
+          combined.set(sessionId, {
+            id: sessionId,
+            workspaceId,
+            title: sessionId,
+            updatedAt: undefined,
+          });
+        }
+      }
       merged[workspaceId] = Array.from(combined.values()).map((session) => {
         const live = liveStates[session.id];
         if (!live) return session;
@@ -1362,6 +1397,20 @@ function App({ relayConfig, remoteIdentity, onQuit, keyboardMode }: AppProps) {
 
     return merged;
   }, [agentEvents.workspaceStates, localBackend, workspaceAgentSessions.sessionsByWorkspace]);
+
+  const refreshAgentSessions = useCallback(async ({
+    expandedWorkspaceIds,
+    selectedWorkspaceId,
+  }: {
+    expandedWorkspaceIds: string[];
+    selectedWorkspaceId: string | null;
+  }) => {
+    const workspaceIds = new Set(expandedWorkspaceIds);
+    if (selectedWorkspaceId) {
+      workspaceIds.add(selectedWorkspaceId);
+    }
+    await Promise.all(Array.from(workspaceIds).map((workspaceId) => workspaceAgentSessions.loadWorkspaceSessions(workspaceId)));
+  }, [workspaceAgentSessions]);
 
   // Spaces browser hook
   const spacesBrowserProps = useSpacesBrowser({
@@ -1385,14 +1434,16 @@ function App({ relayConfig, remoteIdentity, onQuit, keyboardMode }: AppProps) {
       await workspaceAgentSessions.loadWorkspaceSessions(workspaceId);
     },
     onOpenAgentSession: async (workspaceId, agentSessionId) => {
-      if (!localBackend?.attachAgentSession) {
+      if (!localBackend?.attachAgentSession || !localBackend.checkAgentSessionTakeover) {
         throw new Error('Agent attach unavailable');
       }
       await openAgentSession({
+        flow,
         workspaceId,
         agentSessionId,
         persistAgentSessionSelection,
         clearViewOnly: () => setIsViewOnlySession(false),
+        checkAgentSessionTakeover: localBackend.checkAgentSessionTakeover!.bind(localBackend),
         attachAgentSession: localBackend.attachAgentSession.bind(localBackend),
         afterAttach: async () => {
           dispatch({ type: 'SET_VIEW', view: 'terminal' });
@@ -1400,7 +1451,7 @@ function App({ relayConfig, remoteIdentity, onQuit, keyboardMode }: AppProps) {
       });
     },
     onCreateAgentSession: async (workspaceId) => {
-      if (!localBackend?.attachAgentSession) {
+      if (!localBackend?.attachAgentSession || !localBackend.checkAgentSessionTakeover) {
         throw new Error('Agent attach unavailable');
       }
       promptCreateAgentSession({
@@ -1409,9 +1460,11 @@ function App({ relayConfig, remoteIdentity, onQuit, keyboardMode }: AppProps) {
         getCurrentSessions: (id) => workspaceAgentSessions.sessionsByWorkspace[id] ?? [],
         createAgentSession: workspaceAgentSessions.createSession,
         attachOptions: {
+          flow,
           workspaceId,
           persistAgentSessionSelection,
           clearViewOnly: () => setIsViewOnlySession(false),
+          checkAgentSessionTakeover: localBackend.checkAgentSessionTakeover!.bind(localBackend),
           attachAgentSession: localBackend.attachAgentSession.bind(localBackend),
           afterAttach: async () => {
             dispatch({ type: 'SET_VIEW', view: 'terminal' });
@@ -1429,6 +1482,7 @@ function App({ relayConfig, remoteIdentity, onQuit, keyboardMode }: AppProps) {
         requestLocalReplays(undefined, showDismissedReplays),
       ]);
     },
+    onRefreshAgents: refreshAgentSessions,
     onBack: () => dispatch({ type: 'SET_PANEL_FOCUS', focus: 'projects' }),
     onCreateWorkspace: handleNewWorkspaceFlow,
     machineName: currentProject || undefined,
@@ -2213,6 +2267,17 @@ function App({ relayConfig, remoteIdentity, onQuit, keyboardMode }: AppProps) {
                 variant: 'error',
               });
             }
+          } else if (selected?.type === 'agent-session' && selected.session.closed) {
+            flow.showConfirm({
+              title: 'Clear Closed Agent',
+              message: `Remove closed agent session "${selected.session.title}" from history?`,
+              confirmLabel: 'Clear',
+              cancelLabel: 'Cancel',
+              variant: 'warning',
+              onConfirm: () => {
+                void workspaceAgentSessions.clearSession(selected.workspaceId, selected.session.id);
+              },
+            });
           }
         } else if (command === 'kill') {
           // Kill session or stop running process
@@ -2230,6 +2295,17 @@ function App({ relayConfig, remoteIdentity, onQuit, keyboardMode }: AppProps) {
                   workspaceId: selected.workspaceId,
                   processName: selected.processName,
                 });
+              },
+            });
+          } else if (selected?.type === 'agent-session' && !selected.session.closed) {
+            flow.showConfirm({
+              title: 'Close Agent Session',
+              message: `Close agent session "${selected.session.title}"?`,
+              confirmLabel: 'Close',
+              cancelLabel: 'Cancel',
+              variant: 'warning',
+              onConfirm: () => {
+                void workspaceAgentSessions.abortSession(selected.workspaceId, selected.session.id);
               },
             });
           }
@@ -2975,29 +3051,79 @@ export async function launchTUI(
   let renderer = await createRendererForKeyboardMode(initialKeyboardMode);
   let root = createRoot(renderer);
   let activeRenderer = renderer;
+  let cleanupRegistered = false;
+
+  const cleanupRenderer = () => {
+    try {
+      activeRenderer.destroy();
+    } catch {
+      // Best effort only.
+    }
+  };
+
+  const restoreTerminal = () => {
+    restoreTuiTerminalState();
+  };
+
+  const cleanupListeners = () => {
+    process.removeListener('SIGINT', handleQuit);
+    process.removeListener('exit', handleExit);
+    process.removeListener('uncaughtException', handleFatalException);
+    process.removeListener('unhandledRejection', handleFatalRejection);
+  };
+
+  const handleFatal = (kind: 'uncaughtException' | 'unhandledRejection', error: unknown) => {
+    cleanupRenderer();
+    restoreTerminal();
+    const logPath = writeCrashLog(`tui-${kind}`, error, {
+      keyboardMode: requestedKeyboardMode,
+      relayConfigured: Boolean(relayConfig),
+    });
+    const detail = error instanceof Error ? error.stack ?? `${error.name}: ${error.message}` : String(error);
+    try {
+      process.stderr.write(`[gssh] TUI ${kind}: ${detail}\n`);
+      if (logPath) {
+        process.stderr.write(`[gssh] Crash log written to ${logPath}\n`);
+      }
+    } catch {
+      // Best effort only.
+    }
+  };
+
+  function handleFatalException(error: Error): void {
+    handleFatal('uncaughtException', error);
+  }
+
+  function handleFatalRejection(reason: unknown): void {
+    handleFatal('unhandledRejection', reason);
+  }
 
   // Clean exit handler
   const handleQuit = () => {
-    activeRenderer.destroy();
+    cleanupRenderer();
+    restoreTerminal();
 
     const legacyReminder = consumeLegacyCleanupReminderForTui();
     if (legacyReminder) {
       logger.warning(legacyReminder);
     }
 
+    cleanupListeners();
     process.exit(0);
   };
 
-  // Handle SIGINT
-  process.on('SIGINT', handleQuit);
+  const handleExit = () => {
+    restoreTerminal();
+  };
 
-  // Cleanup on exit
-  process.on('exit', () => {
-    // Reset terminal state
-    process.stdout.write('\x1b[?25h'); // Show cursor
-    process.stdout.write('\x1b[?1049l'); // Exit alternate screen
-    process.stdout.write('\x1b[0m'); // Reset colors
-  });
+  // Handle SIGINT
+  if (!cleanupRegistered) {
+    process.prependListener('uncaughtException', handleFatalException);
+    process.prependListener('unhandledRejection', handleFatalRejection);
+    process.on('SIGINT', handleQuit);
+    process.on('exit', handleExit);
+    cleanupRegistered = true;
+  }
 
   const resolvedKeyboardMode = await new Promise<ResolvedKeyboardMode>((resolve) => {
     root.render(
@@ -3014,7 +3140,7 @@ export async function launchTUI(
     resolvedKeyboardMode === 'vt' &&
     initialKeyboardMode !== 'vt'
   ) {
-    activeRenderer.destroy();
+    cleanupRenderer();
     renderer = await createRendererForKeyboardMode('vt');
     activeRenderer = renderer;
     root = createRoot(renderer);

--- a/src/app.tui.tsx
+++ b/src/app.tui.tsx
@@ -1369,6 +1369,7 @@ function App({ relayConfig, remoteIdentity, onQuit, keyboardMode }: AppProps) {
         workspaceId,
         title: session.title,
         updatedAt: undefined,
+        closed: 'closed' in session ? Boolean(session.closed) : undefined,
       }));
       const combined = new Map<string, (typeof baseSessions)[number]>();
       for (const session of snapshotSessions) combined.set(session.id, session);
@@ -1380,6 +1381,7 @@ function App({ relayConfig, remoteIdentity, onQuit, keyboardMode }: AppProps) {
             workspaceId,
             title: sessionId,
             updatedAt: undefined,
+            closed: false,
           });
         }
       }
@@ -3051,8 +3053,6 @@ export async function launchTUI(
   let renderer = await createRendererForKeyboardMode(initialKeyboardMode);
   let root = createRoot(renderer);
   let activeRenderer = renderer;
-  let cleanupRegistered = false;
-
   const cleanupRenderer = () => {
     try {
       activeRenderer.destroy();
@@ -3073,20 +3073,25 @@ export async function launchTUI(
   };
 
   const handleFatal = (kind: 'uncaughtException' | 'unhandledRejection', error: unknown) => {
-    cleanupRenderer();
-    restoreTerminal();
-    const logPath = writeCrashLog(`tui-${kind}`, error, {
-      keyboardMode: requestedKeyboardMode,
-      relayConfigured: Boolean(relayConfig),
-    });
-    const detail = error instanceof Error ? error.stack ?? `${error.name}: ${error.message}` : String(error);
     try {
-      process.stderr.write(`[gssh] TUI ${kind}: ${detail}\n`);
-      if (logPath) {
-        process.stderr.write(`[gssh] Crash log written to ${logPath}\n`);
+      cleanupRenderer();
+      restoreTerminal();
+      cleanupListeners();
+      const logPath = writeCrashLog(`tui-${kind}`, error, {
+        keyboardMode: requestedKeyboardMode,
+        relayConfigured: Boolean(relayConfig),
+      });
+      const detail = error instanceof Error ? error.stack ?? `${error.name}: ${error.message}` : String(error);
+      try {
+        process.stderr.write(`[gssh] TUI ${kind}: ${detail}\n`);
+        if (logPath) {
+          process.stderr.write(`[gssh] Crash log written to ${logPath}\n`);
+        }
+      } catch {
+        // Best effort only.
       }
-    } catch {
-      // Best effort only.
+    } finally {
+      process.exit(1);
     }
   };
 
@@ -3117,13 +3122,10 @@ export async function launchTUI(
   };
 
   // Handle SIGINT
-  if (!cleanupRegistered) {
-    process.prependListener('uncaughtException', handleFatalException);
-    process.prependListener('unhandledRejection', handleFatalRejection);
-    process.on('SIGINT', handleQuit);
-    process.on('exit', handleExit);
-    cleanupRegistered = true;
-  }
+  process.prependListener('uncaughtException', handleFatalException);
+  process.prependListener('unhandledRejection', handleFatalRejection);
+  process.on('SIGINT', handleQuit);
+  process.on('exit', handleExit);
 
   const resolvedKeyboardMode = await new Promise<ResolvedKeyboardMode>((resolve) => {
     root.render(

--- a/src/app.tui.tsx
+++ b/src/app.tui.tsx
@@ -443,6 +443,7 @@ function App({ relayConfig, remoteIdentity, onQuit, keyboardMode }: AppProps) {
       return;
     }
     if (localCommandError.code !== 'SESSION_TAKEN_OVER') {
+      lastLocalCommandErrorRef.current = null;
       return;
     }
     const key = `${localCommandError.code}:${localCommandError.message}`;

--- a/src/app.tui.tsx
+++ b/src/app.tui.tsx
@@ -122,6 +122,7 @@ import {
 } from './tui/kitty-keyboard.js';
 import { useWorkspaceAgentSessions } from './agents/useWorkspaceAgentSessions.js';
 import { useWorkspaceAgentEvents } from './agents/useWorkspaceAgentEvents.js';
+import { collectAgentSessionCounts } from './agents/remote-agent-browser.js';
 import { agentNotificationToInboxItem } from './agents/agentNotificationToInboxItem.js';
 import { handleInboxSessionSelection, openAgentSession, promptCreateAgentSession } from './agents/agent-session-actions.js';
 
@@ -1301,9 +1302,10 @@ function App({ relayConfig, remoteIdentity, onQuit, keyboardMode }: AppProps) {
   }, [localBackend]);
 
   const attachFromInboxSessionId = useCallback(async (sessionId: string) => {
-    if (!localBackend?.attachAgentSession || !localBackend.checkAgentSessionTakeover) {
+    if (!localBackend?.attachAgentSession) {
       throw new Error('Agent attach unavailable');
     }
+    const attachAgentSession = localBackend.attachAgentSession.bind(localBackend);
     await handleInboxSessionSelection({
       sessionId,
       agentInboxItems,
@@ -1319,8 +1321,8 @@ function App({ relayConfig, remoteIdentity, onQuit, keyboardMode }: AppProps) {
           agentSessionId,
           persistAgentSessionSelection,
           clearViewOnly: () => setIsViewOnlySession(false),
-          checkAgentSessionTakeover: localBackend.checkAgentSessionTakeover!.bind(localBackend),
-          attachAgentSession: localBackend.attachAgentSession!.bind(localBackend),
+          checkAgentSessionTakeover: localBackend.checkAgentSessionTakeover?.bind(localBackend),
+          attachAgentSession,
           afterAttach: async () => {
             dispatch({ type: 'SET_VIEW', view: 'terminal' });
           },
@@ -1340,18 +1342,12 @@ function App({ relayConfig, remoteIdentity, onQuit, keyboardMode }: AppProps) {
 
   // Memoize agent session counts to preserve referential stability for useSpacesBrowser
   const agentSessionCounts = useMemo(() => {
-    // Merge explicit session load counts with live event counts, taking the higher value
-    // (event state may be incomplete if it only received updates for a subset of sessions)
-    const counts: Record<string, number> = {};
-    for (const [wid, sessions] of Object.entries(workspaceAgentSessions.sessionsByWorkspace)) {
-      counts[wid] = sessions.length;
-    }
-    for (const [wid, sessions] of Object.entries(agentEvents.workspaceStates)) {
-      const eventCount = Object.keys(sessions).length;
-      counts[wid] = Math.max(counts[wid] ?? 0, eventCount);
-    }
-    return counts;
-  }, [workspaceAgentSessions.sessionsByWorkspace, agentEvents.workspaceStates]);
+    return collectAgentSessionCounts({
+      sessionsByWorkspace: workspaceAgentSessions.sessionsByWorkspace,
+      workspaceStates: agentEvents.workspaceStates,
+      snapshotByWorkspace: localBackend?.getAgentStateSnapshot() ?? {},
+    });
+  }, [agentEvents.workspaceStates, localBackend, workspaceAgentSessions.sessionsByWorkspace]);
 
   const agentSessionsByWorkspace = useMemo(() => {
     const merged: Record<string, typeof workspaceAgentSessions.sessionsByWorkspace[string]> = {};
@@ -1436,26 +1432,28 @@ function App({ relayConfig, remoteIdentity, onQuit, keyboardMode }: AppProps) {
       await workspaceAgentSessions.loadWorkspaceSessions(workspaceId);
     },
     onOpenAgentSession: async (workspaceId, agentSessionId) => {
-      if (!localBackend?.attachAgentSession || !localBackend.checkAgentSessionTakeover) {
+      if (!localBackend?.attachAgentSession) {
         throw new Error('Agent attach unavailable');
       }
+      const attachAgentSession = localBackend.attachAgentSession.bind(localBackend);
       await openAgentSession({
         flow,
         workspaceId,
         agentSessionId,
         persistAgentSessionSelection,
         clearViewOnly: () => setIsViewOnlySession(false),
-        checkAgentSessionTakeover: localBackend.checkAgentSessionTakeover!.bind(localBackend),
-        attachAgentSession: localBackend.attachAgentSession.bind(localBackend),
+        checkAgentSessionTakeover: localBackend.checkAgentSessionTakeover?.bind(localBackend),
+        attachAgentSession,
         afterAttach: async () => {
           dispatch({ type: 'SET_VIEW', view: 'terminal' });
         },
       });
     },
     onCreateAgentSession: async (workspaceId) => {
-      if (!localBackend?.attachAgentSession || !localBackend.checkAgentSessionTakeover) {
+      if (!localBackend?.attachAgentSession) {
         throw new Error('Agent attach unavailable');
       }
+      const attachAgentSession = localBackend.attachAgentSession.bind(localBackend);
       promptCreateAgentSession({
         flow,
         workspaceId,
@@ -1466,8 +1464,8 @@ function App({ relayConfig, remoteIdentity, onQuit, keyboardMode }: AppProps) {
           workspaceId,
           persistAgentSessionSelection,
           clearViewOnly: () => setIsViewOnlySession(false),
-          checkAgentSessionTakeover: localBackend.checkAgentSessionTakeover!.bind(localBackend),
-          attachAgentSession: localBackend.attachAgentSession.bind(localBackend),
+          checkAgentSessionTakeover: localBackend.checkAgentSessionTakeover?.bind(localBackend),
+          attachAgentSession,
           afterAttach: async () => {
             dispatch({ type: 'SET_VIEW', view: 'terminal' });
           },

--- a/src/app.tui.tsx
+++ b/src/app.tui.tsx
@@ -122,7 +122,7 @@ import {
 } from './tui/kitty-keyboard.js';
 import { useWorkspaceAgentSessions } from './agents/useWorkspaceAgentSessions.js';
 import { useWorkspaceAgentEvents } from './agents/useWorkspaceAgentEvents.js';
-import { collectAgentSessionCounts } from './agents/remote-agent-browser.js';
+import { collectAgentSessionCounts, collectWorkspaceSyncIds } from './agents/remote-agent-browser.js';
 import { agentNotificationToInboxItem } from './agents/agentNotificationToInboxItem.js';
 import { handleInboxSessionSelection, openAgentSession, promptCreateAgentSession } from './agents/agent-session-actions.js';
 
@@ -1404,12 +1404,10 @@ function App({ relayConfig, remoteIdentity, onQuit, keyboardMode }: AppProps) {
     expandedWorkspaceIds: string[];
     selectedWorkspaceId: string | null;
   }) => {
-    const workspaceIds = Array.from(new Set([
-      ...expandedWorkspaceIds,
-      ...(selectedWorkspaceId ? [selectedWorkspaceId] : []),
-    ]));
-    await workspaceAgentSessions.syncWorkspaceSessions(workspaceIds);
-  }, [workspaceAgentSessions]);
+    await workspaceAgentSessions.syncWorkspaceSessions(
+      collectWorkspaceSyncIds(workspaceInfos, expandedWorkspaceIds, selectedWorkspaceId),
+    );
+  }, [workspaceAgentSessions, workspaceInfos]);
 
   // Spaces browser hook
   const spacesBrowserProps = useSpacesBrowser({

--- a/src/app.web.tsx
+++ b/src/app.web.tsx
@@ -1880,6 +1880,7 @@ export default function App() {
             />
           )}
         </div>
+        <FlowWeb flow={flow} />
         <Toaster theme="dark" position="top-right" richColors />
       </>
     );

--- a/src/app.web.tsx
+++ b/src/app.web.tsx
@@ -820,6 +820,7 @@ export default function App() {
       collectWorkspaceSyncIds(terminal.workspaces, expandedWorkspaceIds, selectedWorkspaceId),
     );
   }, [terminal.workspaces, workspaceAgentSessions]);
+  const syncWorkspaceAgentSessions = workspaceAgentSessions.syncWorkspaceSessions;
 
   const allWorkspaceSyncKey = useMemo(
     () => terminal.workspaces.map((workspace) => workspace.id).sort().join('|'),
@@ -1170,10 +1171,10 @@ export default function App() {
     }
     lastAllWorkspaceSyncKeyRef.current = allWorkspaceSyncKey;
     terminal.requestSessions();
-    void workspaceAgentSessions.syncWorkspaceSessions(terminal.workspaces.map((workspace) => workspace.id)).catch((error) => {
+    void syncWorkspaceAgentSessions(terminal.workspaces.map((workspace) => workspace.id)).catch((error) => {
       toast.error(error instanceof Error ? error.message : String(error));
     });
-  }, [allWorkspaceSyncKey, terminal, view, workspaceAgentSessions]);
+  }, [allWorkspaceSyncKey, syncWorkspaceAgentSessions, terminal, view]);
 
   useEffect(() => {
     if (view === "terminal" && terminal.status === "established" && terminal.mode === "browsing") {

--- a/src/app.web.tsx
+++ b/src/app.web.tsx
@@ -28,6 +28,7 @@ import { ReviewPage } from './pages/ReviewPage.web.js';
 import { buildEditProcessesCommand } from './lib/processes/editor.js';
 import { useWorkspaceAgentSessions } from './agents/useWorkspaceAgentSessions.js';
 import { handleInboxSessionSelection, openAgentSession, promptCreateAgentSession } from './agents/agent-session-actions.js';
+import { collectAgentSessionCounts, collectWorkspaceSyncIds } from './agents/remote-agent-browser.js';
 
 // Import shared components and hooks
 import {
@@ -470,6 +471,15 @@ export default function App() {
       return;
     }
 
+    if (terminal.commandError.code === 'SESSION_TAKEN_OVER') {
+      flow.showMessage({
+        title: 'Session Taken Over',
+        message: terminal.commandError.message,
+        variant: 'warning',
+      });
+      return;
+    }
+
     flow.showMessage({
       title: 'Session Failed',
       message: terminal.commandError.message,
@@ -745,16 +755,12 @@ export default function App() {
 
   // Memoize agent session counts to preserve referential stability for useSpacesBrowser
   const agentSessionCounts = useMemo(() => {
-    const counts: Record<string, number> = {};
-    for (const [wid, sessions] of Object.entries(workspaceAgentSessions.sessionsByWorkspace)) {
-      counts[wid] = sessions.length;
-    }
-    for (const [wid, sessions] of Object.entries(agentEvents.workspaceStates)) {
-      const eventCount = Object.keys(sessions).length;
-      counts[wid] = Math.max(counts[wid] ?? 0, eventCount);
-    }
-    return counts;
-  }, [workspaceAgentSessions.sessionsByWorkspace, agentEvents.workspaceStates]);
+    return collectAgentSessionCounts({
+      sessionsByWorkspace: workspaceAgentSessions.sessionsByWorkspace,
+      workspaceStates: agentEvents.workspaceStates,
+      snapshotByWorkspace: webBackend?.getAgentStateSnapshot() ?? {},
+    });
+  }, [agentEvents.workspaceStates, webBackend, workspaceAgentSessions.sessionsByWorkspace]);
 
   const agentSessionsByWorkspace = useMemo(() => {
     const merged: Record<string, typeof workspaceAgentSessions.sessionsByWorkspace[string]> = {};
@@ -776,6 +782,16 @@ export default function App() {
       const combined = new Map<string, (typeof baseSessions)[number]>();
       for (const session of snapshotSessions) combined.set(session.id, session);
       for (const session of baseSessions) combined.set(session.id, session);
+      for (const sessionId of Object.keys(liveStates)) {
+        if (!combined.has(sessionId)) {
+          combined.set(sessionId, {
+            id: sessionId,
+            workspaceId,
+            title: sessionId,
+            updatedAt: undefined,
+          });
+        }
+      }
       merged[workspaceId] = Array.from(combined.values()).map((session) => {
         const live = liveStates[session.id];
         if (!live) return session;
@@ -790,6 +806,24 @@ export default function App() {
 
     return merged;
   }, [agentEvents.workspaceStates, webBackend, workspaceAgentSessions.sessionsByWorkspace]);
+
+  const refreshAgentSessions = useCallback(async ({
+    expandedWorkspaceIds,
+    selectedWorkspaceId,
+  }: {
+    expandedWorkspaceIds: string[];
+    selectedWorkspaceId: string | null;
+  }) => {
+    await workspaceAgentSessions.syncWorkspaceSessions(
+      collectWorkspaceSyncIds(terminal.workspaces, expandedWorkspaceIds, selectedWorkspaceId),
+    );
+  }, [terminal.workspaces, workspaceAgentSessions]);
+
+  const allWorkspaceSyncKey = useMemo(
+    () => terminal.workspaces.map((workspace) => workspace.id).sort().join('|'),
+    [terminal.workspaces],
+  );
+  const lastAllWorkspaceSyncKeyRef = useRef<string | null>(null);
 
   // Spaces browser hook
   const spacesBrowserProps = useSpacesBrowser({
@@ -818,14 +852,16 @@ export default function App() {
       await workspaceAgentSessions.loadWorkspaceSessions(workspaceId);
     },
     onOpenAgentSession: async (workspaceId, agentSessionId) => {
-      if (!webBackend?.attachAgentSession) {
+      if (!webBackend?.attachAgentSession || !webBackend.checkAgentSessionTakeover) {
         throw new Error('Agent attach unavailable');
       }
       await openAgentSession({
+        flow,
         workspaceId,
         agentSessionId,
         persistAgentSessionSelection,
         clearViewOnly: () => setIsViewOnlySession(false),
+        checkAgentSessionTakeover: webBackend.checkAgentSessionTakeover!.bind(webBackend),
         attachAgentSession: webBackend.attachAgentSession.bind(webBackend),
         afterAttach: async () => {
           setView('terminal');
@@ -833,7 +869,7 @@ export default function App() {
       });
     },
     onCreateAgentSession: async (workspaceId) => {
-      if (!webBackend?.attachAgentSession) {
+      if (!webBackend?.attachAgentSession || !webBackend.checkAgentSessionTakeover) {
         throw new Error('Agent attach unavailable');
       }
       promptCreateAgentSession({
@@ -842,9 +878,11 @@ export default function App() {
         getCurrentSessions: (id) => workspaceAgentSessions.sessionsByWorkspace[id] ?? [],
         createAgentSession: workspaceAgentSessions.createSession,
         attachOptions: {
+          flow,
           workspaceId,
           persistAgentSessionSelection,
           clearViewOnly: () => setIsViewOnlySession(false),
+          checkAgentSessionTakeover: webBackend.checkAgentSessionTakeover!.bind(webBackend),
           attachAgentSession: webBackend.attachAgentSession.bind(webBackend),
           afterAttach: async () => {
             setView('terminal');
@@ -857,6 +895,7 @@ export default function App() {
     pendingPermissionsByWorkspace: agentEvents.pendingPermissionsByWorkspace,
     onRefresh: () => { terminal.requestWorkspaces(); refreshReplayList(); },
     onRefreshSessions: () => { terminal.requestSessions(); refreshReplayList(); },
+    onRefreshAgents: refreshAgentSessions,
     onBack: handleBackToMachines,
     machineName: selectedProjectName
       ? `${selectedProjectName} - ${selectedMachine?.label || selectedMachine?.machineId || 'machine'}`
@@ -929,7 +968,7 @@ export default function App() {
   );
 
   const attachFromInboxSessionId = useCallback(async (sessionId: string) => {
-    if (!webBackend?.attachAgentSession) {
+    if (!webBackend?.attachAgentSession || !webBackend.checkAgentSessionTakeover) {
       throw new Error('Agent attach unavailable');
     }
     await handleInboxSessionSelection({
@@ -942,10 +981,12 @@ export default function App() {
       },
       openAgentSession: async (workspaceId, agentSessionId) => {
         await openAgentSession({
+          flow,
           workspaceId,
           agentSessionId,
           persistAgentSessionSelection,
           clearViewOnly: () => setIsViewOnlySession(false),
+          checkAgentSessionTakeover: webBackend.checkAgentSessionTakeover!.bind(webBackend),
           attachAgentSession: webBackend.attachAgentSession!.bind(webBackend),
           afterAttach: async () => {
             setView('terminal');
@@ -1116,6 +1157,21 @@ export default function App() {
     terminal.requestSessions,
     terminal.requestNotificationConfig,
   ]);
+
+  useEffect(() => {
+    if (view !== 'terminal' || terminal.status !== 'established' || terminal.mode !== 'browsing' || terminal.workspaces.length === 0) {
+      lastAllWorkspaceSyncKeyRef.current = null;
+      return;
+    }
+    if (lastAllWorkspaceSyncKeyRef.current === allWorkspaceSyncKey) {
+      return;
+    }
+    lastAllWorkspaceSyncKeyRef.current = allWorkspaceSyncKey;
+    terminal.requestSessions();
+    void workspaceAgentSessions.syncWorkspaceSessions(terminal.workspaces.map((workspace) => workspace.id)).catch((error) => {
+      toast.error(error instanceof Error ? error.message : String(error));
+    });
+  }, [allWorkspaceSyncKey, terminal, view, workspaceAgentSessions]);
 
   useEffect(() => {
     if (view === "terminal" && terminal.status === "established" && terminal.mode === "browsing") {

--- a/src/app.web.tsx
+++ b/src/app.web.tsx
@@ -778,6 +778,7 @@ export default function App() {
         workspaceId,
         title: session.title,
         updatedAt: undefined,
+        closed: 'closed' in session ? Boolean(session.closed) : undefined,
       }));
       const combined = new Map<string, (typeof baseSessions)[number]>();
       for (const session of snapshotSessions) combined.set(session.id, session);
@@ -789,6 +790,7 @@ export default function App() {
             workspaceId,
             title: sessionId,
             updatedAt: undefined,
+            closed: false,
           });
         }
       }
@@ -852,7 +854,7 @@ export default function App() {
       await workspaceAgentSessions.loadWorkspaceSessions(workspaceId);
     },
     onOpenAgentSession: async (workspaceId, agentSessionId) => {
-      if (!webBackend?.attachAgentSession || !webBackend.checkAgentSessionTakeover) {
+      if (!webBackend?.attachAgentSession) {
         throw new Error('Agent attach unavailable');
       }
       await openAgentSession({
@@ -861,7 +863,7 @@ export default function App() {
         agentSessionId,
         persistAgentSessionSelection,
         clearViewOnly: () => setIsViewOnlySession(false),
-        checkAgentSessionTakeover: webBackend.checkAgentSessionTakeover!.bind(webBackend),
+        checkAgentSessionTakeover: webBackend.checkAgentSessionTakeover?.bind(webBackend),
         attachAgentSession: webBackend.attachAgentSession.bind(webBackend),
         afterAttach: async () => {
           setView('terminal');
@@ -869,7 +871,7 @@ export default function App() {
       });
     },
     onCreateAgentSession: async (workspaceId) => {
-      if (!webBackend?.attachAgentSession || !webBackend.checkAgentSessionTakeover) {
+      if (!webBackend?.attachAgentSession) {
         throw new Error('Agent attach unavailable');
       }
       promptCreateAgentSession({
@@ -882,7 +884,7 @@ export default function App() {
           workspaceId,
           persistAgentSessionSelection,
           clearViewOnly: () => setIsViewOnlySession(false),
-          checkAgentSessionTakeover: webBackend.checkAgentSessionTakeover!.bind(webBackend),
+          checkAgentSessionTakeover: webBackend.checkAgentSessionTakeover?.bind(webBackend),
           attachAgentSession: webBackend.attachAgentSession.bind(webBackend),
           afterAttach: async () => {
             setView('terminal');
@@ -968,7 +970,7 @@ export default function App() {
   );
 
   const attachFromInboxSessionId = useCallback(async (sessionId: string) => {
-    if (!webBackend?.attachAgentSession || !webBackend.checkAgentSessionTakeover) {
+    if (!webBackend?.attachAgentSession) {
       throw new Error('Agent attach unavailable');
     }
     await handleInboxSessionSelection({
@@ -986,7 +988,7 @@ export default function App() {
           agentSessionId,
           persistAgentSessionSelection,
           clearViewOnly: () => setIsViewOnlySession(false),
-          checkAgentSessionTakeover: webBackend.checkAgentSessionTakeover!.bind(webBackend),
+          checkAgentSessionTakeover: webBackend.checkAgentSessionTakeover?.bind(webBackend),
           attachAgentSession: webBackend.attachAgentSession!.bind(webBackend),
           afterAttach: async () => {
             setView('terminal');

--- a/src/app.web.tsx
+++ b/src/app.web.tsx
@@ -809,6 +809,8 @@ export default function App() {
     return merged;
   }, [agentEvents.workspaceStates, webBackend, workspaceAgentSessions.sessionsByWorkspace]);
 
+  const syncWorkspaceAgentSessions = workspaceAgentSessions.syncWorkspaceSessions;
+
   const refreshAgentSessions = useCallback(async ({
     expandedWorkspaceIds,
     selectedWorkspaceId,
@@ -816,11 +818,10 @@ export default function App() {
     expandedWorkspaceIds: string[];
     selectedWorkspaceId: string | null;
   }) => {
-    await workspaceAgentSessions.syncWorkspaceSessions(
+    await syncWorkspaceAgentSessions(
       collectWorkspaceSyncIds(terminal.workspaces, expandedWorkspaceIds, selectedWorkspaceId),
     );
-  }, [terminal.workspaces, workspaceAgentSessions]);
-  const syncWorkspaceAgentSessions = workspaceAgentSessions.syncWorkspaceSessions;
+  }, [syncWorkspaceAgentSessions, terminal.workspaces]);
 
   const allWorkspaceSyncKey = useMemo(
     () => terminal.workspaces.map((workspace) => workspace.id).sort().join('|'),

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -1492,6 +1492,7 @@ export async function serveStart(options: {
     stopAgentWatch = await watchAgentState({
       onSnapshot: (workspaces) => {
         currentAgentSnapshot = Object.fromEntries(workspaces.map((workspace) => [workspace.workspaceId, workspace]));
+        void sessionManager.broadcastAgentStateSnapshot(currentAgentSnapshot);
       },
       onUpdate: (delta) => {
         applyAgentDelta(delta);
@@ -1520,9 +1521,7 @@ export async function serveStart(options: {
         break;
       case 'client_authenticated': {
         updateDaemonState({ clients: sessionManager.establishedSessionCount });
-        if (Object.keys(currentAgentSnapshot).length > 0) {
-          void sessionManager.sendAgentStateSnapshot(event.connectionId, currentAgentSnapshot);
-        }
+        void sessionManager.sendAgentStateSnapshot(event.connectionId, currentAgentSnapshot);
         break;
       }
       case 'client_disconnected':

--- a/src/components/RemoteMachineScreen.tui.tsx
+++ b/src/components/RemoteMachineScreen.tui.tsx
@@ -42,7 +42,7 @@ import type { ReplayInfo } from '../lib/tmux-lite/replay/index.js';
 import { useWorkspaceAgentSessions } from '../agents/useWorkspaceAgentSessions.js';
 import { useWorkspaceAgentEvents } from '../agents/useWorkspaceAgentEvents.js';
 import { agentNotificationToInboxItem } from '../agents/agentNotificationToInboxItem.js';
-import { collectWorkspaceSyncIds } from '../agents/remote-agent-browser.js';
+import { collectAgentSessionCounts, collectWorkspaceSyncIds } from '../agents/remote-agent-browser.js';
 import { handleInboxSessionSelection, openAgentSession, promptCreateAgentSession } from '../agents/agent-session-actions.js';
 import { toast } from '@opentui-ui/toast';
 import { DEFAULT_NOTIFICATION_CONFIG, useNotifications, type ToastNotification } from '../notifications/index.js';
@@ -621,16 +621,12 @@ export function RemoteMachineScreen({ machine, relayUrl, identity, onBack }: Rem
 
   // Memoize agent session counts to preserve referential stability for useSpacesBrowser
   const agentSessionCounts = useMemo(() => {
-    const counts: Record<string, number> = {};
-    for (const [wid, sessions] of Object.entries(workspaceAgentSessions.sessionsByWorkspace)) {
-      counts[wid] = sessions.length;
-    }
-    for (const [wid, sessions] of Object.entries(agentEvents.workspaceStates)) {
-      const eventCount = Object.keys(sessions).length;
-      counts[wid] = Math.max(counts[wid] ?? 0, eventCount);
-    }
-    return counts;
-  }, [workspaceAgentSessions.sessionsByWorkspace, agentEvents.workspaceStates]);
+    return collectAgentSessionCounts({
+      sessionsByWorkspace: workspaceAgentSessions.sessionsByWorkspace,
+      workspaceStates: agentEvents.workspaceStates,
+      snapshotByWorkspace: remoteBackend?.getAgentStateSnapshot() ?? {},
+    });
+  }, [agentEvents.workspaceStates, remoteBackend, workspaceAgentSessions.sessionsByWorkspace]);
 
   const agentSessionsByWorkspace = useMemo(() => {
     const merged: Record<string, typeof workspaceAgentSessions.sessionsByWorkspace[string]> = {};

--- a/src/components/RemoteMachineScreen.tui.tsx
+++ b/src/components/RemoteMachineScreen.tui.tsx
@@ -676,6 +676,8 @@ export function RemoteMachineScreen({ machine, relayUrl, identity, onBack }: Rem
     return merged;
   }, [agentEvents.workspaceStates, remoteBackend, workspaceAgentSessions.sessionsByWorkspace]);
 
+  const syncWorkspaceAgentSessions = workspaceAgentSessions.syncWorkspaceSessions;
+
   const refreshAgentSessions = useCallback(async ({
     expandedWorkspaceIds,
     selectedWorkspaceId,
@@ -683,11 +685,10 @@ export function RemoteMachineScreen({ machine, relayUrl, identity, onBack }: Rem
     expandedWorkspaceIds: string[];
     selectedWorkspaceId: string | null;
   }) => {
-    await workspaceAgentSessions.syncWorkspaceSessions(
+    await syncWorkspaceAgentSessions(
       collectWorkspaceSyncIds(remote.workspaces, expandedWorkspaceIds, selectedWorkspaceId),
     );
-  }, [remote.workspaces, workspaceAgentSessions]);
-  const syncWorkspaceAgentSessions = workspaceAgentSessions.syncWorkspaceSessions;
+  }, [remote.workspaces, syncWorkspaceAgentSessions]);
 
   const remoteWorkspaceSyncKey = useMemo(
     () => remote.workspaces.map((workspace) => workspace.id).sort().join('|'),

--- a/src/components/RemoteMachineScreen.tui.tsx
+++ b/src/components/RemoteMachineScreen.tui.tsx
@@ -46,6 +46,7 @@ import { handleInboxSessionSelection, openAgentSession, promptCreateAgentSession
 import { toast } from '@opentui-ui/toast';
 import { DEFAULT_NOTIFICATION_CONFIG, useNotifications, type ToastNotification } from '../notifications/index.js';
 import { useUserActivity } from '../hooks/index.js';
+import { executeSafeRefresh } from './remote-refresh.js';
 
 const COLORS = {
   statusBar: '#333333',
@@ -165,6 +166,27 @@ export function RemoteMachineScreen({ machine, relayUrl, identity, onBack }: Rem
     applyBundleRefresh: remote.applyBundleRefresh,
     resolveProjectName: resolveRemoteWorkspaceProjectName,
   });
+  const lastRemoteCommandErrorRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!remote.commandError) {
+      lastRemoteCommandErrorRef.current = null;
+      return;
+    }
+    if (remote.commandError.code !== 'SESSION_TAKEN_OVER') {
+      return;
+    }
+    const key = `${remote.commandError.code}:${remote.commandError.message}`;
+    if (lastRemoteCommandErrorRef.current === key) {
+      return;
+    }
+    lastRemoteCommandErrorRef.current = key;
+    flow.showMessage({
+      title: 'Session Taken Over',
+      message: remote.commandError.message,
+      variant: 'warning',
+    });
+  }, [flow, remote.commandError]);
 
   const bundleConfigFlow = useBundleConfigFlow({
     flow,
@@ -629,6 +651,16 @@ export function RemoteMachineScreen({ machine, relayUrl, identity, onBack }: Rem
       const combined = new Map<string, (typeof baseSessions)[number]>();
       for (const session of snapshotSessions) combined.set(session.id, session);
       for (const session of baseSessions) combined.set(session.id, session);
+      for (const sessionId of Object.keys(liveStates)) {
+        if (!combined.has(sessionId)) {
+          combined.set(sessionId, {
+            id: sessionId,
+            workspaceId,
+            title: sessionId,
+            updatedAt: undefined,
+          });
+        }
+      }
       merged[workspaceId] = Array.from(combined.values()).map((session) => {
         const live = liveStates[session.id];
         if (!live) return session;
@@ -643,6 +675,44 @@ export function RemoteMachineScreen({ machine, relayUrl, identity, onBack }: Rem
 
     return merged;
   }, [agentEvents.workspaceStates, remoteBackend, workspaceAgentSessions.sessionsByWorkspace]);
+
+  const refreshAgentSessions = useCallback(async ({
+    expandedWorkspaceIds,
+    selectedWorkspaceId,
+  }: {
+    expandedWorkspaceIds: string[];
+    selectedWorkspaceId: string | null;
+  }) => {
+    const workspaceIds = new Set(remote.workspaces.map((workspace) => workspace.id));
+    for (const workspaceId of expandedWorkspaceIds) {
+      workspaceIds.add(workspaceId);
+    }
+    if (selectedWorkspaceId) {
+      workspaceIds.add(selectedWorkspaceId);
+    }
+    await workspaceAgentSessions.syncWorkspaceSessions(Array.from(workspaceIds));
+  }, [remote.workspaces, workspaceAgentSessions]);
+
+  const remoteWorkspaceSyncKey = useMemo(
+    () => remote.workspaces.map((workspace) => workspace.id).sort().join('|'),
+    [remote.workspaces],
+  );
+  const lastRemoteWorkspaceSyncKeyRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (remote.status !== 'established' || remote.mode !== 'browsing' || remote.workspaces.length === 0) {
+      lastRemoteWorkspaceSyncKeyRef.current = null;
+      return;
+    }
+    if (lastRemoteWorkspaceSyncKeyRef.current === remoteWorkspaceSyncKey) {
+      return;
+    }
+    lastRemoteWorkspaceSyncKeyRef.current = remoteWorkspaceSyncKey;
+    remote.requestSessions();
+    void workspaceAgentSessions.syncWorkspaceSessions(remote.workspaces.map((workspace) => workspace.id)).catch((error) => {
+      logger.error(`[tui] Initial remote agent sync failed: ${error instanceof Error ? error.message : String(error)}`);
+    });
+  }, [remote.mode, remote.requestSessions, remote.status, remote.workspaces, remoteWorkspaceSyncKey, workspaceAgentSessions]);
 
   const spacesBrowserProps = useSpacesBrowser({
     workspaces: remote.workspaces,
@@ -661,19 +731,21 @@ export function RemoteMachineScreen({ machine, relayUrl, identity, onBack }: Rem
       await workspaceAgentSessions.loadWorkspaceSessions(workspaceId);
     },
     onOpenAgentSession: async (workspaceId, agentSessionId) => {
-      if (!remoteBackend?.attachAgentSession) {
+      if (!remoteBackend?.attachAgentSession || !remoteBackend.checkAgentSessionTakeover) {
         throw new Error('Agent attach unavailable');
       }
       await openAgentSession({
+        flow,
         workspaceId,
         agentSessionId,
         persistAgentSessionSelection,
         clearViewOnly: () => setIsViewOnlySession(false),
+        checkAgentSessionTakeover: remoteBackend.checkAgentSessionTakeover.bind(remoteBackend),
         attachAgentSession: remoteBackend.attachAgentSession.bind(remoteBackend),
       });
     },
     onCreateAgentSession: async (workspaceId) => {
-      if (!remoteBackend?.attachAgentSession) {
+      if (!remoteBackend?.attachAgentSession || !remoteBackend.checkAgentSessionTakeover) {
         throw new Error('Agent attach unavailable');
       }
       promptCreateAgentSession({
@@ -682,9 +754,11 @@ export function RemoteMachineScreen({ machine, relayUrl, identity, onBack }: Rem
         getCurrentSessions: (id) => workspaceAgentSessions.sessionsByWorkspace[id] ?? [],
         createAgentSession: workspaceAgentSessions.createSession,
         attachOptions: {
+          flow,
           workspaceId,
           persistAgentSessionSelection,
           clearViewOnly: () => setIsViewOnlySession(false),
+          checkAgentSessionTakeover: remoteBackend.checkAgentSessionTakeover.bind(remoteBackend),
           attachAgentSession: remoteBackend.attachAgentSession.bind(remoteBackend),
         },
       });
@@ -698,6 +772,7 @@ export function RemoteMachineScreen({ machine, relayUrl, identity, onBack }: Rem
       remote.requestSessions();
       remote.requestReplays();
     },
+    onRefreshAgents: refreshAgentSessions,
     onBack,
     machineName: machine.label || machine.machineId,
   });
@@ -739,10 +814,12 @@ export function RemoteMachineScreen({ machine, relayUrl, identity, onBack }: Rem
       },
       openAgentSession: async (workspaceId, agentSessionId) => {
         await openAgentSession({
+          flow,
           workspaceId,
           agentSessionId,
           persistAgentSessionSelection,
           clearViewOnly: () => setIsViewOnlySession(false),
+          checkAgentSessionTakeover: remoteBackend.checkAgentSessionTakeover!.bind(remoteBackend),
           attachAgentSession: remoteBackend.attachAgentSession!.bind(remoteBackend),
         });
       },
@@ -1034,7 +1111,15 @@ export function RemoteMachineScreen({ machine, relayUrl, identity, onBack }: Rem
     } else if (browseCommand === 'move-down') {
       spacesBrowserProps.moveDown();
     } else if (browseCommand === 'activate') {
-      spacesBrowserProps.activateSelected();
+      try {
+        await spacesBrowserProps.activateSelected();
+      } catch (error) {
+        flow.showMessage({
+          title: 'Action Failed',
+          message: error instanceof Error ? error.message : String(error),
+          variant: 'error',
+        });
+      }
     } else if (browseCommand === 'new') {
       lifecycleController.openCreateMenu(selectedProjectName);
     } else if (browseCommand === 'bundle') {
@@ -1048,7 +1133,22 @@ export function RemoteMachineScreen({ machine, relayUrl, identity, onBack }: Rem
         await handleManageBundleConfig({ workspaceId });
       }
     } else if (browseCommand === 'refresh') {
-      spacesBrowserProps.refresh();
+      await executeSafeRefresh({
+        refresh: spacesBrowserProps.refresh,
+        context: {
+          machineId: machine.machineId,
+          machineLabel: machine.label ?? null,
+          selectedProjectName: selectedProjectName ?? null,
+          selectedItemType: spacesBrowserProps.selectedItem?.type ?? null,
+        },
+        onError: (message) => {
+          flow.showMessage({
+            title: 'Refresh Failed',
+            message,
+            variant: 'error',
+          });
+        },
+      });
     } else if (browseCommand === 'open-inbox') {
       remote.requestInbox();
       setShowInbox(true);
@@ -1077,6 +1177,16 @@ export function RemoteMachineScreen({ machine, relayUrl, identity, onBack }: Rem
             });
           },
         });
+      } else if (selected?.type === 'agent-session' && !selected.session.closed) {
+        flow.showConfirm({
+          title: 'Close Agent Session',
+          message: `Close agent session "${selected.session.title}"?`,
+          variant: 'warning',
+          confirmLabel: 'Close',
+          onConfirm: () => {
+            void workspaceAgentSessions.abortSession(selected.workspaceId, selected.session.id);
+          },
+        });
       }
     } else if (browseCommand === 'delete') {
       const selected = spacesBrowserProps.selectedItem;
@@ -1097,6 +1207,16 @@ export function RemoteMachineScreen({ machine, relayUrl, identity, onBack }: Rem
               workspaceId: selected.workspace.id,
               workspaceName: selected.workspace.name,
             });
+          },
+        });
+      } else if (selected?.type === 'agent-session' && selected.session.closed) {
+        flow.showConfirm({
+          title: 'Clear Closed Agent',
+          message: `Remove closed agent session "${selected.session.title}" from history?`,
+          variant: 'warning',
+          confirmLabel: 'Clear',
+          onConfirm: () => {
+            void workspaceAgentSessions.clearSession(selected.workspaceId, selected.session.id);
           },
         });
       }

--- a/src/components/RemoteMachineScreen.tui.tsx
+++ b/src/components/RemoteMachineScreen.tui.tsx
@@ -42,6 +42,7 @@ import type { ReplayInfo } from '../lib/tmux-lite/replay/index.js';
 import { useWorkspaceAgentSessions } from '../agents/useWorkspaceAgentSessions.js';
 import { useWorkspaceAgentEvents } from '../agents/useWorkspaceAgentEvents.js';
 import { agentNotificationToInboxItem } from '../agents/agentNotificationToInboxItem.js';
+import { collectWorkspaceSyncIds } from '../agents/remote-agent-browser.js';
 import { handleInboxSessionSelection, openAgentSession, promptCreateAgentSession } from '../agents/agent-session-actions.js';
 import { toast } from '@opentui-ui/toast';
 import { DEFAULT_NOTIFICATION_CONFIG, useNotifications, type ToastNotification } from '../notifications/index.js';
@@ -647,6 +648,7 @@ export function RemoteMachineScreen({ machine, relayUrl, identity, onBack }: Rem
         workspaceId,
         title: session.title,
         updatedAt: undefined,
+        closed: 'closed' in session ? Boolean(session.closed) : undefined,
       }));
       const combined = new Map<string, (typeof baseSessions)[number]>();
       for (const session of snapshotSessions) combined.set(session.id, session);
@@ -658,6 +660,7 @@ export function RemoteMachineScreen({ machine, relayUrl, identity, onBack }: Rem
             workspaceId,
             title: sessionId,
             updatedAt: undefined,
+            closed: false,
           });
         }
       }
@@ -683,14 +686,9 @@ export function RemoteMachineScreen({ machine, relayUrl, identity, onBack }: Rem
     expandedWorkspaceIds: string[];
     selectedWorkspaceId: string | null;
   }) => {
-    const workspaceIds = new Set(remote.workspaces.map((workspace) => workspace.id));
-    for (const workspaceId of expandedWorkspaceIds) {
-      workspaceIds.add(workspaceId);
-    }
-    if (selectedWorkspaceId) {
-      workspaceIds.add(selectedWorkspaceId);
-    }
-    await workspaceAgentSessions.syncWorkspaceSessions(Array.from(workspaceIds));
+    await workspaceAgentSessions.syncWorkspaceSessions(
+      collectWorkspaceSyncIds(remote.workspaces, expandedWorkspaceIds, selectedWorkspaceId),
+    );
   }, [remote.workspaces, workspaceAgentSessions]);
 
   const remoteWorkspaceSyncKey = useMemo(
@@ -731,7 +729,7 @@ export function RemoteMachineScreen({ machine, relayUrl, identity, onBack }: Rem
       await workspaceAgentSessions.loadWorkspaceSessions(workspaceId);
     },
     onOpenAgentSession: async (workspaceId, agentSessionId) => {
-      if (!remoteBackend?.attachAgentSession || !remoteBackend.checkAgentSessionTakeover) {
+      if (!remoteBackend?.attachAgentSession) {
         throw new Error('Agent attach unavailable');
       }
       await openAgentSession({
@@ -740,12 +738,12 @@ export function RemoteMachineScreen({ machine, relayUrl, identity, onBack }: Rem
         agentSessionId,
         persistAgentSessionSelection,
         clearViewOnly: () => setIsViewOnlySession(false),
-        checkAgentSessionTakeover: remoteBackend.checkAgentSessionTakeover.bind(remoteBackend),
+        checkAgentSessionTakeover: remoteBackend.checkAgentSessionTakeover?.bind(remoteBackend),
         attachAgentSession: remoteBackend.attachAgentSession.bind(remoteBackend),
       });
     },
     onCreateAgentSession: async (workspaceId) => {
-      if (!remoteBackend?.attachAgentSession || !remoteBackend.checkAgentSessionTakeover) {
+      if (!remoteBackend?.attachAgentSession) {
         throw new Error('Agent attach unavailable');
       }
       promptCreateAgentSession({
@@ -758,7 +756,7 @@ export function RemoteMachineScreen({ machine, relayUrl, identity, onBack }: Rem
           workspaceId,
           persistAgentSessionSelection,
           clearViewOnly: () => setIsViewOnlySession(false),
-          checkAgentSessionTakeover: remoteBackend.checkAgentSessionTakeover.bind(remoteBackend),
+          checkAgentSessionTakeover: remoteBackend.checkAgentSessionTakeover?.bind(remoteBackend),
           attachAgentSession: remoteBackend.attachAgentSession.bind(remoteBackend),
         },
       });
@@ -819,7 +817,7 @@ export function RemoteMachineScreen({ machine, relayUrl, identity, onBack }: Rem
           agentSessionId,
           persistAgentSessionSelection,
           clearViewOnly: () => setIsViewOnlySession(false),
-          checkAgentSessionTakeover: remoteBackend.checkAgentSessionTakeover!.bind(remoteBackend),
+          checkAgentSessionTakeover: remoteBackend.checkAgentSessionTakeover?.bind(remoteBackend),
           attachAgentSession: remoteBackend.attachAgentSession!.bind(remoteBackend),
         });
       },

--- a/src/components/RemoteMachineScreen.tui.tsx
+++ b/src/components/RemoteMachineScreen.tui.tsx
@@ -687,6 +687,7 @@ export function RemoteMachineScreen({ machine, relayUrl, identity, onBack }: Rem
       collectWorkspaceSyncIds(remote.workspaces, expandedWorkspaceIds, selectedWorkspaceId),
     );
   }, [remote.workspaces, workspaceAgentSessions]);
+  const syncWorkspaceAgentSessions = workspaceAgentSessions.syncWorkspaceSessions;
 
   const remoteWorkspaceSyncKey = useMemo(
     () => remote.workspaces.map((workspace) => workspace.id).sort().join('|'),
@@ -704,10 +705,10 @@ export function RemoteMachineScreen({ machine, relayUrl, identity, onBack }: Rem
     }
     lastRemoteWorkspaceSyncKeyRef.current = remoteWorkspaceSyncKey;
     remote.requestSessions();
-    void workspaceAgentSessions.syncWorkspaceSessions(remote.workspaces.map((workspace) => workspace.id)).catch((error) => {
+    void syncWorkspaceAgentSessions(remote.workspaces.map((workspace) => workspace.id)).catch((error) => {
       logger.error(`[tui] Initial remote agent sync failed: ${error instanceof Error ? error.message : String(error)}`);
     });
-  }, [remote.mode, remote.requestSessions, remote.status, remote.workspaces, remoteWorkspaceSyncKey, workspaceAgentSessions]);
+  }, [remote.mode, remote.requestSessions, remote.status, remote.workspaces, remoteWorkspaceSyncKey, syncWorkspaceAgentSessions]);
 
   const spacesBrowserProps = useSpacesBrowser({
     workspaces: remote.workspaces,

--- a/src/components/RemoteMachineScreen.tui.tsx
+++ b/src/components/RemoteMachineScreen.tui.tsx
@@ -1178,8 +1178,8 @@ export function RemoteMachineScreen({ machine, relayUrl, identity, onBack }: Rem
           message: `Close agent session "${selected.session.title}"?`,
           variant: 'warning',
           confirmLabel: 'Close',
-          onConfirm: () => {
-            void workspaceAgentSessions.abortSession(selected.workspaceId, selected.session.id);
+          onConfirm: async () => {
+            await workspaceAgentSessions.abortSession(selected.workspaceId, selected.session.id);
           },
         });
       }
@@ -1210,8 +1210,8 @@ export function RemoteMachineScreen({ machine, relayUrl, identity, onBack }: Rem
           message: `Remove closed agent session "${selected.session.title}" from history?`,
           variant: 'warning',
           confirmLabel: 'Clear',
-          onConfirm: () => {
-            void workspaceAgentSessions.clearSession(selected.workspaceId, selected.session.id);
+          onConfirm: async () => {
+            await workspaceAgentSessions.clearSession(selected.workspaceId, selected.session.id);
           },
         });
       }

--- a/src/components/RemoteMachineScreen.tui.tsx
+++ b/src/components/RemoteMachineScreen.tui.tsx
@@ -1248,6 +1248,7 @@ export function RemoteMachineScreen({ machine, relayUrl, identity, onBack }: Rem
           onActivity={handleTerminalActivity}
           readOnly={isViewOnlySession}
         />
+        <FlowTUI flow={flow} />
       </Fragment>
     );
   }

--- a/src/components/RemoteMachineScreen.tui.tsx
+++ b/src/components/RemoteMachineScreen.tui.tsx
@@ -175,6 +175,7 @@ export function RemoteMachineScreen({ machine, relayUrl, identity, onBack }: Rem
       return;
     }
     if (remote.commandError.code !== 'SESSION_TAKEN_OVER') {
+      lastRemoteCommandErrorRef.current = null;
       return;
     }
     const key = `${remote.commandError.code}:${remote.commandError.message}`;

--- a/src/components/SpacesBrowser.tsx
+++ b/src/components/SpacesBrowser.tsx
@@ -727,9 +727,9 @@ export function useSpacesBrowser(props: UseSpacesBrowserProps): UseSpacesBrowser
     }
     if (onRefreshAgents) {
       const selectedWorkspaceId = selectedItem?.type === 'workspace'
-        ? selectedItem.workspace.id
+        ? (selectedItem.workspace.id.startsWith('orphan:') ? null : selectedItem.workspace.id)
         : selectedItem && 'workspaceId' in selectedItem
-          ? selectedItem.workspaceId
+          ? (selectedItem.workspaceId.startsWith('orphan:') ? null : selectedItem.workspaceId)
           : null;
       await onRefreshAgents({
         expandedWorkspaceIds: Array.from(expandedAgentSections),

--- a/src/components/SpacesBrowser.tsx
+++ b/src/components/SpacesBrowser.tsx
@@ -726,17 +726,20 @@ export function useSpacesBrowser(props: UseSpacesBrowserProps): UseSpacesBrowser
       await onRefreshSessions();
     }
     if (onRefreshAgents) {
-      const selectedWorkspaceId = selectedItem?.type === 'workspace'
-        ? (selectedItem.workspace.id.startsWith('orphan:') ? null : selectedItem.workspace.id)
+      const candidateWorkspaceId = selectedItem?.type === 'workspace'
+        ? selectedItem.workspace.id
         : selectedItem && 'workspaceId' in selectedItem
-          ? (selectedItem.workspaceId.startsWith('orphan:') ? null : selectedItem.workspaceId)
+          ? selectedItem.workspaceId
           : null;
+      const selectedWorkspaceId = candidateWorkspaceId && workspaces.some((workspace) => workspace.id === candidateWorkspaceId)
+        ? candidateWorkspaceId
+        : null;
       await onRefreshAgents({
         expandedWorkspaceIds: Array.from(expandedAgentSections),
         selectedWorkspaceId,
       });
     }
-  }, [expandedAgentSections, onRefresh, onRefreshAgents, onRefreshSessions, selectedItem]);
+  }, [expandedAgentSections, onRefresh, onRefreshAgents, onRefreshSessions, selectedItem, workspaces]);
 
   const back = useCallback(() => {
     onBack();

--- a/src/components/SpacesBrowser.tsx
+++ b/src/components/SpacesBrowser.tsx
@@ -61,12 +61,14 @@ export interface AgentSessionInfo {
   workspaceId: string;
   title: string;
   updatedAt?: string;
+  closed?: boolean;
   status?: SessionStatus;
   pendingPermissionCount?: number;
   errorMessage?: string;
 }
 
 export type AgentSessionDisplayState =
+  | 'closed'
   | 'needs-permission'
   | 'error'
   | 'running'
@@ -74,6 +76,9 @@ export type AgentSessionDisplayState =
   | 'waiting';
 
 export function getAgentSessionDisplayState(session: AgentSessionInfo): AgentSessionDisplayState {
+  if (session.closed) {
+    return 'closed';
+  }
   if ((session.pendingPermissionCount ?? 0) > 0) {
     return 'needs-permission';
   }
@@ -92,6 +97,8 @@ export function getAgentSessionDisplayState(session: AgentSessionInfo): AgentSes
 export function getAgentSessionDisplayLabel(session: AgentSessionInfo): string {
   const state = getAgentSessionDisplayState(session);
   switch (state) {
+    case 'closed':
+      return 'closed';
     case 'needs-permission':
       return `needs permission${(session.pendingPermissionCount ?? 0) > 1 ? ` (${session.pendingPermissionCount})` : ''}`;
     case 'error':
@@ -156,6 +163,8 @@ export interface UseSpacesBrowserProps {
   onRefresh: () => void | Promise<void>;
   /** Called to refresh sessions after workspace refresh (full refresh by default). */
   onRefreshSessions?: () => void | Promise<void>;
+  /** Called to refresh agent state for expanded/selected workspaces. */
+  onRefreshAgents?: (context: { expandedWorkspaceIds: string[]; selectedWorkspaceId: string | null }) => void | Promise<void>;
   onBack: () => void;
   /** Called when user wants to create a new workspace */
   onCreateWorkspace?: () => void;
@@ -506,6 +515,7 @@ export function useSpacesBrowser(props: UseSpacesBrowserProps): UseSpacesBrowser
     onManageBundleConfig,
     onRefresh,
     onRefreshSessions,
+    onRefreshAgents,
     onBack,
     onCreateWorkspace,
     machineName,
@@ -669,7 +679,9 @@ export function useSpacesBrowser(props: UseSpacesBrowserProps): UseSpacesBrowser
     } else if (item.type === 'agents') {
       toggleAgentSection(item.workspaceId);
     } else if (item.type === 'agent-session') {
-      await onOpenAgentSession?.(item.workspaceId, item.session.id);
+      if (!item.session.closed) {
+        await onOpenAgentSession?.(item.workspaceId, item.session.id);
+      }
     } else if (item.type === 'new-agent-session') {
       await onCreateAgentSession?.(item.workspaceId);
     } else if (item.type === 'events') {
@@ -710,11 +722,21 @@ export function useSpacesBrowser(props: UseSpacesBrowserProps): UseSpacesBrowser
 
   const refresh = useCallback(async () => {
     await onRefresh();
-    // Also refresh sessions (shared full refresh policy)
     if (onRefreshSessions) {
       await onRefreshSessions();
     }
-  }, [onRefresh, onRefreshSessions]);
+    if (onRefreshAgents) {
+      const selectedWorkspaceId = selectedItem?.type === 'workspace'
+        ? selectedItem.workspace.id
+        : selectedItem && 'workspaceId' in selectedItem
+          ? selectedItem.workspaceId
+          : null;
+      await onRefreshAgents({
+        expandedWorkspaceIds: Array.from(expandedAgentSections),
+        selectedWorkspaceId,
+      });
+    }
+  }, [expandedAgentSections, onRefresh, onRefreshAgents, onRefreshSessions, selectedItem]);
 
   const back = useCallback(() => {
     onBack();

--- a/src/components/SpacesBrowser.tui.tsx
+++ b/src/components/SpacesBrowser.tui.tsx
@@ -84,7 +84,9 @@ function getSpacesBrowserHint(selectedItem: TreeItem | null | undefined): string
       : '[↑↓] Navigate  [Enter] Expand Agents  [r] Refresh  [q] Back';
   }
   if (selectedItem?.type === 'agent-session') {
-    return '[↑↓] Navigate  [Enter] Open Agent Session  [r] Refresh  [q] Back';
+    return selectedItem.session.closed
+      ? '[↑↓] Navigate  [d] Clear Closed Agent  [r] Refresh  [q] Back'
+      : '[↑↓] Navigate  [Enter] Open Agent Session  [x] Close Agent  [r] Refresh  [q] Back';
   }
   if (selectedItem?.type === 'new-agent-session') {
     return '[↑↓] Navigate  [Enter] New Agent Session  [r] Refresh  [q] Back';
@@ -309,12 +311,13 @@ export function SpacesBrowserTUI(props: SpacesBrowserTUIProps) {
           }
 
           if (item.type === 'agent-session') {
-            const textColor = isSelected ? COLORS.selected : '#C678DD';
+            const textColor = isSelected ? COLORS.selected : item.session.closed ? COLORS.textDim : '#C678DD';
             const prefix = isSelected ? '>' : ' ';
             const state = getAgentSessionDisplayState(item.session);
             const label = getAgentSessionDisplayLabel(item.session);
             const signal =
-              state === 'needs-permission' ? '⚡'
+              state === 'closed' ? '■'
+              : state === 'needs-permission' ? '⚡'
               : state === 'error' ? '!'
               : state === 'running' ? '●'
               : state === 'retrying' ? '↻'

--- a/src/components/SpacesBrowser.web.tsx
+++ b/src/components/SpacesBrowser.web.tsx
@@ -508,7 +508,8 @@ export function SpacesBrowserWeb(props: SpacesBrowserWebProps) {
             const state = getAgentSessionDisplayState(item.session);
             const label = getAgentSessionDisplayLabel(item.session);
             const signal =
-              state === 'needs-permission' ? `⚡ ${label}`
+              state === 'closed' ? `■ ${label}`
+              : state === 'needs-permission' ? `⚡ ${label}`
               : state === 'error' ? `! ${label}`
               : state === 'running' ? `● ${label}`
               : state === 'retrying' ? `↻ ${label}`
@@ -526,7 +527,7 @@ export function SpacesBrowserWeb(props: SpacesBrowserWebProps) {
                 `}
               >
                 <div className="min-w-0 flex-1">
-                  <div className="text-[#c678dd] truncate text-sm">✦ {item.session.title}</div>
+                  <div className={`truncate text-sm ${item.session.closed ? 'text-[#8b949e]' : 'text-[#c678dd]'}`}>✦ {item.session.title}</div>
                   <div className="text-xs text-[#8b949e] truncate">
                     {signal}
                   </div>

--- a/src/components/__tests__/SpacesBrowser.test.ts
+++ b/src/components/__tests__/SpacesBrowser.test.ts
@@ -668,4 +668,37 @@ describe('useSpacesBrowser navigation', () => {
     act(() => { result.current.moveDown(); });
     expect(result.current.selectedIndex).toBe(1);
   });
+
+  it('refreshes agent sessions for expanded and selected workspaces', async () => {
+    const ws1 = makeWorkspace({ id: 'ws-1', name: 'alpha' });
+    const ws2 = makeWorkspace({ id: 'ws-2', name: 'beta' });
+    const onRefresh = mock(async () => {});
+    const onRefreshSessions = mock(async () => {});
+    const onRefreshAgents = mock(async () => {});
+    const props = makeProps({
+      workspaces: [ws1, ws2],
+      onRefresh,
+      onRefreshSessions,
+      onRefreshAgents,
+    });
+    const { result } = renderHook(() => useSpacesBrowser(props));
+
+    act(() => {
+      result.current.toggleWorkspace('ws-1');
+      result.current.toggleAgentSection('ws-1');
+      result.current.toggleWorkspace('ws-2');
+    });
+
+    const ws2Index = result.current.items.findIndex((item) => item.type === 'workspace' && item.workspace.id === 'ws-2');
+    act(() => { result.current.selectIndex(ws2Index); });
+
+    await act(async () => { await result.current.refresh(); });
+
+    expect(onRefresh).toHaveBeenCalledTimes(1);
+    expect(onRefreshSessions).toHaveBeenCalledTimes(1);
+    expect(onRefreshAgents).toHaveBeenCalledWith({
+      expandedWorkspaceIds: ['ws-1'],
+      selectedWorkspaceId: 'ws-2',
+    });
+  });
 });

--- a/src/components/remote-refresh.test.ts
+++ b/src/components/remote-refresh.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it, mock } from 'bun:test';
+import { executeSafeRefresh } from './remote-refresh';
+
+describe('executeSafeRefresh', () => {
+  it('swallows refresh failures and reports a crash log path', async () => {
+    const onError = mock((_message: string) => {});
+    const logError = mock((_message: string) => {});
+
+    await executeSafeRefresh({
+      refresh: async () => {
+        throw new Error('network dropped');
+      },
+      onError,
+      writeLog: mock(() => '/tmp/gssh-crash.log'),
+      logError,
+      context: { machineId: 'machine-1' },
+    });
+
+    expect(onError).toHaveBeenCalledWith('network dropped\nCrash log: /tmp/gssh-crash.log');
+    expect(logError).toHaveBeenCalled();
+  });
+
+  it('does nothing on successful refresh', async () => {
+    const onError = mock((_message: string) => {});
+
+    await executeSafeRefresh({
+      refresh: async () => {},
+      onError,
+    });
+
+    expect(onError).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/remote-refresh.ts
+++ b/src/components/remote-refresh.ts
@@ -18,13 +18,32 @@ export async function executeSafeRefresh(options: ExecuteSafeRefreshOptions): Pr
     await options.refresh();
   } catch (error) {
     const detail = toDetail(error);
-    const logPath = (options.writeLog ?? writeCrashLog)('remote-tui-refresh', error, options.context);
     const logError = options.logError ?? ((message: string) => logger.error(message));
-    if (error instanceof Error && error.stack) {
-      logError(`[tui] Remote refresh failed:\n${error.stack}`);
-    } else {
-      logError(`[tui] Remote refresh failed: ${detail}`);
+    try {
+      let logPath = '';
+      try {
+        logPath = (options.writeLog ?? writeCrashLog)('remote-tui-refresh', error, options.context);
+      } catch (writeError) {
+        logger.error(`[tui] Failed to write refresh crash log: ${toDetail(writeError)}`);
+      }
+
+      try {
+        if (error instanceof Error && error.stack) {
+          logError(`[tui] Remote refresh failed:\n${error.stack}`);
+        } else {
+          logError(`[tui] Remote refresh failed: ${detail}`);
+        }
+      } catch {
+        logger.error(`[tui] Remote refresh failed: ${detail}`);
+      }
+
+      try {
+        options.onError(logPath ? `${detail}\nCrash log: ${logPath}` : detail);
+      } catch {
+        logger.error(`[tui] Failed to surface refresh error: ${detail}`);
+      }
+    } catch {
+      logger.error(`[tui] Remote refresh handling failed: ${detail}`);
     }
-    options.onError(logPath ? `${detail}\nCrash log: ${logPath}` : detail);
   }
 }

--- a/src/components/remote-refresh.ts
+++ b/src/components/remote-refresh.ts
@@ -1,0 +1,30 @@
+import { writeCrashLog } from '../utils/crash-log.js';
+import { logger } from '../utils/logger.js';
+
+interface ExecuteSafeRefreshOptions {
+  refresh: () => Promise<void>;
+  onError: (message: string) => void;
+  context?: Record<string, unknown>;
+  writeLog?: typeof writeCrashLog;
+  logError?: (message: string) => void;
+}
+
+function toDetail(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+export async function executeSafeRefresh(options: ExecuteSafeRefreshOptions): Promise<void> {
+  try {
+    await options.refresh();
+  } catch (error) {
+    const detail = toDetail(error);
+    const logPath = (options.writeLog ?? writeCrashLog)('remote-tui-refresh', error, options.context);
+    const logError = options.logError ?? ((message: string) => logger.error(message));
+    if (error instanceof Error && error.stack) {
+      logError(`[tui] Remote refresh failed:\n${error.stack}`);
+    } else {
+      logError(`[tui] Remote refresh failed: ${detail}`);
+    }
+    options.onError(logPath ? `${detail}\nCrash log: ${logPath}` : detail);
+  }
+}

--- a/src/lib/remote-session/protocol.ts
+++ b/src/lib/remote-session/protocol.ts
@@ -120,6 +120,14 @@ export interface AttachAgentSessionRequest {
   cols?: number;
   rows?: number;
   viewOnly?: boolean;
+  force?: boolean;
+}
+
+export interface CheckAgentSessionTakeoverRequest {
+  type: 'check_agent_session_takeover';
+  requestId: string;
+  workspaceId: string;
+  agentSessionId: string;
 }
 
 export interface ListAgentSessionsRequest {
@@ -127,6 +135,13 @@ export interface ListAgentSessionsRequest {
   requestId: string;
   workspaceId: string;
   mode?: 'known' | 'live';
+}
+
+export interface ClearAgentSessionRequest {
+  type: 'clear_agent_session';
+  requestId: string;
+  workspaceId: string;
+  agentSessionId: string;
 }
 
 export interface CreateAgentSessionRequest {
@@ -651,7 +666,7 @@ export interface AgentSessionsResponse {
   type: 'agent_sessions';
   requestId: string;
   workspaceId: string;
-  sessions: Array<{ id: string; title: string; updatedAt?: string }>;
+  sessions: Array<{ id: string; title: string; updatedAt?: string; closed?: boolean }>;
 }
 
 export interface AgentBoolResponse {
@@ -659,6 +674,15 @@ export interface AgentBoolResponse {
   requestId: string;
   workspaceId: string;
   ok: boolean;
+}
+
+export interface AgentTakeoverStatusResponse {
+  type: 'agent_takeover_status';
+  requestId: string;
+  workspaceId: string;
+  agentSessionId: string;
+  requiresTakeover: boolean;
+  sessionName?: string;
 }
 
 /**
@@ -694,7 +718,9 @@ export type ClientToMachineMessage =
   | UndismissReplayRequest
   | AttachSessionRequest
   | AttachAgentSessionRequest
+  | CheckAgentSessionTakeoverRequest
   | ListAgentSessionsRequest
+  | ClearAgentSessionRequest
   | CreateAgentSessionRequest
   | AbortAgentSessionRequest
   | RespondAgentPermissionRequest
@@ -766,6 +792,7 @@ export type MachineToClientMessage =
   | ProcessStoppedResponse
   | AgentSessionsResponse
   | AgentBoolResponse
+  | AgentTakeoverStatusResponse
   | AgentStateSnapshotPush
   | AgentStateUpdatePush;
 
@@ -813,7 +840,9 @@ export function isBrowseMessage(msg: RemoteSessionMessage): msg is
   | UndismissReplayRequest
   | AttachSessionRequest
   | AttachAgentSessionRequest
+  | CheckAgentSessionTakeoverRequest
   | ListAgentSessionsRequest
+  | ClearAgentSessionRequest
   | CreateAgentSessionRequest
   | AbortAgentSessionRequest
   | RespondAgentPermissionRequest
@@ -840,7 +869,9 @@ export function isBrowseMessage(msg: RemoteSessionMessage): msg is
     'undismiss_replay',
     "attach_session",
     'attach_agent_session',
+    'check_agent_session_takeover',
     'list_agent_sessions',
+    'clear_agent_session',
     'create_agent_session',
     'abort_agent_session',
     'respond_agent_permission',

--- a/src/lib/remote-session/session-handler.ts
+++ b/src/lib/remote-session/session-handler.ts
@@ -43,6 +43,7 @@ import {
 } from '../tmux-lite/replay/service.js';
 import type { ReplayFrame } from '../tmux-lite/replay/types.js';
 import { readReplayManifest } from '../tmux-lite/replay/store.js';
+import { AgentSessionTakeoverRequiredError } from '../../agents/opencode-coordinator.js';
 
 // Import project loading
 import { listProjectSummaries } from "../../core/project-catalog";
@@ -1999,6 +2000,10 @@ export class RemoteSessionHandler {
       });
     } catch (e) {
       const detail = e instanceof Error ? e.message : String(e);
+      if (e instanceof AgentSessionTakeoverRequiredError) {
+        await this.sendError(session, sendResponse, 'TAKEOVER_REQUIRED', detail, { workspaceId });
+        return;
+      }
       await this.sendError(session, sendResponse, 'ATTACH_FAILED', `Failed to attach agent session: ${detail}`);
     }
   }

--- a/src/lib/remote-session/session-handler.ts
+++ b/src/lib/remote-session/session-handler.ts
@@ -28,7 +28,9 @@ import {
   listAgentSessions as listTmuxAgentSessions,
   createAgentSession as createTmuxAgentSession,
   abortAgentSession as abortTmuxAgentSession,
+  clearAgentSession as clearTmuxAgentSession,
   attachAgentSession as attachTmuxAgentSession,
+  getAgentSessionTakeoverState as getTmuxAgentSessionTakeoverState,
   respondToAgentPermission as respondToTmuxAgentPermission,
   type Session,
 } from "../tmux-lite/cli";
@@ -635,6 +637,17 @@ export class RemoteSessionHandler {
         await this.handleCreateAgentSession(session, msg.requestId, msg.workspaceId, msg.title, sendResponse);
         break;
 
+      case 'clear_agent_session':
+        if (!canManage(session.accessType)) {
+          await this.sendError(session, sendResponse, 'PERMISSION_DENIED', 'Requires full access to clear agent sessions', {
+            workspaceId: msg.workspaceId,
+            requestId: msg.requestId,
+          });
+          return;
+        }
+        await this.handleClearAgentSession(session, msg.requestId, msg.workspaceId, msg.agentSessionId, sendResponse);
+        break;
+
       case 'abort_agent_session':
         if (!canManage(session.accessType)) {
           await this.sendError(session, sendResponse, 'PERMISSION_DENIED', 'Requires full access to abort agent sessions', {
@@ -670,7 +683,18 @@ export class RemoteSessionHandler {
           await this.sendError(session, sendResponse, 'PERMISSION_DENIED', 'Requires full access to attach agent sessions');
           return;
         }
-        await this.handleAttachAgentSession(session, msg.workspaceId, msg.agentSessionId, msg.viewOnly, sendResponse);
+        await this.handleAttachAgentSession(session, msg.workspaceId, msg.agentSessionId, msg.viewOnly, msg.force, sendResponse);
+        break;
+
+      case 'check_agent_session_takeover':
+        if (!canManage(session.accessType)) {
+          await this.sendError(session, sendResponse, 'PERMISSION_DENIED', 'Requires full access to inspect agent sessions', {
+            workspaceId: msg.workspaceId,
+            requestId: msg.requestId,
+          });
+          return;
+        }
+        await this.handleCheckAgentSessionTakeover(session, msg.requestId, msg.workspaceId, msg.agentSessionId, sendResponse);
         break;
 
       default: {
@@ -1903,6 +1927,28 @@ export class RemoteSessionHandler {
     }
   }
 
+  private async handleClearAgentSession(
+    _session: RemoteClientSession,
+    requestId: string,
+    workspaceId: string,
+    agentSessionId: string,
+    sendResponse: (data: Uint8Array) => void,
+  ): Promise<void> {
+    try {
+      const target = await this.resolveAgentWorkspaceTarget(workspaceId);
+      const ok = await clearTmuxAgentSession(target, agentSessionId);
+      await this.sendMessage(_session, sendResponse, {
+        type: 'agent_bool',
+        requestId,
+        workspaceId: target.workspaceId,
+        ok,
+      });
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : String(error);
+      await this.sendError(_session, sendResponse, 'AGENT_CLEAR_FAILED', detail, { workspaceId, requestId });
+    }
+  }
+
   private async handleRespondAgentPermission(
     _session: RemoteClientSession,
     requestId: string,
@@ -1932,11 +1978,12 @@ export class RemoteSessionHandler {
     workspaceId: string,
     agentSessionId: string,
     viewOnly: boolean | undefined,
+    force: boolean | undefined,
     sendResponse: (data: Uint8Array) => void,
   ): Promise<void> {
     try {
       const target = await this.resolveAgentWorkspaceTarget(workspaceId);
-      const terminalSession = await attachTmuxAgentSession(target, agentSessionId);
+      const terminalSession = await attachTmuxAgentSession(target, agentSessionId, { force });
 
       session.state = 'attached';
       session.attachedSessionId = terminalSession.id;
@@ -1953,6 +2000,30 @@ export class RemoteSessionHandler {
     } catch (e) {
       const detail = e instanceof Error ? e.message : String(e);
       await this.sendError(session, sendResponse, 'ATTACH_FAILED', `Failed to attach agent session: ${detail}`);
+    }
+  }
+
+  private async handleCheckAgentSessionTakeover(
+    session: RemoteClientSession,
+    requestId: string,
+    workspaceId: string,
+    agentSessionId: string,
+    sendResponse: (data: Uint8Array) => void,
+  ): Promise<void> {
+    try {
+      const target = await this.resolveAgentWorkspaceTarget(workspaceId);
+      const status = await getTmuxAgentSessionTakeoverState(target, agentSessionId);
+      await this.sendMessage(session, sendResponse, {
+        type: 'agent_takeover_status',
+        requestId,
+        workspaceId: target.workspaceId,
+        agentSessionId,
+        requiresTakeover: status.requiresTakeover,
+        sessionName: status.sessionName,
+      });
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : String(error);
+      await this.sendError(session, sendResponse, 'AGENT_TAKEOVER_CHECK_FAILED', detail, { workspaceId, requestId });
     }
   }
 

--- a/src/lib/tmux-lite/agent-control.ts
+++ b/src/lib/tmux-lite/agent-control.ts
@@ -45,9 +45,26 @@ export async function abortAgentSession(target: AgentWorkspaceTarget, agentSessi
   return defaultOpenCodeCoordinator.abortAgentSession(target, agentSessionId);
 }
 
-export async function attachAgentSession(target: AgentWorkspaceTarget, agentSessionId: string): Promise<import('./protocol.js').Session> {
+export async function clearAgentSession(target: AgentWorkspaceTarget, agentSessionId: string): Promise<boolean> {
   await ensureAgentControlInitialized();
-  return defaultOpenCodeCoordinator.ensureAgentTerminalSession(target, agentSessionId);
+  return defaultOpenCodeCoordinator.clearAgentSession(target, agentSessionId);
+}
+
+export async function getAgentSessionTakeoverState(
+  target: AgentWorkspaceTarget,
+  agentSessionId: string,
+): Promise<{ requiresTakeover: boolean; sessionName?: string }> {
+  await ensureAgentControlInitialized();
+  return defaultOpenCodeCoordinator.checkAgentSessionTakeover(target, agentSessionId);
+}
+
+export async function attachAgentSession(
+  target: AgentWorkspaceTarget,
+  agentSessionId: string,
+  options: { force?: boolean } = {},
+): Promise<import('./protocol.js').Session> {
+  await ensureAgentControlInitialized();
+  return defaultOpenCodeCoordinator.ensureAgentTerminalSession(target, agentSessionId, options);
 }
 
 export async function respondToAgentPermission(

--- a/src/lib/tmux-lite/cli.ts
+++ b/src/lib/tmux-lite/cli.ts
@@ -482,12 +482,40 @@ export async function abortAgentSession(
   throw new Error('Unexpected response');
 }
 
+export async function clearAgentSession(
+  target: AgentWorkspaceTargetPayload,
+  agentSessionId: string,
+): Promise<boolean> {
+  await ensureServer();
+  const res = await send({ type: 'agent-clear', target, agentSessionId });
+  if (res.type === 'agent-bool') return res.ok;
+  if (res.type === 'error') throw new Error(res.message);
+  throw new Error('Unexpected response');
+}
+
+export async function getAgentSessionTakeoverState(
+  target: AgentWorkspaceTargetPayload,
+  agentSessionId: string,
+): Promise<{ requiresTakeover: boolean; sessionName?: string }> {
+  await ensureServer();
+  const res = await send({ type: 'agent-takeover-status', target, agentSessionId });
+  if (res.type === 'agent-takeover-status') {
+    return {
+      requiresTakeover: res.status.requiresTakeover,
+      sessionName: res.status.sessionName,
+    };
+  }
+  if (res.type === 'error') throw new Error(res.message);
+  throw new Error('Unexpected response');
+}
+
 export async function attachAgentSession(
   target: AgentWorkspaceTargetPayload,
   agentSessionId: string,
+  options: { force?: boolean } = {},
 ): Promise<Session> {
   await ensureServer();
-  const res = await send({ type: 'agent-attach', target, agentSessionId });
+  const res = await send({ type: 'agent-attach', target, agentSessionId, force: options.force });
   if (res.type === 'session') return res.session;
   if (res.type === 'error') throw new Error(res.message);
   throw new Error('Unexpected response');

--- a/src/lib/tmux-lite/cli.ts
+++ b/src/lib/tmux-lite/cli.ts
@@ -482,12 +482,22 @@ export async function abortAgentSession(
   throw new Error('Unexpected response');
 }
 
+async function sendAgentCommandWithServerRetry(command: Command): Promise<Response> {
+  const response = await send(command);
+  if (response.type === 'error' && /Unknown command/i.test(response.message)) {
+    await killServer();
+    await ensureServer();
+    return send(command);
+  }
+  return response;
+}
+
 export async function clearAgentSession(
   target: AgentWorkspaceTargetPayload,
   agentSessionId: string,
 ): Promise<boolean> {
   await ensureServer();
-  const res = await send({ type: 'agent-clear', target, agentSessionId });
+  const res = await sendAgentCommandWithServerRetry({ type: 'agent-clear', target, agentSessionId });
   if (res.type === 'agent-bool') return res.ok;
   if (res.type === 'error') throw new Error(res.message);
   throw new Error('Unexpected response');
@@ -498,7 +508,7 @@ export async function getAgentSessionTakeoverState(
   agentSessionId: string,
 ): Promise<{ requiresTakeover: boolean; sessionName?: string }> {
   await ensureServer();
-  const res = await send({ type: 'agent-takeover-status', target, agentSessionId });
+  const res = await sendAgentCommandWithServerRetry({ type: 'agent-takeover-status', target, agentSessionId });
   if (res.type === 'agent-takeover-status') {
     return {
       requiresTakeover: res.status.requiresTakeover,

--- a/src/lib/tmux-lite/protocol.ts
+++ b/src/lib/tmux-lite/protocol.ts
@@ -225,6 +225,14 @@ export interface AgentSessionSummaryPayload {
   workspaceId: string;
   title: string;
   updatedAt?: string;
+  closed?: boolean;
+}
+
+export interface AgentTakeoverStatusPayload {
+  workspaceId: string;
+  agentSessionId: string;
+  requiresTakeover: boolean;
+  sessionName?: string;
 }
 
 export type Command =
@@ -268,7 +276,9 @@ export type Command =
   | { type: 'agent-sessions'; target: AgentWorkspaceTargetPayload; mode?: 'known' | 'live' }
   | { type: 'agent-create'; target: AgentWorkspaceTargetPayload; title?: string }
   | { type: 'agent-abort'; target: AgentWorkspaceTargetPayload; agentSessionId: string }
-  | { type: 'agent-attach'; target: AgentWorkspaceTargetPayload; agentSessionId: string }
+  | { type: 'agent-clear'; target: AgentWorkspaceTargetPayload; agentSessionId: string }
+  | { type: 'agent-attach'; target: AgentWorkspaceTargetPayload; agentSessionId: string; force?: boolean }
+  | { type: 'agent-takeover-status'; target: AgentWorkspaceTargetPayload; agentSessionId: string }
   | {
       type: 'agent-permission';
       target: AgentWorkspaceTargetPayload;
@@ -295,6 +305,7 @@ export type Response =
     }
   | { type: 'agent-watch-started' }
   | { type: 'agent-sessions'; sessions: AgentSessionSummaryPayload[] }
+  | { type: 'agent-takeover-status'; status: AgentTakeoverStatusPayload }
   | { type: 'agent-bool'; ok: boolean }
   | { type: "replays"; replays: import('./replay/types.js').ReplayInfo[] }
   | { type: "replay-snapshot"; snapshot: import('./replay/types.js').TerminalSnapshot }

--- a/src/lib/tmux-lite/server.ts
+++ b/src/lib/tmux-lite/server.ts
@@ -49,9 +49,11 @@ import { getReplayMarkdown, getReplaySnapshot, getReplayText } from "./replay/sn
 import {
   attachAgentSession as ensureAgentTerminalSession,
   abortAgentSession,
+  clearAgentSession,
   createAgentSession,
   ensureAgentControlInitialized,
   getAgentControlSnapshot,
+  getAgentSessionTakeoverState,
   getKnownAgentSessions,
   listLiveAgentSessions,
   respondToAgentPermission,
@@ -2010,14 +2012,44 @@ routerListener = Bun.listen({
             }
             break;
 
+          case 'agent-clear':
+            try {
+              await getAgentControlReady();
+              const ok = await clearAgentSession(cmd.target, cmd.agentSessionId);
+              res = { type: 'agent-bool', ok };
+            } catch (e) {
+              const errMsg = e instanceof Error ? e.message : String(e);
+              res = { type: 'error', message: `Failed to clear agent session: ${errMsg}` };
+            }
+            break;
+
           case 'agent-attach':
             try {
               await getAgentControlReady();
-              const session = await ensureAgentTerminalSession(cmd.target, cmd.agentSessionId);
+              const session = await ensureAgentTerminalSession(cmd.target, cmd.agentSessionId, { force: cmd.force });
               res = { type: 'session', session };
             } catch (e) {
               const errMsg = e instanceof Error ? e.message : String(e);
               res = { type: 'error', message: `Failed to attach agent session: ${errMsg}` };
+            }
+            break;
+
+          case 'agent-takeover-status':
+            try {
+              await getAgentControlReady();
+              const status = await getAgentSessionTakeoverState(cmd.target, cmd.agentSessionId);
+              res = {
+                type: 'agent-takeover-status',
+                status: {
+                  workspaceId: cmd.target.workspaceId,
+                  agentSessionId: cmd.agentSessionId,
+                  requiresTakeover: status.requiresTakeover,
+                  sessionName: status.sessionName,
+                },
+              };
+            } catch (e) {
+              const errMsg = e instanceof Error ? e.message : String(e);
+              res = { type: 'error', message: `Failed to inspect agent session: ${errMsg}` };
             }
             break;
 

--- a/src/serve/agent-event-manager.ts
+++ b/src/serve/agent-event-manager.ts
@@ -18,7 +18,7 @@ import {
   type SessionStatus,
   type Permission,
 } from '../agents/opencode-event-types.js';
-import { deleteStoredSession, replaceStoredSessions, upsertStoredSession } from '../agents/opencode-store.js';
+import { markStoredSessionClosed, replaceStoredSessions, upsertStoredSession } from '../agents/opencode-store.js';
 
 // ============================================================================
 // Shared agent state types (used by both machine and client)
@@ -388,7 +388,7 @@ export class AgentEventManager {
         this.previousStatuses.delete(`${workspaceId}:${id}`);
         this.textAccumulators.delete(`${workspaceId}:${id}`);
         this.emit({ type: 'agent_session_deleted', workspaceId, sessionId: id });
-        this.queuePersistedWrite(workspaceId, () => deleteStoredSession(workspaceId, id));
+        this.queuePersistedWrite(workspaceId, () => markStoredSessionClosed(workspaceId, id));
         break;
       }
 

--- a/src/serve/agent-event-manager.ts
+++ b/src/serve/agent-event-manager.ts
@@ -194,10 +194,7 @@ export class AgentEventManager {
 
     if (statusesResp.ok) {
       const statuses = (await statusesResp.json()) as Record<string, SessionStatus>;
-      const allowedSessionIds = new Set(state.sessions.map((session) => session.id));
-      state.statuses = Object.fromEntries(
-        Object.entries(statuses).filter(([sessionId]) => allowedSessionIds.has(sessionId)),
-      );
+      state.statuses = statuses;
       for (const [sessionId, status] of Object.entries(state.statuses)) {
         this.previousStatuses.set(`${info.workspaceId}:${sessionId}`, status);
       }
@@ -263,7 +260,7 @@ export class AgentEventManager {
         const props = raw.properties as { sessionID: string; status: SessionStatus };
         const { sessionID, status } = props;
         if (!state.sessions.some((session) => session.id === sessionID)) {
-          break;
+          state.sessions.push({ id: sessionID, title: sessionID });
         }
         const prevKey = `${workspaceId}:${sessionID}`;
         const prev = this.previousStatuses.get(prevKey);

--- a/src/serve/client-session-manager.ts
+++ b/src/serve/client-session-manager.ts
@@ -647,6 +647,20 @@ export class ClientSessionManager {
   }
 
   /**
+   * Broadcast a full agent state snapshot to all authenticated browsing clients.
+   */
+  async broadcastAgentStateSnapshot(workspaces: Record<string, WorkspaceAgentState>): Promise<void> {
+    const promises: Promise<void>[] = [];
+
+    for (const [connectionId, session] of this.sessions) {
+      if (session.state !== 'browsing' || !session.sessionKeys) continue;
+      promises.push(this.sendAgentStateSnapshot(connectionId, workspaces));
+    }
+
+    await Promise.allSettled(promises);
+  }
+
+  /**
    * Broadcast an agent state delta to all authenticated browsing clients.
    * Called by AgentEventManager whenever state changes.
    */

--- a/src/serve/client-session-manager.ts
+++ b/src/serve/client-session-manager.ts
@@ -16,7 +16,7 @@ import { encodeControl, encodePTY, parseFrames, decodeControl, FrameType, type S
 import { RemoteSessionHandler, type RemoteClientSession } from "../lib/remote-session/index.js";
 import { STREAM_ID, canWrite, type ServeOptions, type ClientSession, type ServeEventHandler, type HandshakeMessageEnvelope } from "./types.js";
 import { createBufferedSocketWriter } from "../utils/bun-socket-writer.js";
-import { serializeRemoteMessage } from "../lib/remote-session/protocol.js";
+import { serializeRemoteMessage, type MachineToClientMessage } from "../lib/remote-session/protocol.js";
 import type { AgentStateUpdateDelta, WorkspaceAgentState } from "./agent-event-manager.js";
 
 // ============================================================================
@@ -69,6 +69,33 @@ export class ClientSessionManager {
       return;
     }
     session.tmuxSocket?.write(frame);
+  }
+
+  private resetAttachedSession(session: ClientSession): Awaited<ReturnType<typeof Bun.connect>> | undefined {
+    const socket = session.tmuxSocket;
+    session.tmuxSocket = undefined;
+    session.tmuxSocketWriter = undefined;
+    session.state = 'browsing';
+    session.attachedSessionId = undefined;
+    session.viewOnly = undefined;
+    session.sessionSocketPath = undefined;
+    session.waitingForResize = undefined;
+    session.frameBuffer = undefined;
+    return socket;
+  }
+
+  private async sendMachineMessages(connectionId: string, messages: MachineToClientMessage[]): Promise<void> {
+    const session = this.sessions.get(connectionId);
+    if (!session?.sessionKeys) {
+      return;
+    }
+
+    const sendToClient = this.createSendCallback(connectionId);
+    for (const message of messages) {
+      const payload = new TextEncoder().encode(serializeRemoteMessage(message));
+      const frame = await createFrame(STREAM_ID.DATA, payload, session.sessionKeys.sendKey);
+      sendToClient(Buffer.from(frame));
+    }
   }
 
   /**
@@ -218,16 +245,11 @@ export class ClientSessionManager {
           // Handle detach specially - close tmux socket and send response to client
           // Store socket reference and clear it BEFORE ending to prevent close callback
           // from triggering handleDisconnect
-          const socket = session.tmuxSocket;
           const writer = session.tmuxSocketWriter;
-          session.tmuxSocket = undefined;
-          session.tmuxSocketWriter = undefined;
-          session.state = "browsing";
-          session.attachedSessionId = undefined;
-          session.viewOnly = undefined;
-          session.sessionSocketPath = undefined;
-          session.waitingForResize = undefined;
-          session.frameBuffer = undefined;
+          const socket = this.resetAttachedSession(session);
+          if (!socket) {
+            return null;
+          }
 
           // Now send detach and close the socket (using framed protocol)
           {
@@ -498,16 +520,23 @@ export class ClientSessionManager {
 
                 if (event.type === "exited") {
                   console.log(`[session-manager] Session exited: ${event.code}`);
-                  // Send exit notification to client
-                  const exitMsg = JSON.stringify({ type: "session_exited", sessionId: session.attachedSessionId, exitCode: event.code });
-                  const exitData = new TextEncoder().encode(exitMsg);
-                  const encFrame = createFrame(STREAM_ID.DATA, exitData, session.sessionKeys.sendKey);
-                  sendToClient(Buffer.from(encFrame));
-                  this.handleDisconnect(connectionId, `Session exited with code ${event.code}`);
+                  const sessionId = session.attachedSessionId;
+                  const socket = this.resetAttachedSession(session);
+                  socket?.end();
+                  if (sessionId) {
+                    void this.sendMachineMessages(connectionId, [
+                      { type: 'session_exited', sessionId, exitCode: event.code },
+                    ]);
+                  }
                   return;
                 } else if (event.type === "kicked") {
                   console.log("[session-manager] Session kicked");
-                  this.handleDisconnect(connectionId, "Session kicked");
+                  const socket = this.resetAttachedSession(session);
+                  socket?.end();
+                  void this.sendMachineMessages(connectionId, [
+                    { type: 'detached' },
+                    { type: 'error', code: 'SESSION_TAKEN_OVER', message: 'This terminal was taken over by another client.' },
+                  ]);
                   return;
                 } else if (event.type === "wide_event") {
                   const eventMsg = JSON.stringify({ type: "wide_event", event: event.event });

--- a/src/session/__tests__/local-session-backend.test.ts
+++ b/src/session/__tests__/local-session-backend.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, mock } from 'bun:test';
 import { LocalSessionBackend, type LocalSessionBackendDependencies } from '../backends/local-session-backend';
 import type { BackendEvent } from '../events';
+import type { SessionEvent } from '../../lib/tmux-lite/protocol';
 import type { NotificationConfig } from '../../notifications/types';
 
 const notificationConfig: NotificationConfig = {
@@ -1392,6 +1393,8 @@ describe('LocalSessionBackend', () => {
         listSessions: mock(async () => []),
         createSession: mock(async () => []),
         abortSession: mock(async () => true),
+        clearSession: mock(async () => true),
+        checkTakeover: mock(async () => ({ requiresTakeover: false })),
         attachSession: ensureAgentTerminalSession,
         respondToPermission: mock(async () => true),
       },
@@ -1401,6 +1404,72 @@ describe('LocalSessionBackend', () => {
     expect(ensureAgentTerminalSession).toHaveBeenCalledWith(
       expect.objectContaining({ workspaceId: 'alpha:ws-1', workspacePath: '/tmp/ws-1' }),
       'agent-ses-1',
+      { force: undefined },
     );
+  });
+
+  it('emits a taken-over notice when a session is kicked', async () => {
+    let socketHandlers:
+      | {
+          onControl: (event: SessionEvent) => void;
+          onClose: () => void;
+          onError: (error: Error) => void;
+        }
+      | null = null;
+    const backend = new LocalSessionBackend({
+      deps: {
+        ensureServer: async () => {},
+        listSessions: async () => [
+          {
+            id: 'sess-1',
+            name: 'shell-1',
+            socketPath: '/tmp/socket-1',
+            pid: 123,
+            attached: false,
+            cwd: '/tmp',
+            createdAt: 10,
+          },
+        ],
+        connectSessionSocket: async (_socketPath, handlers) => {
+          socketHandlers = handlers;
+          return {
+            sendControl: (control) => {
+              if (control.type === 'attach-init') {
+                handlers.onControl({ type: 'attached' });
+              }
+            },
+            sendPty: () => {},
+            close: () => handlers.onClose(),
+          };
+        },
+      },
+      agentControl: {
+        getState: mock(async () => []),
+        watchState: mock(async () => () => {}),
+        listSessions: mock(async () => []),
+        createSession: mock(async () => []),
+        abortSession: mock(async () => true),
+        clearSession: mock(async () => true),
+        checkTakeover: mock(async () => ({ requiresTakeover: false })),
+        attachSession: mock(async () => {
+          throw new Error('unused');
+        }),
+        respondToPermission: mock(async () => true),
+      },
+    });
+    const events: BackendEvent[] = [];
+    backend.onEvent((event) => events.push(event));
+
+    await backend.attachSession({ sessionId: 'sess-1' });
+    expect(socketHandlers).not.toBeNull();
+    socketHandlers!.onControl({ type: 'kicked' });
+    await Bun.sleep(0);
+
+    expect(events).toContainEqual({
+      type: 'command_error',
+      code: 'SESSION_TAKEN_OVER',
+      message: 'This agent terminal was taken over by another client.',
+    });
+    expect(events).toContainEqual({ type: 'detached' });
   });
 });

--- a/src/session/__tests__/local-session-backend.test.ts
+++ b/src/session/__tests__/local-session-backend.test.ts
@@ -1465,11 +1465,11 @@ describe('LocalSessionBackend', () => {
     socketHandlers!.onControl({ type: 'kicked' });
     await Bun.sleep(0);
 
-    expect(events).toContainEqual({
+    expect(events).toContainEqual(expect.objectContaining({
       type: 'command_error',
       code: 'SESSION_TAKEN_OVER',
-      message: 'This agent terminal was taken over by another client.',
-    });
+      message: expect.stringContaining('taken over'),
+    }));
     expect(events).toContainEqual({ type: 'detached' });
   });
 });

--- a/src/session/__tests__/remote-session-backend.test.ts
+++ b/src/session/__tests__/remote-session-backend.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'bun:test';
+import type { AgentStateUpdateDelta } from '../../serve/agent-event-manager';
 import type { Identity } from '../../types/identity';
 import type { BackendEvent } from '../events';
 import {
@@ -316,6 +317,183 @@ describe('RemoteSessionBackend', () => {
     await expect(pending).resolves.toEqual([
       { id: 'agent-1', title: 'Investigate auth', updatedAt: '2026-03-15T12:00:00.000Z' },
     ]);
+  });
+
+  it('checks whether an agent session takeover is required', async () => {
+    const socket = createFakeSocket();
+    const backend = new RemoteSessionBackend({
+      descriptor: {
+        key: buildRemoteBackendKey('wss://relay.test/ws', 'machine-1'),
+        kind: 'remote',
+        label: 'Machine 1',
+        relayUrl: 'wss://relay.test/ws',
+        machineId: 'machine-1',
+      },
+      socket,
+      socketAdapter,
+      identity,
+      machineId: 'machine-1',
+      deviceCertificate: 'test-device-cert',
+      signer: (message) => ({ ...message, signature: { sig: 'x' } }),
+      crypto: cryptoAdapter,
+      handshake: handshakeAdapter,
+    });
+
+    await connectAndHandshake(backend, socket);
+
+    const pending = backend.checkAgentSessionTakeover('project:workspace', 'agent-1');
+    await Bun.sleep(0);
+    const command = decodeRelayDataCommand(cryptoAdapter, socket.sent.at(-1) ?? '') as {
+      type: string;
+      requestId: string;
+    };
+    expect(command.type).toBe('check_agent_session_takeover');
+
+    socket.handlers?.onMessage(
+      makeRelayDataPayload(cryptoAdapter, {
+        type: 'agent_takeover_status',
+        requestId: command.requestId,
+        workspaceId: 'project:workspace',
+        agentSessionId: 'agent-1',
+        requiresTakeover: true,
+        sessionName: 'agent:workspace:1234abcd',
+      })
+    );
+
+    await expect(pending).resolves.toEqual({
+      requiresTakeover: true,
+      sessionName: 'agent:workspace:1234abcd',
+    });
+  });
+
+  it('treats unsupported takeover checks as no-takeover instead of crashing', async () => {
+    const socket = createFakeSocket();
+    const backend = new RemoteSessionBackend({
+      descriptor: {
+        key: buildRemoteBackendKey('wss://relay.test/ws', 'machine-1'),
+        kind: 'remote',
+        label: 'Machine 1',
+        relayUrl: 'wss://relay.test/ws',
+        machineId: 'machine-1',
+      },
+      socket,
+      socketAdapter,
+      identity,
+      machineId: 'machine-1',
+      deviceCertificate: 'test-device-cert',
+      signer: (message) => ({ ...message, signature: { sig: 'x' } }),
+      crypto: cryptoAdapter,
+      handshake: handshakeAdapter,
+    });
+
+    await connectAndHandshake(backend, socket);
+
+    const pending = backend.checkAgentSessionTakeover('project:workspace', 'agent-1');
+    await Bun.sleep(0);
+    const command = decodeRelayDataCommand(cryptoAdapter, socket.sent.at(-1) ?? '') as {
+      requestId: string;
+    };
+
+    socket.handlers?.onMessage(
+      makeRelayDataPayload(cryptoAdapter, {
+        type: 'error',
+        code: 'UNKNOWN_COMMAND',
+        message: 'Unknown command',
+        requestId: command.requestId,
+        workspaceId: 'project:workspace',
+      })
+    );
+
+    await expect(pending).resolves.toEqual({ requiresTakeover: false });
+    await expect(backend.checkAgentSessionTakeover('project:workspace', 'agent-1')).resolves.toEqual({
+      requiresTakeover: false,
+    });
+  });
+
+  it('builds remote agent snapshot from deltas without initial snapshot', async () => {
+    const socket = createFakeSocket();
+    const backend = new RemoteSessionBackend({
+      descriptor: {
+        key: buildRemoteBackendKey('wss://relay.test/ws', 'machine-1'),
+        kind: 'remote',
+        label: 'Machine 1',
+        relayUrl: 'wss://relay.test/ws',
+        machineId: 'machine-1',
+      },
+      socket,
+      socketAdapter,
+      identity,
+      machineId: 'machine-1',
+      deviceCertificate: 'test-device-cert',
+      signer: (message) => ({ ...message, signature: { sig: 'x' } }),
+      crypto: cryptoAdapter,
+      handshake: handshakeAdapter,
+    });
+
+    await connectAndHandshake(backend, socket);
+
+    const deltas: AgentStateUpdateDelta[] = [
+      { type: 'agent_session_created', workspaceId: 'project:workspace', sessionId: 'agent-1', title: 'Draft plan' },
+      { type: 'agent_session_status', workspaceId: 'project:workspace', sessionId: 'agent-1', status: { type: 'busy' } },
+      { type: 'agent_session_updated', workspaceId: 'project:workspace', sessionId: 'agent-2', title: 'Follow up' },
+    ];
+
+    for (const delta of deltas) {
+      socket.handlers?.onMessage(makeRelayDataPayload(cryptoAdapter, { type: 'agent_state_update', delta }));
+    }
+
+    await Bun.sleep(0);
+
+    expect(backend.getAgentStateSnapshot()).toEqual({
+      'project:workspace': {
+        workspaceId: 'project:workspace',
+        sessions: [
+          { id: 'agent-1', title: 'Draft plan' },
+          { id: 'agent-2', title: 'Follow up' },
+        ],
+        statuses: {
+          'agent-1': { type: 'busy' },
+        },
+        pendingPermissions: {},
+        lastMessages: {},
+      },
+    });
+  });
+
+  it('emits a taken-over notice when the attached session is kicked', async () => {
+    const socket = createFakeSocket();
+    const backend = new RemoteSessionBackend({
+      descriptor: {
+        key: buildRemoteBackendKey('wss://relay.test/ws', 'machine-1'),
+        kind: 'remote',
+        label: 'Machine 1',
+        relayUrl: 'wss://relay.test/ws',
+        machineId: 'machine-1',
+      },
+      socket,
+      socketAdapter,
+      identity,
+      machineId: 'machine-1',
+      deviceCertificate: 'test-device-cert',
+      signer: (message) => ({ ...message, signature: { sig: 'x' } }),
+      crypto: cryptoAdapter,
+      handshake: handshakeAdapter,
+    });
+    const events: BackendEvent[] = [];
+    backend.onEvent((event) => events.push(event));
+
+    await connectAndHandshake(backend, socket);
+
+    (backend as any).mode = 'attached';
+    (backend as any).attachedSessionId = 'sess-1';
+    (backend as any).handleSessionEvent({ type: 'kicked' });
+
+    expect(events).toContainEqual({
+      type: 'command_error',
+      code: 'SESSION_TAKEN_OVER',
+      message: 'This agent terminal was taken over by another client.',
+    });
+    expect(events).toContainEqual({ type: 'detached' });
   });
 
   it('buffers PTY output while no callback is registered and flushes on restore', async () => {

--- a/src/session/__tests__/remote-session-backend.test.ts
+++ b/src/session/__tests__/remote-session-backend.test.ts
@@ -491,7 +491,7 @@ describe('RemoteSessionBackend', () => {
     expect(events).toContainEqual({
       type: 'command_error',
       code: 'SESSION_TAKEN_OVER',
-      message: 'This agent terminal was taken over by another client.',
+      message: 'This terminal was taken over by another client.',
     });
     expect(events).toContainEqual({ type: 'detached' });
   });

--- a/src/session/backend.ts
+++ b/src/session/backend.ts
@@ -203,12 +203,14 @@ export interface SessionBackend {
   ): Promise<boolean>;
 
   /** Fast, persisted workspace-scoped agent sessions (history/snapshot-backed). */
-  getKnownAgentSessions?(workspaceId: string): Promise<Array<{ id: string; title: string; updatedAt?: string }>>;
+  getKnownAgentSessions?(workspaceId: string): Promise<Array<{ id: string; title: string; updatedAt?: string; closed?: boolean }>>;
   /** Live refresh of workspace-scoped agent sessions from the runtime. */
-  listAgentSessions?(workspaceId: string): Promise<Array<{ id: string; title: string; updatedAt?: string }>>;
-  createAgentSession?(workspaceId: string, title?: string): Promise<Array<{ id: string; title: string; updatedAt?: string }>>;
+  listAgentSessions?(workspaceId: string): Promise<Array<{ id: string; title: string; updatedAt?: string; closed?: boolean }>>;
+  createAgentSession?(workspaceId: string, title?: string): Promise<Array<{ id: string; title: string; updatedAt?: string; closed?: boolean }>>;
   abortAgentSession?(workspaceId: string, agentSessionId: string): Promise<boolean>;
-  attachAgentSession?(workspaceId: string, agentSessionId: string, options?: { viewOnly?: boolean }): Promise<void>;
+  clearAgentSession?(workspaceId: string, agentSessionId: string): Promise<boolean>;
+  checkAgentSessionTakeover?(workspaceId: string, agentSessionId: string): Promise<{ requiresTakeover: boolean; sessionName?: string }>;
+  attachAgentSession?(workspaceId: string, agentSessionId: string, options?: { viewOnly?: boolean; force?: boolean }): Promise<void>;
 
   /** Retrieve the persisted last-selected agent session ID for a workspace. */
   getAgentSessionPreference(workspaceId: string): Promise<string | null>;

--- a/src/session/backends/local-session-backend.ts
+++ b/src/session/backends/local-session-backend.ts
@@ -1419,7 +1419,7 @@ export class LocalSessionBackend implements SessionBackend {
       this.emit({
         type: 'command_error',
         code: 'SESSION_TAKEN_OVER',
-        message: 'This agent terminal was taken over by another client.',
+        message: 'This terminal was taken over by another client.',
       });
       void this.closeSessionSocket(true);
       return;

--- a/src/session/backends/local-session-backend.ts
+++ b/src/session/backends/local-session-backend.ts
@@ -21,7 +21,9 @@ import {
   listAgentSessions as listTmuxAgentSessions,
   createAgentSession as createTmuxAgentSession,
   abortAgentSession as abortTmuxAgentSession,
+  clearAgentSession as clearTmuxAgentSession,
   attachAgentSession as attachTmuxAgentSession,
+  getAgentSessionTakeoverState as getTmuxAgentSessionTakeoverState,
   respondToAgentPermission as respondToTmuxAgentPermission,
 } from '../../lib/tmux-lite/cli.js';
 import {
@@ -188,6 +190,8 @@ interface LocalAgentControl {
   listSessions: typeof listTmuxAgentSessions;
   createSession: typeof createTmuxAgentSession;
   abortSession: typeof abortTmuxAgentSession;
+  clearSession: typeof clearTmuxAgentSession;
+  checkTakeover: typeof getTmuxAgentSessionTakeoverState;
   attachSession: typeof attachTmuxAgentSession;
   respondToPermission: typeof respondToTmuxAgentPermission;
 }
@@ -468,6 +472,8 @@ export class LocalSessionBackend implements SessionBackend {
       listSessions: options.agentControl?.listSessions ?? listTmuxAgentSessions,
       createSession: options.agentControl?.createSession ?? createTmuxAgentSession,
       abortSession: options.agentControl?.abortSession ?? abortTmuxAgentSession,
+      clearSession: options.agentControl?.clearSession ?? clearTmuxAgentSession,
+      checkTakeover: options.agentControl?.checkTakeover ?? getTmuxAgentSessionTakeoverState,
       attachSession: options.agentControl?.attachSession ?? attachTmuxAgentSession,
       respondToPermission: options.agentControl?.respondToPermission ?? respondToTmuxAgentPermission,
     };
@@ -1410,6 +1416,11 @@ export class LocalSessionBackend implements SessionBackend {
 
   private handleSessionControl(event: SessionEvent, sessionId: string): void {
     if (event.type === 'kicked') {
+      this.emit({
+        type: 'command_error',
+        code: 'SESSION_TAKEN_OVER',
+        message: 'This agent terminal was taken over by another client.',
+      });
       void this.closeSessionSocket(true);
       return;
     }
@@ -1575,17 +1586,17 @@ export class LocalSessionBackend implements SessionBackend {
     return this.agentControl.respondToPermission(target, agentSessionId, permissionId, response);
   }
 
-  async getKnownAgentSessions(workspaceId: string): Promise<Array<{ id: string; title: string; updatedAt?: string }>> {
+  async getKnownAgentSessions(workspaceId: string): Promise<Array<{ id: string; title: string; updatedAt?: string; closed?: boolean }>> {
     const target = await this.resolveAgentWorkspaceTarget(workspaceId);
     return this.agentControl.listSessions(target, 'known');
   }
 
-  async listAgentSessions(workspaceId: string): Promise<Array<{ id: string; title: string; updatedAt?: string }>> {
+  async listAgentSessions(workspaceId: string): Promise<Array<{ id: string; title: string; updatedAt?: string; closed?: boolean }>> {
     const target = await this.resolveAgentWorkspaceTarget(workspaceId);
     return this.agentControl.listSessions(target, 'live');
   }
 
-  async createAgentSession(workspaceId: string, title?: string): Promise<Array<{ id: string; title: string; updatedAt?: string }>> {
+  async createAgentSession(workspaceId: string, title?: string): Promise<Array<{ id: string; title: string; updatedAt?: string; closed?: boolean }>> {
     const target = await this.resolveAgentWorkspaceTarget(workspaceId);
     return this.agentControl.createSession(target, title);
   }
@@ -1595,9 +1606,26 @@ export class LocalSessionBackend implements SessionBackend {
     return this.agentControl.abortSession(target, agentSessionId);
   }
 
-  async attachAgentSession(workspaceId: string, agentSessionId: string, options: { viewOnly?: boolean } = {}): Promise<void> {
+  async clearAgentSession(workspaceId: string, agentSessionId: string): Promise<boolean> {
     const target = await this.resolveAgentWorkspaceTarget(workspaceId);
-    const terminalSession = await this.agentControl.attachSession(target, agentSessionId);
+    return this.agentControl.clearSession(target, agentSessionId);
+  }
+
+  async checkAgentSessionTakeover(
+    workspaceId: string,
+    agentSessionId: string,
+  ): Promise<{ requiresTakeover: boolean; sessionName?: string }> {
+    const target = await this.resolveAgentWorkspaceTarget(workspaceId);
+    return this.agentControl.checkTakeover(target, agentSessionId);
+  }
+
+  async attachAgentSession(
+    workspaceId: string,
+    agentSessionId: string,
+    options: { viewOnly?: boolean; force?: boolean } = {},
+  ): Promise<void> {
+    const target = await this.resolveAgentWorkspaceTarget(workspaceId);
+    const terminalSession = await this.agentControl.attachSession(target, agentSessionId, { force: options.force });
     await this.attachSession({ sessionId: terminalSession.id, viewOnly: options.viewOnly });
   }
 

--- a/src/session/backends/local-session-backend.ts
+++ b/src/session/backends/local-session-backend.ts
@@ -1404,6 +1404,7 @@ export class LocalSessionBackend implements SessionBackend {
       this.sessionSocket = null;
       this.sessionSocketSessionId = null;
     }
+    this.closingSessionSocket = false;
 
     this.attachedSessionId = null;
     this.pendingUtf8Bytes = new Uint8Array(0);

--- a/src/session/backends/remote-session-backend.ts
+++ b/src/session/backends/remote-session-backend.ts
@@ -1335,8 +1335,9 @@ export class RemoteSessionBackend<TSocket, THandshakeState, TServerHello, TServe
       const timeout = setTimeout(() => {
         const pending = this.pendingAgentTakeoverStatus.get(requestId);
         if (!pending) return;
+        this.agentTakeoverCheckSupported = false;
         this.pendingAgentTakeoverStatus.delete(requestId);
-        reject(new Error(`Timed out checking agent session takeover (${workspaceId})`));
+        resolve({ requiresTakeover: false });
       }, DEFAULT_LIFECYCLE_TIMEOUT_MS);
       this.pendingAgentTakeoverStatus.set(requestId, { workspaceId, resolve, reject, timeout });
       void this.sendCommand(command).catch((error) => {

--- a/src/session/backends/remote-session-backend.ts
+++ b/src/session/backends/remote-session-backend.ts
@@ -3082,15 +3082,10 @@ export class RemoteSessionBackend<TSocket, THandshakeState, TServerHello, TServe
           state.lastMessages[delta.sessionId] = delta.preview;
           break;
         case 'agent_session_created':
-          if (!state.sessions.some((s) => s.id === delta.sessionId)) {
-            state.sessions.push({ id: delta.sessionId, title: delta.title });
-          }
           break;
         case 'agent_session_updated': {
           const idx = state.sessions.findIndex((s) => s.id === delta.sessionId);
-          if (idx === -1) {
-            state.sessions.push({ id: delta.sessionId, title: delta.title });
-          } else {
+          if (idx !== -1) {
             state.sessions[idx] = {
               ...state.sessions[idx],
               title: delta.title,

--- a/src/session/backends/remote-session-backend.ts
+++ b/src/session/backends/remote-session-backend.ts
@@ -3091,7 +3091,10 @@ export class RemoteSessionBackend<TSocket, THandshakeState, TServerHello, TServe
           if (idx === -1) {
             state.sessions.push({ id: delta.sessionId, title: delta.title });
           } else {
-            state.sessions[idx] = { id: delta.sessionId, title: delta.title };
+            state.sessions[idx] = {
+              ...state.sessions[idx],
+              title: delta.title,
+            };
           }
           break;
         }

--- a/src/session/backends/remote-session-backend.ts
+++ b/src/session/backends/remote-session-backend.ts
@@ -2128,7 +2128,7 @@ export class RemoteSessionBackend<TSocket, THandshakeState, TServerHello, TServe
         this.rejectPendingUndismissReplay(message.message, undefined, true);
         this.rejectPendingAgentSessions(message.message, message.workspaceId, message.requestId);
         this.rejectPendingAgentBooleans(message.message, message.workspaceId, message.requestId);
-        this.rejectPendingAgentTakeoverStatus(message.message, message.workspaceId, message.requestId);
+        this.rejectPendingAgentTakeoverStatus(message.code, message.message, message.workspaceId, message.requestId);
         if (message.workspaceId) {
           this.rejectPendingWorkspaceDelete(message.code, message.message, message.workspaceId);
         }
@@ -2353,7 +2353,12 @@ export class RemoteSessionBackend<TSocket, THandshakeState, TServerHello, TServe
     }
   }
 
-  private rejectPendingAgentTakeoverStatus(message: string, workspaceId?: string, requestId?: string): void {
+  private rejectPendingAgentTakeoverStatus(
+    code: string | undefined,
+    message: string,
+    workspaceId?: string,
+    requestId?: string,
+  ): void {
     for (const [pendingRequestId, pending] of this.pendingAgentTakeoverStatus) {
       if (requestId && pendingRequestId !== requestId) {
         continue;
@@ -2363,7 +2368,7 @@ export class RemoteSessionBackend<TSocket, THandshakeState, TServerHello, TServe
       }
       clearTimeout(pending.timeout);
       this.pendingAgentTakeoverStatus.delete(pendingRequestId);
-      if (message === 'Unknown command') {
+      if (code === 'UNKNOWN_COMMAND') {
         this.agentTakeoverCheckSupported = false;
         pending.resolve({ requiresTakeover: false });
         continue;
@@ -3011,7 +3016,7 @@ export class RemoteSessionBackend<TSocket, THandshakeState, TServerHello, TServe
     this.rejectPendingWorkspaceDelete('DELETE_FAILED', 'Remote session disconnected', undefined, true);
     this.rejectPendingAgentSessions('Remote session disconnected');
     this.rejectPendingAgentBooleans('Remote session disconnected');
-    this.rejectPendingAgentTakeoverStatus('Remote session disconnected');
+    this.rejectPendingAgentTakeoverStatus(undefined, 'Remote session disconnected');
     this.rejectAllPendingReviewRequests('Remote session disconnected');
     this.connectPromise = null;
     this.connectResolve = null;

--- a/src/session/backends/remote-session-backend.ts
+++ b/src/session/backends/remote-session-backend.ts
@@ -2741,7 +2741,7 @@ export class RemoteSessionBackend<TSocket, THandshakeState, TServerHello, TServe
       this.emit({
         type: 'command_error',
         code: 'SESSION_TAKEN_OVER',
-        message: 'This agent terminal was taken over by another client.',
+        message: 'This terminal was taken over by another client.',
       });
       this.emit({ type: 'detached' });
       return;

--- a/src/session/backends/remote-session-backend.ts
+++ b/src/session/backends/remote-session-backend.ts
@@ -5,6 +5,8 @@ import {
   type ApplyBundleRefreshRequest,
   type AttachSessionRequest,
   type AttachAgentSessionRequest,
+  type CheckAgentSessionTakeoverRequest,
+  type ClearAgentSessionRequest,
   type ListAgentSessionsRequest,
   type CreateAgentSessionRequest,
   type AbortAgentSessionRequest,
@@ -59,6 +61,7 @@ import {
   type StopProcessRequest,
   type AgentSessionsResponse,
   type AgentBoolResponse,
+  type AgentTakeoverStatusResponse,
   type UpdateNotificationConfigRequest,
   type WorkspaceCreatedResponse,
   type GetReplayFrameRequest,
@@ -266,6 +269,7 @@ const MACHINE_TO_CLIENT_TYPES = new Set<string>([
   'process_stopped',
   'agent_sessions',
   'agent_bool',
+  'agent_takeover_status',
   'agent_state_snapshot',
   'agent_state_update',
 ]);
@@ -548,7 +552,7 @@ export class RemoteSessionBackend<TSocket, THandshakeState, TServerHello, TServe
   private pendingReplayFrameChunks = new Map<string, PendingReplayFrameChunk>();
   private pendingAgentSessions = new Map<string, {
     workspaceId: string;
-    resolve: (sessions: Array<{ id: string; title: string; updatedAt?: string }>) => void;
+    resolve: (sessions: Array<{ id: string; title: string; updatedAt?: string; closed?: boolean }>) => void;
     reject: (error: Error) => void;
     timeout: ReturnType<typeof setTimeout>;
   }>();
@@ -558,6 +562,13 @@ export class RemoteSessionBackend<TSocket, THandshakeState, TServerHello, TServe
     reject: (error: Error) => void;
     timeout: ReturnType<typeof setTimeout>;
   }>();
+  private pendingAgentTakeoverStatus = new Map<string, {
+    workspaceId: string;
+    resolve: (status: { requiresTakeover: boolean; sessionName?: string }) => void;
+    reject: (error: Error) => void;
+    timeout: ReturnType<typeof setTimeout>;
+  }>();
+  private agentTakeoverCheckSupported = true;
 
   constructor(options: RemoteSessionBackendOptions<TSocket, THandshakeState, TServerHello, TServerAuth>) {
     this.descriptor = options.descriptor;
@@ -600,6 +611,7 @@ export class RemoteSessionBackend<TSocket, THandshakeState, TServerHello, TServe
       return this.connectPromise;
     }
 
+    this.agentTakeoverCheckSupported = true;
     this.emit({ type: 'status', status: 'connecting' });
     this.attachSocketListeners();
 
@@ -1200,7 +1212,7 @@ export class RemoteSessionBackend<TSocket, THandshakeState, TServerHello, TServe
     await this.sendCommand(command);
   }
 
-  async getKnownAgentSessions(workspaceId: string): Promise<Array<{ id: string; title: string; updatedAt?: string }>> {
+  async getKnownAgentSessions(workspaceId: string): Promise<Array<{ id: string; title: string; updatedAt?: string; closed?: boolean }>> {
     const requestId = crypto.randomUUID();
     const command: ListAgentSessionsRequest = { type: 'list_agent_sessions', requestId, workspaceId, mode: 'known' };
     return new Promise((resolve, reject) => {
@@ -1221,7 +1233,7 @@ export class RemoteSessionBackend<TSocket, THandshakeState, TServerHello, TServe
     });
   }
 
-  async listAgentSessions(workspaceId: string): Promise<Array<{ id: string; title: string; updatedAt?: string }>> {
+  async listAgentSessions(workspaceId: string): Promise<Array<{ id: string; title: string; updatedAt?: string; closed?: boolean }>> {
     const requestId = crypto.randomUUID();
     const command: ListAgentSessionsRequest = { type: 'list_agent_sessions', requestId, workspaceId, mode: 'live' };
     return new Promise((resolve, reject) => {
@@ -1242,7 +1254,7 @@ export class RemoteSessionBackend<TSocket, THandshakeState, TServerHello, TServe
     });
   }
 
-  async createAgentSession(workspaceId: string, title?: string): Promise<Array<{ id: string; title: string; updatedAt?: string }>> {
+  async createAgentSession(workspaceId: string, title?: string): Promise<Array<{ id: string; title: string; updatedAt?: string; closed?: boolean }>> {
     const requestId = crypto.randomUUID();
     const command: CreateAgentSessionRequest = { type: 'create_agent_session', requestId, workspaceId, title };
     return new Promise((resolve, reject) => {
@@ -1284,13 +1296,71 @@ export class RemoteSessionBackend<TSocket, THandshakeState, TServerHello, TServe
     });
   }
 
-  async attachAgentSession(workspaceId: string, agentSessionId: string, options: { viewOnly?: boolean } = {}): Promise<void> {
+  async clearAgentSession(workspaceId: string, agentSessionId: string): Promise<boolean> {
+    const requestId = crypto.randomUUID();
+    const command: ClearAgentSessionRequest = { type: 'clear_agent_session', requestId, workspaceId, agentSessionId };
+    return new Promise((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        const pending = this.pendingAgentBooleans.get(requestId);
+        if (!pending) return;
+        this.pendingAgentBooleans.delete(requestId);
+        reject(new Error(`Timed out clearing agent session (${workspaceId})`));
+      }, DEFAULT_LIFECYCLE_TIMEOUT_MS);
+      this.pendingAgentBooleans.set(requestId, { workspaceId, resolve, reject, timeout });
+      void this.sendCommand(command).catch((error) => {
+        const pending = this.pendingAgentBooleans.get(requestId);
+        if (!pending) return;
+        clearTimeout(pending.timeout);
+        this.pendingAgentBooleans.delete(requestId);
+        pending.reject(error instanceof Error ? error : new Error(String(error)));
+      });
+    });
+  }
+
+  async checkAgentSessionTakeover(
+    workspaceId: string,
+    agentSessionId: string,
+  ): Promise<{ requiresTakeover: boolean; sessionName?: string }> {
+    if (!this.agentTakeoverCheckSupported) {
+      return { requiresTakeover: false };
+    }
+    const requestId = crypto.randomUUID();
+    const command: CheckAgentSessionTakeoverRequest = {
+      type: 'check_agent_session_takeover',
+      requestId,
+      workspaceId,
+      agentSessionId,
+    };
+    return new Promise((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        const pending = this.pendingAgentTakeoverStatus.get(requestId);
+        if (!pending) return;
+        this.pendingAgentTakeoverStatus.delete(requestId);
+        reject(new Error(`Timed out checking agent session takeover (${workspaceId})`));
+      }, DEFAULT_LIFECYCLE_TIMEOUT_MS);
+      this.pendingAgentTakeoverStatus.set(requestId, { workspaceId, resolve, reject, timeout });
+      void this.sendCommand(command).catch((error) => {
+        const pending = this.pendingAgentTakeoverStatus.get(requestId);
+        if (!pending) return;
+        clearTimeout(pending.timeout);
+        this.pendingAgentTakeoverStatus.delete(requestId);
+        pending.reject(error instanceof Error ? error : new Error(String(error)));
+      });
+    });
+  }
+
+  async attachAgentSession(
+    workspaceId: string,
+    agentSessionId: string,
+    options: { viewOnly?: boolean; force?: boolean } = {},
+  ): Promise<void> {
     this.viewOnly = options.viewOnly ?? false;
     const command: AttachAgentSessionRequest = {
       type: 'attach_agent_session',
       workspaceId,
       agentSessionId,
       viewOnly: options.viewOnly,
+      force: options.force,
     };
     await this.sendCommand(command);
   }
@@ -2038,6 +2108,9 @@ export class RemoteSessionBackend<TSocket, THandshakeState, TServerHello, TServe
       case 'agent_bool':
         this.resolveAgentBoolean(message as AgentBoolResponse);
         return;
+      case 'agent_takeover_status':
+        this.resolveAgentTakeoverStatus(message as AgentTakeoverStatusResponse);
+        return;
       case 'error':
         this.rejectPendingBundleRefreshRequests(message.message);
         this.rejectPendingGithubRepoList(message.message);
@@ -2054,6 +2127,7 @@ export class RemoteSessionBackend<TSocket, THandshakeState, TServerHello, TServe
         this.rejectPendingUndismissReplay(message.message, undefined, true);
         this.rejectPendingAgentSessions(message.message, message.workspaceId, message.requestId);
         this.rejectPendingAgentBooleans(message.message, message.workspaceId, message.requestId);
+        this.rejectPendingAgentTakeoverStatus(message.message, message.workspaceId, message.requestId);
         if (message.workspaceId) {
           this.rejectPendingWorkspaceDelete(message.code, message.message, message.workspaceId);
         }
@@ -2113,6 +2187,19 @@ export class RemoteSessionBackend<TSocket, THandshakeState, TServerHello, TServe
     clearTimeout(pending.timeout);
     this.pendingAgentBooleans.delete(message.requestId);
     pending.resolve(message.ok);
+  }
+
+  private resolveAgentTakeoverStatus(message: AgentTakeoverStatusResponse): void {
+    const pending = this.pendingAgentTakeoverStatus.get(message.requestId);
+    if (!pending) {
+      return;
+    }
+    clearTimeout(pending.timeout);
+    this.pendingAgentTakeoverStatus.delete(message.requestId);
+    pending.resolve({
+      requiresTakeover: message.requiresTakeover,
+      sessionName: message.sessionName,
+    });
   }
 
   private resolveRemoteBranchList(message: RemoteBranchListResponse): void {
@@ -2261,6 +2348,29 @@ export class RemoteSessionBackend<TSocket, THandshakeState, TServerHello, TServe
       }
       clearTimeout(pending.timeout);
       this.pendingAgentBooleans.delete(pendingRequestId);
+      pending.reject(new Error(message));
+    }
+  }
+
+  private rejectPendingAgentTakeoverStatus(message: string, workspaceId?: string, requestId?: string): void {
+    for (const [pendingRequestId, pending] of this.pendingAgentTakeoverStatus) {
+      if (requestId && pendingRequestId !== requestId) {
+        continue;
+      }
+      if (workspaceId && !workspaceIdsMatch(pending.workspaceId, workspaceId)) {
+        continue;
+      }
+      clearTimeout(pending.timeout);
+      this.pendingAgentTakeoverStatus.delete(pendingRequestId);
+      if (message === 'Unknown command') {
+        this.agentTakeoverCheckSupported = false;
+        pending.resolve({ requiresTakeover: false });
+        continue;
+      }
+      if (message === 'Remote session disconnected') {
+        pending.resolve({ requiresTakeover: false });
+        continue;
+      }
       pending.reject(new Error(message));
     }
   }
@@ -2627,6 +2737,11 @@ export class RemoteSessionBackend<TSocket, THandshakeState, TServerHello, TServe
     if (message.type === 'kicked') {
       this.mode = 'browsing';
       this.attachedSessionId = null;
+      this.emit({
+        type: 'command_error',
+        code: 'SESSION_TAKEN_OVER',
+        message: 'This agent terminal was taken over by another client.',
+      });
       this.emit({ type: 'detached' });
       return;
     }
@@ -2895,6 +3010,7 @@ export class RemoteSessionBackend<TSocket, THandshakeState, TServerHello, TServe
     this.rejectPendingWorkspaceDelete('DELETE_FAILED', 'Remote session disconnected', undefined, true);
     this.rejectPendingAgentSessions('Remote session disconnected');
     this.rejectPendingAgentBooleans('Remote session disconnected');
+    this.rejectPendingAgentTakeoverStatus('Remote session disconnected');
     this.rejectAllPendingReviewRequests('Remote session disconnected');
     this.connectPromise = null;
     this.connectResolve = null;
@@ -2927,40 +3043,58 @@ export class RemoteSessionBackend<TSocket, THandshakeState, TServerHello, TServe
     const delta = msg.delta;
     // Apply delta to local cache
     if ('workspaceId' in delta && 'sessionId' in delta) {
-      const state = this.agentStateCache[delta.workspaceId];
-      if (state) {
-        switch (delta.type) {
-          case 'agent_session_status':
-            state.statuses[delta.sessionId] = delta.status;
-            break;
-          case 'agent_permission_added':
-            if (!state.pendingPermissions[delta.sessionId]) state.pendingPermissions[delta.sessionId] = [];
-            state.pendingPermissions[delta.sessionId].push(delta.permission);
-            break;
-          case 'agent_permission_removed':
-            if (state.pendingPermissions[delta.sessionId]) {
-              state.pendingPermissions[delta.sessionId] = state.pendingPermissions[delta.sessionId].filter(
-                (p) => p.id !== delta.permissionId,
-              );
-            }
-            break;
-          case 'agent_last_message':
-            state.lastMessages[delta.sessionId] = delta.preview;
-            break;
-          case 'agent_session_created':
-            if (!state.sessions.some((s) => s.id === delta.sessionId)) {
-              state.sessions.push({ id: delta.sessionId, title: delta.title });
-            }
-            break;
-          case 'agent_session_updated': {
-            const idx = state.sessions.findIndex((s) => s.id === delta.sessionId);
-            if (idx !== -1) state.sessions[idx] = { id: delta.sessionId, title: delta.title };
-            break;
+      const state = this.agentStateCache[delta.workspaceId] ?? {
+        workspaceId: delta.workspaceId,
+        sessions: [],
+        statuses: {},
+        pendingPermissions: {},
+        lastMessages: {},
+      };
+      this.agentStateCache[delta.workspaceId] = state;
+      if (delta.type !== 'agent_session_deleted' && !state.sessions.some((session) => session.id === delta.sessionId)) {
+        state.sessions.push({
+          id: delta.sessionId,
+          title: 'title' in delta ? delta.title : delta.sessionId,
+        });
+      }
+      switch (delta.type) {
+        case 'agent_session_status':
+          state.statuses[delta.sessionId] = delta.status;
+          break;
+        case 'agent_permission_added':
+          if (!state.pendingPermissions[delta.sessionId]) state.pendingPermissions[delta.sessionId] = [];
+          state.pendingPermissions[delta.sessionId].push(delta.permission);
+          break;
+        case 'agent_permission_removed':
+          if (state.pendingPermissions[delta.sessionId]) {
+            state.pendingPermissions[delta.sessionId] = state.pendingPermissions[delta.sessionId].filter(
+              (p) => p.id !== delta.permissionId,
+            );
           }
-          case 'agent_session_deleted':
-            state.sessions = state.sessions.filter((s) => s.id !== delta.sessionId);
-            break;
+          break;
+        case 'agent_last_message':
+          state.lastMessages[delta.sessionId] = delta.preview;
+          break;
+        case 'agent_session_created':
+          if (!state.sessions.some((s) => s.id === delta.sessionId)) {
+            state.sessions.push({ id: delta.sessionId, title: delta.title });
+          }
+          break;
+        case 'agent_session_updated': {
+          const idx = state.sessions.findIndex((s) => s.id === delta.sessionId);
+          if (idx === -1) {
+            state.sessions.push({ id: delta.sessionId, title: delta.title });
+          } else {
+            state.sessions[idx] = { id: delta.sessionId, title: delta.title };
+          }
+          break;
         }
+        case 'agent_session_deleted':
+          state.sessions = state.sessions.filter((s) => s.id !== delta.sessionId);
+          delete state.statuses[delta.sessionId];
+          delete state.pendingPermissions[delta.sessionId];
+          delete state.lastMessages[delta.sessionId];
+          break;
       }
     }
     for (const handler of this.agentStateHandlers) {

--- a/src/session/useSessionEngine.ts
+++ b/src/session/useSessionEngine.ts
@@ -108,6 +108,11 @@ export function useSessionEngine() {
           break;
         case 'attached':
           dispatch({
+            type: 'SET_COMMAND_ERROR',
+            backendKey,
+            commandError: null,
+          });
+          dispatch({
             type: 'SET_ATTACHED_SESSION',
             backendKey,
             sessionId: event.sessionId,

--- a/src/utils/tui-terminal-cleanup.test.ts
+++ b/src/utils/tui-terminal-cleanup.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it, mock } from 'bun:test';
+import { restoreTuiTerminalState, TUI_RESET_SEQUENCES } from './tui-terminal-cleanup';
+
+describe('restoreTuiTerminalState', () => {
+  it('restores raw mode and writes terminal reset sequences', () => {
+    const writes: string[] = [];
+    const stdout = {
+      isTTY: true,
+      write: mock((chunk: string) => {
+        writes.push(chunk);
+        return true;
+      }),
+    };
+    const stdin = {
+      isTTY: true,
+      setRawMode: mock((_mode: boolean) => {}),
+    };
+
+    restoreTuiTerminalState({ stdout, stdin });
+
+    expect(stdin.setRawMode).toHaveBeenCalledWith(false);
+    expect(writes).toEqual([...TUI_RESET_SEQUENCES]);
+  });
+
+  it('skips terminal writes when stdout is not a tty', () => {
+    const stdout = {
+      isTTY: false,
+      write: mock((_chunk: string) => true),
+    };
+
+    restoreTuiTerminalState({ stdout, stdin: null });
+
+    expect(stdout.write).not.toHaveBeenCalled();
+  });
+});

--- a/src/utils/tui-terminal-cleanup.ts
+++ b/src/utils/tui-terminal-cleanup.ts
@@ -1,0 +1,44 @@
+const TUI_RESET_SEQUENCES = [
+  '\x1b[?1000l',
+  '\x1b[?1002l',
+  '\x1b[?1003l',
+  '\x1b[?1004l',
+  '\x1b[?1006l',
+  '\x1b[?1015l',
+  '\x1b[?2004l',
+  '\x1b[?25h',
+  '\x1b[?1049l',
+  '\x1b[0m',
+] as const;
+
+export interface TuiTerminalCleanupOptions {
+  stdout?: Pick<NodeJS.WriteStream, 'write' | 'isTTY'> | null;
+  stdin?: Pick<NodeJS.ReadStream, 'isTTY'> & { setRawMode?: (mode: boolean) => void } | null;
+}
+
+export function restoreTuiTerminalState(options: TuiTerminalCleanupOptions = {}): void {
+  const stdout = options.stdout ?? process.stdout;
+  const stdin = options.stdin ?? process.stdin;
+
+  if (stdin?.isTTY && typeof stdin.setRawMode === 'function') {
+    try {
+      stdin.setRawMode(false);
+    } catch {
+      // Best effort only.
+    }
+  }
+
+  if (!stdout?.isTTY) {
+    return;
+  }
+
+  for (const sequence of TUI_RESET_SEQUENCES) {
+    try {
+      stdout.write(sequence);
+    } catch {
+      // Best effort only.
+    }
+  }
+}
+
+export { TUI_RESET_SEQUENCES };


### PR DESCRIPTION
## Summary
- fix remote agent session hydration so TUI and web recover missing agent rows, snapshot-only waiting sessions, and stale remote status more reliably
- add safer agent takeover, close/clear lifecycle handling, and mixed-version/disconnect fallback behavior for remote clients
- harden remote TUI refresh/crash cleanup and add regression coverage for the new remote agent session flows

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches agent session lifecycle across UI, remote protocol, and tmux-lite coordination (takeover/force attach, close/clear, snapshot/delta hydration), which could affect attach behavior and session state consistency. Changes are well-covered by new unit tests but span multiple layers and message types.
> 
> **Overview**
> **Improves remote agent session reliability and lifecycle controls.** Agent session lists now merge *snapshot + known history + live refresh*, preserve rows when live refresh is empty, and support targeted multi-workspace syncing via new `collectAgentSessionCounts`/`collectWorkspaceSyncIds` and `onRefreshAgents` wiring in both TUI and web.
> 
> **Adds agent takeover + closed-session UX.** `openAgentSession` now checks for takeover, prompts before forcing attach, and propagates `force` through the remote protocol and tmux-lite server; sessions are tracked as `closed`, rendered as such, prevented from opening, and can be **closed** (`abort`) or **cleared from history** (`clear`) with new backend/protocol APIs.
> 
> **Hardens recovery and crash handling.** Agent event hydration now creates missing sessions from deltas, clears stale error state on subsequent updates, and the serve daemon broadcasts snapshots on watch updates; session backends surface a `SESSION_TAKEN_OVER` warning on `kicked`, and the TUI adds safer refresh/error logging plus robust terminal-state restore and fatal crash logging.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7ffd9ad6a6ff2383da30d3e9bb3668a64d0e1cab. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Agent session takeover flow with confirmation for forced attachments
  * Ability to clear closed agent sessions and bulk/manual refresh across workspaces
  * SpacesBrowser onRefreshAgents callback and periodic remote workspace sync

* **Improvements**
  * Unified session counts across UI, snapshots and remote sources
  * Closed sessions tracked, shown as muted/closed and prevented from reopening
  * Improved takeover warnings, error handling, TUI cleanup and lifecycle robustness

* **Tests**
  * Added tests for takeover, sync/refresh, UI refresh, safe refresh/error logging, and terminal cleanup
<!-- end of auto-generated comment: release notes by coderabbit.ai -->