### PR TITLE
refactor: unify local secure store startup bindings and migration prompts

### DIFF
--- a/src/app.tui.tsx
+++ b/src/app.tui.tsx
@@ -2367,7 +2367,7 @@ function App({ relayConfig, remoteIdentity, onQuit, keyboardMode }: AppProps) {
           <Toaster position="top-right" />
           <box flexDirection="column" flexGrow={1} justifyContent="center" alignItems="center">
             <text fg={COLORS.error}>Missing remote identity</text>
-            <text fg={COLORS.textDim} marginTop={1}>Set GITSPACE_IDENTITY_PASSWORD and reconnect</text>
+            <text fg={COLORS.textDim} marginTop={1}>Set GITSPACE_LOCAL_STORE_PASSWORD and reconnect</text>
           </box>
         </Fragment>
       );

--- a/src/cli/commands/relay.ts
+++ b/src/cli/commands/relay.ts
@@ -49,6 +49,7 @@ export function registerRelayCommands(parent: Command): void {
     .option('--mode <mode>', 'Startup mode: auto (local + hosted if available), hosted (require tunnel, keep local), local (local only)', 'auto')
     .option('--label <label>', 'Human-readable label for this relay')
     .option('-y, --yes', 'Auto-confirm prompts')
+    .option('--password-stdin', 'Read local secure store password from stdin')
     .option('--foreground', "Run in foreground (don't daemonize)")
     .option('--takeover', 'Clear persisted relay owner state so the current identity can take over')
     .action(withErrorHandler(async (options) => {
@@ -60,6 +61,7 @@ export function registerRelayCommands(parent: Command): void {
         mode: parseRelayStartMode(options.mode),
         label: options.label,
         yes: options.yes,
+        passwordStdin: options.passwordStdin,
         foreground: options.foreground,
         takeover: options.takeover,
       });

--- a/src/cli/commands/user.ts
+++ b/src/cli/commands/user.ts
@@ -147,7 +147,7 @@ function registerAuthCommands(user: Command): void {
     .command('login')
     .description('Login with GitHub')
     .option('-y, --yes', 'Auto-confirm prompts')
-    .option('--password-stdin', 'Read local identity password from stdin')
+    .option('--password-stdin', 'Read local secure store password from stdin')
     .action(withErrorHandler(async (options) => {
       const { authLogin } = await import('../../commands/auth.js');
       await authLogin(options);

--- a/src/commands/__tests__/cloud-launch.test.ts
+++ b/src/commands/__tests__/cloud-launch.test.ts
@@ -8,7 +8,7 @@ import { writeRelayConfig } from '../../core/identity.js';
 import { addTrustedRelay } from '../../core/trusted-relays.js';
 import {
   bindControlRelayIdentity,
-  bindControlOwner,
+  bindPersistedOwnerIdentity,
   ensureControlStore,
   getCloudWorkspace,
   listCloudEvents,
@@ -80,7 +80,7 @@ function setup() {
   process.env.HOME = testDir;
   process.env.GITSPACE_CONTROL_DIR = join(testDir, '.relay', 'control');
   ensureControlStore();
-  bindControlOwner(TEST_OWNER_ID);
+  bindPersistedOwnerIdentity(TEST_OWNER_ID);
 
   mockCreateWorkspaceImpl = async () => ({ providerWorkspaceId: 'sprite-123', rawState: 'running' });
   mockExecImpl = async () => ({ exitCode: 0, stdout: 'started', stderr: '' });

--- a/src/commands/__tests__/cloud-lifecycle.test.ts
+++ b/src/commands/__tests__/cloud-lifecycle.test.ts
@@ -20,7 +20,7 @@ import { cloudDestroy, cloudResume, cloudStop } from '../cloud.js';
 import { writeRelayConfig } from '../../core/identity.js';
 import { addTrustedRelay } from '../../core/trusted-relays.js';
 import {
-  bindControlOwner,
+  bindPersistedOwnerIdentity,
   bindControlRelayIdentity,
   ensureControlStore,
   getCloudWorkspace,
@@ -87,7 +87,7 @@ function setup() {
   process.env.HOME = testDir;
   process.env.GITSPACE_CONTROL_DIR = join(testDir, '.relay', 'control');
   ensureControlStore();
-  bindControlOwner(OWNER_ID);
+  bindPersistedOwnerIdentity(OWNER_ID);
 }
 
 function seedSavedRelayConfig(args: { relayUrl: string; cloudRelayUrl?: string }) {

--- a/src/commands/__tests__/cloud-live.integration.test.ts
+++ b/src/commands/__tests__/cloud-live.integration.test.ts
@@ -14,7 +14,7 @@ import {
 } from '../cloud.js';
 import { SpritesProvider } from '../../relay/control/sprites-provider.js';
 import {
-  bindControlOwner,
+  bindPersistedOwnerIdentity,
   ensureControlStore,
   getCloudWorkspace,
   listCloudEvents,
@@ -61,7 +61,7 @@ function setupEnv(): void {
   process.env.GITSPACE_CONTROL_DIR = join(testDir, '.relay', 'control');
 
   ensureControlStore();
-  bindControlOwner(OWNER_ID);
+  bindPersistedOwnerIdentity(OWNER_ID);
 }
 
 function teardownEnv(): void {

--- a/src/commands/__tests__/cloud-relay.integration.test.ts
+++ b/src/commands/__tests__/cloud-relay.integration.test.ts
@@ -11,7 +11,7 @@ import {
 } from '../cloud.js';
 import { SpritesProvider } from '../../relay/control/sprites-provider.js';
 import {
-  bindControlOwner,
+  bindPersistedOwnerIdentity,
   ensureControlStore,
   getCloudWorkspace,
   listCloudEvents,
@@ -31,9 +31,9 @@ const keychainToken = RUN_RELAY_LIVE && !envToken ? await getSpritesToken() : nu
 const SPRITES_TOKEN = envToken || keychainToken || '';
 const relayDescribe = RUN_RELAY_LIVE && Boolean(SPRITES_TOKEN) ? describe : describe.skip;
 
-const OWNER_ID = 'owner-cloud-relay-live-001';
 const TEST_OWNER_USER_ROOT = mnemonicToUserIdentity(generateMnemonic());
 const OWNER_USER_ROOT_ID = TEST_OWNER_USER_ROOT.id;
+const OWNER_ID = OWNER_USER_ROOT_ID;
 const SPRITES_APP_ID = process.env.SPRITES_APP_ID ?? `gssh-live-relay-${Date.now().toString(36)}`;
 
 setDefaultTimeout(900_000);
@@ -214,7 +214,7 @@ relayDescribe('cloud relay live integration', () => {
     process.env.GITSPACE_CONTROL_DIR = join(testDir, '.relay', 'control');
 
     ensureControlStore();
-    bindControlOwner(OWNER_ID);
+    bindPersistedOwnerIdentity(OWNER_ID);
     setVaultMeta('vault_initialized', '1');
     setVaultMeta('owner_user_root_id', OWNER_USER_ROOT_ID);
 

--- a/src/commands/__tests__/connect-command-trust.test.ts
+++ b/src/commands/__tests__/connect-command-trust.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { generateAndSaveKeypair } from '../../core/identity.js';
 import { addTrustedRelay, getTrustedRelay } from '../../core/trusted-relays.js';
+import { getControlDbPath } from '../../relay/control/store.js';
 
 let promptConfirmQueue: boolean[] = [];
 let promptPasswordValue: string | null = null;
@@ -173,6 +174,39 @@ describe('connect command relay trust flow', () => {
           yes: true,
         }),
       ).rejects.toThrow(/invalid password|failed to unlock identity/i);
+    } finally {
+      server.stop(true);
+    }
+  });
+
+  test('wrong password does not poison legacy migration before a later correct connect attempt', async () => {
+    const relayPubkey = Buffer.from('relay-legacy-migration-pubkey').toString('base64');
+    const server = startRelayHealthServer(relayPubkey);
+    const relayUrl = `ws://127.0.0.1:${server.port}/ws`;
+
+    await generateAndSaveKeypair('correct-password', 'test-host');
+    rmSync(getControlDbPath(), { force: true });
+    rmSync(`${getControlDbPath()}-shm`, { force: true });
+    rmSync(`${getControlDbPath()}-wal`, { force: true });
+
+    try {
+      promptPasswordValue = 'wrong-password';
+      await expect(
+        connectToRemote('machine-test', {
+          relay: relayUrl,
+          relayPubkey,
+          yes: true,
+        }),
+      ).rejects.toThrow(/invalid password|failed to unlock/i);
+
+      promptPasswordValue = 'correct-password';
+      await expect(
+        connectToRemote('machine-test', {
+          relay: relayUrl,
+          relayPubkey,
+          yes: true,
+        }),
+      ).rejects.toThrow(/connection failed|websocket/i);
     } finally {
       server.stop(true);
     }

--- a/src/commands/__tests__/control-socket.test.ts
+++ b/src/commands/__tests__/control-socket.test.ts
@@ -14,7 +14,7 @@ import { existsSync, mkdtempSync, rmSync, unlinkSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
-  bindControlOwner,
+  bindPersistedOwnerIdentity,
   ensureControlStore,
   upsertCloudWorkspace,
 } from '../../relay/control/store.js';
@@ -117,7 +117,7 @@ describe('control socket – control_meta command', () => {
   });
 
   test('returns control_meta with ownerIdentityId after owner is bound', async () => {
-    bindControlOwner('test-owner-id');
+    bindPersistedOwnerIdentity('test-owner-id');
 
     const response = await queryControlMeta();
     expect(response).not.toBeNull();
@@ -150,13 +150,13 @@ describe('control socket – assert_owner command', () => {
   });
 
   test('assert_owner returns ok for the correct owner', async () => {
-    bindControlOwner('real-owner');
+    bindPersistedOwnerIdentity('real-owner');
     const result = await sendAssertOwnerCommand('real-owner');
     expect(result.success).toBe(true);
   });
 
   test('assert_owner returns error for a different identity', async () => {
-    bindControlOwner('real-owner');
+    bindPersistedOwnerIdentity('real-owner');
     const result = await sendAssertOwnerCommand('impostor');
     expect(result.success).toBe(false);
     expect(result.error).toMatch(/mismatch/i);
@@ -182,21 +182,21 @@ describe('control socket – list_cloud_workspaces command', () => {
   });
 
   test('list_cloud_workspaces returns error when called by non-owner identity', async () => {
-    bindControlOwner('owner-id');
+    bindPersistedOwnerIdentity('owner-id');
     const result = await sendListCloudWorkspacesCommand('impostor-id');
     expect(result.success).toBe(false);
     expect(result.error).toMatch(/mismatch/i);
   });
 
   test('list_cloud_workspaces returns empty list for owner when no workspaces exist', async () => {
-    bindControlOwner('owner-id');
+    bindPersistedOwnerIdentity('owner-id');
     const result = await sendListCloudWorkspacesCommand('owner-id');
     expect(result.success).toBe(true);
     expect(result.workspaces).toEqual([]);
   });
 
   test('list_cloud_workspaces returns workspaces for owner', async () => {
-    bindControlOwner('owner-id');
+    bindPersistedOwnerIdentity('owner-id');
     upsertCloudWorkspace({
       id: 'ws-socket-test',
       provider: 'sprites',

--- a/src/commands/__tests__/device-identity-password.test.ts
+++ b/src/commands/__tests__/device-identity-password.test.ts
@@ -76,4 +76,43 @@ describe('device identity password context', () => {
     expect(generateAndSaveKeypairMock).toHaveBeenCalledWith('env-password', expect.any(String));
     expect(promptPasswordMock).not.toHaveBeenCalled();
   });
+
+  test('resolved shared context still creates a keypair when missing', async () => {
+    const promptPasswordMock = mock(async () => null as string | null);
+    const promptConfirmMock = mock(async () => true);
+    const keypairExistsMock = mock(() => false);
+    const generateAndSaveKeypairMock = mock(async () => undefined);
+
+    mock.module('../../utils/prompts.js', () => ({
+      promptPassword: promptPasswordMock,
+      promptConfirm: promptConfirmMock,
+    }));
+
+    mock.module('../../core/identity.js', () => ({
+      keypairExists: keypairExistsMock,
+      generateAndSaveKeypair: generateAndSaveKeypairMock,
+    }));
+
+    mock.module('../../utils/password-stdin.js', () => ({
+      readPasswordFromStdin: mock(async () => 'stdin-password'),
+    }));
+
+    mock.module('../local-store-password.js', () => ({
+      getLocalStorePasswordFromEnv: () => null,
+    }));
+
+    const {
+      ensureDeviceIdentityPassword,
+      createDeviceIdentityPasswordContext,
+    } = await import(`../device-identity-password.js?test=${Date.now()}`);
+
+    const context = createDeviceIdentityPasswordContext();
+    context.password = 'seeded-password';
+    context.resolved = true;
+
+    const password = await ensureDeviceIdentityPassword({ yes: true }, context);
+
+    expect(password).toBe('seeded-password');
+    expect(generateAndSaveKeypairMock).toHaveBeenCalledWith('seeded-password', expect.any(String));
+  });
 });

--- a/src/commands/__tests__/device-identity-password.test.ts
+++ b/src/commands/__tests__/device-identity-password.test.ts
@@ -115,4 +115,43 @@ describe('device identity password context', () => {
     expect(password).toBe('seeded-password');
     expect(generateAndSaveKeypairMock).toHaveBeenCalledWith('seeded-password', expect.any(String));
   });
+
+  test('prompts for the existing identity password during legacy migration', async () => {
+    const promptPasswordMock = mock(async () => 'legacy-password');
+    const promptConfirmMock = mock(async () => true);
+    const keypairExistsMock = mock(() => true);
+    const generateAndSaveKeypairMock = mock(async () => undefined);
+
+    mock.module('../../utils/prompts.js', () => ({
+      promptPassword: promptPasswordMock,
+      promptConfirm: promptConfirmMock,
+    }));
+
+    mock.module('../../core/identity.js', () => ({
+      keypairExists: keypairExistsMock,
+      generateAndSaveKeypair: generateAndSaveKeypairMock,
+    }));
+
+    mock.module('../../core/local-secure-store.js', () => ({
+      localSecureStoreExists: () => false,
+    }));
+
+    mock.module('../../utils/password-stdin.js', () => ({
+      readPasswordFromStdin: mock(async () => 'stdin-password'),
+    }));
+
+    mock.module('../local-store-password.js', () => ({
+      getLocalStorePasswordFromEnv: () => null,
+    }));
+
+    const { ensureDeviceIdentityPassword } = await import(`../device-identity-password.js?test=${Date.now()}`);
+
+    const password = await ensureDeviceIdentityPassword();
+
+    expect(password).toBe('legacy-password');
+    expect(promptPasswordMock).toHaveBeenCalledWith(
+      'Enter your existing device identity password to migrate it into the new local secure store:',
+    );
+    expect(promptConfirmMock).not.toHaveBeenCalled();
+  });
 });

--- a/src/commands/__tests__/device-identity-password.test.ts
+++ b/src/commands/__tests__/device-identity-password.test.ts
@@ -43,4 +43,37 @@ describe('device identity password context', () => {
     expect(readPasswordFromStdinMock).toHaveBeenCalledTimes(1);
     expect(promptPasswordMock).not.toHaveBeenCalled();
   });
+
+  test('uses env password without skipping first-run identity creation', async () => {
+    const promptPasswordMock = mock(async () => null as string | null);
+    const promptConfirmMock = mock(async () => true);
+    const keypairExistsMock = mock(() => false);
+    const generateAndSaveKeypairMock = mock(async () => undefined);
+
+    mock.module('../../utils/prompts.js', () => ({
+      promptPassword: promptPasswordMock,
+      promptConfirm: promptConfirmMock,
+    }));
+
+    mock.module('../../core/identity.js', () => ({
+      keypairExists: keypairExistsMock,
+      generateAndSaveKeypair: generateAndSaveKeypairMock,
+    }));
+
+    mock.module('../../utils/password-stdin.js', () => ({
+      readPasswordFromStdin: mock(async () => 'stdin-password'),
+    }));
+
+    mock.module('../local-store-password.js', () => ({
+      getLocalStorePasswordFromEnv: () => 'env-password',
+    }));
+
+    const { ensureDeviceIdentityPassword } = await import(`../device-identity-password.js?test=${Date.now()}`);
+
+    const password = await ensureDeviceIdentityPassword({ yes: true });
+
+    expect(password).toBe('env-password');
+    expect(generateAndSaveKeypairMock).toHaveBeenCalledWith('env-password', expect.any(String));
+    expect(promptPasswordMock).not.toHaveBeenCalled();
+  });
 });

--- a/src/commands/__tests__/local-store-password.test.ts
+++ b/src/commands/__tests__/local-store-password.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, describe, expect, mock, test } from 'bun:test';
+
+describe('local store password prompts', () => {
+  afterEach(() => {
+    mock.restore();
+  });
+
+  test('uses the existing device identity password during legacy migration', async () => {
+    const promptPasswordMock = mock(async () => 'legacy-password');
+    const promptConfirmMock = mock(async () => true);
+
+    mock.module('../../utils/prompts.js', () => ({
+      promptPassword: promptPasswordMock,
+      promptConfirm: promptConfirmMock,
+    }));
+
+    mock.module('../../core/local-secure-store.js', () => ({
+      localSecureStoreExists: () => false,
+    }));
+
+    mock.module('../../core/identity.js', () => ({
+      keypairExists: () => true,
+    }));
+
+    const { ensureLocalStorePassword } = await import(`../local-store-password.js?test=${Date.now()}`);
+
+    const password = await ensureLocalStorePassword();
+
+    expect(password).toBe('legacy-password');
+    expect(promptPasswordMock).toHaveBeenCalledWith(
+      'Enter your existing device identity password to migrate it into the new local secure store:',
+    );
+    expect(promptConfirmMock).not.toHaveBeenCalled();
+  });
+
+  test('still creates and confirms a new password for fresh installs', async () => {
+    const promptPasswordMock = mock(async (prompt: string) => (
+      prompt === 'Confirm local secure store password:' ? 'new-password' : 'new-password'
+    ));
+    const promptConfirmMock = mock(async () => true);
+
+    mock.module('../../utils/prompts.js', () => ({
+      promptPassword: promptPasswordMock,
+      promptConfirm: promptConfirmMock,
+    }));
+
+    mock.module('../../core/local-secure-store.js', () => ({
+      localSecureStoreExists: () => false,
+    }));
+
+    mock.module('../../core/identity.js', () => ({
+      keypairExists: () => false,
+    }));
+
+    const { ensureLocalStorePassword } = await import(`../local-store-password.js?test=${Date.now()}`);
+
+    const password = await ensureLocalStorePassword();
+
+    expect(password).toBe('new-password');
+    expect(promptConfirmMock).toHaveBeenCalledWith(
+      'No local secure store password is configured. Create one now?',
+      true,
+    );
+    expect(promptPasswordMock).toHaveBeenNthCalledWith(1, 'Create password for local secure store:');
+    expect(promptPasswordMock).toHaveBeenNthCalledWith(2, 'Confirm local secure store password:');
+  });
+});

--- a/src/commands/__tests__/relay-owner-repair.test.ts
+++ b/src/commands/__tests__/relay-owner-repair.test.ts
@@ -131,6 +131,20 @@ describe('bindRelayOwnerForStartup', () => {
     });
   });
 
+  test('reports repaired owner binding when only vault owner metadata exists', async () => {
+    await withIsolatedEnv(async () => {
+      setVaultMeta('owner_user_root_id', 'owner-a');
+
+      const result = bindRelayOwnerForStartup('owner-a');
+
+      expect(result).toEqual({
+        repairedOwnerBinding: true,
+        missingVaultInitialization: false,
+      });
+      expect(getPersistedOwnerIdentityId()).toBe('owner-a');
+    });
+  });
+
   test('can explicitly take over relay ownership by clearing persisted control state', async () => {
     await withIsolatedEnv(async () => {
       await unlockLocalSecureStore('test-password');

--- a/src/commands/__tests__/relay-owner-repair.test.ts
+++ b/src/commands/__tests__/relay-owner-repair.test.ts
@@ -2,7 +2,8 @@ import { describe, expect, test } from 'bun:test';
 import { existsSync, mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { ensureControlStore, getVaultMeta, listVaultMachines, setVaultMeta, upsertVaultMachine } from '../../relay/control/store.js';
+import { bindPersistedOwnerIdentity, ensureControlStore, getPersistedOwnerIdentityId, getVaultMeta, listVaultMachines, setVaultMeta, upsertVaultMachine } from '../../relay/control/store.js';
+import { readLocalStoreJson, unlockLocalSecureStore, writeLocalStoreJson } from '../../core/local-secure-store.js';
 import { assertRelayOwnerRepairIsSafe, bindRelayOwnerForStartup, takeOverRelayOwnerForStartup } from '../relay.js';
 
 let envLock: Promise<void> = Promise.resolve();
@@ -95,7 +96,7 @@ describe('bindRelayOwnerForStartup', () => {
         repairedOwnerBinding: true,
         missingVaultInitialization: false,
       });
-      expect(getVaultMeta('owner_user_root_id')).toBe('owner-a');
+      expect(getPersistedOwnerIdentityId()).toBe('owner-a');
       expect(getVaultMeta('vault_initialized')).toBe('1');
     });
   });
@@ -108,15 +109,32 @@ describe('bindRelayOwnerForStartup', () => {
         repairedOwnerBinding: true,
         missingVaultInitialization: true,
       });
-      expect(getVaultMeta('owner_user_root_id')).toBe('owner-a');
+      expect(getPersistedOwnerIdentityId()).toBe('owner-a');
       expect(getVaultMeta('vault_initialized')).toBeUndefined();
       expect(getVaultMeta('vault_salt')).toBeUndefined();
       expect(getVaultMeta('vault_key_check')).toBeUndefined();
     }, { initializeVault: false });
   });
 
+  test('repairs owner binding drift when control owner already matches current identity', async () => {
+    await withIsolatedEnv(async () => {
+      bindPersistedOwnerIdentity('owner-a');
+      setVaultMeta('owner_user_root_id', 'owner-b');
+
+      const result = bindRelayOwnerForStartup('owner-a');
+
+      expect(result).toEqual({
+        repairedOwnerBinding: true,
+        missingVaultInitialization: false,
+      });
+      expect(getPersistedOwnerIdentityId()).toBe('owner-a');
+    });
+  });
+
   test('can explicitly take over relay ownership by clearing persisted control state', async () => {
     await withIsolatedEnv(async () => {
+      await unlockLocalSecureStore('test-password');
+      writeLocalStoreJson('test', 'preserved', { ok: true });
       setVaultMeta('owner_user_root_id', 'owner-b');
       upsertVaultMachine({
         machineId: 'machine-a',
@@ -131,9 +149,10 @@ describe('bindRelayOwnerForStartup', () => {
         repairedOwnerBinding: true,
         missingVaultInitialization: true,
       });
-      expect(getVaultMeta('owner_user_root_id')).toBe('owner-a');
+      expect(getPersistedOwnerIdentityId()).toBe('owner-a');
       expect(getVaultMeta('vault_initialized')).toBeUndefined();
       expect(listVaultMachines()).toHaveLength(0);
+      expect(readLocalStoreJson<{ ok: boolean }>('test', 'preserved')).toEqual({ ok: true });
     });
   });
 });

--- a/src/commands/__tests__/serve-owner-binding.test.ts
+++ b/src/commands/__tests__/serve-owner-binding.test.ts
@@ -4,10 +4,9 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
   bindControlRelayIdentity,
-  bindControlOwner,
+  bindPersistedOwnerIdentity,
   ensureControlStore,
-  getControlOwnerIdentityId,
-  getVaultMeta,
+  getPersistedOwnerIdentityId,
   listVaultMachines,
   readControlMeta,
   setVaultMeta,
@@ -67,23 +66,34 @@ describe('ensureServeOwnerBindingForStartup', () => {
       const result = await ensureServeOwnerBindingForStartup('owner-a');
 
       expect(result).toEqual({ tookOver: false });
-      expect(getControlOwnerIdentityId()).toBe('owner-a');
-      expect(getVaultMeta('owner_user_root_id')).toBe('owner-a');
+      expect(getPersistedOwnerIdentityId()).toBe('owner-a');
     });
   });
 
   test('throws a helpful mismatch error without takeover', async () => {
     await withIsolatedEnv(async () => {
-      bindControlOwner('owner-b');
+      bindPersistedOwnerIdentity('owner-b');
       setVaultMeta('owner_user_root_id', 'owner-b');
 
       await expect(ensureServeOwnerBindingForStartup('owner-a')).rejects.toThrow(/machine serve start --takeover/i);
     });
   });
 
+  test('repairs owner binding drift without takeover when one persisted binding matches current identity', async () => {
+    await withIsolatedEnv(async () => {
+      bindPersistedOwnerIdentity('owner-a');
+      setVaultMeta('owner_user_root_id', 'owner-b');
+
+      const result = await ensureServeOwnerBindingForStartup('owner-a');
+
+      expect(result).toEqual({ tookOver: false });
+      expect(getPersistedOwnerIdentityId()).toBe('owner-a');
+    });
+  });
+
   test('takeover clears persisted control state and rebinds to the recovered owner', async () => {
     await withIsolatedEnv(async () => {
-      bindControlOwner('owner-b');
+      bindPersistedOwnerIdentity('owner-b');
       setVaultMeta('owner_user_root_id', 'owner-b');
       upsertVaultMachine({
         machineId: 'machine-a',
@@ -98,16 +108,14 @@ describe('ensureServeOwnerBindingForStartup', () => {
       });
 
       expect(result).toEqual({ tookOver: true });
-      expect(getControlOwnerIdentityId()).toBe('owner-a');
-      expect(getVaultMeta('owner_user_root_id')).toBe('owner-a');
+      expect(getPersistedOwnerIdentityId()).toBe('owner-a');
       expect(listVaultMachines()).toHaveLength(0);
     });
   });
 
   test('throws a helpful relay mismatch error without takeover', async () => {
     await withIsolatedEnv(async () => {
-      bindControlOwner('owner-a');
-      setVaultMeta('owner_user_root_id', 'owner-a');
+      bindPersistedOwnerIdentity('owner-a');
       bindControlRelayIdentity({
         relayIdentityId: 'old-relay-id',
         relaySigningPublicKey: Buffer.alloc(32, 2).toString('base64'),
@@ -122,8 +130,7 @@ describe('ensureServeOwnerBindingForStartup', () => {
 
   test('takeover clears persisted relay pin and rebinds owner state', async () => {
     await withIsolatedEnv(async () => {
-      bindControlOwner('owner-a');
-      setVaultMeta('owner_user_root_id', 'owner-a');
+      bindPersistedOwnerIdentity('owner-a');
       bindControlRelayIdentity({
         relayIdentityId: 'old-relay-id',
         relaySigningPublicKey: Buffer.alloc(32, 2).toString('base64'),
@@ -137,8 +144,7 @@ describe('ensureServeOwnerBindingForStartup', () => {
       });
 
       expect(result).toEqual({ tookOver: true });
-      expect(getControlOwnerIdentityId()).toBe('owner-a');
-      expect(getVaultMeta('owner_user_root_id')).toBe('owner-a');
+      expect(getPersistedOwnerIdentityId()).toBe('owner-a');
       expect(readControlMeta().relayIdentityId).toBeUndefined();
       expect(readControlMeta().relayFingerprint).toBeUndefined();
     });
@@ -146,8 +152,7 @@ describe('ensureServeOwnerBindingForStartup', () => {
 
   test('takeover also clears pinned relay identity even when owner already matches', async () => {
     await withIsolatedEnv(async () => {
-      bindControlOwner('owner-a');
-      setVaultMeta('owner_user_root_id', 'owner-a');
+      bindPersistedOwnerIdentity('owner-a');
       bindControlRelayIdentity({
         relayIdentityId: 'relay-old',
         relaySigningPublicKey: 'old-key',
@@ -160,7 +165,7 @@ describe('ensureServeOwnerBindingForStartup', () => {
       });
 
       expect(result).toEqual({ tookOver: true });
-      expect(getControlOwnerIdentityId()).toBe('owner-a');
+      expect(getPersistedOwnerIdentityId()).toBe('owner-a');
       expect(readControlMeta().relayIdentityId).toBeUndefined();
       expect(readControlMeta().relayFingerprint).toBeUndefined();
     });

--- a/src/commands/connect.ts
+++ b/src/commands/connect.ts
@@ -11,6 +11,7 @@ import { promptConfirm, promptInput, selectOne } from '../utils/prompts.js';
 import {
   loadKeypair,
   readRelayConfig,
+  shouldDeferLocalStoreUnlockForLegacyIdentityMigration,
 } from '../core/identity.js';
 import { createLocalDeviceCertificate } from '../core/user-identity.js';
 import WebSocket from 'ws';
@@ -260,7 +261,9 @@ export async function connectToRemote(
     logger.info('Cancelled');
     return;
   }
-  await unlockLocalSecureStore(localStorePassword);
+  if (!shouldDeferLocalStoreUnlockForLegacyIdentityMigration()) {
+    await unlockLocalSecureStore(localStorePassword);
+  }
   devicePasswordContext.password = localStorePassword;
 
   // Step 3: Load local identity
@@ -428,7 +431,9 @@ export async function listRemoteMachines(options: {
     logger.info('Cancelled');
     return;
   }
-  await unlockLocalSecureStore(localStorePassword);
+  if (!shouldDeferLocalStoreUnlockForLegacyIdentityMigration()) {
+    await unlockLocalSecureStore(localStorePassword);
+  }
   devicePasswordContext.password = localStorePassword;
 
   const password = await ensureDeviceIdentityPassword({ yes: options.yes }, devicePasswordContext);

--- a/src/commands/connect.ts
+++ b/src/commands/connect.ts
@@ -35,6 +35,10 @@ import {
   createDeviceIdentityPasswordContext,
   ensureDeviceIdentityPassword,
 } from './device-identity-password.js';
+import {
+  createLocalStorePasswordContext,
+  ensureLocalStorePassword,
+} from './local-store-password.js';
 import { ensureUserRootIdentityWithRecovery } from './identity-recovery.js';
 import {
   addTrustedRelay,
@@ -45,6 +49,7 @@ import { formatRelayFingerprint } from '../relay/identity.js';
 import type {
   WorkspaceInfo,
 } from '../lib/remote-session/protocol.js';
+import { unlockLocalSecureStore } from '../core/local-secure-store.js';
 
 export interface RelayIdentityProbe {
   publicKey: string;
@@ -201,6 +206,7 @@ export async function connectToRemote(
   options: { relay?: string; machine?: string; relayPubkey?: string; yes?: boolean; passwordStdin?: boolean } = {}
 ): Promise<void> {
   const devicePasswordContext = createDeviceIdentityPasswordContext({ passwordStdin: options.passwordStdin });
+  const localStorePasswordContext = createLocalStorePasswordContext({ passwordStdin: options.passwordStdin });
   if (!target && !options.machine) {
     throw new SpacesError(
       'Connection target required.\n\nUsage:\n  gssh client connect <machine-id> --relay <url>\n  gssh client connect --machine <id> --relay <url>\n\nList available machines:\n  gssh client machines list --relay <url>',
@@ -245,6 +251,14 @@ export async function connectToRemote(
     context: 'remote client authorization',
   });
 
+  const localStorePassword = await ensureLocalStorePassword({ yes: options.yes }, localStorePasswordContext);
+  if (!localStorePassword) {
+    logger.info('Cancelled');
+    return;
+  }
+  await unlockLocalSecureStore(localStorePassword);
+  devicePasswordContext.password = localStorePassword;
+
   // Step 3: Load local identity
   const password = await ensureDeviceIdentityPassword({ yes: options.yes }, devicePasswordContext);
   if (!password) {
@@ -255,7 +269,7 @@ export async function connectToRemote(
   const identity = await loadKeypair(password);
   if (!identity) {
     throw new SpacesError(
-      'Failed to unlock identity. Check your password.',
+      'Failed to unlock local secure store identity. Check your password.',
       'USER_ERROR',
       1
     );
@@ -384,6 +398,7 @@ export async function listRemoteMachines(options: {
   passwordStdin?: boolean;
 }): Promise<void> {
   const devicePasswordContext = createDeviceIdentityPasswordContext({ passwordStdin: options.passwordStdin });
+  const localStorePasswordContext = createLocalStorePasswordContext({ passwordStdin: options.passwordStdin });
   if (!options.relay) {
     throw new SpacesError('Relay URL is required. Use --relay <url>.', 'USER_ERROR', 1);
   }
@@ -399,6 +414,14 @@ export async function listRemoteMachines(options: {
     yes: options.yes,
     context: 'remote machine directory authorization',
   });
+
+  const localStorePassword = await ensureLocalStorePassword({ yes: options.yes }, localStorePasswordContext);
+  if (!localStorePassword) {
+    logger.info('Cancelled');
+    return;
+  }
+  await unlockLocalSecureStore(localStorePassword);
+  devicePasswordContext.password = localStorePassword;
 
   const password = await ensureDeviceIdentityPassword({ yes: options.yes }, devicePasswordContext);
   if (!password) {

--- a/src/commands/connect.ts
+++ b/src/commands/connect.ts
@@ -251,6 +251,10 @@ export async function connectToRemote(
     context: 'remote client authorization',
   });
 
+  if (typeof devicePasswordContext.password === 'string' && !localStorePasswordContext.password) {
+    localStorePasswordContext.password = devicePasswordContext.password;
+  }
+
   const localStorePassword = await ensureLocalStorePassword({ yes: options.yes }, localStorePasswordContext);
   if (!localStorePassword) {
     logger.info('Cancelled');
@@ -414,6 +418,10 @@ export async function listRemoteMachines(options: {
     yes: options.yes,
     context: 'remote machine directory authorization',
   });
+
+  if (typeof devicePasswordContext.password === 'string' && !localStorePasswordContext.password) {
+    localStorePasswordContext.password = devicePasswordContext.password;
+  }
 
   const localStorePassword = await ensureLocalStorePassword({ yes: options.yes }, localStorePasswordContext);
   if (!localStorePassword) {

--- a/src/commands/connect.ts
+++ b/src/commands/connect.ts
@@ -37,8 +37,8 @@ import {
   ensureDeviceIdentityPassword,
 } from './device-identity-password.js';
 import {
-  createLocalStorePasswordContext,
   ensureLocalStorePassword,
+  type LocalStorePasswordContext,
 } from './local-store-password.js';
 import { ensureUserRootIdentityWithRecovery } from './identity-recovery.js';
 import {
@@ -207,7 +207,7 @@ export async function connectToRemote(
   options: { relay?: string; machine?: string; relayPubkey?: string; yes?: boolean; passwordStdin?: boolean } = {}
 ): Promise<void> {
   const devicePasswordContext = createDeviceIdentityPasswordContext({ passwordStdin: options.passwordStdin });
-  const localStorePasswordContext = createLocalStorePasswordContext({ passwordStdin: options.passwordStdin });
+  const localStorePasswordContext = devicePasswordContext as unknown as LocalStorePasswordContext;
   if (!target && !options.machine) {
     throw new SpacesError(
       'Connection target required.\n\nUsage:\n  gssh client connect <machine-id> --relay <url>\n  gssh client connect --machine <id> --relay <url>\n\nList available machines:\n  gssh client machines list --relay <url>',
@@ -405,7 +405,7 @@ export async function listRemoteMachines(options: {
   passwordStdin?: boolean;
 }): Promise<void> {
   const devicePasswordContext = createDeviceIdentityPasswordContext({ passwordStdin: options.passwordStdin });
-  const localStorePasswordContext = createLocalStorePasswordContext({ passwordStdin: options.passwordStdin });
+  const localStorePasswordContext = devicePasswordContext as unknown as LocalStorePasswordContext;
   if (!options.relay) {
     throw new SpacesError('Relay URL is required. Use --relay <url>.', 'USER_ERROR', 1);
   }

--- a/src/commands/connect.ts
+++ b/src/commands/connect.ts
@@ -252,10 +252,6 @@ export async function connectToRemote(
     context: 'remote client authorization',
   });
 
-  if (typeof devicePasswordContext.password === 'string' && !localStorePasswordContext.password) {
-    localStorePasswordContext.password = devicePasswordContext.password;
-  }
-
   const localStorePassword = await ensureLocalStorePassword({ yes: options.yes }, localStorePasswordContext);
   if (!localStorePassword) {
     logger.info('Cancelled');
@@ -421,10 +417,6 @@ export async function listRemoteMachines(options: {
     yes: options.yes,
     context: 'remote machine directory authorization',
   });
-
-  if (typeof devicePasswordContext.password === 'string' && !localStorePasswordContext.password) {
-    localStorePasswordContext.password = devicePasswordContext.password;
-  }
 
   const localStorePassword = await ensureLocalStorePassword({ yes: options.yes }, localStorePasswordContext);
   if (!localStorePassword) {

--- a/src/commands/connect.ts
+++ b/src/commands/connect.ts
@@ -34,6 +34,7 @@ import {
 } from '../types/errors.js';
 import {
   createDeviceIdentityPasswordContext,
+  type DeviceIdentityPasswordContext,
   ensureDeviceIdentityPassword,
 } from './device-identity-password.js';
 import {
@@ -206,8 +207,10 @@ export async function connectToRemote(
   target?: string,
   options: { relay?: string; machine?: string; relayPubkey?: string; yes?: boolean; passwordStdin?: boolean } = {}
 ): Promise<void> {
-  const devicePasswordContext = createDeviceIdentityPasswordContext({ passwordStdin: options.passwordStdin });
-  const localStorePasswordContext = devicePasswordContext as unknown as LocalStorePasswordContext;
+  const sharedPasswordContext: DeviceIdentityPasswordContext & LocalStorePasswordContext =
+    createDeviceIdentityPasswordContext({ passwordStdin: options.passwordStdin });
+  const devicePasswordContext: DeviceIdentityPasswordContext = sharedPasswordContext;
+  const localStorePasswordContext: LocalStorePasswordContext = sharedPasswordContext;
   if (!target && !options.machine) {
     throw new SpacesError(
       'Connection target required.\n\nUsage:\n  gssh client connect <machine-id> --relay <url>\n  gssh client connect --machine <id> --relay <url>\n\nList available machines:\n  gssh client machines list --relay <url>',
@@ -400,8 +403,10 @@ export async function listRemoteMachines(options: {
   yes?: boolean;
   passwordStdin?: boolean;
 }): Promise<void> {
-  const devicePasswordContext = createDeviceIdentityPasswordContext({ passwordStdin: options.passwordStdin });
-  const localStorePasswordContext = devicePasswordContext as unknown as LocalStorePasswordContext;
+  const sharedPasswordContext: DeviceIdentityPasswordContext & LocalStorePasswordContext =
+    createDeviceIdentityPasswordContext({ passwordStdin: options.passwordStdin });
+  const devicePasswordContext: DeviceIdentityPasswordContext = sharedPasswordContext;
+  const localStorePasswordContext: LocalStorePasswordContext = sharedPasswordContext;
   if (!options.relay) {
     throw new SpacesError('Relay URL is required. Use --relay <url>.', 'USER_ERROR', 1);
   }

--- a/src/commands/device-identity-password.ts
+++ b/src/commands/device-identity-password.ts
@@ -67,11 +67,15 @@ export async function ensureDeviceIdentityPassword(
   context?: DeviceIdentityPasswordContext,
 ): Promise<string | null> {
   const envPassword = getLocalStorePasswordFromEnv();
-  if (envPassword) {
-    return envPassword;
+  const sharedContext = getSharedPasswordContext(context, {
+    ...options,
+    passwordStdin: options.passwordStdin || Boolean(envPassword),
+  });
+
+  if (envPassword && sharedContext && typeof sharedContext.password !== 'string') {
+    sharedContext.password = envPassword;
   }
 
-  const sharedContext = getSharedPasswordContext(context, options);
   if (sharedContext?.resolved) {
     return sharedContext.password;
   }

--- a/src/commands/device-identity-password.ts
+++ b/src/commands/device-identity-password.ts
@@ -1,6 +1,7 @@
 import os from 'os';
 import { promptConfirm, promptPassword } from '../utils/prompts.js';
 import { generateAndSaveKeypair, keypairExists } from '../core/identity.js';
+import { localSecureStoreExists } from '../core/local-secure-store.js';
 import { NoIdentityError, SpacesError } from '../types/errors.js';
 import { logger } from '../utils/logger.js';
 import { readPasswordFromStdin } from '../utils/password-stdin.js';
@@ -119,7 +120,9 @@ export async function ensureDeviceIdentityPassword(
   }
 
   const { password } = await resolvePasswordInput(
-    'Enter password to unlock local secure store:',
+    keypairExists() && !localSecureStoreExists()
+      ? 'Enter your existing device identity password to migrate it into the new local secure store:'
+      : 'Enter password to unlock local secure store:',
     sharedContext,
   );
   return remember(password);

--- a/src/commands/device-identity-password.ts
+++ b/src/commands/device-identity-password.ts
@@ -76,10 +76,6 @@ export async function ensureDeviceIdentityPassword(
     sharedContext.password = envPassword;
   }
 
-  if (sharedContext?.resolved) {
-    return sharedContext.password;
-  }
-
   const remember = (password: string | null): string | null => {
     if (sharedContext) {
       sharedContext.resolved = true;
@@ -106,7 +102,7 @@ export async function ensureDeviceIdentityPassword(
       return remember(null);
     }
 
-    if (!fromStdin) {
+    if (!fromStdin && !(sharedContext?.resolved && typeof sharedContext.password === 'string')) {
       const confirmPassword = await promptPassword('Confirm local secure store password:');
       if (password !== confirmPassword) {
         throw new SpacesError('Password confirmation does not match.', 'USER_ERROR', 1);
@@ -116,6 +112,10 @@ export async function ensureDeviceIdentityPassword(
     await generateAndSaveKeypair(password, os.hostname());
     logger.success('Created local secure store identity');
     return remember(password);
+  }
+
+  if (sharedContext?.resolved) {
+    return sharedContext.password;
   }
 
   const { password } = await resolvePasswordInput(

--- a/src/commands/host.ts
+++ b/src/commands/host.ts
@@ -6,6 +6,7 @@
 
 import { existsSync, writeFileSync, readFileSync } from 'fs';
 import { join } from 'path';
+import { markLegacyLocalStorageMigrated, readLocalStoreJson, writeLocalStoreJson } from '../core/local-secure-store.js';
 import { getSecret, setSecret, deleteSecret } from '../utils/secrets.js';
 import { getSpacesDir } from '../core/config.js';
 import { getPublicKeyWithoutPassword } from '../core/identity.js';
@@ -263,10 +264,18 @@ function getHostConfigPath(): string {
   return join(getSpacesDir(), 'host.json');
 }
 
+const LOCAL_STORE_NAMESPACE = 'host';
+const LOCAL_STORE_KEY = 'config';
+
 /**
  * Read host config from disk
  */
 export function readHostConfig(): HostConfig | null {
+	const stored = readLocalStoreJson<HostConfig>(LOCAL_STORE_NAMESPACE, LOCAL_STORE_KEY);
+	if (stored) {
+		return stored;
+	}
+
   const configPath = getHostConfigPath();
   if (!existsSync(configPath)) {
     return null;
@@ -274,7 +283,10 @@ export function readHostConfig(): HostConfig | null {
 
   try {
     const content = readFileSync(configPath, 'utf-8');
-    return JSON.parse(content) as HostConfig;
+    const config = JSON.parse(content) as HostConfig;
+    writeLocalStoreJson(LOCAL_STORE_NAMESPACE, LOCAL_STORE_KEY, config);
+    markLegacyLocalStorageMigrated(true);
+    return config;
   } catch {
     return null;
   }
@@ -284,6 +296,7 @@ export function readHostConfig(): HostConfig | null {
  * Write host config to disk
  */
 function writeHostConfig(config: HostConfig): void {
+	writeLocalStoreJson(LOCAL_STORE_NAMESPACE, LOCAL_STORE_KEY, config);
   const configPath = getHostConfigPath();
   writeFileSync(configPath, JSON.stringify(config, null, 2), {
     encoding: 'utf-8',

--- a/src/commands/host.ts
+++ b/src/commands/host.ts
@@ -271,32 +271,40 @@ const LOCAL_STORE_KEY = 'config';
  * Read host config from disk
  */
 export function readHostConfig(): HostConfig | null {
-	const stored = readLocalStoreJson<HostConfig>(LOCAL_STORE_NAMESPACE, LOCAL_STORE_KEY);
-	if (stored) {
-		return stored;
-	}
+  const stored = readLocalStoreJson<HostConfig>(LOCAL_STORE_NAMESPACE, LOCAL_STORE_KEY);
+  if (stored) {
+    return stored;
+  }
 
   const configPath = getHostConfigPath();
   if (!existsSync(configPath)) {
     return null;
   }
 
+  let config: HostConfig;
   try {
     const content = readFileSync(configPath, 'utf-8');
-    const config = JSON.parse(content) as HostConfig;
-    writeLocalStoreJson(LOCAL_STORE_NAMESPACE, LOCAL_STORE_KEY, config);
-    markLegacyLocalStorageMigrated(true);
-    return config;
+    config = JSON.parse(content) as HostConfig;
   } catch {
     return null;
   }
+
+  try {
+    writeLocalStoreJson(LOCAL_STORE_NAMESPACE, LOCAL_STORE_KEY, config);
+    markLegacyLocalStorageMigrated(true);
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    console.warn(`[host] Failed to migrate host config into local secure store: ${detail}`);
+  }
+
+  return config;
 }
 
 /**
  * Write host config to disk
  */
 function writeHostConfig(config: HostConfig): void {
-	writeLocalStoreJson(LOCAL_STORE_NAMESPACE, LOCAL_STORE_KEY, config);
+  writeLocalStoreJson(LOCAL_STORE_NAMESPACE, LOCAL_STORE_KEY, config);
   const configPath = getHostConfigPath();
   writeFileSync(configPath, JSON.stringify(config, null, 2), {
     encoding: 'utf-8',

--- a/src/commands/invite.ts
+++ b/src/commands/invite.ts
@@ -120,14 +120,14 @@ async function loadSignedClientContext(): Promise<{
     throw new NoIdentityError();
   }
 
-  const password = await promptPassword('Enter password to unlock identity:');
+  const password = await promptPassword('Enter password to unlock local secure store identity:');
   if (!password) {
     throw new SpacesError('Cancelled', 'USER_ERROR', 1);
   }
 
   const identity = await loadKeypair(password);
   if (!identity) {
-    throw new SpacesError('Failed to unlock identity. Check your password.', 'USER_ERROR', 1);
+    throw new SpacesError('Failed to unlock local secure store identity. Check your password.', 'USER_ERROR', 1);
   }
 
   const deviceCertificate = await createLocalDeviceCertificate(identity);

--- a/src/commands/local-store-password.ts
+++ b/src/commands/local-store-password.ts
@@ -38,6 +38,13 @@ async function resolvePasswordInput(
   prompt: string,
   context: LocalStorePasswordContext | undefined,
 ): Promise<{ password: string | null; fromStdin: boolean }> {
+  if (typeof context?.password === 'string') {
+    return {
+      password: context.password,
+      fromStdin: context.passwordStdin,
+    };
+  }
+
   if (context?.passwordStdin) {
     context.stdinPasswordPromise ??= readPasswordFromStdin();
     return {

--- a/src/commands/local-store-password.ts
+++ b/src/commands/local-store-password.ts
@@ -64,12 +64,15 @@ export async function ensureLocalStorePassword(
   context?: LocalStorePasswordContext,
 ): Promise<string | null> {
   const envPassword = getLocalStorePasswordFromEnv();
+  const sharedContext = context ?? createLocalStorePasswordContext(options);
+  sharedContext.passwordStdin ||= Boolean(options.passwordStdin);
+
   if (envPassword) {
+    sharedContext.resolved = true;
+    sharedContext.password = envPassword;
     return envPassword;
   }
 
-  const sharedContext = context ?? createLocalStorePasswordContext(options);
-  sharedContext.passwordStdin ||= Boolean(options.passwordStdin);
   if (sharedContext.resolved) {
     return sharedContext.password;
   }

--- a/src/commands/local-store-password.ts
+++ b/src/commands/local-store-password.ts
@@ -1,21 +1,21 @@
-import os from 'os';
 import { promptConfirm, promptPassword } from '../utils/prompts.js';
-import { generateAndSaveKeypair, keypairExists } from '../core/identity.js';
-import { NoIdentityError, SpacesError } from '../types/errors.js';
-import { logger } from '../utils/logger.js';
 import { readPasswordFromStdin } from '../utils/password-stdin.js';
-import { getLocalStorePasswordFromEnv } from './local-store-password.js';
+import { localSecureStoreExists } from '../core/local-secure-store.js';
+import { SpacesError } from '../types/errors.js';
 
-export interface DeviceIdentityPasswordContext {
+export const LOCAL_STORE_PASSWORD_ENV = 'GITSPACE_LOCAL_STORE_PASSWORD';
+const LEGACY_LOCAL_STORE_PASSWORD_ENV = 'GITSPACE_IDENTITY_PASSWORD';
+
+export interface LocalStorePasswordContext {
   resolved: boolean;
   password: string | null;
   passwordStdin: boolean;
   stdinPasswordPromise: Promise<string> | null;
 }
 
-export function createDeviceIdentityPasswordContext(
+export function createLocalStorePasswordContext(
   options: { passwordStdin?: boolean } = {},
-): DeviceIdentityPasswordContext {
+): LocalStorePasswordContext {
   return {
     resolved: false,
     password: null,
@@ -24,30 +24,20 @@ export function createDeviceIdentityPasswordContext(
   };
 }
 
-function getSharedPasswordContext(
-  context: DeviceIdentityPasswordContext | undefined,
-  options: { passwordStdin?: boolean },
-): DeviceIdentityPasswordContext | undefined {
-  if (!context && !options.passwordStdin) {
-    return undefined;
+export function getLocalStorePasswordFromEnv(): string | null {
+  const explicit = process.env[LOCAL_STORE_PASSWORD_ENV]?.trim();
+  if (explicit) {
+    return explicit;
   }
 
-  const sharedContext = context ?? createDeviceIdentityPasswordContext(options);
-  sharedContext.passwordStdin ||= Boolean(options.passwordStdin);
-  return sharedContext;
+  const legacy = process.env[LEGACY_LOCAL_STORE_PASSWORD_ENV]?.trim();
+  return legacy || null;
 }
 
 async function resolvePasswordInput(
   prompt: string,
-  context: DeviceIdentityPasswordContext | undefined,
+  context: LocalStorePasswordContext | undefined,
 ): Promise<{ password: string | null; fromStdin: boolean }> {
-  if (typeof context?.password === 'string') {
-    return {
-      password: context.password,
-      fromStdin: context.passwordStdin,
-    };
-  }
-
   if (context?.passwordStdin) {
     context.stdinPasswordPromise ??= readPasswordFromStdin();
     return {
@@ -62,36 +52,35 @@ async function resolvePasswordInput(
   };
 }
 
-export async function ensureDeviceIdentityPassword(
+export async function ensureLocalStorePassword(
   options: { yes?: boolean; passwordStdin?: boolean } = {},
-  context?: DeviceIdentityPasswordContext,
+  context?: LocalStorePasswordContext,
 ): Promise<string | null> {
   const envPassword = getLocalStorePasswordFromEnv();
   if (envPassword) {
     return envPassword;
   }
 
-  const sharedContext = getSharedPasswordContext(context, options);
-  if (sharedContext?.resolved) {
+  const sharedContext = context ?? createLocalStorePasswordContext(options);
+  sharedContext.passwordStdin ||= Boolean(options.passwordStdin);
+  if (sharedContext.resolved) {
     return sharedContext.password;
   }
 
   const remember = (password: string | null): string | null => {
-    if (sharedContext) {
-      sharedContext.resolved = true;
-      sharedContext.password = password;
-    }
-
+    sharedContext.resolved = true;
+    sharedContext.password = password;
     return password;
   };
 
-  if (!keypairExists()) {
+  const storeExists = localSecureStoreExists();
+  if (!storeExists) {
     const shouldCreate = options.yes || await promptConfirm(
-      'No local secure store identity found. Create one now?',
+      'No local secure store password is configured. Create one now?',
       true,
     );
     if (!shouldCreate) {
-      throw new NoIdentityError();
+      throw new SpacesError('Cancelled', 'USER_ERROR', 1);
     }
 
     const { password, fromStdin } = await resolvePasswordInput(
@@ -109,8 +98,6 @@ export async function ensureDeviceIdentityPassword(
       }
     }
 
-    await generateAndSaveKeypair(password, os.hostname());
-    logger.success('Created local secure store identity');
     return remember(password);
   }
 

--- a/src/commands/local-store-password.ts
+++ b/src/commands/local-store-password.ts
@@ -1,5 +1,6 @@
 import { promptConfirm, promptPassword } from '../utils/prompts.js';
 import { readPasswordFromStdin } from '../utils/password-stdin.js';
+import { keypairExists } from '../core/identity.js';
 import { localSecureStoreExists } from '../core/local-secure-store.js';
 import { SpacesError } from '../types/errors.js';
 
@@ -84,6 +85,14 @@ export async function ensureLocalStorePassword(
   };
 
   const storeExists = localSecureStoreExists();
+  if (!storeExists && keypairExists()) {
+    const { password } = await resolvePasswordInput(
+      'Enter your existing device identity password to migrate it into the new local secure store:',
+      sharedContext,
+    );
+    return remember(password);
+  }
+
   if (!storeExists) {
     const shouldCreate = options.yes || await promptConfirm(
       'No local secure store password is configured. Create one now?',

--- a/src/commands/machine-enroll.ts
+++ b/src/commands/machine-enroll.ts
@@ -305,7 +305,7 @@ export async function enrollMachine(options: {
     throw new NoIdentityError();
   }
 
-  const password = await promptPassword('Enter password to unlock identity:');
+  const password = await promptPassword('Enter password to unlock local secure store identity:');
   if (!password) {
     logger.info('Cancelled');
     return;

--- a/src/commands/relay.ts
+++ b/src/commands/relay.ts
@@ -702,7 +702,6 @@ export async function startRelay(options: {
       });
     if (userRoot) {
       ownerUserRootId = userRoot.id;
-      const startupPlan = planStartupControlState({ ownerUserRootId });
       let ownerBinding;
       try {
         ownerBinding = bindRelayOwnerForStartup(ownerUserRootId);
@@ -710,6 +709,8 @@ export async function startRelay(options: {
         if (!options.takeover || !isRelayOwnerMismatchError(error)) {
           throw error;
         }
+
+        const startupPlan = planStartupControlState({ ownerUserRootId });
 
         if (!options.yes) {
           const confirmed = await promptConfirm(

--- a/src/commands/relay.ts
+++ b/src/commands/relay.ts
@@ -17,14 +17,13 @@ import {
   loadOrCreateRelayIdentity,
   formatRelayFingerprint,
 } from "../relay/identity.js";
+import { unlockLocalSecureStore } from '../core/local-secure-store.js';
 import { loadUserRootIdentity } from "../core/user-identity.js";
 import { getSpacesDir } from "../core/config.js";
 import {
-  bindControlOwner,
+  bindPersistedOwnerIdentity,
   ensureControlStore,
   getControlDbPath,
-  setVaultMeta,
-  getVaultMeta,
   isVaultInitialized,
   listVaultMachines,
   listVaultMachinesForOwner,
@@ -39,6 +38,17 @@ import {
 import { promptConfirm, selectOne } from "../utils/prompts.js";
 import { isCloudflaredInstalled, trackCloudflaredOutput } from "../utils/cloudflared.js";
 import { ensureUserRootIdentityWithRecovery } from "./identity-recovery.js";
+import {
+  createLocalStorePasswordContext,
+  ensureLocalStorePassword,
+  LOCAL_STORE_PASSWORD_ENV,
+} from './local-store-password.js';
+import {
+  formatStartupControlStateMismatch,
+  formatStartupControlStateTakeoverPrompt,
+  formatStartupControlStateTakeoverWarning,
+  planStartupControlState,
+} from '../core/control-state-startup.js';
 
 /** Default port for relay server (4480 = "GIT0" on phone keypad) */
 const DEFAULT_PORT = 4480;
@@ -111,31 +121,27 @@ export function bindRelayOwnerForStartup(ownerUserRootId: string): {
 } {
   ensureControlStore();
 
-  const existingOwner = getVaultMeta("owner_user_root_id");
-  if (existingOwner && existingOwner !== ownerUserRootId) {
+  const plan = planStartupControlState({ ownerUserRootId });
+  if (plan.hasUnrepairableOwnerMismatch) {
     throw new SpacesError(
-      `Relay is already owned by a different user root identity.\n`
-      + `  Existing owner: ${existingOwner.slice(0, 8)}...\n`
-      + `  Current user:   ${ownerUserRootId.slice(0, 8)}...\n\n`
-      + 'Recover the original identity, or re-run with `gssh relay start --takeover` to clear persisted relay control state and rebind ownership.',
-      "USER_ERROR",
+      formatStartupControlStateMismatch(plan, {
+        subject: 'relay',
+        takeoverCommand: 'gssh relay start --takeover',
+      }),
+      'USER_ERROR',
       1,
     );
   }
 
   const vaultInitialized = isVaultInitialized();
-  if (!existingOwner) {
+  if (!plan.ownerBinding.effectiveOwnerId && !plan.ownerBinding.mismatch) {
     assertRelayOwnerRepairIsSafe(ownerUserRootId);
   }
 
-  bindControlOwner(ownerUserRootId);
-
-  if (!existingOwner) {
-    setVaultMeta("owner_user_root_id", ownerUserRootId);
-  }
+  const ownerBinding = bindPersistedOwnerIdentity(ownerUserRootId);
 
   return {
-    repairedOwnerBinding: !existingOwner,
+    repairedOwnerBinding: ownerBinding.bound || ownerBinding.repaired,
     missingVaultInitialization: !vaultInitialized,
   };
 }
@@ -150,7 +156,7 @@ export function takeOverRelayOwnerForStartup(ownerUserRootId: string): {
 
 function isRelayOwnerMismatchError(error: unknown): boolean {
   return error instanceof SpacesError
-    && error.message.includes('Relay is already owned by a different user root identity.');
+    && error.message.includes('Persisted local control bindings do not match the current identity.');
 }
 
 interface RelayRuntimeState {
@@ -455,11 +461,24 @@ export async function startRelay(options: {
   mode?: RelayStartMode;
   label?: string;
   yes?: boolean;
+  passwordStdin?: boolean;
   foreground?: boolean;
   takeover?: boolean;
 }): Promise<void> {
+  const localStorePasswordContext = createLocalStorePasswordContext({
+    passwordStdin: options.passwordStdin,
+  });
+
   if (!options.foreground) {
     logger.log("Starting relay daemon...");
+
+    const localStorePassword = await ensureLocalStorePassword({
+      yes: options.yes,
+      passwordStdin: options.passwordStdin,
+    }, localStorePasswordContext);
+    if (!localStorePassword) {
+      throw new SpacesError('Cancelled', 'USER_ERROR', 1);
+    }
 
     let daemonSelectedSubdomain: string | undefined;
     let daemonSelectedHostname: string | undefined;
@@ -521,6 +540,7 @@ export async function startRelay(options: {
       stderr: Bun.file(logFile),
       env: {
         ...process.env,
+        [LOCAL_STORE_PASSWORD_ENV]: localStorePassword,
         ...(daemonSelectedSubdomain
           ? {
               [RELAY_SELECTED_SUBDOMAIN_ENV]: daemonSelectedSubdomain,
@@ -547,6 +567,15 @@ export async function startRelay(options: {
     logger.log(logContent);
     throw new SpacesError("Failed to start relay daemon. Check log above for details.", "SYSTEM_ERROR", 2);
   }
+
+  const localStorePassword = await ensureLocalStorePassword({
+    yes: options.yes,
+    passwordStdin: options.passwordStdin,
+  }, localStorePasswordContext);
+  if (!localStorePassword) {
+    throw new SpacesError('Cancelled', 'USER_ERROR', 1);
+  }
+  await unlockLocalSecureStore(localStorePassword);
 
   const existingState = readRelayState();
   if (existingState?.pid && isProcessRunning(existingState.pid)) {
@@ -671,6 +700,7 @@ export async function startRelay(options: {
       });
     if (userRoot) {
       ownerUserRootId = userRoot.id;
+      const startupPlan = planStartupControlState({ ownerUserRootId });
       let ownerBinding;
       try {
         ownerBinding = bindRelayOwnerForStartup(ownerUserRootId);
@@ -681,7 +711,10 @@ export async function startRelay(options: {
 
         if (!options.yes) {
           const confirmed = await promptConfirm(
-            'Relay ownership belongs to a different identity. Clear persisted relay registrations, access lists, invites, and owner metadata so the current identity can take over?',
+            formatStartupControlStateTakeoverPrompt(startupPlan, {
+              subject: 'relay',
+              takeoverCommand: 'gssh relay start --takeover',
+            }),
             false,
           );
           if (!confirmed) {
@@ -689,7 +722,10 @@ export async function startRelay(options: {
           }
         }
 
-        logger.warning('Clearing persisted relay control state and taking ownership with the current identity.');
+        logger.warning(formatStartupControlStateTakeoverWarning(startupPlan, {
+          subject: 'relay',
+          takeoverCommand: 'gssh relay start --takeover',
+        }));
         ownerBinding = takeOverRelayOwnerForStartup(ownerUserRootId);
       }
 

--- a/src/commands/relay.ts
+++ b/src/commands/relay.ts
@@ -155,8 +155,10 @@ export function takeOverRelayOwnerForStartup(ownerUserRootId: string): {
 }
 
 function isRelayOwnerMismatchError(error: unknown): boolean {
-  return error instanceof SpacesError
-    && error.message.includes('Persisted local control bindings do not match the current identity.');
+  return error instanceof SpacesError && (
+    error.message.includes('Persisted local control bindings do not match the current identity.')
+    || error.message.includes('Local control bindings mismatch.')
+  );
 }
 
 interface RelayRuntimeState {

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -104,9 +104,9 @@ import {
 } from './device-identity-password.js';
 import { ensureUserRootIdentityWithRecovery } from './identity-recovery.js';
 import {
-  createLocalStorePasswordContext,
   ensureLocalStorePassword,
   LOCAL_STORE_PASSWORD_ENV,
+  type LocalStorePasswordContext,
 } from './local-store-password.js';
 import { unlockLocalSecureStore } from '../core/local-secure-store.js';
 import {
@@ -1019,7 +1019,7 @@ export async function serveStart(options: {
   yes?: boolean;
 } = {}): Promise<void> {
   const devicePasswordContext = createDeviceIdentityPasswordContext({ passwordStdin: options.passwordStdin });
-  const localStorePasswordContext = createLocalStorePasswordContext({ passwordStdin: options.passwordStdin });
+  const localStorePasswordContext = devicePasswordContext as unknown as LocalStorePasswordContext;
 
   // Check if already running
   if (isServeRunning()) {

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -1086,7 +1086,9 @@ export async function serveStart(options: {
         logger.info('Cancelled');
         return;
       }
-      await unlockLocalSecureStore(localStorePassword);
+      if (!shouldDeferLocalStoreUnlockForLegacyIdentityMigration()) {
+        await unlockLocalSecureStore(localStorePassword);
+      }
       devicePasswordContext.password = localStorePassword;
     }
 

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -82,14 +82,10 @@ import {
   type RelayCandidate,
 } from '../core/relay-discovery.js';
 import {
+  bindPersistedOwnerIdentity,
   bindControlRelayIdentity,
-  bindControlOwner,
   ensureControlStore,
-  readControlMeta,
-  getControlOwnerIdentityId,
-  getVaultMeta,
   resetControlStore,
-  setVaultMeta,
 } from '../relay/control/store.js';
 import {
   connectMachineRelay,
@@ -106,6 +102,18 @@ import {
   type DeviceIdentityPasswordContext,
 } from './device-identity-password.js';
 import { ensureUserRootIdentityWithRecovery } from './identity-recovery.js';
+import {
+  createLocalStorePasswordContext,
+  ensureLocalStorePassword,
+  LOCAL_STORE_PASSWORD_ENV,
+} from './local-store-password.js';
+import { unlockLocalSecureStore } from '../core/local-secure-store.js';
+import {
+  formatStartupControlStateMismatch,
+  formatStartupControlStateTakeoverPrompt,
+  formatStartupControlStateTakeoverWarning,
+  planStartupControlState,
+} from '../core/control-state-startup.js';
 
 /** Package version for daemon status */
 const PACKAGE_VERSION = '1.0.0';
@@ -137,45 +145,23 @@ export async function ensureServeOwnerBindingForStartup(
 ): Promise<{ tookOver: boolean }> {
   ensureControlStore();
 
-  const currentVaultOwner = getVaultMeta('owner_user_root_id');
-  const currentControlOwner = getControlOwnerIdentityId();
-  const controlMeta = readControlMeta();
-  const hasPinnedRelayIdentity = Boolean(
-    controlMeta.relayIdentityId || controlMeta.relaySigningPublicKey || controlMeta.relayFingerprint,
-  );
-  const currentRelayIdentityId = options.currentRelay ? computeIdentityId(options.currentRelay.publicKey) : undefined;
-  const relayMismatch = Boolean(
-    options.currentRelay
-      && (
-        (controlMeta.relayIdentityId && controlMeta.relayIdentityId !== currentRelayIdentityId)
-        || (controlMeta.relaySigningPublicKey && controlMeta.relaySigningPublicKey !== options.currentRelay.publicKey)
-        || (controlMeta.relayFingerprint && controlMeta.relayFingerprint !== options.currentRelay.fingerprint)
-      ),
-  );
-
-  const needsTakeover = (currentVaultOwner && currentVaultOwner !== ownerUserRootId)
-    || (currentControlOwner && currentControlOwner !== ownerUserRootId)
-    || relayMismatch;
+  const plan = planStartupControlState({
+    ownerUserRootId,
+    currentRelay: options.currentRelay,
+  });
 
   const shouldForceResetForTakeover = Boolean(
     options.takeover
-    && !needsTakeover
-    && (currentVaultOwner || currentControlOwner || hasPinnedRelayIdentity),
+    && !plan.needsTakeover
+    && (plan.ownerBinding.controlOwnerId || plan.ownerBinding.vaultOwnerId || plan.hasPinnedRelayIdentity),
   );
 
-  if (needsTakeover || shouldForceResetForTakeover) {
+  if (plan.needsTakeover || shouldForceResetForTakeover) {
     if (!options.takeover) {
-      const mismatchMessage = [
-        'Persisted relay control state belongs to a different identity.',
-        '',
-        `  Current user: ${ownerUserRootId.slice(0, 8)}...`,
-        currentControlOwner ? `  Control owner: ${currentControlOwner.slice(0, 8)}...` : null,
-        currentVaultOwner ? `  Vault owner:   ${currentVaultOwner.slice(0, 8)}...` : null,
-        relayMismatch ? `  Pinned relay:  ${controlMeta.relayFingerprint ?? controlMeta.relayIdentityId}` : null,
-        relayMismatch ? `  Current relay: ${options.currentRelay?.fingerprint}` : null,
-        '',
-        'Re-run with `gssh machine serve start --takeover` to clear the persisted relay control state and bind it to the recovered identity.',
-      ].filter((line): line is string => line !== null).join('\n');
+      const mismatchMessage = formatStartupControlStateMismatch(plan, {
+        subject: 'machine serve',
+        takeoverCommand: 'gssh machine serve start --takeover',
+      });
 
       logger.error(`[serve] owner binding mismatch during startup.\n${mismatchMessage}`);
       throw new SpacesError(
@@ -186,10 +172,11 @@ export async function ensureServeOwnerBindingForStartup(
     }
 
     if (!options.yes) {
-      const confirmed = await promptConfirm(
-        needsTakeover
-          ? 'Persisted relay control state belongs to a different identity. Clear it and rebind this machine to the current recovered identity?'
-          : 'Clear persisted relay control state and relay identity pins before starting machine serve?',
+        const confirmed = await promptConfirm(
+          formatStartupControlStateTakeoverPrompt(plan, {
+            subject: 'machine serve',
+            takeoverCommand: 'gssh machine serve start --takeover',
+          }),
         false,
       );
       if (!confirmed) {
@@ -198,24 +185,17 @@ export async function ensureServeOwnerBindingForStartup(
     }
 
     logger.warning(
-      needsTakeover
-        ? 'Clearing persisted relay control state and rebinding machine serve ownership to the current identity.'
-        : 'Clearing persisted relay control state and relay identity pins before machine serve startup.',
+      formatStartupControlStateTakeoverWarning(plan, {
+        subject: 'machine serve',
+        takeoverCommand: 'gssh machine serve start --takeover',
+      }),
     );
     resetControlStore();
-    ensureControlStore();
-    bindControlOwner(ownerUserRootId);
-    setVaultMeta('owner_user_root_id', ownerUserRootId);
+    bindPersistedOwnerIdentity(ownerUserRootId);
     return { tookOver: true };
   }
 
-  if (!currentControlOwner) {
-    bindControlOwner(ownerUserRootId);
-  }
-
-  if (!currentVaultOwner) {
-    setVaultMeta('owner_user_root_id', ownerUserRootId);
-  }
+  bindPersistedOwnerIdentity(ownerUserRootId);
 
   return { tookOver: false };
 }
@@ -1037,6 +1017,7 @@ export async function serveStart(options: {
   yes?: boolean;
 } = {}): Promise<void> {
   const devicePasswordContext = createDeviceIdentityPasswordContext({ passwordStdin: options.passwordStdin });
+  const localStorePasswordContext = createLocalStorePasswordContext({ passwordStdin: options.passwordStdin });
 
   // Check if already running
   if (isServeRunning()) {
@@ -1049,6 +1030,7 @@ export async function serveStart(options: {
   const skipOwnerBindingCheck = process.env.GITSPACE_SKIP_OWNER_BINDING_CHECK === '1';
 
   let password: string | null = null;
+  let localStorePassword: string | null = null;
   let identity: Identity | null = null;
   let signingPrivateKey: Uint8Array | null = null;
   let publicIdentity: PublicIdentity | null = null;
@@ -1068,22 +1050,40 @@ export async function serveStart(options: {
         throw new SpacesError('Unlock mode requires --enrollment-token', 'USER_ERROR', 1);
       }
     } else {
+      localStorePassword = await ensureLocalStorePassword({ yes: options.yes }, localStorePasswordContext);
+      if (!localStorePassword) {
+        logger.info('Cancelled');
+        return;
+      }
+      await unlockLocalSecureStore(localStorePassword);
+      devicePasswordContext.password = localStorePassword;
+
       password = await ensureDeviceIdentityPassword({ yes: options.yes }, devicePasswordContext);
       if (!password) {
         logger.info('Cancelled');
         return;
       }
 
-      // Validate password before daemonizing
+      // Validate secure store + identity before daemonizing
       const loadedIdentity = await loadKeypair(password);
       if (!loadedIdentity) {
         throw new SpacesError(
-          'Failed to unlock identity. Check your password.',
+          'Failed to unlock local secure store identity. Check your password.',
           'USER_ERROR',
           1
         );
       }
 
+    }
+
+    if (usingUnlockMode) {
+      localStorePassword = await ensureLocalStorePassword({ yes: options.yes }, localStorePasswordContext);
+      if (!localStorePassword) {
+        logger.info('Cancelled');
+        return;
+      }
+      await unlockLocalSecureStore(localStorePassword);
+      devicePasswordContext.password = localStorePassword;
     }
 
     if (!options.relay) {
@@ -1164,13 +1164,14 @@ export async function serveStart(options: {
       env: {
         ...process.env,
         GITSPACE_SKIP_OWNER_BINDING_CHECK: '1',
+        ...(localStorePassword ? { [LOCAL_STORE_PASSWORD_ENV]: localStorePassword } : {}),
       },
     });
 
     // Send password via stdin (non-unlock mode)
     if (!usingUnlockMode) {
       if (!password) {
-        throw new SpacesError('Failed to pass identity password to serve daemon startup.', 'SYSTEM_ERROR', 2);
+        throw new SpacesError('Failed to pass local secure store password to serve daemon startup.', 'SYSTEM_ERROR', 2);
       }
 
       child.stdin.write(password);
@@ -1196,6 +1197,15 @@ export async function serveStart(options: {
       throw new SpacesError('Failed to start serve daemon. Check log above for details.', 'SYSTEM_ERROR', 2);
     }
   }
+
+  localStorePassword = await ensureLocalStorePassword({ yes: options.yes }, localStorePasswordContext);
+  if (!localStorePassword) {
+    logger.info('Cancelled');
+    cleanupServeFiles();
+    return;
+  }
+  await unlockLocalSecureStore(localStorePassword);
+  devicePasswordContext.password = localStorePassword;
 
   // Foreground mode identity resolution
   if (usingUnlockMode) {
@@ -1232,7 +1242,7 @@ export async function serveStart(options: {
     if (!identity) {
       cleanupServeFiles();
       throw new SpacesError(
-        'Failed to unlock identity. Check your password.',
+        'Failed to unlock local secure store identity. Check your password.',
         'USER_ERROR',
         1
       );

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -1018,8 +1018,10 @@ export async function serveStart(options: {
   takeover?: boolean;
   yes?: boolean;
 } = {}): Promise<void> {
-  const devicePasswordContext = createDeviceIdentityPasswordContext({ passwordStdin: options.passwordStdin });
-  const localStorePasswordContext = devicePasswordContext as unknown as LocalStorePasswordContext;
+  const sharedPasswordContext: DeviceIdentityPasswordContext & LocalStorePasswordContext =
+    createDeviceIdentityPasswordContext({ passwordStdin: options.passwordStdin });
+  const devicePasswordContext: DeviceIdentityPasswordContext = sharedPasswordContext;
+  const localStorePasswordContext: LocalStorePasswordContext = sharedPasswordContext;
 
   // Check if already running
   if (isServeRunning()) {

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -191,6 +191,7 @@ export async function ensureServeOwnerBindingForStartup(
       }),
     );
     resetControlStore();
+    ensureControlStore();
     bindPersistedOwnerIdentity(ownerUserRootId);
     return { tookOver: true };
   }

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -29,6 +29,7 @@ import {
   loadKeypair,
   readMachineIdentity,
   getPublicKeyWithoutPassword,
+  shouldDeferLocalStoreUnlockForLegacyIdentityMigration,
   writeRelayConfig,
 } from '../core/identity.js';
 import { loadUserRootIdentity, createLocalDeviceCertificate } from '../core/user-identity.js';
@@ -1056,7 +1057,9 @@ export async function serveStart(options: {
         logger.info('Cancelled');
         return;
       }
-      await unlockLocalSecureStore(localStorePassword);
+      if (!shouldDeferLocalStoreUnlockForLegacyIdentityMigration()) {
+        await unlockLocalSecureStore(localStorePassword);
+      }
       devicePasswordContext.password = localStorePassword;
 
       password = await ensureDeviceIdentityPassword({ yes: options.yes }, devicePasswordContext);
@@ -1205,7 +1208,9 @@ export async function serveStart(options: {
     cleanupServeFiles();
     return;
   }
-  await unlockLocalSecureStore(localStorePassword);
+  if (!shouldDeferLocalStoreUnlockForLegacyIdentityMigration()) {
+    await unlockLocalSecureStore(localStorePassword);
+  }
   devicePasswordContext.password = localStorePassword;
 
   // Foreground mode identity resolution

--- a/src/core/__tests__/local-secure-store.test.ts
+++ b/src/core/__tests__/local-secure-store.test.ts
@@ -21,6 +21,7 @@ import {
   writeMachineIdentity,
   writeRelayConfig,
 } from '../identity.js';
+import { getControlDbPath } from '../../relay/control/store.js';
 
 let originalHome: string | undefined;
 let testDir: string;
@@ -88,5 +89,19 @@ describe('local secure store', () => {
 
     clearRelayConfig();
     expect(readRelayConfig()).toBeNull();
+  });
+
+  test('does not permanently initialize the local store with a wrong password before legacy keypair migration', async () => {
+    const created = await generateAndSaveKeypair('secret-password', 'legacy-device');
+
+    lockLocalSecureStore();
+    rmSync(getControlDbPath(), { force: true });
+    rmSync(`${getControlDbPath()}-shm`, { force: true });
+    rmSync(`${getControlDbPath()}-wal`, { force: true });
+
+    await expect(loadKeypair('wrong-password')).rejects.toThrow();
+
+    const loaded = await loadKeypair('secret-password');
+    expect(loaded.id).toBe(created.id);
   });
 });

--- a/src/core/__tests__/local-secure-store.test.ts
+++ b/src/core/__tests__/local-secure-store.test.ts
@@ -1,0 +1,92 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { existsSync, mkdtempSync, rmSync, unlinkSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  lockLocalSecureStore,
+  readLocalStoreJson,
+  readLocalStoreSecretJson,
+  unlockLocalSecureStore,
+  writeLocalStoreJson,
+  writeLocalStoreSecretJson,
+} from '../local-secure-store.js';
+import {
+  clearRelayConfig,
+  generateAndSaveKeypair,
+  getKeypairPath,
+  getPublicKeyWithoutPassword,
+  loadKeypair,
+  readMachineIdentity,
+  readRelayConfig,
+  writeMachineIdentity,
+  writeRelayConfig,
+} from '../identity.js';
+
+let originalHome: string | undefined;
+let testDir: string;
+
+beforeEach(() => {
+  originalHome = process.env.HOME;
+  testDir = mkdtempSync(join(tmpdir(), 'gssh-local-store-'));
+  process.env.HOME = testDir;
+});
+
+afterEach(() => {
+  lockLocalSecureStore();
+  if (originalHome === undefined) {
+    delete process.env.HOME;
+  } else {
+    process.env.HOME = originalHome;
+  }
+
+  if (testDir && existsSync(testDir)) {
+    rmSync(testDir, { recursive: true, force: true });
+  }
+});
+
+describe('local secure store', () => {
+  test('persists plain and encrypted JSON records', async () => {
+    await unlockLocalSecureStore('secret-password');
+
+    writeLocalStoreJson('test', 'plain', { hello: 'world' });
+    writeLocalStoreSecretJson('test', 'secret', { token: 'abc123' });
+
+    expect(readLocalStoreJson<{ hello: string }>('test', 'plain')).toEqual({ hello: 'world' });
+    expect(readLocalStoreSecretJson<{ token: string }>('test', 'secret')).toEqual({ token: 'abc123' });
+
+    lockLocalSecureStore();
+    await unlockLocalSecureStore('secret-password');
+    expect(readLocalStoreSecretJson<{ token: string }>('test', 'secret')?.token).toBe('abc123');
+  });
+
+  test('stores keypairs and configs in control db with legacy fallback retained', async () => {
+    const created = await generateAndSaveKeypair('secret-password', 'test-device');
+    expect(getPublicKeyWithoutPassword()?.id).toBe(created.id);
+
+    const keypairPath = getKeypairPath();
+    expect(existsSync(keypairPath)).toBe(true);
+    unlinkSync(keypairPath);
+
+    const loaded = await loadKeypair('secret-password');
+    expect(loaded.id).toBe(created.id);
+
+    writeMachineIdentity({
+      machineId: 'machine-1',
+      machineName: 'My Machine',
+      relayUrl: 'wss://relay.example.test/ws',
+      registeredAt: '2026-03-16T00:00:00.000Z',
+    });
+    expect(readMachineIdentity()?.machineId).toBe('machine-1');
+
+    writeRelayConfig({
+      relayUrl: 'wss://relay.example.test/ws',
+      cloudRelayUrl: 'wss://cloud.example.test/ws',
+      machineId: 'machine-1',
+      savedAt: Date.now(),
+    });
+    expect(readRelayConfig()?.machineId).toBe('machine-1');
+
+    clearRelayConfig();
+    expect(readRelayConfig()).toBeNull();
+  });
+});

--- a/src/core/control-state-startup.ts
+++ b/src/core/control-state-startup.ts
@@ -1,7 +1,7 @@
 import { computeIdentityId } from '../relay/identity.js';
 import {
+  peekPersistedOwnerBinding,
   readControlMeta,
-  readPersistedOwnerBinding,
   type PersistedOwnerBinding,
 } from '../relay/control/store.js';
 import type { ControlMeta } from '../relay/control/types.js';
@@ -33,7 +33,7 @@ export function planStartupControlState(input: {
   ownerUserRootId: string;
   currentRelay?: StartupCurrentRelayBinding;
 }): StartupControlStatePlan {
-  const ownerBinding = readPersistedOwnerBinding();
+  const ownerBinding = peekPersistedOwnerBinding();
   const controlMeta = readControlMeta();
   const hasPinnedRelayIdentity = Boolean(
     controlMeta.relayIdentityId || controlMeta.relaySigningPublicKey || controlMeta.relayFingerprint,

--- a/src/core/control-state-startup.ts
+++ b/src/core/control-state-startup.ts
@@ -29,10 +29,6 @@ export interface StartupControlStateTextOptions {
   subject: 'machine serve' | 'relay';
 }
 
-function getSubjectNoun(subject: StartupControlStateTextOptions['subject']): string {
-  return subject === 'relay' ? 'relay' : 'machine';
-}
-
 export function planStartupControlState(input: {
   ownerUserRootId: string;
   currentRelay?: StartupCurrentRelayBinding;
@@ -98,7 +94,7 @@ export function formatStartupControlStateTakeoverPrompt(
   options: StartupControlStateTextOptions,
 ): string {
   if (plan.needsTakeover) {
-    return `Persisted local control bindings do not match the current identity. Clear them and rebind this ${getSubjectNoun(options.subject)} to the recovered identity?`;
+    return `Persisted local control bindings do not match the current identity. Clear them and rebind this ${options.subject === 'relay' ? 'relay' : 'machine'} to the recovered identity?`;
   }
 
   if (plan.hasPinnedRelayIdentity) {

--- a/src/core/control-state-startup.ts
+++ b/src/core/control-state-startup.ts
@@ -72,6 +72,18 @@ export function formatStartupControlStateMismatch(
   plan: StartupControlStatePlan,
   options: StartupControlStateTextOptions,
 ): string {
+  if (plan.relayMismatch && !plan.hasUnrepairableOwnerMismatch) {
+    return [
+      'Persisted local control bindings are pinned to a different relay.',
+      '',
+      `  Current user: ${plan.ownerUserRootId.slice(0, 8)}...`,
+      `  Pinned relay:  ${plan.controlMeta.relayFingerprint ?? plan.controlMeta.relayIdentityId}`,
+      `  Current relay: ${plan.currentRelay?.fingerprint}`,
+      '',
+      `Re-run with \`${options.takeoverCommand}\` to clear the persisted relay pin and rebind local control bindings to the current relay.`,
+    ].join('\n');
+  }
+
   const lines = [
     'Persisted local control bindings do not match the current identity.',
     '',
@@ -93,6 +105,14 @@ export function formatStartupControlStateTakeoverPrompt(
   plan: StartupControlStatePlan,
   options: StartupControlStateTextOptions,
 ): string {
+  if (plan.relayMismatch && !plan.hasUnrepairableOwnerMismatch) {
+    if (options.subject === 'machine serve') {
+      return 'Persisted local control bindings are pinned to a different relay. Clear the relay pin and rebind machine serve to the current relay?';
+    }
+
+    return 'Persisted local control bindings are pinned to a different relay. Clear the relay pin and rebind the relay startup state?';
+  }
+
   if (plan.needsTakeover) {
     return `Persisted local control bindings do not match the current identity. Clear them and rebind this ${options.subject === 'relay' ? 'relay' : 'machine'} to the recovered identity?`;
   }
@@ -112,6 +132,14 @@ export function formatStartupControlStateTakeoverWarning(
   plan: StartupControlStatePlan,
   options: StartupControlStateTextOptions,
 ): string {
+  if (plan.relayMismatch && !plan.hasUnrepairableOwnerMismatch) {
+    if (options.subject === 'machine serve') {
+      return 'Clearing persisted relay pin and rebinding machine serve to the current relay.';
+    }
+
+    return 'Clearing persisted relay pin and rebinding relay startup state to the current relay.';
+  }
+
   if (plan.needsTakeover) {
     return `Clearing persisted local control bindings and rebinding ${options.subject} ownership to the current identity.`;
   }

--- a/src/core/control-state-startup.ts
+++ b/src/core/control-state-startup.ts
@@ -1,0 +1,128 @@
+import { computeIdentityId } from '../relay/identity.js';
+import {
+  readControlMeta,
+  readPersistedOwnerBinding,
+  type PersistedOwnerBinding,
+} from '../relay/control/store.js';
+import type { ControlMeta } from '../relay/control/types.js';
+
+export interface StartupCurrentRelayBinding {
+  publicKey: string;
+  fingerprint: string;
+}
+
+export interface StartupControlStatePlan {
+  ownerUserRootId: string;
+  ownerBinding: PersistedOwnerBinding;
+  controlMeta: ControlMeta;
+  currentRelay?: StartupCurrentRelayBinding;
+  currentRelayIdentityId?: string;
+  hasPinnedRelayIdentity: boolean;
+  relayMismatch: boolean;
+  repairableOwnerMismatch: boolean;
+  hasUnrepairableOwnerMismatch: boolean;
+  needsTakeover: boolean;
+}
+
+export interface StartupControlStateTextOptions {
+  takeoverCommand: string;
+  subject: 'machine serve' | 'relay';
+}
+
+function getSubjectNoun(subject: StartupControlStateTextOptions['subject']): string {
+  return subject === 'relay' ? 'relay' : 'machine';
+}
+
+export function planStartupControlState(input: {
+  ownerUserRootId: string;
+  currentRelay?: StartupCurrentRelayBinding;
+}): StartupControlStatePlan {
+  const ownerBinding = readPersistedOwnerBinding();
+  const controlMeta = readControlMeta();
+  const hasPinnedRelayIdentity = Boolean(
+    controlMeta.relayIdentityId || controlMeta.relaySigningPublicKey || controlMeta.relayFingerprint,
+  );
+  const currentRelayIdentityId = input.currentRelay
+    ? computeIdentityId(input.currentRelay.publicKey)
+    : undefined;
+  const relayMismatch = Boolean(
+    input.currentRelay
+      && ((controlMeta.relayIdentityId && controlMeta.relayIdentityId !== currentRelayIdentityId)
+        || (controlMeta.relaySigningPublicKey && controlMeta.relaySigningPublicKey !== input.currentRelay.publicKey)
+        || (controlMeta.relayFingerprint && controlMeta.relayFingerprint !== input.currentRelay.fingerprint)),
+  );
+  const repairableOwnerMismatch = ownerBinding.mismatch
+    && (ownerBinding.controlOwnerId === input.ownerUserRootId || ownerBinding.vaultOwnerId === input.ownerUserRootId);
+  const hasUnrepairableOwnerMismatch = Boolean(!repairableOwnerMismatch && (
+    (ownerBinding.controlOwnerId && ownerBinding.controlOwnerId !== input.ownerUserRootId)
+    || (ownerBinding.vaultOwnerId && ownerBinding.vaultOwnerId !== input.ownerUserRootId)
+  ));
+
+  return {
+    ownerUserRootId: input.ownerUserRootId,
+    ownerBinding,
+    controlMeta,
+    currentRelay: input.currentRelay,
+    currentRelayIdentityId,
+    hasPinnedRelayIdentity,
+    relayMismatch,
+    repairableOwnerMismatch,
+    hasUnrepairableOwnerMismatch,
+    needsTakeover: hasUnrepairableOwnerMismatch || relayMismatch,
+  };
+}
+
+export function formatStartupControlStateMismatch(
+  plan: StartupControlStatePlan,
+  options: StartupControlStateTextOptions,
+): string {
+  const lines = [
+    'Persisted local control bindings do not match the current identity.',
+    '',
+    `  Current user: ${plan.ownerUserRootId.slice(0, 8)}...`,
+    plan.ownerBinding.controlOwnerId ? `  Control owner: ${plan.ownerBinding.controlOwnerId.slice(0, 8)}...` : null,
+    plan.ownerBinding.vaultOwnerId ? `  Vault owner:   ${plan.ownerBinding.vaultOwnerId.slice(0, 8)}...` : null,
+    plan.relayMismatch ? `  Pinned relay:  ${plan.controlMeta.relayFingerprint ?? plan.controlMeta.relayIdentityId}` : null,
+    plan.relayMismatch ? `  Current relay: ${plan.currentRelay?.fingerprint}` : null,
+    '',
+    options.subject === 'relay'
+      ? `Recover the original identity, or re-run with \`${options.takeoverCommand}\` to clear persisted local control bindings and rebind ownership.`
+      : `Re-run with \`${options.takeoverCommand}\` to clear the persisted local control bindings and bind them to the recovered identity.`,
+  ];
+
+  return lines.filter((line): line is string => line !== null).join('\n');
+}
+
+export function formatStartupControlStateTakeoverPrompt(
+  plan: StartupControlStatePlan,
+  options: StartupControlStateTextOptions,
+): string {
+  if (plan.needsTakeover) {
+    return `Persisted local control bindings do not match the current identity. Clear them and rebind this ${getSubjectNoun(options.subject)} to the recovered identity?`;
+  }
+
+  if (plan.hasPinnedRelayIdentity) {
+    if (options.subject === 'machine serve') {
+      return 'Clear persisted local control bindings and relay identity pins before starting machine serve?';
+    }
+
+    return 'Clear persisted local control bindings before starting the relay?';
+  }
+
+  return `Clear persisted local control bindings before starting ${options.subject}?`;
+}
+
+export function formatStartupControlStateTakeoverWarning(
+  plan: StartupControlStatePlan,
+  options: StartupControlStateTextOptions,
+): string {
+  if (plan.needsTakeover) {
+    return `Clearing persisted local control bindings and rebinding ${options.subject} ownership to the current identity.`;
+  }
+
+  if (plan.hasPinnedRelayIdentity && options.subject === 'machine serve') {
+    return 'Clearing persisted local control bindings and relay identity pins before machine serve startup.';
+  }
+
+  return `Clearing persisted local control bindings before ${options.subject} startup.`;
+}

--- a/src/core/identity.ts
+++ b/src/core/identity.ts
@@ -428,12 +428,10 @@ export function readMachineIdentity(): MachineIdentity | null {
 		return null;
 	}
 
+	let identity: MachineIdentity;
 	try {
 		const content = readFileSync(machineIdentityPath, 'utf-8');
-		const identity = JSON.parse(content) as MachineIdentity;
-		writeLocalStoreJson(LOCAL_STORE_NAMESPACE_IDENTITY, LOCAL_STORE_KEY_MACHINE_IDENTITY, identity);
-		markLegacyLocalStorageMigrated(true);
-		return identity;
+		identity = JSON.parse(content) as MachineIdentity;
 	} catch (error) {
 		throw new SpacesError(
 			`Failed to read machine identity: ${
@@ -443,6 +441,15 @@ export function readMachineIdentity(): MachineIdentity | null {
 			2
 		);
 	}
+
+	try {
+		writeLocalStoreJson(LOCAL_STORE_NAMESPACE_IDENTITY, LOCAL_STORE_KEY_MACHINE_IDENTITY, identity);
+		markLegacyLocalStorageMigrated(true);
+	} catch {
+		// Keep returning the parsed legacy value even if opportunistic migration fails.
+	}
+
+	return identity;
 }
 
 /**
@@ -525,12 +532,10 @@ export function readRelayConfig(): RelayConfig | null {
 		return null;
 	}
 
+	let config: RelayConfig;
 	try {
 		const content = readFileSync(relayConfigPath, 'utf-8');
-		const config = JSON.parse(content) as RelayConfig;
-		writeLocalStoreJson(LOCAL_STORE_NAMESPACE_IDENTITY, LOCAL_STORE_KEY_RELAY_CONFIG, config);
-		markLegacyLocalStorageMigrated(true);
-		return config;
+		config = JSON.parse(content) as RelayConfig;
 	} catch (error) {
 		throw new SpacesError(
 			`Failed to read relay config: ${
@@ -540,6 +545,15 @@ export function readRelayConfig(): RelayConfig | null {
 			2
 		);
 	}
+
+	try {
+		writeLocalStoreJson(LOCAL_STORE_NAMESPACE_IDENTITY, LOCAL_STORE_KEY_RELAY_CONFIG, config);
+		markLegacyLocalStorageMigrated(true);
+	} catch {
+		// Keep returning the parsed legacy value even if opportunistic migration fails.
+	}
+
+	return config;
 }
 
 /**

--- a/src/core/identity.ts
+++ b/src/core/identity.ts
@@ -17,6 +17,7 @@ import {
 	existsSync,
 	mkdirSync,
 	readFileSync,
+	unlinkSync,
 	writeFileSync,
 } from 'node:fs';
 import { join } from 'node:path';
@@ -34,6 +35,15 @@ import {
 import { seal, open } from '../lib/tmux-lite/crypto/secretbox.js';
 import { deriveKey, generateSalt } from '../lib/tmux-lite/crypto/keys.js';
 import { getSpacesDir } from './config.js';
+import {
+	markLegacyLocalStorageMigrated,
+	readLocalStoreJson,
+	readLocalStoreSecretJson,
+	unlockLocalSecureStore,
+	writeLocalStoreJson,
+	writeLocalStoreSecretJson,
+	deleteLocalStoreJson,
+} from './local-secure-store.js';
 import {
 	SpacesError,
 	NoIdentityError,
@@ -68,6 +78,20 @@ interface DecryptedSecrets {
 	signingSecretKey: string;
 	keyExchangePrivateKey: string;
 }
+
+interface StoredDeviceIdentityPublic {
+	id: string;
+	label?: string;
+	createdAt: number;
+	signingPublicKey: string;
+	keyExchangePublicKey: string;
+}
+
+const LOCAL_STORE_NAMESPACE_IDENTITY = 'identity';
+const LOCAL_STORE_KEY_DEVICE_PUBLIC = 'device-public';
+const LOCAL_STORE_KEY_DEVICE_SECRETS = 'device-secrets';
+const LOCAL_STORE_KEY_MACHINE_IDENTITY = 'machine-identity';
+const LOCAL_STORE_KEY_RELAY_CONFIG = 'relay-config';
 
 // ============================================================================
 // Directory Paths
@@ -108,6 +132,40 @@ function ensureIdentityDir(): void {
 	if (!existsSync(identityDir)) {
 		mkdirSync(identityDir, { recursive: true, mode: 0o700 });
 	}
+}
+
+function readStoredDeviceIdentityPublic(): StoredDeviceIdentityPublic | null {
+	return readLocalStoreJson<StoredDeviceIdentityPublic>(
+		LOCAL_STORE_NAMESPACE_IDENTITY,
+		LOCAL_STORE_KEY_DEVICE_PUBLIC,
+	) ?? null;
+}
+
+function writeStoredDeviceIdentityPublic(value: StoredDeviceIdentityPublic): void {
+	writeLocalStoreJson(LOCAL_STORE_NAMESPACE_IDENTITY, LOCAL_STORE_KEY_DEVICE_PUBLIC, value);
+}
+
+function readStoredDeviceIdentitySecrets(): DecryptedSecrets | null {
+	return readLocalStoreSecretJson<DecryptedSecrets>(
+		LOCAL_STORE_NAMESPACE_IDENTITY,
+		LOCAL_STORE_KEY_DEVICE_SECRETS,
+	) ?? null;
+}
+
+function writeStoredDeviceIdentitySecrets(value: DecryptedSecrets): void {
+	writeLocalStoreSecretJson(LOCAL_STORE_NAMESPACE_IDENTITY, LOCAL_STORE_KEY_DEVICE_SECRETS, value);
+}
+
+function migrateLegacyKeypairToLocalStore(storage: EncryptedKeypairStorage, secrets: DecryptedSecrets): void {
+	writeStoredDeviceIdentityPublic({
+		id: storage.id,
+		label: storage.label,
+		createdAt: storage.createdAt,
+		signingPublicKey: storage.signingPublicKey,
+		keyExchangePublicKey: storage.keyExchangePublicKey,
+	});
+	writeStoredDeviceIdentitySecrets(secrets);
+	markLegacyLocalStorageMigrated(true);
 }
 
 // ============================================================================
@@ -158,6 +216,16 @@ export async function generateAndSaveKeypair(
 	const secretsJson = JSON.stringify(secrets);
 	const encryptedSecrets = seal(Buffer.from(secretsJson, 'utf-8'), encryptionKey);
 
+	await unlockLocalSecureStore(password);
+	writeStoredDeviceIdentityPublic({
+		id: identity.id,
+		label: identity.label,
+		createdAt: identity.createdAt,
+		signingPublicKey: serialized.signingPublicKey,
+		keyExchangePublicKey: serialized.keyExchangePublicKey,
+	});
+	writeStoredDeviceIdentitySecrets(secrets);
+
 	// Create storage format
 	const storage: EncryptedKeypairStorage = {
 		version: 1,
@@ -203,6 +271,21 @@ export async function generateAndSaveKeypair(
 export async function loadKeypair(password: string): Promise<Identity> {
 	if (!keypairExists()) {
 		throw new NoIdentityError();
+	}
+
+	await unlockLocalSecureStore(password);
+	const storedPublic = readStoredDeviceIdentityPublic();
+	const storedSecrets = readStoredDeviceIdentitySecrets();
+	if (storedPublic && storedSecrets) {
+		return deserializeIdentity({
+			id: storedPublic.id,
+			label: storedPublic.label,
+			createdAt: storedPublic.createdAt,
+			signingPublicKey: storedPublic.signingPublicKey,
+			keyExchangePublicKey: storedPublic.keyExchangePublicKey,
+			signingSecretKey: storedSecrets.signingSecretKey,
+			keyExchangePrivateKey: storedSecrets.keyExchangePrivateKey,
+		});
 	}
 
 	// Read storage file
@@ -256,6 +339,7 @@ export async function loadKeypair(password: string): Promise<Identity> {
 	};
 
 	// Deserialize to Identity format
+	migrateLegacyKeypairToLocalStore(storage, secrets);
 	return deserializeIdentity(storedIdentity);
 }
 
@@ -265,7 +349,7 @@ export async function loadKeypair(password: string): Promise<Identity> {
  * @returns True if keypair.json exists
  */
 export function keypairExists(): boolean {
-	return existsSync(getKeypairPath());
+	return readStoredDeviceIdentityPublic() !== null || existsSync(getKeypairPath());
 }
 
 /**
@@ -277,7 +361,17 @@ export function keypairExists(): boolean {
  * @returns Public identity if keypair exists, null otherwise
  */
 export function getPublicKeyWithoutPassword(): PublicIdentity | null {
-	if (!keypairExists()) {
+	const storedPublic = readStoredDeviceIdentityPublic();
+	if (storedPublic) {
+		return {
+			id: storedPublic.id,
+			signingPublicKey: storedPublic.signingPublicKey,
+			keyExchangePublicKey: storedPublic.keyExchangePublicKey,
+			label: storedPublic.label,
+		};
+	}
+
+	if (!existsSync(getKeypairPath())) {
 		return null;
 	}
 
@@ -312,6 +406,14 @@ export function getPublicKeyWithoutPassword(): PublicIdentity | null {
  * @returns Machine identity if exists, null otherwise
  */
 export function readMachineIdentity(): MachineIdentity | null {
+	const stored = readLocalStoreJson<MachineIdentity>(
+		LOCAL_STORE_NAMESPACE_IDENTITY,
+		LOCAL_STORE_KEY_MACHINE_IDENTITY,
+	);
+	if (stored) {
+		return stored;
+	}
+
 	const machineIdentityPath = getMachineIdentityPath();
 
 	if (!existsSync(machineIdentityPath)) {
@@ -320,7 +422,10 @@ export function readMachineIdentity(): MachineIdentity | null {
 
 	try {
 		const content = readFileSync(machineIdentityPath, 'utf-8');
-		return JSON.parse(content) as MachineIdentity;
+		const identity = JSON.parse(content) as MachineIdentity;
+		writeLocalStoreJson(LOCAL_STORE_NAMESPACE_IDENTITY, LOCAL_STORE_KEY_MACHINE_IDENTITY, identity);
+		markLegacyLocalStorageMigrated(true);
+		return identity;
 	} catch (error) {
 		throw new SpacesError(
 			`Failed to read machine identity: ${
@@ -340,6 +445,7 @@ export function readMachineIdentity(): MachineIdentity | null {
  * @param identity - Machine identity to write
  */
 export function writeMachineIdentity(identity: MachineIdentity): void {
+	writeLocalStoreJson(LOCAL_STORE_NAMESPACE_IDENTITY, LOCAL_STORE_KEY_MACHINE_IDENTITY, identity);
 	ensureIdentityDir();
 
 	try {
@@ -397,6 +503,14 @@ export function getRelayConfigPath(): string {
  * @returns Relay config if exists, null otherwise
  */
 export function readRelayConfig(): RelayConfig | null {
+	const stored = readLocalStoreJson<RelayConfig>(
+		LOCAL_STORE_NAMESPACE_IDENTITY,
+		LOCAL_STORE_KEY_RELAY_CONFIG,
+	);
+	if (stored) {
+		return stored;
+	}
+
 	const relayConfigPath = getRelayConfigPath();
 
 	if (!existsSync(relayConfigPath)) {
@@ -405,7 +519,10 @@ export function readRelayConfig(): RelayConfig | null {
 
 	try {
 		const content = readFileSync(relayConfigPath, 'utf-8');
-		return JSON.parse(content) as RelayConfig;
+		const config = JSON.parse(content) as RelayConfig;
+		writeLocalStoreJson(LOCAL_STORE_NAMESPACE_IDENTITY, LOCAL_STORE_KEY_RELAY_CONFIG, config);
+		markLegacyLocalStorageMigrated(true);
+		return config;
 	} catch (error) {
 		throw new SpacesError(
 			`Failed to read relay config: ${
@@ -425,6 +542,7 @@ export function readRelayConfig(): RelayConfig | null {
  * @param config - Relay configuration to write
  */
 export function writeRelayConfig(config: RelayConfig): void {
+	writeLocalStoreJson(LOCAL_STORE_NAMESPACE_IDENTITY, LOCAL_STORE_KEY_RELAY_CONFIG, config);
 	ensureIdentityDir();
 
 	try {
@@ -453,11 +571,11 @@ export function writeRelayConfig(config: RelayConfig): void {
  * Removes the relay config file if it exists.
  */
 export function clearRelayConfig(): void {
+	deleteLocalStoreJson(LOCAL_STORE_NAMESPACE_IDENTITY, LOCAL_STORE_KEY_RELAY_CONFIG);
 	const relayConfigPath = getRelayConfigPath();
 
 	if (existsSync(relayConfigPath)) {
 		try {
-			const { unlinkSync } = require('node:fs');
 			unlinkSync(relayConfigPath);
 		} catch (error) {
 			// Ignore errors when clearing

--- a/src/core/identity.ts
+++ b/src/core/identity.ts
@@ -360,6 +360,10 @@ export function keypairExists(): boolean {
 	return readStoredDeviceIdentityPublic() !== null || existsSync(getKeypairPath());
 }
 
+export function shouldDeferLocalStoreUnlockForLegacyIdentityMigration(): boolean {
+	return keypairExists() && !localSecureStoreExists();
+}
+
 /**
  * Get the public identity without requiring password
  *

--- a/src/core/identity.ts
+++ b/src/core/identity.ts
@@ -36,6 +36,7 @@ import { seal, open } from '../lib/tmux-lite/crypto/secretbox.js';
 import { deriveKey, generateSalt } from '../lib/tmux-lite/crypto/keys.js';
 import { getSpacesDir } from './config.js';
 import {
+	localSecureStoreExists,
 	markLegacyLocalStorageMigrated,
 	readLocalStoreJson,
 	readLocalStoreSecretJson,
@@ -273,19 +274,22 @@ export async function loadKeypair(password: string): Promise<Identity> {
 		throw new NoIdentityError();
 	}
 
-	await unlockLocalSecureStore(password);
-	const storedPublic = readStoredDeviceIdentityPublic();
-	const storedSecrets = readStoredDeviceIdentitySecrets();
-	if (storedPublic && storedSecrets) {
-		return deserializeIdentity({
-			id: storedPublic.id,
-			label: storedPublic.label,
-			createdAt: storedPublic.createdAt,
-			signingPublicKey: storedPublic.signingPublicKey,
-			keyExchangePublicKey: storedPublic.keyExchangePublicKey,
-			signingSecretKey: storedSecrets.signingSecretKey,
-			keyExchangePrivateKey: storedSecrets.keyExchangePrivateKey,
-		});
+	const hasInitializedLocalStore = localSecureStoreExists();
+	if (hasInitializedLocalStore) {
+		await unlockLocalSecureStore(password);
+		const storedPublic = readStoredDeviceIdentityPublic();
+		const storedSecrets = readStoredDeviceIdentitySecrets();
+		if (storedPublic && storedSecrets) {
+			return deserializeIdentity({
+				id: storedPublic.id,
+				label: storedPublic.label,
+				createdAt: storedPublic.createdAt,
+				signingPublicKey: storedPublic.signingPublicKey,
+				keyExchangePublicKey: storedPublic.keyExchangePublicKey,
+				signingSecretKey: storedSecrets.signingSecretKey,
+				keyExchangePrivateKey: storedSecrets.keyExchangePrivateKey,
+			});
+		}
 	}
 
 	// Read storage file
@@ -337,6 +341,10 @@ export async function loadKeypair(password: string): Promise<Identity> {
 		signingSecretKey: secrets.signingSecretKey,
 		keyExchangePrivateKey: secrets.keyExchangePrivateKey,
 	};
+
+	if (!hasInitializedLocalStore) {
+		await unlockLocalSecureStore(password);
+	}
 
 	// Deserialize to Identity format
 	migrateLegacyKeypairToLocalStore(storage, secrets);

--- a/src/core/local-secure-store.ts
+++ b/src/core/local-secure-store.ts
@@ -5,7 +5,6 @@ import {
   getLocalStoreRecord,
   getLocalStoreSecret,
   removeLocalStoreRecord,
-  removeLocalStoreSecret,
   setLocalStoreMeta,
   upsertLocalStoreRecord,
   upsertLocalStoreSecret,
@@ -129,14 +128,4 @@ export function writeLocalStoreSecretJson(namespace: string, key: string, value:
 export function markLegacyLocalStorageMigrated(retained: boolean = true): void {
   setLocalStoreMeta(META_KEY_LEGACY_STORAGE_MIGRATED_AT, new Date().toISOString());
   setLocalStoreMeta(META_KEY_LEGACY_STORAGE_RETAINED, retained ? '1' : '0');
-}
-
-export function getLegacyLocalStorageMigrationState(): {
-  migratedAt?: string;
-  retained: boolean;
-} {
-  return {
-    migratedAt: getLocalStoreMeta(META_KEY_LEGACY_STORAGE_MIGRATED_AT),
-    retained: getLocalStoreMeta(META_KEY_LEGACY_STORAGE_RETAINED) !== '0',
-  };
 }

--- a/src/core/local-secure-store.ts
+++ b/src/core/local-secure-store.ts
@@ -1,0 +1,151 @@
+import { deriveKey, generateSalt } from '../lib/tmux-lite/crypto/keys.js';
+import { open, seal } from '../lib/tmux-lite/crypto/secretbox.js';
+import {
+  deleteLocalStoreMeta,
+  getLocalStoreMeta,
+  getLocalStoreRecord,
+  getLocalStoreSecret,
+  removeLocalStoreRecord,
+  removeLocalStoreSecret,
+  setLocalStoreMeta,
+  upsertLocalStoreRecord,
+  upsertLocalStoreSecret,
+} from '../relay/control/store.js';
+import { InvalidPasswordError, SpacesError } from '../types/errors.js';
+
+const META_KEY_PASSWORD_SALT = 'store_password_salt';
+const META_KEY_PASSWORD_KEY_CHECK = 'store_password_key_check';
+const META_KEY_LEGACY_STORAGE_MIGRATED_AT = 'legacy_storage_migrated_at';
+const META_KEY_LEGACY_STORAGE_RETAINED = 'legacy_storage_retained';
+const PASSWORD_CHECK_PLAINTEXT = 'gitspace-local-secure-store-v1';
+
+let unlockedStoreKey: Buffer | null = null;
+
+function parseJsonRecord<T>(valueJson: string, context: string): T {
+  try {
+    return JSON.parse(valueJson) as T;
+  } catch (error) {
+    throw new SpacesError(
+      `Failed to parse ${context}: ${error instanceof Error ? error.message : 'Unknown error'}`,
+      'SYSTEM_ERROR',
+      2,
+    );
+  }
+}
+
+function requireUnlockedStoreKey(): Buffer {
+  if (!unlockedStoreKey) {
+    throw new SpacesError(
+      'Local secure store is locked. Unlock it before accessing encrypted records.',
+      'USER_ERROR',
+      1,
+    );
+  }
+
+  return unlockedStoreKey;
+}
+
+function hasStorePasswordMetadata(): boolean {
+  return Boolean(getLocalStoreMeta(META_KEY_PASSWORD_SALT) && getLocalStoreMeta(META_KEY_PASSWORD_KEY_CHECK));
+}
+
+export function localSecureStoreExists(): boolean {
+  return hasStorePasswordMetadata();
+}
+
+export function isLocalSecureStoreUnlocked(): boolean {
+  return unlockedStoreKey !== null;
+}
+
+export function lockLocalSecureStore(): void {
+  if (unlockedStoreKey) {
+    unlockedStoreKey.fill(0);
+    unlockedStoreKey = null;
+  }
+}
+
+export async function unlockLocalSecureStore(password: string): Promise<void> {
+  const saltBase64 = getLocalStoreMeta(META_KEY_PASSWORD_SALT);
+  const keyCheckBase64 = getLocalStoreMeta(META_KEY_PASSWORD_KEY_CHECK);
+
+  if (!saltBase64 || !keyCheckBase64) {
+    const salt = generateSalt();
+    const key = await deriveKey(password, salt);
+    const keyCheck = seal(Buffer.from(PASSWORD_CHECK_PLAINTEXT, 'utf-8'), key);
+
+    setLocalStoreMeta(META_KEY_PASSWORD_SALT, salt.toString('base64'));
+    setLocalStoreMeta(META_KEY_PASSWORD_KEY_CHECK, keyCheck.toString('base64'));
+    unlockedStoreKey = Buffer.from(key);
+    return;
+  }
+
+  const key = await deriveKey(password, Buffer.from(saltBase64, 'base64'));
+  const plaintext = open(Buffer.from(keyCheckBase64, 'base64'), key);
+  if (!plaintext || plaintext.toString('utf-8') !== PASSWORD_CHECK_PLAINTEXT) {
+    throw new InvalidPasswordError();
+  }
+
+  unlockedStoreKey = Buffer.from(key);
+}
+
+export function readLocalStoreJson<T>(namespace: string, key: string): T | undefined {
+  const record = getLocalStoreRecord(namespace, key);
+  if (!record) {
+    return undefined;
+  }
+
+  return parseJsonRecord<T>(record.valueJson, `${namespace}/${key}`);
+}
+
+export function writeLocalStoreJson(namespace: string, key: string, value: unknown): void {
+  upsertLocalStoreRecord(namespace, key, JSON.stringify(value));
+}
+
+export function deleteLocalStoreJson(namespace: string, key: string): boolean {
+  return removeLocalStoreRecord(namespace, key);
+}
+
+export function readLocalStoreSecretJson<T>(namespace: string, key: string): T | undefined {
+  const record = getLocalStoreSecret(namespace, key);
+  if (!record) {
+    return undefined;
+  }
+
+  const plaintext = open(Buffer.from(record.ciphertext, 'base64'), requireUnlockedStoreKey());
+  if (!plaintext) {
+    throw new InvalidPasswordError();
+  }
+
+  return parseJsonRecord<T>(plaintext.toString('utf-8'), `${namespace}/${key}`);
+}
+
+export function writeLocalStoreSecretJson(namespace: string, key: string, value: unknown): void {
+  const ciphertext = seal(
+    Buffer.from(JSON.stringify(value), 'utf-8'),
+    requireUnlockedStoreKey(),
+  ).toString('base64');
+  upsertLocalStoreSecret(namespace, key, ciphertext);
+}
+
+export function deleteLocalStoreSecretJson(namespace: string, key: string): boolean {
+  return removeLocalStoreSecret(namespace, key);
+}
+
+export function markLegacyLocalStorageMigrated(retained: boolean = true): void {
+  setLocalStoreMeta(META_KEY_LEGACY_STORAGE_MIGRATED_AT, new Date().toISOString());
+  setLocalStoreMeta(META_KEY_LEGACY_STORAGE_RETAINED, retained ? '1' : '0');
+}
+
+export function clearLegacyLocalStorageMigrationMarker(): void {
+  deleteLocalStoreMeta(META_KEY_LEGACY_STORAGE_MIGRATED_AT);
+}
+
+export function getLegacyLocalStorageMigrationState(): {
+  migratedAt?: string;
+  retained: boolean;
+} {
+  return {
+    migratedAt: getLocalStoreMeta(META_KEY_LEGACY_STORAGE_MIGRATED_AT),
+    retained: getLocalStoreMeta(META_KEY_LEGACY_STORAGE_RETAINED) !== '0',
+  };
+}

--- a/src/core/local-secure-store.ts
+++ b/src/core/local-secure-store.ts
@@ -1,7 +1,6 @@
 import { deriveKey, generateSalt } from '../lib/tmux-lite/crypto/keys.js';
 import { open, seal } from '../lib/tmux-lite/crypto/secretbox.js';
 import {
-  deleteLocalStoreMeta,
   getLocalStoreMeta,
   getLocalStoreRecord,
   getLocalStoreSecret,
@@ -127,17 +126,9 @@ export function writeLocalStoreSecretJson(namespace: string, key: string, value:
   upsertLocalStoreSecret(namespace, key, ciphertext);
 }
 
-export function deleteLocalStoreSecretJson(namespace: string, key: string): boolean {
-  return removeLocalStoreSecret(namespace, key);
-}
-
 export function markLegacyLocalStorageMigrated(retained: boolean = true): void {
   setLocalStoreMeta(META_KEY_LEGACY_STORAGE_MIGRATED_AT, new Date().toISOString());
   setLocalStoreMeta(META_KEY_LEGACY_STORAGE_RETAINED, retained ? '1' : '0');
-}
-
-export function clearLegacyLocalStorageMigrationMarker(): void {
-  deleteLocalStoreMeta(META_KEY_LEGACY_STORAGE_MIGRATED_AT);
 }
 
 export function getLegacyLocalStorageMigrationState(): {

--- a/src/core/trusted-relays.ts
+++ b/src/core/trusted-relays.ts
@@ -11,6 +11,7 @@ import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { isIP } from "node:net";
 import { join } from "node:path";
 import { getIdentityDir } from "./identity.js";
+import { markLegacyLocalStorageMigrated, readLocalStoreJson, writeLocalStoreJson } from './local-secure-store.js';
 import { formatRelayFingerprint } from "../relay/identity.js";
 
 // ============================================================================
@@ -43,6 +44,8 @@ export type RelayTrustStatus = "trusted" | "mismatch" | "unknown";
 // ============================================================================
 
 const TRUSTED_RELAYS_FILE = "trusted-relays.json";
+const LOCAL_STORE_NAMESPACE = 'trust';
+const LOCAL_STORE_KEY = 'trusted-relays';
 
 // ============================================================================
 // Paths
@@ -287,6 +290,11 @@ export function isCloudReachableRelayUrl(url: string): boolean {
  * Load trusted relays from disk
  */
 export function getTrustedRelays(): TrustedRelay[] {
+	const stored = readLocalStoreJson<TrustedRelay[]>(LOCAL_STORE_NAMESPACE, LOCAL_STORE_KEY);
+	if (stored) {
+		return stored;
+	}
+
   const path = getTrustedRelaysPath();
 
   if (!existsSync(path)) {
@@ -295,7 +303,10 @@ export function getTrustedRelays(): TrustedRelay[] {
 
   try {
     const content = readFileSync(path, "utf-8");
-    return JSON.parse(content) as TrustedRelay[];
+    const relays = JSON.parse(content) as TrustedRelay[];
+    writeLocalStoreJson(LOCAL_STORE_NAMESPACE, LOCAL_STORE_KEY, relays);
+    markLegacyLocalStorageMigrated(true);
+    return relays;
   } catch {
     console.warn("[trusted-relays] Failed to parse trusted relays file");
     return [];
@@ -306,6 +317,7 @@ export function getTrustedRelays(): TrustedRelay[] {
  * Save trusted relays to disk
  */
 function saveTrustedRelays(relays: TrustedRelay[]): void {
+	writeLocalStoreJson(LOCAL_STORE_NAMESPACE, LOCAL_STORE_KEY, relays);
   const identityDir = getIdentityDir();
 
   // Create directory if needed (should already exist from identity setup)

--- a/src/core/trusted-relays.ts
+++ b/src/core/trusted-relays.ts
@@ -290,10 +290,10 @@ export function isCloudReachableRelayUrl(url: string): boolean {
  * Load trusted relays from disk
  */
 export function getTrustedRelays(): TrustedRelay[] {
-	const stored = readLocalStoreJson<TrustedRelay[]>(LOCAL_STORE_NAMESPACE, LOCAL_STORE_KEY);
-	if (stored) {
-		return stored;
-	}
+  const stored = readLocalStoreJson<TrustedRelay[]>(LOCAL_STORE_NAMESPACE, LOCAL_STORE_KEY);
+  if (stored) {
+    return stored;
+  }
 
   const path = getTrustedRelaysPath();
 
@@ -301,23 +301,31 @@ export function getTrustedRelays(): TrustedRelay[] {
     return [];
   }
 
+  let relays: TrustedRelay[];
   try {
     const content = readFileSync(path, "utf-8");
-    const relays = JSON.parse(content) as TrustedRelay[];
-    writeLocalStoreJson(LOCAL_STORE_NAMESPACE, LOCAL_STORE_KEY, relays);
-    markLegacyLocalStorageMigrated(true);
-    return relays;
+    relays = JSON.parse(content) as TrustedRelay[];
   } catch {
     console.warn("[trusted-relays] Failed to parse trusted relays file");
     return [];
   }
+
+  try {
+    writeLocalStoreJson(LOCAL_STORE_NAMESPACE, LOCAL_STORE_KEY, relays);
+    markLegacyLocalStorageMigrated(true);
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    console.warn(`[trusted-relays] Failed to migrate trusted relays into local secure store: ${detail}`);
+  }
+
+  return relays;
 }
 
 /**
  * Save trusted relays to disk
  */
 function saveTrustedRelays(relays: TrustedRelay[]): void {
-	writeLocalStoreJson(LOCAL_STORE_NAMESPACE, LOCAL_STORE_KEY, relays);
+  writeLocalStoreJson(LOCAL_STORE_NAMESPACE, LOCAL_STORE_KEY, relays);
   const identityDir = getIdentityDir();
 
   // Create directory if needed (should already exist from identity setup)

--- a/src/hooks/useRemoteMachines.tui.ts
+++ b/src/hooks/useRemoteMachines.tui.ts
@@ -6,6 +6,7 @@ import { useCallback, useMemo } from 'react';
 import type { Identity } from '../types/identity.js';
 import { keypairExists, loadKeypair } from '../core/identity.js';
 import { createLocalDeviceCertificate } from '../core/user-identity.js';
+import { getLocalStorePasswordFromEnv } from '../commands/local-store-password.js';
 import { signMessage } from '../relay/signing.js';
 import type { MachineInfo } from '../components/index.js';
 import {
@@ -61,7 +62,7 @@ async function resolveIdentity(options: UseRemoteMachinesOptions): Promise<Ident
     return null;
   }
 
-  const password = options.identityPassword || process.env.GITSPACE_IDENTITY_PASSWORD;
+  const password = options.identityPassword || getLocalStorePasswordFromEnv();
   if (!password) {
     return null;
   }
@@ -81,7 +82,7 @@ export function useRemoteMachines(options: UseRemoteMachinesOptions = {}): UseRe
       return true;
     }
 
-    const password = options.identityPassword || process.env.GITSPACE_IDENTITY_PASSWORD;
+    const password = options.identityPassword || getLocalStorePasswordFromEnv();
     return !!password && keypairExists();
   }, [options.identity, options.identityPassword]);
   const shouldAutoConnect = isRemoteMode
@@ -115,7 +116,7 @@ export function useRemoteMachines(options: UseRemoteMachinesOptions = {}): UseRe
       const identity = await resolveIdentity(options);
       if (!identity) {
         throw new Error(
-          'Remote relay requires an unlocked local device identity.'
+          'Remote relay requires an unlocked local secure store identity.'
         );
       }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,7 +42,6 @@ import { SpacesError } from './types/errors.js';
 import { installOwnerSyncWriteHandler } from './core/owner-sync.js';
 import { findReachableRelayCandidate } from './core/relay-discovery.js';
 import { keypairExists, loadKeypair } from './core/identity.js';
-import { promptPassword } from './utils/prompts.js';
 import type { Identity } from './types/identity.js';
 
 // ============================================================================
@@ -132,66 +131,29 @@ let hasOnlyTuiOptions = true;
 async function resolveRemoteTuiIdentity(options: {
 	relayRequestedExplicitly: boolean;
 	relayLabel: string;
+	localStorePassword: string;
 }): Promise<Identity | null> {
 	if (!keypairExists()) {
 		if (options.relayRequestedExplicitly) {
 			throw new SpacesError(
-				'Remote relay access requires a local device identity. Run `gssh user auth login` or create one before using `gssh --relay`.',
+				'Remote relay access requires a local secure store identity. Run `gssh user auth login` or create one before using `gssh --relay`.',
 				'USER_ERROR',
 				1,
 			);
 		}
-		return null;
-	}
-
-	const passwordFromEnv = process.env.GITSPACE_IDENTITY_PASSWORD;
-	if (passwordFromEnv) {
-		try {
-			return await loadKeypair(passwordFromEnv);
-		} catch (error) {
-			if (options.relayRequestedExplicitly) {
-				throw error instanceof SpacesError
-					? error
-					: new SpacesError('Failed to unlock local device identity.', 'USER_ERROR', 1);
-			}
-			logger.warning(
-				`Could not unlock local device identity for remote machines (${error instanceof Error ? error.message : String(error)}). Falling back to an interactive prompt.`,
-			);
-		}
-	}
-
-	if (!(process.stdin.isTTY && process.stdout.isTTY)) {
-		if (options.relayRequestedExplicitly) {
-			throw new SpacesError(
-				'Remote relay access requires unlocking your local device identity in an interactive terminal.',
-				'USER_ERROR',
-				1,
-			);
-		}
-		return null;
-	}
-
-	logger.log('');
-	logger.info(`Remote machines are available via ${options.relayLabel}.`);
-	const password = await promptPassword('Enter password to unlock your local device identity (leave blank to stay local):');
-	if (!password) {
-		if (options.relayRequestedExplicitly) {
-			throw new SpacesError('Cancelled', 'USER_ERROR', 1);
-		}
-		logger.dim('Starting in local-only mode. Use `gssh --relay <url>` to try again later.');
 		return null;
 	}
 
 	try {
-		return await loadKeypair(password);
+		return await loadKeypair(options.localStorePassword);
 	} catch (error) {
 		if (options.relayRequestedExplicitly) {
 			throw error instanceof SpacesError
 				? error
-				: new SpacesError('Failed to unlock local device identity.', 'USER_ERROR', 1);
+				: new SpacesError('Failed to unlock local secure store identity.', 'USER_ERROR', 1);
 		}
 		logger.warning(
-			`Could not unlock local device identity for remote machines (${error instanceof Error ? error.message : String(error)}). Starting in local-only mode.`,
+			`Could not unlock local secure store identity for remote machines (${error instanceof Error ? error.message : String(error)}). Starting in local-only mode.`,
 		);
 		return null;
 	}
@@ -223,9 +185,17 @@ if (process.argv.length === 2 || hasOnlyTuiOptions) {
 	// ---- TUI mode ----
 	const { checkFirstTimeSetup } = await import('./cli/setup.js');
 	const { launchTUI } = await import('./tui/index.js');
+	const { unlockLocalSecureStore } = await import('./core/local-secure-store.js');
+	const { ensureLocalStorePassword } = await import('./commands/local-store-password.js');
 
 	checkFirstTimeSetup()
 		.then(async () => {
+			const localStorePassword = await ensureLocalStorePassword();
+			if (!localStorePassword) {
+				throw new SpacesError('Cancelled', 'USER_ERROR', 1);
+			}
+			await unlockLocalSecureStore(localStorePassword);
+
 			const relayCandidate = relayUrlFromArgs
 				? { url: relayUrlFromArgs, label: relayUrlFromArgs, source: 'explicit' as const }
 				: await findReachableRelayCandidate({ includeLocalRelay: false });
@@ -234,6 +204,7 @@ if (process.argv.length === 2 || hasOnlyTuiOptions) {
 				? await resolveRemoteTuiIdentity({
 					relayRequestedExplicitly: Boolean(relayUrlFromArgs),
 					relayLabel: relayCandidate.label,
+					localStorePassword,
 				})
 				: null;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -194,7 +194,11 @@ if (process.argv.length === 2 || hasOnlyTuiOptions) {
 			if (!localStorePassword) {
 				throw new SpacesError('Cancelled', 'USER_ERROR', 1);
 			}
-			await unlockLocalSecureStore(localStorePassword);
+
+			const { shouldDeferLocalStoreUnlockForLegacyIdentityMigration } = await import('./core/identity.js');
+			if (!shouldDeferLocalStoreUnlockForLegacyIdentityMigration()) {
+				await unlockLocalSecureStore(localStorePassword);
+			}
 
 			const relayCandidate = relayUrlFromArgs
 				? { url: relayUrlFromArgs, label: relayUrlFromArgs, source: 'explicit' as const }

--- a/src/relay/control/schema.ts
+++ b/src/relay/control/schema.ts
@@ -192,6 +192,51 @@ const CONTROL_MIGRATIONS: ControlMigration[] = [
       `,
     ],
   },
+  {
+    version: 6,
+    statements: [
+      `
+      CREATE TABLE IF NOT EXISTS local_store_meta (
+        key TEXT PRIMARY KEY,
+        value TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+      )
+      `,
+      `
+      CREATE TABLE IF NOT EXISTS local_store_records (
+        namespace TEXT NOT NULL,
+        key TEXT NOT NULL,
+        value_json TEXT NOT NULL,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL,
+        PRIMARY KEY(namespace, key)
+      )
+      `,
+      `
+      CREATE INDEX IF NOT EXISTS idx_local_store_records_namespace
+      ON local_store_records(namespace)
+      `,
+      `
+      CREATE TABLE IF NOT EXISTS local_store_secrets (
+        namespace TEXT NOT NULL,
+        key TEXT NOT NULL,
+        ciphertext TEXT NOT NULL,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL,
+        PRIMARY KEY(namespace, key)
+      )
+      `,
+      `
+      CREATE INDEX IF NOT EXISTS idx_local_store_secrets_namespace
+      ON local_store_secrets(namespace)
+      `,
+      `
+      INSERT INTO local_store_meta(key, value, updated_at)
+      VALUES ('legacy_storage_retained', '1', CURRENT_TIMESTAMP)
+      ON CONFLICT(key) DO NOTHING
+      `,
+    ],
+  },
 ];
 
 function ensureMigrationsTable(db: Database): void {

--- a/src/relay/control/store.test.ts
+++ b/src/relay/control/store.test.ts
@@ -3,10 +3,12 @@ import { existsSync, mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
-  bindControlOwner,
+  bindPersistedOwnerIdentity,
   ensureControlStore,
   getControlDbPath,
+  getPersistedOwnerIdentityId,
   listCloudWorkspaces,
+  readPersistedOwnerBinding,
 } from './store.js';
 import {
   consumeRootInviteToken,
@@ -54,21 +56,23 @@ describe('control store', () => {
     const meta = ensureControlStore();
 
     expect(existsSync(getControlDbPath())).toBe(true);
-    expect(meta.schemaVersion).toBe(5);
+    expect(meta.schemaVersion).toBe(6);
     expect(meta.createdAt.length).toBeGreaterThan(0);
     expect(meta.updatedAt.length).toBeGreaterThan(0);
     expect(meta.ownerIdentityId).toBeUndefined();
   });
 
   test('binds owner once and rejects different owner identity', () => {
-    const first = bindControlOwner('owner-1');
+    const first = bindPersistedOwnerIdentity('owner-1');
     expect(first.bound).toBe(true);
     expect(first.ownerIdentityId).toBe('owner-1');
+    expect(getPersistedOwnerIdentityId()).toBe('owner-1');
+    expect(readPersistedOwnerBinding().vaultOwnerId).toBe('owner-1');
 
-    const second = bindControlOwner('owner-1');
+    const second = bindPersistedOwnerIdentity('owner-1');
     expect(second.bound).toBe(false);
 
-    expect(() => bindControlOwner('owner-2')).toThrow(/owner mismatch/i);
+    expect(() => bindPersistedOwnerIdentity('owner-2')).toThrow(/mismatch/i);
   });
 
   test('lists cloud workspaces as empty by default', () => {

--- a/src/relay/control/store.ts
+++ b/src/relay/control/store.ts
@@ -1,6 +1,6 @@
 import { Database } from 'bun:sqlite';
 import { createHash, randomBytes, randomUUID } from 'node:crypto';
-import { existsSync, mkdirSync, rmSync } from 'node:fs';
+import { existsSync, mkdirSync } from 'node:fs';
 import { join } from 'node:path';
 import { getSpacesDir } from '../../core/config.js';
 import { SpacesError } from '../../types/errors.js';
@@ -10,6 +10,9 @@ import type {
   CloudBootstrapTokenRecord,
   CloudWorkspaceRecord,
   ControlMeta,
+  LocalStoreMetaKey,
+  LocalStoreRecord,
+  LocalStoreSecretRecord,
   VaultAccessListEntry,
   VaultCategoryRecord,
   VaultMachineRecord,
@@ -18,7 +21,7 @@ import type {
   VaultSyncCategory,
 } from './types.js';
 
-const CONTROL_SCHEMA_VERSION = 5;
+const CONTROL_SCHEMA_VERSION = 6;
 const CONTROL_DIR_OVERRIDE_ENV = 'GITSPACE_CONTROL_DIR';
 
 const META_KEY_SCHEMA_VERSION = 'schema_version';
@@ -64,10 +67,49 @@ export function getControlDbPath(): string {
 }
 
 export function resetControlStore(): void {
-  const controlDbPath = getControlDbPath();
-  rmSync(controlDbPath, { force: true });
-  rmSync(`${controlDbPath}-shm`, { force: true });
-  rmSync(`${controlDbPath}-wal`, { force: true });
+  withControlDb((db) => {
+    const tablesToClear = [
+      'machine_access_list',
+      'relay_access_list',
+      'root_invites',
+      'vault_machine_unlock_keys',
+      'vault_access_list',
+      'vault_sync_categories',
+      'cloud_events',
+      'cloud_bootstrap_tokens',
+      'cloud_register_permits',
+      'cloud_workspaces',
+      'vault_machines',
+      'vault_meta',
+    ].filter((tableName) => {
+      const row = db.query(
+        `
+          SELECT 1
+          FROM sqlite_master
+          WHERE type = 'table' AND name = ?
+        `,
+      ).get(tableName);
+      return row !== null;
+    });
+
+    db.exec('BEGIN');
+    try {
+      for (const tableName of tablesToClear) {
+        db.exec(`DELETE FROM ${tableName}`);
+      }
+      db.query(
+        `
+          DELETE FROM control_meta
+          WHERE key NOT IN (?, ?, ?)
+        `,
+      ).run(META_KEY_SCHEMA_VERSION, META_KEY_CREATED_AT, META_KEY_UPDATED_AT);
+      setMetaValue(db, META_KEY_UPDATED_AT, nowIso());
+      db.exec('COMMIT');
+    } catch (error) {
+      db.exec('ROLLBACK');
+      throw error;
+    }
+  });
 }
 
 function ensureControlDir(): void {
@@ -205,20 +247,131 @@ export function writeControlMeta(meta: ControlMeta): void {
   });
 }
 
-export function getControlOwnerIdentityId(): string | undefined {
-  return withControlDb((db) => getMetaValue(db, META_KEY_OWNER_IDENTITY_ID));
+function getVaultMetaValueFromDb(db: Database, key: VaultMetaKey): string | undefined {
+  const row = db.query('SELECT value FROM vault_meta WHERE key = ?').get(key) as
+    | { value: string }
+    | null;
+  return row?.value;
+}
+
+function setVaultMetaValueInDb(db: Database, key: VaultMetaKey, value: string): void {
+  db.query(
+    `
+      INSERT INTO vault_meta(key, value)
+      VALUES (?, ?)
+      ON CONFLICT(key) DO UPDATE
+      SET value = excluded.value
+    `
+  ).run(key, value);
+}
+
+export interface PersistedOwnerBinding {
+  controlOwnerId?: string;
+  vaultOwnerId?: string;
+  effectiveOwnerId?: string;
+  mismatch: boolean;
+  repaired: boolean;
+}
+
+function readPersistedOwnerBindingFromDb(db: Database): PersistedOwnerBinding {
+  let controlOwnerId = getMetaValue(db, META_KEY_OWNER_IDENTITY_ID);
+  let vaultOwnerId = getVaultMetaValueFromDb(db, 'owner_user_root_id');
+  let repaired = false;
+
+  if (!controlOwnerId && vaultOwnerId) {
+    setMetaValue(db, META_KEY_OWNER_IDENTITY_ID, vaultOwnerId);
+    controlOwnerId = vaultOwnerId;
+    repaired = true;
+  } else if (controlOwnerId && !vaultOwnerId) {
+    setVaultMetaValueInDb(db, 'owner_user_root_id', controlOwnerId);
+    vaultOwnerId = controlOwnerId;
+    repaired = true;
+  }
+
+  const mismatch = Boolean(controlOwnerId && vaultOwnerId && controlOwnerId !== vaultOwnerId);
+  const effectiveOwnerId = mismatch ? undefined : (controlOwnerId ?? vaultOwnerId);
+
+  return {
+    controlOwnerId,
+    vaultOwnerId,
+    effectiveOwnerId,
+    mismatch,
+    repaired,
+  };
+}
+
+export function readPersistedOwnerBinding(): PersistedOwnerBinding {
+  return withControlDb((db) => readPersistedOwnerBindingFromDb(db));
+}
+
+export function getPersistedOwnerIdentityId(): string | undefined {
+  return readPersistedOwnerBinding().effectiveOwnerId;
+}
+
+export function bindPersistedOwnerIdentity(ownerIdentityId: string): {
+  bound: boolean;
+  repaired: boolean;
+  ownerIdentityId: string;
+} {
+  return withControlDb((db) => {
+    const binding = readPersistedOwnerBindingFromDb(db);
+
+    if (!binding.controlOwnerId && !binding.vaultOwnerId) {
+      setMetaValue(db, META_KEY_OWNER_IDENTITY_ID, ownerIdentityId);
+      setVaultMetaValueInDb(db, 'owner_user_root_id', ownerIdentityId);
+      setMetaValue(db, META_KEY_UPDATED_AT, nowIso());
+      return { bound: true, repaired: false, ownerIdentityId };
+    }
+
+    if (!binding.mismatch) {
+      if (binding.effectiveOwnerId !== ownerIdentityId) {
+        throw new SpacesError(
+          `Local control bindings mismatch. Persisted owner '${binding.effectiveOwnerId}' does not match current identity '${ownerIdentityId}'.`,
+          'USER_ERROR',
+          1
+        );
+      }
+
+      return { bound: false, repaired: binding.repaired, ownerIdentityId };
+    }
+
+    const canRepairToCurrentIdentity = binding.controlOwnerId === ownerIdentityId
+      || binding.vaultOwnerId === ownerIdentityId;
+
+    if (!canRepairToCurrentIdentity) {
+      throw new SpacesError(
+        `Local control bindings mismatch. Persisted control owner '${binding.controlOwnerId}' and vault owner '${binding.vaultOwnerId}' do not match current identity '${ownerIdentityId}'.`,
+        'USER_ERROR',
+        1
+      );
+    }
+
+    setMetaValue(db, META_KEY_OWNER_IDENTITY_ID, ownerIdentityId);
+    setVaultMetaValueInDb(db, 'owner_user_root_id', ownerIdentityId);
+    setMetaValue(db, META_KEY_UPDATED_AT, nowIso());
+    return { bound: false, repaired: true, ownerIdentityId };
+  });
 }
 
 export function isControlOwner(identityId: string): boolean {
-  const ownerIdentityId = getControlOwnerIdentityId();
+  const ownerIdentityId = getPersistedOwnerIdentityId();
   return ownerIdentityId === identityId;
 }
 
 export function assertControlOwner(identityId: string): void {
-  const ownerIdentityId = getControlOwnerIdentityId();
+  const ownerBinding = readPersistedOwnerBinding();
+  if (ownerBinding.mismatch) {
+    throw new SpacesError(
+      `Local control bindings mismatch. Persisted control owner '${ownerBinding.controlOwnerId}' and vault owner '${ownerBinding.vaultOwnerId}' do not match current identity '${identityId}'.`,
+      'USER_ERROR',
+      1
+    );
+  }
+
+  const ownerIdentityId = ownerBinding.effectiveOwnerId;
   if (!ownerIdentityId) {
     throw new SpacesError(
-      'Control relay owner is not initialized.',
+      'Local control bindings are not initialized.',
       'SYSTEM_ERROR',
       2
     );
@@ -226,33 +379,11 @@ export function assertControlOwner(identityId: string): void {
 
   if (ownerIdentityId !== identityId) {
     throw new SpacesError(
-      `Control relay owner mismatch. This control node is owned by '${ownerIdentityId}', but current identity is '${identityId}'.`,
+      `Local control bindings mismatch. Persisted owner '${ownerIdentityId}' does not match current identity '${identityId}'.`,
       'USER_ERROR',
       1
     );
   }
-}
-
-export function bindControlOwner(ownerIdentityId: string): { bound: boolean; ownerIdentityId: string } {
-  return withControlDb((db) => {
-    const currentOwner = getMetaValue(db, META_KEY_OWNER_IDENTITY_ID);
-
-    if (!currentOwner) {
-      setMetaValue(db, META_KEY_OWNER_IDENTITY_ID, ownerIdentityId);
-      setMetaValue(db, META_KEY_UPDATED_AT, nowIso());
-      return { bound: true, ownerIdentityId };
-    }
-
-    if (currentOwner !== ownerIdentityId) {
-      throw new SpacesError(
-        `Control relay owner mismatch. This control node is owned by '${currentOwner}', but current identity is '${ownerIdentityId}'.`,
-        'USER_ERROR',
-        1
-      );
-    }
-
-    return { bound: false, ownerIdentityId };
-  });
 }
 
 export interface BindControlRelayIdentityInput {
@@ -284,10 +415,10 @@ export function bindControlRelayIdentity(
     if (!sameIdentityId || !sameSigningKey || !sameFingerprint) {
       throw new SpacesError(
         [
-          `Control relay identity mismatch. Pinned relay '${currentRelayFingerprint ?? currentRelayIdentityId}', current relay '${input.relayFingerprint}'.`,
+          `Local control bindings mismatch. Pinned relay '${currentRelayFingerprint ?? currentRelayIdentityId}', current relay '${input.relayFingerprint}'.`,
           '',
-          'This relay pin is stored in ~/gitspace/.relay/control/control.db, not the trusted relay list.',
-          'If this relay change is expected, re-run `gssh machine serve start --takeover` to clear persisted control state and re-bind to the current relay.',
+          'This relay pin is stored in the local control database, not the trusted relay list.',
+          'If this relay change is expected, re-run `gssh machine serve start --takeover` to clear persisted local control bindings and re-bind to the current relay.',
         ].join('\n'),
         'USER_ERROR',
         1
@@ -295,6 +426,195 @@ export function bindControlRelayIdentity(
     }
 
     return { bound: false, relayIdentityId: input.relayIdentityId };
+  });
+}
+
+// ============================================================================
+// Local Secure Store
+// ============================================================================
+
+interface LocalStoreRecordRow {
+  namespace: string;
+  key: string;
+  value_json: string;
+  created_at: string;
+  updated_at: string;
+}
+
+interface LocalStoreSecretRow {
+  namespace: string;
+  key: string;
+  ciphertext: string;
+  created_at: string;
+  updated_at: string;
+}
+
+function getLocalStoreMetaValue(db: Database, key: LocalStoreMetaKey): string | undefined {
+  const row = db.query('SELECT value FROM local_store_meta WHERE key = ?').get(key) as
+    | { value: string }
+    | null;
+  return row?.value;
+}
+
+function setLocalStoreMetaValue(db: Database, key: LocalStoreMetaKey, value: string): void {
+  db.query(
+    `
+      INSERT INTO local_store_meta(key, value, updated_at)
+      VALUES (?, ?, ?)
+      ON CONFLICT(key) DO UPDATE
+      SET value = excluded.value,
+          updated_at = excluded.updated_at
+    `
+  ).run(key, value, nowIso());
+}
+
+function deleteLocalStoreMetaValue(db: Database, key: LocalStoreMetaKey): void {
+  db.query('DELETE FROM local_store_meta WHERE key = ?').run(key);
+}
+
+function mapLocalStoreRecordRow(row: LocalStoreRecordRow): LocalStoreRecord {
+  return {
+    namespace: row.namespace,
+    key: row.key,
+    valueJson: row.value_json,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+function mapLocalStoreSecretRow(row: LocalStoreSecretRow): LocalStoreSecretRecord {
+  return {
+    namespace: row.namespace,
+    key: row.key,
+    ciphertext: row.ciphertext,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+export function getLocalStoreMeta(key: LocalStoreMetaKey): string | undefined {
+  return withControlDb((db) => getLocalStoreMetaValue(db, key));
+}
+
+export function setLocalStoreMeta(key: LocalStoreMetaKey, value: string): void {
+  withControlDb((db) => {
+    setLocalStoreMetaValue(db, key, value);
+  });
+}
+
+export function deleteLocalStoreMeta(key: LocalStoreMetaKey): void {
+  withControlDb((db) => {
+    deleteLocalStoreMetaValue(db, key);
+  });
+}
+
+export function getLocalStoreRecord(namespace: string, key: string): LocalStoreRecord | undefined {
+  return withControlDb((db) => {
+    const row = db.query(
+      'SELECT * FROM local_store_records WHERE namespace = ? AND key = ?'
+    ).get(namespace, key) as LocalStoreRecordRow | null;
+    return row ? mapLocalStoreRecordRow(row) : undefined;
+  });
+}
+
+export function listLocalStoreRecords(namespace: string): LocalStoreRecord[] {
+  return withControlDb((db) => {
+    const rows = db.query(
+      'SELECT * FROM local_store_records WHERE namespace = ? ORDER BY updated_at DESC'
+    ).all(namespace) as LocalStoreRecordRow[];
+    return rows.map(mapLocalStoreRecordRow);
+  });
+}
+
+export function upsertLocalStoreRecord(namespace: string, key: string, valueJson: string): LocalStoreRecord {
+  return withControlDb((db) => {
+    const now = nowIso();
+    const existing = db.query(
+      'SELECT created_at FROM local_store_records WHERE namespace = ? AND key = ?'
+    ).get(namespace, key) as { created_at: string } | null;
+    const createdAt = existing?.created_at ?? now;
+
+    db.query(
+      `
+        INSERT INTO local_store_records(namespace, key, value_json, created_at, updated_at)
+        VALUES (?, ?, ?, ?, ?)
+        ON CONFLICT(namespace, key) DO UPDATE
+        SET value_json = excluded.value_json,
+            updated_at = excluded.updated_at
+      `
+    ).run(namespace, key, valueJson, createdAt, now);
+
+    return {
+      namespace,
+      key,
+      valueJson,
+      createdAt,
+      updatedAt: now,
+    };
+  });
+}
+
+export function removeLocalStoreRecord(namespace: string, key: string): boolean {
+  return withControlDb((db) => {
+    const result = db.query(
+      'DELETE FROM local_store_records WHERE namespace = ? AND key = ?'
+    ).run(namespace, key);
+    return result.changes > 0;
+  });
+}
+
+export function getLocalStoreSecret(namespace: string, key: string): LocalStoreSecretRecord | undefined {
+  return withControlDb((db) => {
+    const row = db.query(
+      'SELECT * FROM local_store_secrets WHERE namespace = ? AND key = ?'
+    ).get(namespace, key) as LocalStoreSecretRow | null;
+    return row ? mapLocalStoreSecretRow(row) : undefined;
+  });
+}
+
+export function listLocalStoreSecrets(namespace: string): LocalStoreSecretRecord[] {
+  return withControlDb((db) => {
+    const rows = db.query(
+      'SELECT * FROM local_store_secrets WHERE namespace = ? ORDER BY updated_at DESC'
+    ).all(namespace) as LocalStoreSecretRow[];
+    return rows.map(mapLocalStoreSecretRow);
+  });
+}
+
+export function upsertLocalStoreSecret(namespace: string, key: string, ciphertext: string): LocalStoreSecretRecord {
+  return withControlDb((db) => {
+    const now = nowIso();
+    const existing = db.query(
+      'SELECT created_at FROM local_store_secrets WHERE namespace = ? AND key = ?'
+    ).get(namespace, key) as { created_at: string } | null;
+    const createdAt = existing?.created_at ?? now;
+
+    db.query(
+      `
+        INSERT INTO local_store_secrets(namespace, key, ciphertext, created_at, updated_at)
+        VALUES (?, ?, ?, ?, ?)
+        ON CONFLICT(namespace, key) DO UPDATE
+        SET ciphertext = excluded.ciphertext,
+            updated_at = excluded.updated_at
+      `
+    ).run(namespace, key, ciphertext, createdAt, now);
+
+    return {
+      namespace,
+      key,
+      ciphertext,
+      createdAt,
+      updatedAt: now,
+    };
+  });
+}
+
+export function removeLocalStoreSecret(namespace: string, key: string): boolean {
+  return withControlDb((db) => {
+    const result = db.query(
+      'DELETE FROM local_store_secrets WHERE namespace = ? AND key = ?'
+    ).run(namespace, key);
+    return result.changes > 0;
   });
 }
 

--- a/src/relay/control/store.ts
+++ b/src/relay/control/store.ts
@@ -4,6 +4,7 @@ import { existsSync, mkdirSync } from 'node:fs';
 import { join } from 'node:path';
 import { getSpacesDir } from '../../core/config.js';
 import { SpacesError } from '../../types/errors.js';
+import { logger } from '../../utils/logger.js';
 import { applyControlMigrations } from './schema.js';
 import type {
   CloudBootstrapState,
@@ -333,42 +334,57 @@ export function bindPersistedOwnerIdentity(ownerIdentityId: string): {
   ownerIdentityId: string;
 } {
   return withControlDb((db) => {
-    const binding = readPersistedOwnerBindingFromDb(db);
+    db.exec('BEGIN IMMEDIATE');
+    try {
+      const binding = readPersistedOwnerBindingFromDb(db);
 
-    if (!binding.controlOwnerId && !binding.vaultOwnerId) {
-      setMetaValue(db, META_KEY_OWNER_IDENTITY_ID, ownerIdentityId);
-      setVaultMetaValueInDb(db, 'owner_user_root_id', ownerIdentityId);
-      setMetaValue(db, META_KEY_UPDATED_AT, nowIso());
-      return { bound: true, repaired: false, ownerIdentityId };
-    }
+      if (!binding.controlOwnerId && !binding.vaultOwnerId) {
+        setMetaValue(db, META_KEY_OWNER_IDENTITY_ID, ownerIdentityId);
+        setVaultMetaValueInDb(db, 'owner_user_root_id', ownerIdentityId);
+        setMetaValue(db, META_KEY_UPDATED_AT, nowIso());
+        db.exec('COMMIT');
+        return { bound: true, repaired: false, ownerIdentityId };
+      }
 
-    if (!binding.mismatch) {
-      if (binding.effectiveOwnerId !== ownerIdentityId) {
+      if (!binding.mismatch) {
+        if (binding.effectiveOwnerId !== ownerIdentityId) {
+          logger.error(
+            `Local control binding owner mismatch: persisted=${binding.effectiveOwnerId ?? 'unset'} current=${ownerIdentityId}`,
+          );
+          throw new SpacesError(
+            `Local control bindings mismatch. Persisted owner '${binding.effectiveOwnerId}' does not match current identity '${ownerIdentityId}'.`,
+            'USER_ERROR',
+            1
+          );
+        }
+
+        db.exec('COMMIT');
+        return { bound: false, repaired: binding.repaired, ownerIdentityId };
+      }
+
+      const canRepairToCurrentIdentity = binding.controlOwnerId === ownerIdentityId
+        || binding.vaultOwnerId === ownerIdentityId;
+
+      if (!canRepairToCurrentIdentity) {
+        logger.error(
+          `Local control binding mismatch: control=${binding.controlOwnerId ?? 'unset'} vault=${binding.vaultOwnerId ?? 'unset'} current=${ownerIdentityId}`,
+        );
         throw new SpacesError(
-          `Local control bindings mismatch. Persisted owner '${binding.effectiveOwnerId}' does not match current identity '${ownerIdentityId}'.`,
+          `Local control bindings mismatch. Persisted control owner '${binding.controlOwnerId}' and vault owner '${binding.vaultOwnerId}' do not match current identity '${ownerIdentityId}'.`,
           'USER_ERROR',
           1
         );
       }
 
-      return { bound: false, repaired: binding.repaired, ownerIdentityId };
+      setMetaValue(db, META_KEY_OWNER_IDENTITY_ID, ownerIdentityId);
+      setVaultMetaValueInDb(db, 'owner_user_root_id', ownerIdentityId);
+      setMetaValue(db, META_KEY_UPDATED_AT, nowIso());
+      db.exec('COMMIT');
+      return { bound: false, repaired: true, ownerIdentityId };
+    } catch (error) {
+      db.exec('ROLLBACK');
+      throw error;
     }
-
-    const canRepairToCurrentIdentity = binding.controlOwnerId === ownerIdentityId
-      || binding.vaultOwnerId === ownerIdentityId;
-
-    if (!canRepairToCurrentIdentity) {
-      throw new SpacesError(
-        `Local control bindings mismatch. Persisted control owner '${binding.controlOwnerId}' and vault owner '${binding.vaultOwnerId}' do not match current identity '${ownerIdentityId}'.`,
-        'USER_ERROR',
-        1
-      );
-    }
-
-    setMetaValue(db, META_KEY_OWNER_IDENTITY_ID, ownerIdentityId);
-    setVaultMetaValueInDb(db, 'owner_user_root_id', ownerIdentityId);
-    setMetaValue(db, META_KEY_UPDATED_AT, nowIso());
-    return { bound: false, repaired: true, ownerIdentityId };
   });
 }
 
@@ -380,6 +396,9 @@ export function isControlOwner(identityId: string): boolean {
 export function assertControlOwner(identityId: string): void {
   const ownerBinding = readPersistedOwnerBinding();
   if (ownerBinding.mismatch) {
+    logger.error(
+      `Local control binding mismatch: control=${ownerBinding.controlOwnerId ?? 'unset'} vault=${ownerBinding.vaultOwnerId ?? 'unset'} current=${identityId}`,
+    );
     throw new SpacesError(
       `Local control bindings mismatch. Persisted control owner '${ownerBinding.controlOwnerId}' and vault owner '${ownerBinding.vaultOwnerId}' do not match current identity '${identityId}'.`,
       'USER_ERROR',
@@ -389,6 +408,7 @@ export function assertControlOwner(identityId: string): void {
 
   const ownerIdentityId = ownerBinding.effectiveOwnerId;
   if (!ownerIdentityId) {
+    logger.error('Local control bindings are not initialized.');
     throw new SpacesError(
       'Local control bindings are not initialized.',
       'SYSTEM_ERROR',
@@ -397,6 +417,9 @@ export function assertControlOwner(identityId: string): void {
   }
 
   if (ownerIdentityId !== identityId) {
+    logger.error(
+      `Local control binding owner mismatch: persisted=${ownerIdentityId} current=${identityId}`,
+    );
     throw new SpacesError(
       `Local control bindings mismatch. Persisted owner '${ownerIdentityId}' does not match current identity '${identityId}'.`,
       'USER_ERROR',
@@ -432,6 +455,9 @@ export function bindControlRelayIdentity(
     const sameFingerprint = currentRelayFingerprint === input.relayFingerprint;
 
     if (!sameIdentityId || !sameSigningKey || !sameFingerprint) {
+      logger.error(
+        `Relay pin mismatch: persisted=${currentRelayFingerprint ?? currentRelayIdentityId ?? 'unset'} current=${input.relayFingerprint}`,
+      );
       throw new SpacesError(
         [
           `Local control bindings mismatch. Pinned relay '${currentRelayFingerprint ?? currentRelayIdentityId}', current relay '${input.relayFingerprint}'.`,

--- a/src/relay/control/store.ts
+++ b/src/relay/control/store.ts
@@ -275,8 +275,10 @@ export interface PersistedOwnerBinding {
 }
 
 function peekPersistedOwnerBindingFromDb(db: Database): PersistedOwnerBinding {
-  let controlOwnerId = getMetaValue(db, META_KEY_OWNER_IDENTITY_ID);
-  let vaultOwnerId = getVaultMetaValueFromDb(db, 'owner_user_root_id');
+  const originalControlOwnerId = getMetaValue(db, META_KEY_OWNER_IDENTITY_ID);
+  const originalVaultOwnerId = getVaultMetaValueFromDb(db, 'owner_user_root_id');
+  let controlOwnerId = originalControlOwnerId;
+  let vaultOwnerId = originalVaultOwnerId;
 
   if (!controlOwnerId && vaultOwnerId) {
     controlOwnerId = vaultOwnerId;
@@ -287,8 +289,8 @@ function peekPersistedOwnerBindingFromDb(db: Database): PersistedOwnerBinding {
   const mismatch = Boolean(controlOwnerId && vaultOwnerId && controlOwnerId !== vaultOwnerId);
   const effectiveOwnerId = mismatch ? undefined : (controlOwnerId ?? vaultOwnerId);
   const repaired = Boolean(
-    (controlOwnerId && !getVaultMetaValueFromDb(db, 'owner_user_root_id'))
-    || (vaultOwnerId && !getMetaValue(db, META_KEY_OWNER_IDENTITY_ID))
+    (controlOwnerId && !originalVaultOwnerId)
+    || (vaultOwnerId && !originalControlOwnerId)
   );
 
   return {

--- a/src/relay/control/store.ts
+++ b/src/relay/control/store.ts
@@ -278,39 +278,39 @@ function peekPersistedOwnerBindingFromDb(db: Database): PersistedOwnerBinding {
   let controlOwnerId = getMetaValue(db, META_KEY_OWNER_IDENTITY_ID);
   let vaultOwnerId = getVaultMetaValueFromDb(db, 'owner_user_root_id');
 
+  if (!controlOwnerId && vaultOwnerId) {
+    controlOwnerId = vaultOwnerId;
+  } else if (controlOwnerId && !vaultOwnerId) {
+    vaultOwnerId = controlOwnerId;
+  }
+
   const mismatch = Boolean(controlOwnerId && vaultOwnerId && controlOwnerId !== vaultOwnerId);
   const effectiveOwnerId = mismatch ? undefined : (controlOwnerId ?? vaultOwnerId);
+  const repaired = Boolean(
+    (controlOwnerId && !getVaultMetaValueFromDb(db, 'owner_user_root_id'))
+    || (vaultOwnerId && !getMetaValue(db, META_KEY_OWNER_IDENTITY_ID))
+  );
 
   return {
     controlOwnerId,
     vaultOwnerId,
     effectiveOwnerId,
     mismatch,
-    repaired: false,
+    repaired,
   };
 }
 
 function readPersistedOwnerBindingFromDb(db: Database): PersistedOwnerBinding {
   const binding = peekPersistedOwnerBindingFromDb(db);
 
-  if (!binding.controlOwnerId && binding.vaultOwnerId) {
-    setMetaValue(db, META_KEY_OWNER_IDENTITY_ID, binding.vaultOwnerId);
-    return {
-      ...binding,
-      controlOwnerId: binding.vaultOwnerId,
-      effectiveOwnerId: binding.vaultOwnerId,
-      repaired: true,
-    };
-  }
-
-  if (binding.controlOwnerId && !binding.vaultOwnerId) {
-    setVaultMetaValueInDb(db, 'owner_user_root_id', binding.controlOwnerId);
-    return {
-      ...binding,
-      vaultOwnerId: binding.controlOwnerId,
-      effectiveOwnerId: binding.controlOwnerId,
-      repaired: true,
-    };
+  if (binding.repaired) {
+    if (!getMetaValue(db, META_KEY_OWNER_IDENTITY_ID) && binding.controlOwnerId) {
+      setMetaValue(db, META_KEY_OWNER_IDENTITY_ID, binding.controlOwnerId);
+    }
+    if (!getVaultMetaValueFromDb(db, 'owner_user_root_id') && binding.vaultOwnerId) {
+      setVaultMetaValueInDb(db, 'owner_user_root_id', binding.vaultOwnerId);
+    }
+    return binding;
   }
 
   return binding;

--- a/src/relay/control/store.ts
+++ b/src/relay/control/store.ts
@@ -517,15 +517,6 @@ export function getLocalStoreRecord(namespace: string, key: string): LocalStoreR
   });
 }
 
-export function listLocalStoreRecords(namespace: string): LocalStoreRecord[] {
-  return withControlDb((db) => {
-    const rows = db.query(
-      'SELECT * FROM local_store_records WHERE namespace = ? ORDER BY updated_at DESC'
-    ).all(namespace) as LocalStoreRecordRow[];
-    return rows.map(mapLocalStoreRecordRow);
-  });
-}
-
 export function upsertLocalStoreRecord(namespace: string, key: string, valueJson: string): LocalStoreRecord {
   return withControlDb((db) => {
     const now = nowIso();
@@ -569,15 +560,6 @@ export function getLocalStoreSecret(namespace: string, key: string): LocalStoreS
       'SELECT * FROM local_store_secrets WHERE namespace = ? AND key = ?'
     ).get(namespace, key) as LocalStoreSecretRow | null;
     return row ? mapLocalStoreSecretRow(row) : undefined;
-  });
-}
-
-export function listLocalStoreSecrets(namespace: string): LocalStoreSecretRecord[] {
-  return withControlDb((db) => {
-    const rows = db.query(
-      'SELECT * FROM local_store_secrets WHERE namespace = ? ORDER BY updated_at DESC'
-    ).all(namespace) as LocalStoreSecretRow[];
-    return rows.map(mapLocalStoreSecretRow);
   });
 }
 

--- a/src/relay/control/store.ts
+++ b/src/relay/control/store.ts
@@ -513,10 +513,6 @@ function setLocalStoreMetaValue(db: Database, key: LocalStoreMetaKey, value: str
   ).run(key, value, nowIso());
 }
 
-function deleteLocalStoreMetaValue(db: Database, key: LocalStoreMetaKey): void {
-  db.query('DELETE FROM local_store_meta WHERE key = ?').run(key);
-}
-
 function mapLocalStoreRecordRow(row: LocalStoreRecordRow): LocalStoreRecord {
   return {
     namespace: row.namespace,
@@ -544,12 +540,6 @@ export function getLocalStoreMeta(key: LocalStoreMetaKey): string | undefined {
 export function setLocalStoreMeta(key: LocalStoreMetaKey, value: string): void {
   withControlDb((db) => {
     setLocalStoreMetaValue(db, key, value);
-  });
-}
-
-export function deleteLocalStoreMeta(key: LocalStoreMetaKey): void {
-  withControlDb((db) => {
-    deleteLocalStoreMetaValue(db, key);
   });
 }
 

--- a/src/relay/control/store.ts
+++ b/src/relay/control/store.ts
@@ -273,20 +273,9 @@ export interface PersistedOwnerBinding {
   repaired: boolean;
 }
 
-function readPersistedOwnerBindingFromDb(db: Database): PersistedOwnerBinding {
+function peekPersistedOwnerBindingFromDb(db: Database): PersistedOwnerBinding {
   let controlOwnerId = getMetaValue(db, META_KEY_OWNER_IDENTITY_ID);
   let vaultOwnerId = getVaultMetaValueFromDb(db, 'owner_user_root_id');
-  let repaired = false;
-
-  if (!controlOwnerId && vaultOwnerId) {
-    setMetaValue(db, META_KEY_OWNER_IDENTITY_ID, vaultOwnerId);
-    controlOwnerId = vaultOwnerId;
-    repaired = true;
-  } else if (controlOwnerId && !vaultOwnerId) {
-    setVaultMetaValueInDb(db, 'owner_user_root_id', controlOwnerId);
-    vaultOwnerId = controlOwnerId;
-    repaired = true;
-  }
 
   const mismatch = Boolean(controlOwnerId && vaultOwnerId && controlOwnerId !== vaultOwnerId);
   const effectiveOwnerId = mismatch ? undefined : (controlOwnerId ?? vaultOwnerId);
@@ -296,12 +285,42 @@ function readPersistedOwnerBindingFromDb(db: Database): PersistedOwnerBinding {
     vaultOwnerId,
     effectiveOwnerId,
     mismatch,
-    repaired,
+    repaired: false,
   };
+}
+
+function readPersistedOwnerBindingFromDb(db: Database): PersistedOwnerBinding {
+  const binding = peekPersistedOwnerBindingFromDb(db);
+
+  if (!binding.controlOwnerId && binding.vaultOwnerId) {
+    setMetaValue(db, META_KEY_OWNER_IDENTITY_ID, binding.vaultOwnerId);
+    return {
+      ...binding,
+      controlOwnerId: binding.vaultOwnerId,
+      effectiveOwnerId: binding.vaultOwnerId,
+      repaired: true,
+    };
+  }
+
+  if (binding.controlOwnerId && !binding.vaultOwnerId) {
+    setVaultMetaValueInDb(db, 'owner_user_root_id', binding.controlOwnerId);
+    return {
+      ...binding,
+      vaultOwnerId: binding.controlOwnerId,
+      effectiveOwnerId: binding.controlOwnerId,
+      repaired: true,
+    };
+  }
+
+  return binding;
 }
 
 export function readPersistedOwnerBinding(): PersistedOwnerBinding {
   return withControlDb((db) => readPersistedOwnerBindingFromDb(db));
+}
+
+export function peekPersistedOwnerBinding(): PersistedOwnerBinding {
+  return withControlDb((db) => peekPersistedOwnerBindingFromDb(db));
 }
 
 export function getPersistedOwnerIdentityId(): string | undefined {

--- a/src/relay/control/types.ts
+++ b/src/relay/control/types.ts
@@ -17,6 +17,28 @@ export interface ControlMeta {
   updatedAt: string;
 }
 
+export type LocalStoreMetaKey =
+  | 'store_password_salt'
+  | 'store_password_key_check'
+  | 'legacy_storage_migrated_at'
+  | 'legacy_storage_retained';
+
+export interface LocalStoreRecord {
+  namespace: string;
+  key: string;
+  valueJson: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface LocalStoreSecretRecord {
+  namespace: string;
+  key: string;
+  ciphertext: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
 export interface CloudWorkspaceRecord {
   id: string;
   provider: 'sprites';

--- a/src/relay/identity.ts
+++ b/src/relay/identity.ts
@@ -105,16 +105,24 @@ function readStoredRelayPublicIdentity(): RelayPublicIdentity | null {
   ) ?? null;
 }
 
-function writeStoredRelayIdentity(identity: RelayIdentity): void {
+function writeStoredRelayPublicIdentity(identity: RelayPublicIdentity): void {
   writeLocalStoreJson(LOCAL_STORE_NAMESPACE, LOCAL_STORE_KEY_PUBLIC_IDENTITY, {
     id: identity.id,
     signingPublicKey: identity.signingPublicKey,
     label: identity.label,
     createdAt: identity.createdAt,
   } satisfies RelayPublicIdentity);
+}
+
+function writeStoredRelayPrivateIdentity(identity: RelayIdentity): void {
   writeLocalStoreSecretJson(LOCAL_STORE_NAMESPACE, LOCAL_STORE_KEY_PRIVATE_IDENTITY, {
     signingPrivateKey: Buffer.from(identity.signingPrivateKey).toString('base64'),
   });
+}
+
+function writeStoredRelayIdentity(identity: RelayIdentity): void {
+  writeStoredRelayPublicIdentity(identity);
+  writeStoredRelayPrivateIdentity(identity);
 }
 
 function readStoredRelayPrivateKey(): Uint8Array | null {
@@ -204,8 +212,9 @@ export function generateRelayIdentity(label?: string): RelayIdentity {
  * @param identity - Relay identity to save
  */
 export async function saveRelayIdentity(identity: RelayIdentity): Promise<void> {
+  writeStoredRelayPublicIdentity(identity);
   if (isLocalSecureStoreUnlocked()) {
-    writeStoredRelayIdentity(identity);
+    writeStoredRelayPrivateIdentity(identity);
   }
 
   ensureRelayDir();
@@ -312,7 +321,7 @@ export async function loadRelayIdentity(): Promise<RelayIdentity | null> {
  * Check if relay identity exists on disk
  */
 export function relayIdentityExists(): boolean {
-	return readStoredRelayPublicIdentity() !== null || existsSync(getRelayIdentityPath());
+  return readStoredRelayPublicIdentity() !== null || existsSync(getRelayIdentityPath());
 }
 
 /**
@@ -323,16 +332,16 @@ export function relayIdentityExists(): boolean {
  * @returns Public identity if exists, null otherwise
  */
 export function getRelayPublicIdentity(): RelayPublicIdentity | null {
-	const stored = readStoredRelayPublicIdentity();
-	if (stored) {
-		return stored;
-	}
+  const stored = readStoredRelayPublicIdentity();
+  if (stored) {
+    return stored;
+  }
 
-	const identityPath = getRelayIdentityPath();
+  const identityPath = getRelayIdentityPath();
 
-	if (!existsSync(identityPath)) {
-		return null;
-	}
+  if (!existsSync(identityPath)) {
+    return null;
+  }
 
   try {
     const content = readFileSync(identityPath, "utf-8");
@@ -392,6 +401,7 @@ export async function loadOrCreateRelayIdentity(label?: string): Promise<RelayId
         JSON.stringify(publicIdentity, null, 2),
         { encoding: "utf-8", mode: 0o600 }
       );
+      writeStoredRelayPublicIdentity(publicIdentity);
 
       console.log(`[relay] Created identity from env var: ${formatRelayFingerprint(publicKeyB64)}`);
       return identity;

--- a/src/relay/identity.ts
+++ b/src/relay/identity.ts
@@ -17,6 +17,14 @@ import { ed25519 } from "@noble/curves/ed25519.js";
 import { sha256 } from "@noble/hashes/sha2.js";
 import { setSecret, getSecret } from "../utils/secrets.js";
 import { getSpacesDir } from "../core/config.js";
+import {
+  isLocalSecureStoreUnlocked,
+  markLegacyLocalStorageMigrated,
+  readLocalStoreJson,
+  readLocalStoreSecretJson,
+  writeLocalStoreJson,
+  writeLocalStoreSecretJson,
+} from '../core/local-secure-store.js';
 
 // ============================================================================
 // Types
@@ -56,6 +64,9 @@ const ENV_PRIVATE_KEY = "RELAY_PRIVATE_KEY";
 
 /** Identity file name */
 const IDENTITY_FILENAME = "identity.json";
+const LOCAL_STORE_NAMESPACE = 'relay';
+const LOCAL_STORE_KEY_PUBLIC_IDENTITY = 'public-identity';
+const LOCAL_STORE_KEY_PRIVATE_IDENTITY = 'private-identity';
 
 // ============================================================================
 // Paths
@@ -85,6 +96,36 @@ function ensureRelayDir(): void {
   if (!existsSync(relayDir)) {
     mkdirSync(relayDir, { recursive: true, mode: 0o700 });
   }
+}
+
+function readStoredRelayPublicIdentity(): RelayPublicIdentity | null {
+  return readLocalStoreJson<RelayPublicIdentity>(
+    LOCAL_STORE_NAMESPACE,
+    LOCAL_STORE_KEY_PUBLIC_IDENTITY,
+  ) ?? null;
+}
+
+function writeStoredRelayIdentity(identity: RelayIdentity): void {
+  writeLocalStoreJson(LOCAL_STORE_NAMESPACE, LOCAL_STORE_KEY_PUBLIC_IDENTITY, {
+    id: identity.id,
+    signingPublicKey: identity.signingPublicKey,
+    label: identity.label,
+    createdAt: identity.createdAt,
+  } satisfies RelayPublicIdentity);
+  writeLocalStoreSecretJson(LOCAL_STORE_NAMESPACE, LOCAL_STORE_KEY_PRIVATE_IDENTITY, {
+    signingPrivateKey: Buffer.from(identity.signingPrivateKey).toString('base64'),
+  });
+}
+
+function readStoredRelayPrivateKey(): Uint8Array | null {
+  const stored = readLocalStoreSecretJson<{ signingPrivateKey: string }>(
+    LOCAL_STORE_NAMESPACE,
+    LOCAL_STORE_KEY_PRIVATE_IDENTITY,
+  );
+  if (!stored?.signingPrivateKey) {
+    return null;
+  }
+  return new Uint8Array(Buffer.from(stored.signingPrivateKey, 'base64'));
 }
 
 // ============================================================================
@@ -163,6 +204,10 @@ export function generateRelayIdentity(label?: string): RelayIdentity {
  * @param identity - Relay identity to save
  */
 export async function saveRelayIdentity(identity: RelayIdentity): Promise<void> {
+  if (isLocalSecureStoreUnlocked()) {
+    writeStoredRelayIdentity(identity);
+  }
+
   ensureRelayDir();
 
   // Save private key to keychain
@@ -194,21 +239,22 @@ export async function saveRelayIdentity(identity: RelayIdentity): Promise<void> 
  * @returns Relay identity if exists, null otherwise
  */
 export async function loadRelayIdentity(): Promise<RelayIdentity | null> {
-  const identityPath = getRelayIdentityPath();
+  const storedPublicIdentity = readStoredRelayPublicIdentity();
+  let publicIdentity: RelayPublicIdentity | null = storedPublicIdentity;
 
-  // Check if public identity file exists
-  if (!existsSync(identityPath)) {
-    return null;
-  }
+  if (!publicIdentity) {
+    const identityPath = getRelayIdentityPath();
+    if (!existsSync(identityPath)) {
+      return null;
+    }
 
-  // Load public identity from disk
-  let publicIdentity: RelayPublicIdentity;
-  try {
-    const content = readFileSync(identityPath, "utf-8");
-    publicIdentity = JSON.parse(content) as RelayPublicIdentity;
-  } catch {
-    console.warn("[relay] Failed to parse identity file");
-    return null;
+    try {
+      const content = readFileSync(identityPath, "utf-8");
+      publicIdentity = JSON.parse(content) as RelayPublicIdentity;
+    } catch {
+      console.warn("[relay] Failed to parse identity file");
+      return null;
+    }
   }
 
   // Try to load private key from env var first
@@ -216,10 +262,16 @@ export async function loadRelayIdentity(): Promise<RelayIdentity | null> {
   let source = "env";
 
   if (!privateKeyB64) {
-    // Fall back to keychain
-    const keychainValue = await getSecret(KEYCHAIN_KEY);
-    privateKeyB64 = keychainValue ?? undefined;
-    source = "keychain";
+    const storedPrivateKey = isLocalSecureStoreUnlocked() ? readStoredRelayPrivateKey() : null;
+    if (storedPrivateKey) {
+      privateKeyB64 = Buffer.from(storedPrivateKey).toString('base64');
+      source = 'local-store';
+    } else {
+      // Fall back to keychain
+      const keychainValue = await getSecret(KEYCHAIN_KEY);
+      privateKeyB64 = keychainValue ?? undefined;
+      source = "keychain";
+    }
   }
 
   if (!privateKeyB64) {
@@ -239,10 +291,17 @@ export async function loadRelayIdentity(): Promise<RelayIdentity | null> {
       return null;
     }
 
-    return {
+    const identity: RelayIdentity = {
       ...publicIdentity,
       signingPrivateKey: privateKey,
     };
+
+    if (source === 'keychain' && isLocalSecureStoreUnlocked()) {
+      writeStoredRelayIdentity(identity);
+      markLegacyLocalStorageMigrated(true);
+    }
+
+    return identity;
   } catch (err) {
     console.warn(`[relay] Failed to load private key from ${source}:`, err);
     return null;
@@ -253,7 +312,7 @@ export async function loadRelayIdentity(): Promise<RelayIdentity | null> {
  * Check if relay identity exists on disk
  */
 export function relayIdentityExists(): boolean {
-  return existsSync(getRelayIdentityPath());
+	return readStoredRelayPublicIdentity() !== null || existsSync(getRelayIdentityPath());
 }
 
 /**
@@ -264,15 +323,23 @@ export function relayIdentityExists(): boolean {
  * @returns Public identity if exists, null otherwise
  */
 export function getRelayPublicIdentity(): RelayPublicIdentity | null {
-  const identityPath = getRelayIdentityPath();
+	const stored = readStoredRelayPublicIdentity();
+	if (stored) {
+		return stored;
+	}
 
-  if (!existsSync(identityPath)) {
-    return null;
-  }
+	const identityPath = getRelayIdentityPath();
+
+	if (!existsSync(identityPath)) {
+		return null;
+	}
 
   try {
     const content = readFileSync(identityPath, "utf-8");
-    return JSON.parse(content) as RelayPublicIdentity;
+    const identity = JSON.parse(content) as RelayPublicIdentity;
+    writeLocalStoreJson(LOCAL_STORE_NAMESPACE, LOCAL_STORE_KEY_PUBLIC_IDENTITY, identity);
+    markLegacyLocalStorageMigrated(true);
+    return identity;
   } catch {
     return null;
   }

--- a/src/relay/identity.ts
+++ b/src/relay/identity.ts
@@ -288,6 +288,7 @@ export async function loadRelayIdentity(): Promise<RelayIdentity | null> {
     return null;
   }
 
+  let identity: RelayIdentity;
   try {
     const privateKey = new Uint8Array(Buffer.from(privateKeyB64, "base64"));
 
@@ -300,21 +301,26 @@ export async function loadRelayIdentity(): Promise<RelayIdentity | null> {
       return null;
     }
 
-    const identity: RelayIdentity = {
+    identity = {
       ...publicIdentity,
       signingPrivateKey: privateKey,
     };
 
-    if (source === 'keychain' && isLocalSecureStoreUnlocked()) {
-      writeStoredRelayIdentity(identity);
-      markLegacyLocalStorageMigrated(true);
-    }
-
-    return identity;
   } catch (err) {
     console.warn(`[relay] Failed to load private key from ${source}:`, err);
     return null;
   }
+
+  if (source === 'keychain' && isLocalSecureStoreUnlocked()) {
+    try {
+      writeStoredRelayIdentity(identity);
+      markLegacyLocalStorageMigrated(true);
+    } catch (error) {
+      console.warn('[relay] Failed to migrate relay identity into local secure store:', error);
+    }
+  }
+
+  return identity;
 }
 
 /**
@@ -346,8 +352,12 @@ export function getRelayPublicIdentity(): RelayPublicIdentity | null {
   try {
     const content = readFileSync(identityPath, "utf-8");
     const identity = JSON.parse(content) as RelayPublicIdentity;
-    writeLocalStoreJson(LOCAL_STORE_NAMESPACE, LOCAL_STORE_KEY_PUBLIC_IDENTITY, identity);
-    markLegacyLocalStorageMigrated(true);
+    try {
+      writeLocalStoreJson(LOCAL_STORE_NAMESPACE, LOCAL_STORE_KEY_PUBLIC_IDENTITY, identity);
+      markLegacyLocalStorageMigrated(true);
+    } catch (error) {
+      console.warn('[relay] Failed to migrate relay public identity into local secure store:', error);
+    }
     return identity;
   } catch {
     return null;

--- a/src/relay/server.ts
+++ b/src/relay/server.ts
@@ -31,6 +31,7 @@ import {
   consumeCloudRegisterPermit,
   getCloudWorkspace,
   getCloudWorkspaceByMachinePublicKey,
+  getPersistedOwnerIdentityId,
   markCloudBootstrapReady,
 } from "./control/store.js";
 import { getWorkspaceIdentity } from "./control/workspace-identity.js";
@@ -183,7 +184,6 @@ import {
 } from "./persistent-registry.js";
 import {
   getVaultMachine,
-  getVaultMeta,
   isVaultInitialized,
   upsertVaultMachine,
 } from "./control/store.js";
@@ -485,7 +485,7 @@ function authenticateOwnerClient<T extends {
     return null;
   }
 
-  const configuredOwnerUserRootId = state.ownerUserRootId ?? getVaultMeta("owner_user_root_id") ?? null;
+  const configuredOwnerUserRootId = state.ownerUserRootId ?? getPersistedOwnerIdentityId() ?? null;
   if (!configuredOwnerUserRootId) {
     ws.send(serializeMessage(createErrorMessage("FORBIDDEN", "Relay owner user root is not configured")));
     return null;
@@ -595,7 +595,7 @@ export function createRelayServer(config: RelayConfig): Server<WebSocketData> {
   };
 
   // Determine owner from vault metadata when available
-  const ownerUserRootId = getVaultMeta('owner_user_root_id') ?? null;
+  const ownerUserRootId = getPersistedOwnerIdentityId() ?? null;
   if (ownerUserRootId) {
     console.log(`[relay] Vault owner: ${ownerUserRootId.slice(0, 8)}...`);
     console.log(`[relay] Vault state: ${isVaultInitialized() ? getVaultLockState() : 'uninitialized'}`);
@@ -1030,7 +1030,7 @@ async function handleProtocolMessage(
 
           // Extract user root ID from the certificate and check against relay owner
           const certUserRootId = getUserRootIdFromCert(cert);
-          const relayOwnerUserRootId = state.ownerUserRootId ?? getVaultMeta('owner_user_root_id') ?? null;
+          const relayOwnerUserRootId = state.ownerUserRootId ?? getPersistedOwnerIdentityId() ?? null;
 
           if (relayOwnerUserRootId && certUserRootId === relayOwnerUserRootId) {
             // Certificate is signed by the relay's owner — auto-authorize
@@ -1118,7 +1118,7 @@ async function handleProtocolMessage(
           return;
         }
 
-        const relayOwnerUserRootId = state.ownerUserRootId ?? getVaultMeta('owner_user_root_id') ?? null;
+        const relayOwnerUserRootId = state.ownerUserRootId ?? getPersistedOwnerIdentityId() ?? null;
         if (relayOwnerUserRootId && relayOwnerUserRootId !== parsedInvite.ownerUserRootId) {
           ws.send(serializeMessage(createErrorMessage("FORBIDDEN", "Invite owner does not match relay owner")));
           ws.close();
@@ -1168,7 +1168,7 @@ async function handleProtocolMessage(
       const resolvedOwnerUserRootId = enrollmentOwnerUserRootId
         ?? persistedMachine?.ownerUserRootId
         ?? state.ownerUserRootId
-        ?? getVaultMeta('owner_user_root_id')
+        ?? getPersistedOwnerIdentityId()
         ?? null;
 
       if (!resolvedOwnerUserRootId) {
@@ -1635,7 +1635,7 @@ async function handleProtocolMessage(
         return;
       }
 
-      const storedOwner = state.ownerUserRootId ?? getVaultMeta('owner_user_root_id');
+      const storedOwner = state.ownerUserRootId ?? getPersistedOwnerIdentityId();
       if (storedOwner && storedOwner !== userRootId) {
         ws.send(serializeMessage({
           type: "unlock_relay_result",

--- a/src/utils/__tests__/secrets-local-store.test.ts
+++ b/src/utils/__tests__/secrets-local-store.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 const testDir = mkdtempSync(join(tmpdir(), 'gssh-secrets-local-store-'));
+const originalHome = process.env.HOME;
 process.env.HOME = testDir;
 process.env.GSSH_ENABLE_TEST_SECRETS_BACKEND = '1';
 process.env.GSSH_TEST_SECRETS_FILE = join(testDir, 'test-secrets.json');
@@ -24,6 +25,11 @@ beforeEach(() => {
 afterAll(() => {
   clearSecretsCache();
   lockLocalSecureStore();
+  if (originalHome === undefined) {
+    delete process.env.HOME;
+  } else {
+    process.env.HOME = originalHome;
+  }
   delete process.env.GSSH_TEST_SECRETS_FILE;
   delete process.env.GSSH_ENABLE_TEST_SECRETS_BACKEND;
   if (existsSync(testDir)) {

--- a/src/utils/__tests__/secrets-local-store.test.ts
+++ b/src/utils/__tests__/secrets-local-store.test.ts
@@ -1,0 +1,58 @@
+import { afterAll, describe, expect, test } from 'bun:test';
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const testDir = mkdtempSync(join(tmpdir(), 'gssh-secrets-local-store-'));
+process.env.HOME = testDir;
+process.env.GSSH_ENABLE_TEST_SECRETS_BACKEND = '1';
+process.env.GSSH_TEST_SECRETS_FILE = join(testDir, 'test-secrets.json');
+
+const {
+  clearSecretsCache,
+  getProjectSecret,
+  getSecret,
+  setProjectSecret,
+  setSecret,
+} = await import('../secrets.js');
+const { unlockLocalSecureStore, readLocalStoreSecretJson, lockLocalSecureStore } = await import('../../core/local-secure-store.js');
+
+afterAll(() => {
+  clearSecretsCache();
+  lockLocalSecureStore();
+  delete process.env.GSSH_TEST_SECRETS_FILE;
+  delete process.env.GSSH_ENABLE_TEST_SECRETS_BACKEND;
+  if (existsSync(testDir)) {
+    rmSync(testDir, { recursive: true, force: true });
+  }
+});
+
+describe('secrets local secure store migration', () => {
+  test('stores non-root secrets in control db and keeps root mnemonic in keychain backend', async () => {
+    await unlockLocalSecureStore('test-password');
+
+    await setSecret('GITSPACE_TOKEN', 'token-123');
+    await setProjectSecret('demo', 'BUNDLE_TOKEN', 'bundle-456');
+    await setSecret('USER_ROOT_IDENTITY', 'root-secret');
+
+    expect(await getSecret('GITSPACE_TOKEN')).toBe('token-123');
+    expect(await getProjectSecret('demo', 'BUNDLE_TOKEN')).toBe('bundle-456');
+    expect(await getSecret('USER_ROOT_IDENTITY')).toBe('root-secret');
+
+    const stored = readLocalStoreSecretJson<{
+      global: Record<string, string>;
+      projects: Record<string, Record<string, string>>;
+    }>('secrets', 'unified');
+
+    expect(stored?.global.GITSPACE_TOKEN).toBe('token-123');
+    expect(stored?.projects.demo?.BUNDLE_TOKEN).toBe('bundle-456');
+    expect(stored?.global.USER_ROOT_IDENTITY).toBeUndefined();
+
+    const testSecretsFile = process.env.GSSH_TEST_SECRETS_FILE!;
+    const rawBackend = JSON.parse(readFileSync(testSecretsFile, 'utf-8')) as {
+      entries?: Record<string, string>;
+    };
+
+    expect(rawBackend.entries?.['com.gitspace:USER_ROOT_IDENTITY']).toBe('root-secret');
+  });
+});

--- a/src/utils/__tests__/secrets-local-store.test.ts
+++ b/src/utils/__tests__/secrets-local-store.test.ts
@@ -1,5 +1,5 @@
-import { afterAll, describe, expect, test } from 'bun:test';
-import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { afterAll, beforeEach, describe, expect, test } from 'bun:test';
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -16,6 +16,10 @@ const {
   setSecret,
 } = await import('../secrets.js');
 const { unlockLocalSecureStore, readLocalStoreSecretJson, lockLocalSecureStore } = await import('../../core/local-secure-store.js');
+
+beforeEach(() => {
+  clearSecretsCache();
+});
 
 afterAll(() => {
   clearSecretsCache();
@@ -54,5 +58,41 @@ describe('secrets local secure store migration', () => {
     };
 
     expect(rawBackend.entries?.['com.gitspace:USER_ROOT_IDENTITY']).toBe('root-secret');
+  });
+
+  test('migrates root mnemonic out of legacy unified blob on read', async () => {
+    const testSecretsFile = process.env.GSSH_TEST_SECRETS_FILE!;
+    const legacyUnifiedBlob = {
+      global: {
+        USER_ROOT_IDENTITY: 'legacy-root-secret',
+        GITSPACE_TOKEN: 'legacy-token',
+      },
+      projects: {},
+      metadata: {
+        schemaVersion: 2,
+        legacyMigrationComplete: false,
+        legacyEntriesRetained: false,
+      },
+    };
+
+    const rawBackend = {
+      entries: {
+        'com.gitspace:secrets': JSON.stringify(legacyUnifiedBlob),
+      },
+    };
+    writeFileSync(testSecretsFile, JSON.stringify(rawBackend, null, 2), 'utf-8');
+
+    expect(await getSecret('USER_ROOT_IDENTITY')).toBe('legacy-root-secret');
+
+    const migratedBackend = JSON.parse(readFileSync(testSecretsFile, 'utf-8')) as {
+      entries?: Record<string, string>;
+    };
+    expect(migratedBackend.entries?.['com.gitspace:USER_ROOT_IDENTITY']).toBe('legacy-root-secret');
+
+    const migratedUnifiedBlob = JSON.parse(migratedBackend.entries?.['com.gitspace:secrets'] ?? '{}') as {
+      global?: Record<string, string>;
+    };
+    expect(migratedUnifiedBlob.global?.USER_ROOT_IDENTITY).toBeUndefined();
+    expect(migratedUnifiedBlob.global?.GITSPACE_TOKEN).toBe('legacy-token');
   });
 });

--- a/src/utils/secrets.ts
+++ b/src/utils/secrets.ts
@@ -237,6 +237,36 @@ function stripKeychainOnlySecrets(blob: UnifiedSecretsBlob): UnifiedSecretsBlob 
   };
 }
 
+async function migrateRootUserSecretFromUnifiedBlob(blob: UnifiedSecretsBlob): Promise<{
+  blob: UnifiedSecretsBlob;
+  migrated: boolean;
+  rootUserSecret: string | null;
+}> {
+  const rootUserSecret = typeof blob.global[ROOT_USER_SECRET_KEY] === 'string'
+    && blob.global[ROOT_USER_SECRET_KEY].length > 0
+    ? blob.global[ROOT_USER_SECRET_KEY]
+    : null;
+
+  if (!rootUserSecret) {
+    return {
+      blob: stripKeychainOnlySecrets(blob),
+      migrated: false,
+      rootUserSecret: null,
+    };
+  }
+
+  const directRootUserSecret = await readSecretValue(ROOT_USER_SECRET_KEY);
+  if (!directRootUserSecret) {
+    await writeSecretValue(ROOT_USER_SECRET_KEY, rootUserSecret);
+  }
+
+  return {
+    blob: stripKeychainOnlySecrets(blob),
+    migrated: true,
+    rootUserSecret,
+  };
+}
+
 function normalizeRecord(value: unknown): Record<string, string> {
   if (!value || typeof value !== 'object') {
     return {};
@@ -317,11 +347,16 @@ async function loadUnifiedSecretsBlob(): Promise<UnifiedSecretsBlob> {
   }
 
   const raw = await readSecretValue(UNIFIED_SECRETS_KEY);
+  const parsed = parseUnifiedSecretsBlob(raw);
+  const { blob, migrated } = await migrateRootUserSecretFromUnifiedBlob(parsed);
 
-  unifiedSecretsCache = parseUnifiedSecretsBlob(raw);
-  unifiedSecretsCache = stripKeychainOnlySecrets(unifiedSecretsCache);
+  unifiedSecretsCache = blob;
   if (unifiedSecretsCache.metadata.legacyMigrationComplete) {
     legacyEntriesDetected = unifiedSecretsCache.metadata.legacyEntriesRetained;
+  }
+
+  if (migrated) {
+    await writeSecretValue(UNIFIED_SECRETS_KEY, JSON.stringify(unifiedSecretsCache));
   }
 
   if (isLocalSecureStoreUnlocked()) {
@@ -665,7 +700,24 @@ export async function setSecret(key: string, value: string): Promise<void> {
  */
 export async function getSecret(key: string): Promise<string | null> {
   if (key === ROOT_USER_SECRET_KEY) {
-    return readSecretValue(key);
+    const directValue = await readSecretValue(key);
+    if (directValue) {
+      return directValue;
+    }
+
+    const rawUnifiedBlob = await readSecretValue(UNIFIED_SECRETS_KEY);
+    if (!rawUnifiedBlob) {
+      return null;
+    }
+
+    const parsed = parseUnifiedSecretsBlob(rawUnifiedBlob);
+    const { blob, migrated, rootUserSecret } = await migrateRootUserSecretFromUnifiedBlob(parsed);
+    if (migrated) {
+      unifiedSecretsCache = blob;
+      await writeSecretValue(UNIFIED_SECRETS_KEY, JSON.stringify(blob));
+    }
+
+    return rootUserSecret;
   }
 
   const blob = await loadUnifiedSecretsBlob();

--- a/src/utils/secrets.ts
+++ b/src/utils/secrets.ts
@@ -12,6 +12,12 @@
 
 import { notifyOwnerSyncCategoryDirty } from '../core/owner-sync-events.js';
 import {
+  isLocalSecureStoreUnlocked,
+  markLegacyLocalStorageMigrated,
+  readLocalStoreSecretJson,
+  writeLocalStoreSecretJson,
+} from '../core/local-secure-store.js';
+import {
   chmodSync,
   existsSync,
   lstatSync,
@@ -55,6 +61,9 @@ function resolveTestSecretsFilePath(): string | null {
 }
 
 const TEST_SECRETS_FILE = resolveTestSecretsFilePath();
+const LOCAL_STORE_NAMESPACE = 'secrets';
+const LOCAL_STORE_KEY_UNIFIED_BLOB = 'unified';
+const ROOT_USER_SECRET_KEY = 'USER_ROOT_IDENTITY';
 
 // Keychain entry names
 const UNIFIED_SECRETS_KEY = 'secrets';
@@ -218,6 +227,16 @@ function createEmptyBlob(): UnifiedSecretsBlob {
   };
 }
 
+function stripKeychainOnlySecrets(blob: UnifiedSecretsBlob): UnifiedSecretsBlob {
+  const global = { ...blob.global };
+  delete global[ROOT_USER_SECRET_KEY];
+  return {
+    global,
+    projects: { ...blob.projects },
+    metadata: { ...blob.metadata },
+  };
+}
+
 function normalizeRecord(value: unknown): Record<string, string> {
   if (!value || typeof value !== 'object') {
     return {};
@@ -286,17 +305,34 @@ async function loadUnifiedSecretsBlob(): Promise<UnifiedSecretsBlob> {
     return unifiedSecretsCache;
   }
 
+  if (isLocalSecureStoreUnlocked()) {
+    const stored = readLocalStoreSecretJson<UnifiedSecretsBlob>(LOCAL_STORE_NAMESPACE, LOCAL_STORE_KEY_UNIFIED_BLOB);
+    if (stored) {
+      unifiedSecretsCache = stripKeychainOnlySecrets(stored);
+      if (unifiedSecretsCache.metadata.legacyMigrationComplete) {
+        legacyEntriesDetected = unifiedSecretsCache.metadata.legacyEntriesRetained;
+      }
+      return unifiedSecretsCache;
+    }
+  }
+
   const raw = await readSecretValue(UNIFIED_SECRETS_KEY);
 
   unifiedSecretsCache = parseUnifiedSecretsBlob(raw);
+  unifiedSecretsCache = stripKeychainOnlySecrets(unifiedSecretsCache);
   if (unifiedSecretsCache.metadata.legacyMigrationComplete) {
     legacyEntriesDetected = unifiedSecretsCache.metadata.legacyEntriesRetained;
+  }
+
+  if (isLocalSecureStoreUnlocked()) {
+    writeLocalStoreSecretJson(LOCAL_STORE_NAMESPACE, LOCAL_STORE_KEY_UNIFIED_BLOB, unifiedSecretsCache);
+    markLegacyLocalStorageMigrated(true);
   }
   return unifiedSecretsCache;
 }
 
 async function saveUnifiedSecretsBlob(blob: UnifiedSecretsBlob): Promise<void> {
-  const normalized: UnifiedSecretsBlob = {
+  const normalized = stripKeychainOnlySecrets({
     global: { ...blob.global },
     projects: { ...blob.projects },
     metadata: {
@@ -304,8 +340,13 @@ async function saveUnifiedSecretsBlob(blob: UnifiedSecretsBlob): Promise<void> {
       legacyMigrationComplete: blob.metadata.legacyMigrationComplete === true,
       legacyEntriesRetained: blob.metadata.legacyEntriesRetained === true,
     },
-  };
+  });
   unifiedSecretsCache = normalized;
+
+  if (isLocalSecureStoreUnlocked()) {
+    writeLocalStoreSecretJson(LOCAL_STORE_NAMESPACE, LOCAL_STORE_KEY_UNIFIED_BLOB, normalized);
+    markLegacyLocalStorageMigrated(true);
+  }
 
   await writeSecretValue(UNIFIED_SECRETS_KEY, JSON.stringify(normalized));
 }
@@ -604,6 +645,12 @@ async function saveGlobalSecretsBlob(secrets: Record<string, string>): Promise<v
  * Used for: GITSPACE_TOKEN, TUNNEL_TOKEN_{subdomain}, etc.
  */
 export async function setSecret(key: string, value: string): Promise<void> {
+  if (key === ROOT_USER_SECRET_KEY) {
+    await writeSecretValue(key, value);
+    notifyGlobalSecretChangeForSync(key);
+    return;
+  }
+
   const secrets = await loadGlobalSecretsBlob();
   secrets[key] = value;
   await saveGlobalSecretsBlob(secrets);
@@ -617,6 +664,10 @@ export async function setSecret(key: string, value: string): Promise<void> {
  * format for seamless migration from older versions.
  */
 export async function getSecret(key: string): Promise<string | null> {
+  if (key === ROOT_USER_SECRET_KEY) {
+    return readSecretValue(key);
+  }
+
   const blob = await loadUnifiedSecretsBlob();
   const secrets = blob.global;
 
@@ -659,6 +710,14 @@ export async function getSecret(key: string): Promise<string | null> {
  * Delete a global secret
  */
 export async function deleteSecret(key: string): Promise<boolean> {
+  if (key === ROOT_USER_SECRET_KEY) {
+    const deleted = await removeSecretValue(key);
+    if (deleted) {
+      notifyGlobalSecretChangeForSync(key);
+    }
+    return deleted;
+  }
+
   const secrets = await loadGlobalSecretsBlob();
   if (!(key in secrets)) {
     return false;
@@ -680,15 +739,25 @@ export async function exportSecretsForOwnerSyncSnapshot(): Promise<OwnerSyncSecr
   for (const [projectName, values] of Object.entries(blob.projects)) {
     projects[projectName] = { ...values };
   }
+
+  const global = { ...blob.global };
+  const rootIdentity = await readSecretValue(ROOT_USER_SECRET_KEY);
+  if (rootIdentity) {
+    global[ROOT_USER_SECRET_KEY] = rootIdentity;
+  }
+
   return {
-    global: { ...blob.global },
+    global,
     projects,
   };
 }
 
 export async function importSecretsFromOwnerSyncSnapshot(snapshot: OwnerSyncSecretsSnapshot): Promise<void> {
   const blob = await loadUnifiedSecretsBlob();
-  blob.global = { ...snapshot.global };
+  const global = normalizeRecord(snapshot.global);
+  const rootIdentity = global[ROOT_USER_SECRET_KEY];
+  delete global[ROOT_USER_SECRET_KEY];
+  blob.global = global;
 
   const projects: Record<string, Record<string, string>> = {};
   for (const [projectName, values] of Object.entries(snapshot.projects)) {
@@ -696,6 +765,9 @@ export async function importSecretsFromOwnerSyncSnapshot(snapshot: OwnerSyncSecr
   }
   blob.projects = projects;
   await saveUnifiedSecretsBlob(blob);
+  if (typeof rootIdentity === 'string' && rootIdentity.length > 0) {
+    await writeSecretValue(ROOT_USER_SECRET_KEY, rootIdentity);
+  }
 }
 
 export interface PreloadAllSecretsResult {


### PR DESCRIPTION
## Summary
- move local device/relay identity, trusted relay config, host config, and unified secret storage onto the control DB-backed local secure store while keeping the root mnemonic outside the store
- unify TUI, relay, serve, and connect around a local-secure-store-first unlock flow and make takeover/reset preserve secure-store data instead of deleting the full control DB
- collapse owner drift handling into a shared persisted owner binding + startup control-state planner for relay and machine serve

## Testing
- `bun test src/relay/control/store.test.ts src/commands/__tests__/control-socket.test.ts`
- `bun test src/commands/__tests__/serve-owner-binding.test.ts src/commands/__tests__/relay-owner-repair.test.ts`
- `bun test src/commands/__tests__/connect-command-trust.test.ts src/commands/__tests__/connect-relay-trust.test.ts`
- `bun test src/commands/__tests__/cloud-connect-password-stdin.integration.test.ts src/commands/__tests__/cloud-connect-recovery-password-stdin.integration.test.ts`
- `bun test src/commands/__tests__/cloud-launch.test.ts src/commands/__tests__/cloud-lifecycle.test.ts src/commands/__tests__/cloud-connect.test.ts`
- `bun test src/core/__tests__/local-secure-store.test.ts src/utils/__tests__/secrets-local-store.test.ts`
- `bun test src/commands/__tests__/device-identity-password.test.ts`

## Related
- Related to #64
- Related to #76
- Follow-up hardening in #84

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches credential/unlock flows and persisted control ownership binding logic across `connect`, `serve`, and `relay`, so regressions could block startup or access if migration/unlock ordering is wrong. Data migration is largely additive with legacy fallback, reducing risk but still affecting stateful paths.
> 
> **Overview**
> Introduces a password-protected, control-DB–backed **local secure store** and migrates local state into it (device/relay identities, relay config, machine identity, trusted relays, host config, and most secrets), with opportunistic migration from legacy files/keychain and explicit retention of the root mnemonic outside the store.
> 
> Unifies `gssh` startup and command flows (`tui`, `connect`, `serve`, `relay`) around **local-store-first password resolution** (new `GITSPACE_LOCAL_STORE_PASSWORD`, `--password-stdin` support for relay start, updated prompts/errors), and avoids “poisoning” migrations on wrong passwords.
> 
> Refactors control ownership handling by adding `bindPersistedOwnerIdentity` + a shared `planStartupControlState`/formatters, improving drift repair and takeover messaging; `resetControlStore` now clears operational tables/metadata without deleting the whole DB so secure-store data can be preserved.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 12852f57fcccec92192934bb5eeef4bb44f4b659. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add --password-stdin for relay start to supply local secure store password non‑interactively.
  * Introduce a password‑protected local secure store for credentials, secrets, and migration.

* **Enhancements**
  * Host, relay, and secrets flows now read from and cache to the local secure store.
  * Improved startup ownership/mismatch planning with clearer takeover prompts.
  * User-facing text now references GITSPACE_LOCAL_STORE_PASSWORD / “local secure store identity.”

* **Tests**
  * New and updated tests cover local secure store, migration, and ownership repair scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->