### PR TITLE
fix: add missing 'reconnecting' status to web app status message maps

### DIFF
--- a/src/app.web.tsx
+++ b/src/app.web.tsx
@@ -21,6 +21,7 @@ import { useUserActivity } from "./hooks/index.js";
 import { useBundleRefreshAttachFlow } from './session/useBundleRefreshAttachFlow.js';
 import { useBundleConfigFlow } from './session/useBundleConfigFlow.js';
 import { useAttachController } from './app/session/useAttachController.js';
+import { CONNECTION_STATUS_LABELS } from './app/session/types.js';
 import { useProcessActions } from './app/session/useProcessActions.js';
 import { useWorkspaceDeleteFlow } from './app/session/useWorkspaceDeleteFlow.js';
 import { useLifecycleController } from './app/session/useLifecycleController.js';
@@ -1523,15 +1524,7 @@ export default function App() {
 
     // Connection not yet established — show a targeted connecting screen
     // rather than falling through to the generic machine list.
-    const statusMessage = {
-      disconnected: "Disconnected",
-      connecting: "Connecting to relay...",
-      reconnecting: "Connection lost. Reconnecting...",
-      connected: "Connected, authenticating...",
-      handshaking: "Establishing secure connection...",
-      established: "Connected!",
-      error: "Connection failed",
-    }[terminal.status];
+    const statusMessage = CONNECTION_STATUS_LABELS[terminal.status];
 
     return (
       <>
@@ -1556,15 +1549,7 @@ export default function App() {
 
   if (view === 'replay' && activeReplay) {
     if (terminal.status !== 'established' || terminal.mode !== 'browsing') {
-      const statusMessage = {
-        disconnected: 'Disconnected',
-        connecting: 'Connecting to relay...',
-        reconnecting: 'Connection lost. Reconnecting...',
-        connected: 'Connected, authenticating...',
-        handshaking: 'Establishing secure connection...',
-        established: 'Connected!',
-        error: 'Connection failed',
-      }[terminal.status];
+      const statusMessage = CONNECTION_STATUS_LABELS[terminal.status];
 
       return (
         <>
@@ -1904,15 +1889,7 @@ export default function App() {
 
   // ========== Terminal Connecting View ==========
   if (view === "terminal") {
-    const statusMessage = {
-      disconnected: "Disconnected",
-      connecting: "Connecting to relay...",
-      reconnecting: "Connection lost. Reconnecting...",
-      connected: "Connected, authenticating...",
-      handshaking: "Establishing secure connection...",
-      established: "Connected!",
-      error: "Connection failed",
-    }[terminal.status];
+    const statusMessage = CONNECTION_STATUS_LABELS[terminal.status];
 
     return (
       <>

--- a/src/app.web.tsx
+++ b/src/app.web.tsx
@@ -1526,6 +1526,7 @@ export default function App() {
     const statusMessage = {
       disconnected: "Disconnected",
       connecting: "Connecting to relay...",
+      reconnecting: "Connection lost. Reconnecting...",
       connected: "Connected, authenticating...",
       handshaking: "Establishing secure connection...",
       established: "Connected!",
@@ -1558,6 +1559,7 @@ export default function App() {
       const statusMessage = {
         disconnected: 'Disconnected',
         connecting: 'Connecting to relay...',
+        reconnecting: 'Connection lost. Reconnecting...',
         connected: 'Connected, authenticating...',
         handshaking: 'Establishing secure connection...',
         established: 'Connected!',

--- a/src/app/session/types.ts
+++ b/src/app/session/types.ts
@@ -7,6 +7,19 @@ export type SessionClientConnectionStatus =
   | 'reconnecting'
   | 'error'
 
+/**
+ * Human-readable labels for each connection status.
+ * Typed as an exhaustive Record so adding a new status to the union
+ * causes a compile error until a label is provided here.
+ */
+export const CONNECTION_STATUS_LABELS: Record<SessionClientConnectionStatus, string> = {
+  disconnected: 'Disconnected',
+  connecting: 'Connecting to relay...',
+  reconnecting: 'Connection lost. Reconnecting...',
+  established: 'Connected!',
+  error: 'Connection failed',
+}
+
 export type SessionClientMode = 'browsing' | 'attached'
 
 export type SessionClientScriptState = ScriptRuntimeState


### PR DESCRIPTION
## Summary

- Adds the missing `reconnecting` key to two status-message lookup objects in `app.web.tsx` (review loading screen and replay loading screen) that were causing TypeScript build failures
- The `reconnecting` status was introduced in #69 but only added to one of the three status-message maps, leaving two incomplete
- Build now passes cleanly

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI text refactor that centralizes connection-status messaging; main risk is mismatched/undefined labels if new statuses are added elsewhere.
> 
> **Overview**
> **Fixes missing/duplicated connection status messaging** by introducing `CONNECTION_STATUS_LABELS` as an exhaustive `Record` keyed by `SessionClientConnectionStatus`.
> 
> `app.web.tsx` now uses this shared map for the review loading, replay loading, and terminal connecting screens, ensuring the `reconnecting` state consistently renders "Connection lost. Reconnecting..." and preventing future TypeScript exhaustiveness gaps.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b8464f9a8c98bb2292de4cd265a7d20eabd76785. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Consistent, user-friendly connection status messages across review, replay loading, and connection views.
  * New visible labels include: "Disconnected", "Connecting to relay...", "Connection lost. Reconnecting...", "Connected!", and "Connection failed".
<!-- end of auto-generated comment: release notes by coderabbit.ai -->